### PR TITLE
Fix Asustor NAS template 'sysBiosVersion' OID

### DIFF
--- a/Unsorted/template_snmp_asustor_nas/5.4/template_snmp_asustor_nas.yaml
+++ b/Unsorted/template_snmp_asustor_nas/5.4/template_snmp_asustor_nas.yaml
@@ -151,7 +151,7 @@ zabbix_export:
           uuid: 4e507850a1304b74a27a9480f459a309
           name: sysBiosVersion
           type: SNMP_AGENT
-          snmp_oid: 1.3.6.1.4.1.44738.1.6.0
+          snmp_oid: 1.3.6.1.4.1.44738.1.3.0
           key: sysBiosVersion
           delay: 1h
           trends: '0'


### PR DESCRIPTION
According to the MIB definition the 'sysBiosVersion' is 1.3.6.1.4.1.44738.1.3.0
References: https://www.asustor.com/online/College_topic?topic=271