### PR TITLE
Update template_tcp_udp_windows_connections.yaml

### DIFF
--- a/Operating_Systems/Windows/template_tcp_udp_windows_connections/6.0/template_tcp_udp_windows_connections.yaml
+++ b/Operating_Systems/Windows/template_tcp_udp_windows_connections/6.0/template_tcp_udp_windows_connections.yaml
@@ -23,15 +23,15 @@ zabbix_export:
         
         
         UserParameter=sockstat.sockets, netstat -ano | find /V "hola" /C  
-         UserParameter=sockstat.tcp.inuse, netstat -ano | findstr ESTABLISHED  
+         UserParameter=sockstat.tcp.inuse, netstat -ano | findstr "ESTABLISHED"  
          UserParameter=sockstat.tcp.inuse.count, netstat -ano | find /C "ESTABLISHED"  
-         UserParameter=sockstat.tcp.orphan, netstat -ano | findstr CLOSE\_WAIT  
-         UserParameter=sockstat.tcp.orphan.count, netstat -ano | find /C "CLOSE\_WAIT"  
-         UserParameter=sockstat.tcp.timewait, netstat -ano | findstr TIME\_WAIT   
-         UserParameter=sockstat.tcp.timewait.count, netstat -ano | find /C "TIME\_WAIT"  
-         UserParameter=sockstat.tcp.allocated, netstat -ano | findstr LISTENING  
+         UserParameter=sockstat.tcp.orphan, netstat -ano | findstr "CLOSE_WAIT"
+         UserParameter=sockstat.tcp.orphan.count, netstat -ano | find /C "CLOSE_WAIT"  
+         UserParameter=sockstat.tcp.timewait, netstat -ano | findstr "TIME_WAIT"   
+         UserParameter=sockstat.tcp.timewait.count, netstat -ano | find /C "TIME_WAIT"  
+         UserParameter=sockstat.tcp.allocated, netstat -ano | findstr "LISTENING"  
          UserParameter=sockstat.tcp.allocated.count, netstat -ano | find /C "LISTENING"  
-         UserParameter=sockstat.udp.inuse, netstat -ano | findstr UDP  
+         UserParameter=sockstat.udp.inuse, netstat -ano | findstr "UDP"  
          UserParameter=sockstat.udp.inuse.count, netstat -ano | find /C "UDP" 
         
         


### PR DESCRIPTION
Does not need escaping when inside `"`

Tested on Win 10 and Win 11 machines.

If `_` is escaped inside quotes, does not work correctly..
Quoting all of them, seems to be the safest