### PR TITLE
Removed positional macros from item name

### DIFF
--- a/Applications/Firewall/template_fail2ban/5.4/template_fail2ban.yaml
+++ b/Applications/Firewall/template_fail2ban/5.4/template_fail2ban.yaml
@@ -76,7 +76,7 @@ zabbix_export:
           item_prototypes:
             -
               uuid: 8cc0b05211fc4278b2feb46727a4ca97
-              name: 'Fail2ban $1 banned IPs'
+              name: 'Fail2ban {#JAIL} banned IPs'
               key: 'fail2ban.status[{#JAIL}]'
               delay: '60'
               units: count

--- a/Applications/Firewall/template_fail2ban/6.0/template_fail2ban.yaml
+++ b/Applications/Firewall/template_fail2ban/6.0/template_fail2ban.yaml
@@ -76,7 +76,7 @@ zabbix_export:
           item_prototypes:
             -
               uuid: 8cc0b05211fc4278b2feb46727a4ca97
-              name: 'Fail2ban $1 banned IPs'
+              name: 'Fail2ban {#JAIL} banned IPs'
               key: 'fail2ban.status[{#JAIL}]'
               delay: '60'
               units: count


### PR DESCRIPTION
They are deprecated and don't work properly: https://www.zabbix.com/documentation/4.0/en/manual/installation/upgrade_notes_400#deprecated-macros-in-item-names