### PR TITLE
Add a comment to allow the execution of the script

### DIFF
--- a/Cloud/template_nextcloud_monitoring_api/5.4/README.md
+++ b/Cloud/template_nextcloud_monitoring_api/5.4/README.md
@@ -10,6 +10,9 @@ Needs **curl** to be installed on the Nextcloud server.
 
 **You need to set the macros according to your environment.**
 
+**You also need to allow the execution of the script in Zabbix Agent configuration file**
+For example, `AllowKey=system.run["curl *"]`
+
 
 Fully compatible with Nextcloud versions 14 - 17.
 


### PR DESCRIPTION
The Zabbix Agent configuration should contain an allow rule to be able to execute the script with the curl command that this template needs.