### PR TITLE
Add generic tool to renew uuid values in 5.4 yaml files

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,7 @@
+
+Notice that from Zabbix version 5.4 and onwards, templates
+[requires unique uuid values](https://support.zabbix.com/browse/ZBXNEXT-6411).
+This means that if you want to create a new template based on an existing
+template with just a few modifications (e.g. very typical for printer templates)
+then you need to replace all the existing uuid values with new values in your
+new template. The `renew_uuids.py` script makes that trivially simple.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,7 +1,29 @@
 
+# Tools
+
+## renew_uuids.py
+
 Notice that from Zabbix version 5.4 and onwards, templates
 [requires unique uuid values](https://support.zabbix.com/browse/ZBXNEXT-6411).
 This means that if you want to create a new template based on an existing
 template with just a few modifications (e.g. very typical for printer templates)
 then you need to replace all the existing uuid values with new values in your
 new template. The `renew_uuids.py` script makes that trivially simple.
+
+### Example usage
+
+Creating a new `template_nginx_for_zabbix_5.0` based on the existing 4.0 template:
+
+```shell
+$ cd Applications/Web-servers
+$ cp -a template_nginx_for_zabbix_4.0 template_nginx_for_zabbix_5.0
+$ cd template_nginx_for_zabbix_5.0/5.0
+$ mv template_nginx_for_zabbix_4.0.xml template_nginx_for_zabbix_5.0.xml
+$ cd ../5.4
+$ mv template_nginx_for_zabbix_4.0.yaml template_nginx_for_zabbix_5.0.yaml
+$ ../../../../tools/renew_uuids.py --help      # Optional
+$ ../../../../tools/renew_uuids.py --input template_nginx_for_zabbix_5.0.yaml --output newfile
+$ kdiff3 template_nginx_for_zabbix_5.0.yaml newfile      # (optional) review
+$ mv newfile template_nginx_for_zabbix_5.0.yaml
+$ ... # whatever further changes are needed to update to 5.0 ...
+```

--- a/tools/renew_uuids.py
+++ b/tools/renew_uuids.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import re
+import uuid
+import argparse
+
+def find_uuids_in_file(filename):
+    """Reads the whole file and searches for uuid occurences.
+
+    Returns a dictionary with keys for all found uuids, and new replacement
+    uuids as its values.
+    """
+    uuidre = re.compile(r'\buuid:\s*(?P<uuid>[0-9a-f]{32})\b')
+    result = {}
+    with open(filename, mode = 'r', encoding = 'utf-8') as f:
+        for line in f:
+            m = uuidre.search(line)
+            if not m or not m.group('uuid'):
+                continue
+            old_uuid = m.group('uuid')
+            if not result.get(old_uuid):
+                new_uuid = uuid.uuid4().hex
+                result[old_uuid] = new_uuid
+    return result
+
+def copy_file_and_replace_uuids(input_filename, output_filename, uuids):
+    """Copies the content from input to output, replacing any occurences of
+    uuids keys with its corresponding value.
+    """
+    with open(input_filename, mode = 'r', encoding = 'utf-8') as inputf:
+        with open(output_filename, mode = 'w+', encoding = 'utf-8') as outputf:
+            for line in inputf:
+                for k in uuids.keys():
+                    line = line.replace(k, uuids[k])
+                outputf.write(line)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Replace existing uuid values with new ones')
+    parser.add_argument('-i', '--input', dest='input', required=True, help='input file')
+    parser.add_argument('-o', '--output', dest='output', required=True, help='output file')
+    args = parser.parse_args()
+
+    copy_file_and_replace_uuids(args.input, args.output, find_uuids_in_file(args.input))

--- a/tools/renew_uuids.py
+++ b/tools/renew_uuids.py
@@ -3,6 +3,10 @@ import re
 import uuid
 import argparse
 
+non_replace_uuids = {
+    '7df96b18c230490a9a0a9e2307226338': 'Templates',
+}
+
 def find_uuids_in_file(filename):
     """Reads the whole file and searches for uuid occurences.
 
@@ -17,6 +21,8 @@ def find_uuids_in_file(filename):
             if not m or not m.group('uuid'):
                 continue
             old_uuid = m.group('uuid')
+            if non_replace_uuids.get(old_uuid):
+                continue
             if not result.get(old_uuid):
                 new_uuid = uuid.uuid4().hex
                 result[old_uuid] = new_uuid


### PR DESCRIPTION
When someone want to make a new template that is based on one of the already existing template (say creating a new `template_nginx_for_zabbix_5.0` based on the existing `template_nginx_for_zabbix_4.0`), this script helps initializing the new template with new uuid values.