### PR TITLE
Fix md raid template

### DIFF
--- a/Server_Hardware/Other/template_md_raid/6.0/template_md_raid.yaml
+++ b/Server_Hardware/Other/template_md_raid/6.0/template_md_raid.yaml
@@ -22,7 +22,7 @@ zabbix_export:
           item_prototypes:
             -
               uuid: 61bdf950e6c9471c919a9f549b02fa20
-              name: 'MD $1 degraded'
+              name: 'MD {#MDNAME} degraded'
               key: 'md.degraded[{#MDNAME}]'
               delay: 5m
               history: '3600'
@@ -40,7 +40,7 @@ zabbix_export:
                   priority: HIGH
             -
               uuid: 34537ac721304c0ea4192777528fba95
-              name: 'MD $1 raid disks'
+              name: 'MD {#MDNAME} raid disks'
               key: 'md.raid_disks[{#MDNAME}]'
               delay: '3600'
               history: '3600'
@@ -58,7 +58,7 @@ zabbix_export:
                   priority: WARNING
             -
               uuid: b34710292d384172a02c977d76d00c63
-              name: 'MD $1 sync action'
+              name: 'MD {#MDNAME} sync action'
               key: 'md.sync_action[{#MDNAME}]'
               delay: '300'
               history: '3600'

--- a/Server_Hardware/Other/template_md_raid/6.0/userparameter_md.conf
+++ b/Server_Hardware/Other/template_md_raid/6.0/userparameter_md.conf
@@ -1,0 +1,5 @@
+UserParameter=md.discover,ls /sys/class/block | awk 'BEGIN{printf "{\"data\":["}; /^md[0-9]+$/ {printf c"{\"{#MDNAME}\":\""$1"\"}";c=","}; END{print "]}"}'
+UserParameter=md.degraded[*],cat /sys/block/$1/md/degraded
+UserParameter=md.sync_action[*],cat /sys/block/$1/md/sync_action
+UserParameter=md.raid_disks[*],cat /sys/block/$1/md/raid_disks
+


### PR DESCRIPTION
* Added missing user configuration file
* fixed variable names from $1 to {#MDNAME} for item prototypes in discovery rule.

This now works.