### PR TITLE
Update template_vmmanager_6_master.yaml

### DIFF
--- a/Virtualization/VMmanager/template_vmmanager_6_master/5.4/template_vmmanager_6_master.yaml
+++ b/Virtualization/VMmanager/template_vmmanager_6_master/5.4/template_vmmanager_6_master.yaml
@@ -615,7 +615,7 @@ zabbix_export:
                     name: 'VMmanager 6'
               templates:
                 -
-                  name: 'Template OS Linux by Zabbix agent'
+                  name: 'Linux by Zabbix agent'
               custom_interfaces: 'YES'
               interfaces:
                 -


### PR DESCRIPTION
There is no 'Template Linux by Zabbix agent' in 5.4 server version. It was renamed to 'Linux by Zabbix agent'