### PR TITLE
Generic webpage by Web scenarios

### DIFF
--- a/Web_scenarios/template_generic_webpage/5.4/README.md
+++ b/Web_scenarios/template_generic_webpage/5.4/README.md
@@ -1,0 +1,40 @@
+
+# Generic webpage by Web scenarios
+
+## Overview
+
+Generic webpage monitoring by a basic Web scenario, easy to configure. Alerting on unavailability.
+
+Add the target webpage in Macros:
+{$URL}, full URL of the page to monitor. (For example : https://mywebpage.com)
+
+## Author
+Patxi Andueza 
+
+## Macros used
+
+|  Macro|Default value|Description|
+|--|--|--|
+| {$URL} | < Put the page URL here > |Full URL of the page to monitor. (For example : https://www.mywebpage.com/)|
+|{$UPDATE.INTERVAL}|1m|Every so often a request is made to the website.|
+|{$TRIES.UNTIL.TRIGGER}|2|Attempts until the trigger is fired. (Minimum value 1, so that it is triggered immediately).|
+
+
+## Template links
+
+There are no template links in this template.
+
+## Discovery rules
+
+There are no discovery rules in this template.
+
+## Items collected
+
+There are no items in this template other than those predefined by the web scenario.
+
+
+## Triggers
+
+|Name|Description|Expression|Priority|
+|----|-----------|----------|--------|
+|Webpage not available|<p>The website has failed to return the status code 200 (OK) on {$TRIES.UNTIL.TRIGGER} occasions.</p>|<p>**Expression**: last(/Generic webpage by Web scenarios/web.test.fail[Webpage availability],{$TRIES.UNTIL.TRIGGER})<>0</p><p>**Recovery expression**: </p>|High|

--- a/Web_scenarios/template_generic_webpage/5.4/template_generic_webpage.yaml
+++ b/Web_scenarios/template_generic_webpage/5.4/template_generic_webpage.yaml
@@ -1,0 +1,88 @@
+zabbix_export:
+  version: '5.4'
+  date: '2022-05-26T13:54:19Z'
+  groups:
+    -
+      uuid: 7df96b18c230490a9a0a9e2307226338
+      name: Templates
+  templates:
+    -
+      uuid: 22bd2ae920484b5b985faa9125ecce12
+      template: 'Generic webpage by Web scenarios'
+      name: 'Generic webpage by Web scenarios'
+      description: |
+        Created by Patxi Andueza.
+        
+        
+        Add the target webpage in Macros:
+        
+        {$URL}, full URL of the page to monitor. (For example : https://mywebpage.com)
+      groups:
+        -
+          name: Templates
+      httptests:
+        -
+          uuid: 7cf20f1d150c4300b4a498e995421c9f
+          name: 'Webpage availability'
+          delay: '{$UPDATE.INTERVAL}'
+          steps:
+            -
+              name: 'Webpage availability'
+              url: '{$URL}'
+              status_codes: '200'
+      macros:
+        -
+          macro: '{$TRIES.UNTIL.TRIGGER}'
+          value: '2'
+          description: 'Attempts until the trigger is fired. (Minimum value 1, so that it is triggered immediately).'
+        -
+          macro: '{$UPDATE.INTERVAL}'
+          value: 1m
+          description: 'Every so often a request is made to the website.'
+        -
+          macro: '{$URL}'
+          value: '<Put the page URL here>'
+          description: 'Full URL of the page to monitor. (For example : https://mywebpage.com/)'
+  triggers:
+    -
+      uuid: 76132502af0c4f4e8adad4a3caa8833a
+      expression: 'last(/Generic webpage by Web scenarios/web.test.fail[Webpage availability],{$TRIES.UNTIL.TRIGGER})<>0'
+      name: 'Webpage not available'
+      priority: HIGH
+      description: 'The website has failed to return the status code 200 (OK) on {$TRIES.UNTIL.TRIGGER} occasions.'
+  graphs:
+    -
+      uuid: 8819615d93824951936b43f72328009a
+      name: 'Response time'
+      graph_items:
+        -
+          sortorder: '1'
+          drawtype: FILLED_REGION
+          color: 0097A7
+          item:
+            host: 'Generic webpage by Web scenarios'
+            key: 'web.test.time[Webpage availability,Webpage availability,resp]'
+        -
+          sortorder: '2'
+          color: D32F2F
+          item:
+            host: 'Generic webpage by Web scenarios'
+            key: 'web.test.fail[Webpage availability]'
+    -
+      uuid: 5b33f9f5696349abbd7a04fa8c65eb10
+      name: Speed
+      graph_items:
+        -
+          sortorder: '1'
+          drawtype: FILLED_REGION
+          color: 689F38
+          item:
+            host: 'Generic webpage by Web scenarios'
+            key: 'web.test.in[Webpage availability,,bps]'
+        -
+          sortorder: '2'
+          color: D32F2F
+          yaxisside: RIGHT
+          item:
+            host: 'Generic webpage by Web scenarios'
+            key: 'web.test.fail[Webpage availability]'


### PR DESCRIPTION
Generic webpage monitoring by a basic Web scenario, easy to configure. Alerting on unavailability.

Add the target webpage in Macros:
{$URL}, full URL of the page to monitor. (For example : https://mywebpage.com)