### PR TITLE
Added IBM Tivoli Workload Scheduler template

### DIFF
--- a/Applications/Job_Schedulers/template_ibm_tws_tivoli_workload_scheduler/6.0/README.md
+++ b/Applications/Job_Schedulers/template_ibm_tws_tivoli_workload_scheduler/6.0/README.md
@@ -1,0 +1,132 @@
+# IBM Tivoli Workload Scheduler Jobs - TWS
+
+## Overview
+
+Monitor TWS jobs parsing the application event.log as documented in [console-job-scheduling-events-format](https://www.ibm.com/docs/en/workload-automation/9.4.0?topic=console-job-scheduling-events-format)
+
+Parsing the event.log is the most simple and common way to monitor the TWS Jobs status.
+
+## Author
+
+- Marco Ostaska
+- Bruno Colobialle
+- Thays Trindade
+
+## Macros used
+
+|Name|Description|Default|Type|
+|----|-----------|-------|----|
+|{$101_JOB_STATSU6}|(101) Job Abend with job status 6 (continue after recovery job)| ^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+6\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$101_JOB_STATUS1}|(101) Job Abend with job status 1 (stop)| ^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+1\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$101_JOB_STATUS2}|(101) Job Abend with job status 2 (stop after recovery job)| ^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+2\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$101_JOB_STATUS3}|(101) Job Abend with job status 3 (rerun)| ^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+3\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$101_JOB_STATUS4}|(101) Job Abend with job status 4 (rerunafter recovery job)| ^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+4\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$101_JOB_STATUS5}|(101) Job Abend with job status 5 (continue)| ^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+5\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$101_JOB_STATUS20}|(101) Job Abend with job status 20 (this is the run of the recovery job)| ^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+20\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$101_OUTPUT}|<schedule_name> (<schedule_ia>) <job_name>| \2 (\3) \1|Text macro|
+|{$101_STATUS10}|(101) Job Abend with job status 10 (this is the rerun of the job)| ^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+10\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$102_JOB_FAILED}|(102)External Job is in Error status"| ^102\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S\*)|Text macro|
+|{$102_OUTPUT}|<schedule_name> (<schedule_ia>) <job_name>| \2 (\3) \1|Text macro|
+|{$105_JOB_SUSPENDED}|(105)Job suspended| ^105\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S\*)|Text macro|
+|{$107_JOB_CANCEL}|(107) Job was canceled| ^107\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S\*)|Text macro|
+|{$111_JOB_CANT}|(111) Job failed to start| ^111\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S++)\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S\*)|Text macro|
+|{$111_OUTPUT}|<schedule_name>(<schedule_ia>).<job_name> failed to start on CPU <job_cpu> - Reason: <tws_msg>| \4(\5).\1 failed to start on CPU \2 - Reason: \3|Text macro|
+|{$115_JOB_STUCK}|(115) is in Stuck status| ^115\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S\*)|Text macro|
+|{$115_OUTPUT}|<schedule_name>(<schedule_ia>).<job_name> on CPU <job_cpu>| \3(\4).\1 on CPU \2|Text macro|
+|{$120_JOB_LATE}|(120) Job is late| ^120\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$120_OUTPUT}|<schedule_name> (<schedule_ia>) <job_name> is late on CPU <job_cpu>| \3 (\4) \1 is late on CPU \2|Text macro|
+|{$121_JOB_UNTIL_CONT}|(121) Job until(continue) expired| ^121\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$121_OUTPUT}|<schedule_name>(<schedule_ia>).<job_name>: <job_cpu>| \3(\4).\1: \2|Text macro|
+|{$122_JOB_UNTIL_CANC}|(122) Job until(cancel) expired| ^122\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$122_OUTPUT}|<schedule_name> (<schedule_ia>) <job_name> until(cancel) expired on CPU <job_cpu>| \3 (\4) \1 until(cancel) expired on CPU \2|Text macro|
+|{$151_OUTPUT}|<schedule_name> (<schedule_ia>)| \1(\2)|Text macro|
+|{$151_SCHEDULE_ABEND}|(151) Schedule %s(%s) has failed| ^151\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S\*)|Text macro|
+|{$152_OUTPUT}|Schedule <schedule_name> (<schedule_ia>) is stuck| Schedule \1 (\2) is stuck|Text macro|
+|{$152_SCHEDULE_STUCK}|(152) Schedule is stuck| ^152\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S\*)|Text macro|
+|{$155_OUTPUT}|Schedule <schedule_name> (<schedule_ia>) suspended| Schedule \1 (\2) suspended|Text macro|
+|{$155_SCHEDULE_SUSP}|(155) Schedule suspended| ^153\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S\*)|Text macro|
+|{$157_SCHEDULE_CANCEL}|(157) Schedule was canceled| ^157\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S\*)|Text macro|
+|{$162_OUTPUT}|<property_number> of Schedule <schedule_name> (<schedule_ia>) changed to <property_value>| \1 of Schedule\3(\4) changed to \2|Text macro|
+|{$162_SCHEDULE_MODIFY}|(162) Property of Schedule changed| ^162\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S\*)|Text macro|
+|{$163_OUTPUT}|Schedule <schedule_name> (<schedule_ia>) is late| Schedule \1 (\2) is late|Text macro|
+|{$163_SCHEDULE_LATE}|(163) Schedule is late| ^163\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$164_OUTPUT}|Schedule <schedule_name> (<schedule_ia>) until(continue) expired| Schedule \1 (\2) until(continue) expired|Text macro|
+|{$164_SCHEDULE_UNTIL_CONT}|(164) Schedule until(continue) expired| ^164\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$165_OUTPUT}|<schedule_name> (<schedule_ia>)| \1 (\2)|Text macro|
+|{$165_SCHEDULE_UNTIL_CANC}|(165) Schedule until(cancel) expired| ^165\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S\*|Text macro|
+|{$251_LINK_DROPPED_STATE1}|(251) Comm unlinked - state 1(for unknown reason)| ^251\s+(\S+)\s+1\s\*\S\*|Text macro|
+|{$251_LINK_DROPPED_STATE3}|(251) Comm link - state 3(down due to an error)| ^251\s+(\S+)\s+3\s\*\S\*|Text macro|
+|{$251_OUTPUT}|<to_cpu>| \1|Text macro|
+|{$252_LINK_FAILED_STATE1}|(252) Comm link - state 1(down for unknown reason)| ^252\s+(\S+)\s+1\s\*\S\*|Text macro|
+|{$252_LINK_FAILED_STATE3}|(252) Comm link - state 3(down due to error)| ^252\s+(\S+)\s+3\s\*\S\*|Text macro|
+|{$252_OUTPUT}|<to_cpu>| \1|Text macro|
+|{$TWS_EVENT_LOG}|TWS even.log file to be monitored| /appl/maestro/IBM/wa/TWSDATA/event.log|Text macro|
+
+
+## Template links
+
+There are no template links in this template.
+
+## Discovery rules
+
+There are no discovery rules in this template.
+
+## Items collected
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|101_job_abend_satus6| (101) Job Abend with with recovery status 6(succ)| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$101_JOB_STATSU6},,,skip,{$101_OUTPUT}] |
+|101_job_abend_status1| (101) Job Abend with recovery status 1 (stop)| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$101_JOB_STATUS1},,,skip,{$101_OUTPUT}] |
+|101_job_abend_status2| (101) Job Abend with recovery status 2 (stop after recovery job)| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$101_JOB_STATUS2},,,skip,{$101_OUTPUT}] |
+|101_job_abend_status3| (101) Job Abend with recovery status 3(rerun)| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$101_JOB_STATUS3},,,skip,{$101_OUTPUT}] |
+|101_job_abend_status4| (101) Job Abend with recovery status 4 (rerun after the recovery job)| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$101_JOB_STATUS4},,,skip,{$101_OUTPUT}] |
+|101_job_abend_status5| (101) Job Abend with recovery status 5 (continue)| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$101_JOB_STATUS5},,,skip,{$101_OUTPUT}] |
+|101_job_abend_status20| (101) Job Abend with recovery status 20 (this is the run of the recovery job)| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$101_JOB_STATUS20},,,skip,{$101_OUTPUT}] |
+|101_job_abend_status10| (101) Job Abend with recovery status 10 (this is the rerun of the job)| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$101_STATUS10},,,skip,{$101_OUTPUT}] |
+|102_job_failed| (102) Job Failed| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$102_JOB_FAILED},,,skip,{$102_OUTPUT}] |
+|111_job_cant| (111) Job failed to start| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$111_JOB_CANT},,,skip,{$111_OUTPUT}] |
+|115_in_stuck| (115) Job is in Stuck status| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$115_JOB_STUCK},,,skip,{$115_OUTPUT}] |
+|120_job_late| (120) Job is late| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$120_JOB_LATE},,,skip,{$120_OUTPUT}] |
+|121_job_until_cont| (121) Job until(continue) expired| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$121_JOB_UNTIL_CONT},,,skip,{$121_OUTPUT}] |
+|122_job_until_canc| (122) Job until(cancel) expired| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$122_JOB_UNTIL_CANC},,,skip,{$122_OUTPUT}] |
+|151_schedule_abend| (151) Schedule has failed| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$151_SCHEDULE_ABEND},,,skip,{$151_OUTPUT}] |
+|152_schedule_stuck| (152) Schedule is stuck.| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$152_SCHEDULE_STUCK},,,skip,{$152_OUTPUT}] |
+|155_schedule_susp| (155) Schedule is suspended.| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$155_SCHEDULE_SUSP},,,skip,{$155_OUTPUT}] |
+|162_schedule_modify| (162) Property Schedule changed| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$162_SCHEDULE_MODIFY},,,skip,{$162_OUTPUT}] |
+|163_schedule_late| (163) Schedule is late.| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$163_SCHEDULE_LATE},,,skip,{$163_OUTPUT}] |
+|164_schedule_until_cont| (164) Schedule until(continue) expired.| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$164_SCHEDULE_UNTIL_CONT},,,skip,{$164_OUTPUT}] |
+|165_schedule_until_canc| (165) Schedule until(cancel) expired| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$165_SCHEDULE_UNTIL_CANC},,,skip,{$165_OUTPUT}] |
+|251_link_dropped_state1| (251) Comm unlinked - state 1(for unknown reason)| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$251_LINK_DROPPED_STATE1},,,skip,{$251_OUTPUT}] |
+|251_link_dropped_state3| (251) Comm link - state 3(down due to an error)| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$251_LINK_DROPPED_STATE3},,,skip,{$251_OUTPUT}] |
+|252_link_failed_state1| (252) Comm link - state 1(down for unknown reason)| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$252_LINK_FAILED_STATE1},,,skip,{$252_OUTPUT}] |
+|252_link_failed_state3| (252) Comm link - state 3(down due to error)| ZABBIX_ACTIVE| log[{$TWS_EVENT_LOG},{$252_LINK_FAILED_STATE3},,,skip,{$252_OUTPUT}] |
+
+## Triggers
+
+|Name|Description|Expression|Priority|
+|----|-----------|----|----|
+|101_job_abend_satus6| (101) Job Abend with with recovery status 6(succ)| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATSU6},,,skip,{$101_OUTPUT}])=1| HIGH |
+|101_job_abend_status1| (101) Job Abend with recovery status 1 (stop)| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATUS1},,,skip,{$101_OUTPUT}])=1| AVERAGE |
+|101_job_abend_status2| (101) Job Abend with recovery status 2 (stop after recovery job)| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATUS2},,,skip,{$101_OUTPUT}])=1| HIGH |
+|101_job_abend_status3| (101) Job Abend with recovery status 3(rerun)| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATUS3},,,skip,{$101_OUTPUT}])=1| INFO |
+|101_job_abend_status4| (101) Job Abend with recovery status 4 (rerun after the recovery job)| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATUS4},,,skip,{$101_OUTPUT}])=1| INFO |
+|101_job_abend_status5| (101) Job Abend with recovery status 5 (continue)| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATUS5},,,skip,{$101_OUTPUT}])=1| HIGH |
+|101_job_abend_status20| (101) Job Abend with recovery status 20 (this is the run of the recovery job)| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATUS20},,,skip,{$101_OUTPUT}])=1| WARNING |
+|101_job_abend_status10| (101) Job Abend with recovery status 10 (this is the rerun of the job)| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_STATUS10},,,skip,{$101_OUTPUT}])=1| WARNING |
+|102_job_failed| (102) Job Failed| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$102_JOB_FAILED},,,skip,{$102_OUTPUT}])=1| HIGH |
+|111_job_cant| (111) Job failed to start| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$111_JOB_CANT},,,skip,{$111_OUTPUT}])=1| HIGH |
+|115_in_stuck| (115) Job is in Stuck status| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$115_JOB_STUCK},,,skip,{$115_OUTPUT}])=1| WARNING |
+|120_job_late| (120) Job is late| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$120_JOB_LATE},,,skip,{$120_OUTPUT}])=1| WARNING |
+|121_job_until_cont| (121) Job until(continue) expired| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$121_JOB_UNTIL_CONT},,,skip,{$121_OUTPUT}])=1| WARNING |
+|122_job_until_canc| (122) Job until(cancel) expired| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$122_JOB_UNTIL_CANC},,,skip,{$122_OUTPUT}])=1| WARNING |
+|151_schedule_abend| (151) Schedule has failed| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$151_SCHEDULE_ABEND},,,skip,{$151_OUTPUT}])=1| HIGH |
+|152_schedule_stuck| (152) Schedule is stuck.| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$152_SCHEDULE_STUCK},,,skip,{$152_OUTPUT}])=1| HIGH |
+|155_schedule_susp| (155) Schedule is suspended.| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$155_SCHEDULE_SUSP},,,skip,{$155_OUTPUT}])=1| WARNING |
+|162_schedule_modify| (162) Property Schedule changed| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$162_SCHEDULE_MODIFY},,,skip,{$162_OUTPUT}])=1| WARNING |
+|163_schedule_late| (163) Schedule is late.| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$163_SCHEDULE_LATE},,,skip,{$163_OUTPUT}])=1| WARNING |
+|164_schedule_until_cont| (164) Schedule until(continue) expired| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$164_SCHEDULE_UNTIL_CONT},,,skip,{$164_OUTPUT}])=1| WARNING |
+|165_schedule_until_canc| (165) Schedule until(cancel) expired| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$165_SCHEDULE_UNTIL_CANC},,,skip,{$165_OUTPUT}])=1| WARNING |
+|251_link_dropped_state1| (251) Comm unlinked - state 1(for unknown reason)| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$251_LINK_DROPPED_STATE1},,,skip,{$251_OUTPUT}])=1| WARNING |
+|251_link_dropped_state3| (251) Comm link - state 3(down due to an error)| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$251_LINK_DROPPED_STATE3},,,skip,{$251_OUTPUT}])=1| WARNING |
+|252_link_failed_state1| (252) Comm link - state 1(down for unknown reason)| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$252_LINK_FAILED_STATE1},,,skip,{$252_OUTPUT}])=1| HIGH |
+|252_link_failed_state3| (252) Comm link - state 3(down due to error)| find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$252_LINK_FAILED_STATE3},,,skip,{$252_OUTPUT}])=1| HIGH |

--- a/Applications/Job_Schedulers/template_ibm_tws_tivoli_workload_scheduler/6.0/template_ibm_tws_tivoli_workload_scheduler.yaml
+++ b/Applications/Job_Schedulers/template_ibm_tws_tivoli_workload_scheduler/6.0/template_ibm_tws_tivoli_workload_scheduler.yaml
@@ -1,0 +1,877 @@
+zabbix_export:
+  version: '6.0'
+  date: '2022-11-10T15:11:07Z'
+  groups:
+    -
+      uuid: 2e7ad915be80465492e9e366a5d2ee9b
+      name: tws
+  templates:
+    -
+      uuid: cd18bd964c4b456cad3489b02f0d00e6
+      template: 'IBM Tivoli Workload Scheduler Jobs - TWS'
+      name: 'IBM Tivoli Workload Scheduler Jobs - TWS'
+      description: 'Monitor TWS jobs parsing the application event.log as documented in https://www.ibm.com/docs/en/workload-automation/9.4.0?topic=console-job-scheduling-events-format'
+      groups:
+        -
+          name: tws
+      items:
+        -
+          uuid: a7bf746744c547af85b9d3a0f8b53f88
+          name: 101_job_abend_satus6
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$101_JOB_STATSU6},,,skip,{$101_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(101) Job Abend with with recovery status 6(succ)'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: f0c9e0994e0642079ad57448dc2dd027
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATSU6},,,skip,{$101_OUTPUT}])=1'
+              name: 101_job_abend_satus6
+              event_name: 'Job {ITEM.LASTVALUE1} failed, running recovery job then continuing with schedule'
+              priority: HIGH
+              description: '(101) Job Abend with with recovery status 6(succ)'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 050f46212fc644179a6e0ae7cf032f17
+          name: 101_job_abend_status1
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$101_JOB_STATUS1},,,skip,{$101_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(101) Job Abend with recovery status 1 (stop)'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 6da8f72702524d8db1cebf814969b87f
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATUS1},,,skip,{$101_OUTPUT}])=1'
+              name: 101_job_abend_status1
+              event_name: '{ITEM.LASTVALUE1} failed, no recovery specified'
+              priority: AVERAGE
+              description: '(101) Job Abend with recovery status 1 (stop)'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 2763e2d73bc447e6a04d4ef822d27e60
+          name: 101_job_abend_status2
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$101_JOB_STATUS2},,,skip,{$101_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(101) Job Abend with recovery status 2 (stop after recovery job)'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 65d943531fa741948b8f31a95c27799e
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATUS2},,,skip,{$101_OUTPUT}])=1'
+              name: 101_job_abend_status2
+              event_name: '{ITEM.LASTVALUE1} failed, recovery job will be run then schedule will be stopped'
+              priority: HIGH
+              description: '(101) Job Abend with recovery status 2 (stop after recovery job)'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: be34fed3400d428dbda2199ab4c597cc
+          name: 101_job_abend_status3
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$101_JOB_STATUS3},,,skip,{$101_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(101) Job Abend with recovery status 3(rerun)'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 2c28c1d8a2564530be60555e0745d572
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATUS3},,,skip,{$101_OUTPUT}])=1'
+              name: 101_job_abend_status3
+              event_name: '{ITEM.LASTVALUE1} failed, this job will be rerun'
+              priority: INFO
+              description: '(101) Job Abend with recovery status 3(rerun)'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 023d3e6f6a3a4fe79200b3d82e6a1307
+          name: 101_job_abend_status4
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$101_JOB_STATUS4},,,skip,{$101_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(101) Job Abend with recovery status 4 (rerun after the recovery job)'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 4cbbf5bc592e4b00a127b7f5cc23c399
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATUS4},,,skip,{$101_OUTPUT}])=1'
+              name: 101_job_abend_status4
+              event_name: 'Job {ITEM.LASTVALUE1} failed, this job will be rerun after the recovery job.'
+              priority: INFO
+              description: '(101) Job Abend with recovery status 4 (rerun after the recovery job)'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 01ee9f5542cd42859d5277193fe6bd00
+          name: 101_job_abend_status5
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$101_JOB_STATUS5},,,skip,{$101_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(101) Job Abend with recovery status 5 (continue)'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: de8b7f3217564fd5877e8f2047b41a4c
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATUS5},,,skip,{$101_OUTPUT}])=1'
+              name: 101_job_abend_status5
+              event_name: 'Job {ITEM.LASTVALUE1} failed, continuing with schedule.'
+              priority: HIGH
+              description: '(101) Job Abend with recovery status 5 (continue)'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 6e050a895a8843b8a72f998453f7b374
+          name: 101_job_abend_status20
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$101_JOB_STATUS20},,,skip,{$101_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(101) Job Abend with recovery status 20 (this is the run of the recovery job)'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 4cff12f31c554d86a97f79931ef7256f
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_JOB_STATUS20},,,skip,{$101_OUTPUT}])=1'
+              name: 101_job_abend_status20
+              event_name: 'Failure while recovering job {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: '(101) Job Abend with recovery status 20 (this is the run of the recovery job)'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 7a77a30aeeeb426784e568370c286b91
+          name: 101_job_abend_status10
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$101_STATUS10},,,skip,{$101_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(101) Job Abend with recovery status 10 (this is the rerun of the job)'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 29c7b97c2d504d79bfd6825864a0319d
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$101_STATUS10},,,skip,{$101_OUTPUT}])=1'
+              name: 101_job_abend_status10
+              event_name: 'Failure while rerunning failed job {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: '(101) Job Abend with recovery status 10 (this is the rerun of the job)'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: a4c33db207034af49437c838b29e44f9
+          name: 102_job_failed
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$102_JOB_FAILED},,,skip,{$102_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(102) Job Failed'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 75d5537616c94c728fd1cf924a8b04fd
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$102_JOB_FAILED},,,skip,{$102_OUTPUT}])=1'
+              name: 102_job_failed
+              event_name: 'External Job {ITEM.LASTVALUE1} is in Error status'
+              priority: HIGH
+              description: '(102) Job Failed'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: bf5946cca5254d92840919a6dda977f4
+          name: 111_job_cant
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$111_JOB_CANT},,,skip,{$111_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(111) Job failed to start'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 130cf987005b496a9de55c8996a602c3
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$111_JOB_CANT},,,skip,{$111_OUTPUT}])=1'
+              name: 111_job_cant
+              event_name: 'Job {ITEM.LASTVALUE1} +++'
+              priority: HIGH
+              description: '(111) Job failed to start'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 09ccdc99dd8d4a1b9d31474aa1731672
+          name: 115_in_stuck
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$115_JOB_STUCK},,,skip,{$115_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(115) Job is in Stuck status'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: ed58cfa000fa4cb993b1dcb876d22816
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$115_JOB_STUCK},,,skip,{$115_OUTPUT}])=1'
+              name: 115_in_stuck
+              event_name: 'Job {ITEM.LASTVALUE1} is in Stuck status'
+              priority: WARNING
+              description: '(115) Job is in Stuck status'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 1311d990d8b74353a4a56f610afe61a0
+          name: 120_job_late
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$120_JOB_LATE},,,skip,{$120_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(120) Job is late'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: ad7e926de00a4f4fbff9c5f90b49e882
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$120_JOB_LATE},,,skip,{$120_OUTPUT}])=1'
+              name: 120_job_late
+              event_name: 'Job {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: '(120) Job is late'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: afeeed2408e34fc5a56533eafbed7dd6
+          name: 121_job_until_cont
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$121_JOB_UNTIL_CONT},,,skip,{$121_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(121) Job until(continue) expired'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 8f578bec220f432d8e0f8de42dba8aee
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$121_JOB_UNTIL_CONT},,,skip,{$121_OUTPUT}])=1'
+              name: 121_job_until_cont
+              event_name: 'Job {ITEM.LASTVALUE1} expired until(continue)'
+              priority: WARNING
+              description: '(121) Job until(continue) expired'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: bddf47754b21421e80f11f1b0b2adfdc
+          name: 122_job_until_canc
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$122_JOB_UNTIL_CANC},,,skip,{$122_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(122) Job until(cancel) expired'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 550a4be2f555431db783371dedc26190
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$122_JOB_UNTIL_CANC},,,skip,{$122_OUTPUT}])=1'
+              name: 122_job_until_canc
+              event_name: 'Job {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: '(122) Job until(cancel) expired'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 92ef0faee9794db8b130802e038d7d03
+          name: 151_schedule_abend
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$151_SCHEDULE_ABEND},,,skip,{$151_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(151) Schedule has failed'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: e7e4ca5edf744d6593ec776145e07261
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$151_SCHEDULE_ABEND},,,skip,{$151_OUTPUT}])=1'
+              name: 151_schedule_abend
+              event_name: 'Schedule {ITEM.LASTVALUE1} has failed'
+              priority: HIGH
+              description: '(151) Schedule has failed'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 5feee4ba38fe4ab68d560dc54719fe70
+          name: 152_schedule_stuck
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$152_SCHEDULE_STUCK},,,skip,{$152_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(152) Schedule is stuck.'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 060c5657cf8d4c3b96c4a01f10050e66
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$152_SCHEDULE_STUCK},,,skip,{$152_OUTPUT}])=1'
+              name: 152_schedule_stuck
+              event_name: 'Job {ITEM.LASTVALUE1}'
+              priority: HIGH
+              description: '(152) Schedule is stuck.'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 1b8ee0255c484fbe8b8cc254a111b68b
+          name: 155_schedule_susp
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$155_SCHEDULE_SUSP},,,skip,{$155_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(155) Schedule is suspended.'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: bc8cbb2b0a684529be83570339c9f003
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$155_SCHEDULE_SUSP},,,skip,{$155_OUTPUT}])=1'
+              name: 155_schedule_susp
+              event_name: 'Job {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: '(155) Schedule is suspended.'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 3692aec610b146d8af567eb53e55e034
+          name: 162_schedule_modify
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$162_SCHEDULE_MODIFY},,,skip,{$162_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(162) Property Schedule changed'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 7638c0de7da24d83957ca6c59d29ac57
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$162_SCHEDULE_MODIFY},,,skip,{$162_OUTPUT}])=1'
+              name: 162_schedule_modify
+              event_name: 'Property {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: '(162) Property Schedule changed'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: c1de63f906b04095934e8a3a6a47c524
+          name: 163_schedule_late
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$163_SCHEDULE_LATE},,,skip,{$163_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(163) Schedule is late.'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: ba477d4632bf4b0095cd217777b87fa6
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$163_SCHEDULE_LATE},,,skip,{$163_OUTPUT}])=1'
+              name: 163_schedule_late
+              event_name: 'Job {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: '(163) Schedule is late.'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: b9eb4fb764544fc4ab2a6e4dd453ea9c
+          name: 164_schedule_until_cont
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$164_SCHEDULE_UNTIL_CONT},,,skip,{$164_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(164) Schedule until(continue) expired.'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 8bf07bcaef69484db7ad3a000be5be6d
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$164_SCHEDULE_UNTIL_CONT},,,skip,{$164_OUTPUT}])=1'
+              name: 164_schedule_until_cont
+              event_name: 'Schedule {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: '(164) Schedule until(continue) expired'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: eebe96418af942b2963fd817829b181c
+          name: 165_schedule_until_canc
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$165_SCHEDULE_UNTIL_CANC},,,skip,{$165_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(165) Schedule until(cancel) expired'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 67ef4427adac4fd0ad8d540eaacf8278
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$165_SCHEDULE_UNTIL_CANC},,,skip,{$165_OUTPUT}])=1'
+              name: 165_schedule_until_canc
+              event_name: 'Schedule {ITEM.LASTVALUE1} until(cancel) expired'
+              priority: WARNING
+              description: '(165) Schedule until(cancel) expired'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: b97aadf1ef754a05a56859f76d801d1b
+          name: 251_link_dropped_state1
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$251_LINK_DROPPED_STATE1},,,skip,{$251_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(251) Comm unlinked - state 1(for unknown reason)'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: d00443b672644d1ab48628ea7a7775c7
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$251_LINK_DROPPED_STATE1},,,skip,{$251_OUTPUT}])=1'
+              name: 251_link_dropped_state1
+              event_name: 'Comm link {ITEM.LASTVALUE1} unlinked for unknown reason'
+              priority: WARNING
+              description: '(251) Comm unlinked - state 1(for unknown reason)'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: b30c57b0e76b4a4bbeb48214e82dd010
+          name: 251_link_dropped_state3
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$251_LINK_DROPPED_STATE3},,,skip,{$251_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(251) Comm link - state 3(down due to an error)'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 7977798ba92d433e81891e998739d497
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$251_LINK_DROPPED_STATE3},,,skip,{$251_OUTPUT}])=1'
+              name: 251_link_dropped_state3
+              event_name: 'Comm link {ITEM.LASTVALUE1} dropped due to error'
+              priority: WARNING
+              description: '(251) Comm link - state 3(down due to an error)'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: c747863f995d4c0a9a1b98124a721291
+          name: 252_link_failed_state1
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$252_LINK_FAILED_STATE1},,,skip,{$252_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(252) Comm link - state 1(down for unknown reason)'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: 8472a4c71058495faceb88986510d8d1
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$252_LINK_FAILED_STATE1},,,skip,{$252_OUTPUT}])=1'
+              name: 252_link_failed_state1
+              event_name: 'Comm link {ITEM.LASTVALUE1} down for unknown reason'
+              priority: HIGH
+              description: '(252) Comm link - state 1(down for unknown reason)'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+        -
+          uuid: 50d8a51c51054a59bd23b8911d3a61fd
+          name: 252_link_failed_state3
+          type: ZABBIX_ACTIVE
+          key: 'log[{$TWS_EVENT_LOG},{$252_LINK_FAILED_STATE3},,,skip,{$252_OUTPUT}]'
+          delay: 1s
+          trends: '0'
+          value_type: LOG
+          description: '(252) Comm link - state 3(down due to error)'
+          tags:
+            -
+              tag: application
+              value: TWS
+          triggers:
+            -
+              uuid: f931e48ac25146deb0f4be38085ddf72
+              expression: 'find(/IBM Tivoli Workload Scheduler Jobs - TWS/log[{$TWS_EVENT_LOG},{$252_LINK_FAILED_STATE3},,,skip,{$252_OUTPUT}])=1'
+              name: 252_link_failed_state3
+              event_name: 'Comm link {ITEM.LASTVALUE1} down due to error'
+              priority: HIGH
+              description: '(252) Comm link - state 3(down due to error)'
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                -
+                  tag: application
+                  value: TWS
+      tags:
+        -
+          tag: application
+          value: TWS
+      macros:
+        -
+          macro: '{$101_JOB_STATSU6}'
+          value: '^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+6\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(101) Job Abend with job status 6 (continue after recovery job)'
+        -
+          macro: '{$101_JOB_STATUS1}'
+          value: '^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+1\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(101) Job Abend with job status 1 (stop)'
+        -
+          macro: '{$101_JOB_STATUS2}'
+          value: '^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+2\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(101) Job Abend with job status 2 (stop after recovery job)'
+        -
+          macro: '{$101_JOB_STATUS3}'
+          value: '^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+3\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(101) Job Abend with job status 3 (rerun)'
+        -
+          macro: '{$101_JOB_STATUS4}'
+          value: '^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+4\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(101) Job Abend with job status 4 (rerunafter recovery job)'
+        -
+          macro: '{$101_JOB_STATUS5}'
+          value: '^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+5\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(101) Job Abend with job status 5 (continue)'
+        -
+          macro: '{$101_JOB_STATUS20}'
+          value: '^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+20\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(101) Job Abend with job status 20 (this is the run of the recovery job)'
+        -
+          macro: '{$101_OUTPUT}'
+          value: '\2 (\3) \1'
+          description: '<schedule_name> (<schedule_ia>) <job_name>'
+        -
+          macro: '{$101_STATUS10}'
+          value: '^101\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+10\s+\S+\s+\S+\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(101) Job Abend with job status 10 (this is the rerun of the job)'
+        -
+          macro: '{$102_JOB_FAILED}'
+          value: '^102\s+\S+\s+\S+\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S*)'
+          description: '(102)External Job is in Error status"'
+        -
+          macro: '{$102_OUTPUT}'
+          value: '\2 (\3) \1'
+          description: '<schedule_name> (<schedule_ia>) <job_name>'
+        -
+          macro: '{$105_JOB_SUSPENDED}'
+          value: '^105\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S*)'
+          description: '(105)Job suspended'
+        -
+          macro: '{$107_JOB_CANCEL}'
+          value: '^107\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S*)'
+          description: '(107) Job was canceled'
+        -
+          macro: '{$111_JOB_CANT}'
+          value: '^111\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S++)\s+\+++\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S*)'
+          description: '(111) Job failed to start'
+        -
+          macro: '{$111_OUTPUT}'
+          value: '\4(\5).\1 failed to start on CPU \2 - Reason: \3'
+          description: '<schedule_name>(<schedule_ia>).<job_name> failed to start on CPU <job_cpu> - Reason: <tws_msg>'
+        -
+          macro: '{$115_JOB_STUCK}'
+          value: '^115\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S*)'
+          description: '(115) is in Stuck status'
+        -
+          macro: '{$115_OUTPUT}'
+          value: '\3(\4).\1 on CPU \2'
+          description: '<schedule_name>(<schedule_ia>).<job_name> on CPU <job_cpu>'
+        -
+          macro: '{$120_JOB_LATE}'
+          value: '^120\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(120) Job is late'
+        -
+          macro: '{$120_OUTPUT}'
+          value: '\3 (\4) \1 is late on CPU \2'
+          description: '<schedule_name> (<schedule_ia>) <job_name> is late on CPU <job_cpu>'
+        -
+          macro: '{$121_JOB_UNTIL_CONT}'
+          value: '^121\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(121) Job until(continue) expired'
+        -
+          macro: '{$121_OUTPUT}'
+          value: '\3(\4).\1: \2'
+          description: '<schedule_name>(<schedule_ia>).<job_name>: <job_cpu>'
+        -
+          macro: '{$122_JOB_UNTIL_CANC}'
+          value: '^122\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(122) Job until(cancel) expired'
+        -
+          macro: '{$122_OUTPUT}'
+          value: '\3 (\4) \1 until(cancel) expired on CPU \2'
+          description: '<schedule_name> (<schedule_ia>) <job_name> until(cancel) expired on CPU <job_cpu>'
+        -
+          macro: '{$151_OUTPUT}'
+          value: \1(\2)
+          description: '<schedule_name> (<schedule_ia>)'
+        -
+          macro: '{$151_SCHEDULE_ABEND}'
+          value: '^151\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S*)'
+          description: '(151) Schedule %s(%s) has failed'
+        -
+          macro: '{$152_OUTPUT}'
+          value: 'Schedule \1 (\2) is stuck'
+          description: 'Schedule <schedule_name> (<schedule_ia>) is stuck'
+        -
+          macro: '{$152_SCHEDULE_STUCK}'
+          value: '^152\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S*)'
+          description: '(152) Schedule is stuck'
+        -
+          macro: '{$155_OUTPUT}'
+          value: 'Schedule \1 (\2) suspended'
+          description: 'Schedule <schedule_name> (<schedule_ia>) suspended'
+        -
+          macro: '{$155_SCHEDULE_SUSP}'
+          value: '^153\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S*)'
+          description: '(155) Schedule suspended'
+        -
+          macro: '{$157_SCHEDULE_CANCEL}'
+          value: '^157\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S*)'
+          description: '(157) Schedule was canceled'
+        -
+          macro: '{$162_OUTPUT}'
+          value: '\1 of Schedule\3(\4) changed to \2'
+          description: '<property_number> of Schedule <schedule_name> (<schedule_ia>) changed to <property_value>'
+        -
+          macro: '{$162_SCHEDULE_MODIFY}'
+          value: '^162\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S*)'
+          description: '(162) Property of Schedule changed'
+        -
+          macro: '{$163_OUTPUT}'
+          value: 'Schedule \1 (\2) is late'
+          description: 'Schedule <schedule_name> (<schedule_ia>) is late'
+        -
+          macro: '{$163_SCHEDULE_LATE}'
+          value: '^163\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(163) Schedule is late'
+        -
+          macro: '{$164_OUTPUT}'
+          value: 'Schedule \1 (\2) until(continue) expired'
+          description: 'Schedule <schedule_name> (<schedule_ia>) until(continue) expired'
+        -
+          macro: '{$164_SCHEDULE_UNTIL_CONT}'
+          value: '^164\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(164) Schedule until(continue) expired'
+        -
+          macro: '{$165_OUTPUT}'
+          value: '\1 (\2)'
+          description: '<schedule_name> (<schedule_ia>)'
+        -
+          macro: '{$165_SCHEDULE_UNTIL_CANC}'
+          value: '^165\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+(\S+)\s+(\S+)\s+\S*'
+          description: '(165) Schedule until(cancel) expired'
+        -
+          macro: '{$251_LINK_DROPPED_STATE1}'
+          value: '^251\s+(\S+)\s+1\s*\S*'
+          description: '(251) Comm unlinked - state 1(for unknown reason)'
+        -
+          macro: '{$251_LINK_DROPPED_STATE3}'
+          value: '^251\s+(\S+)\s+3\s*\S*'
+          description: '(251) Comm link - state 3(down due to an error)'
+        -
+          macro: '{$251_OUTPUT}'
+          value: \1
+          description: '<to_cpu>'
+        -
+          macro: '{$252_LINK_FAILED_STATE1}'
+          value: '^252\s+(\S+)\s+1\s*\S*'
+          description: '(252) Comm link - state 1(down for unknown reason)'
+        -
+          macro: '{$252_LINK_FAILED_STATE3}'
+          value: '^252\s+(\S+)\s+3\s*\S*'
+          description: '(252) Comm link - state 3(down due to error)'
+        -
+          macro: '{$252_OUTPUT}'
+          value: \1
+          description: '<to_cpu>'
+        -
+          macro: '{$TWS_EVENT_LOG}'
+          value: /appl/maestro/IBM/wa/TWSDATA/event.log
+          description: 'TWS even.log file to be monitored'

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ This repository is dedicated to templates that are created and maintained by Zab
         * [Template App Generic Java JMX](Applications/Java_Application/template_app_generic_java_jmx_with_metaspace)
         * [App Glassfish server.jvm](Applications/Java_Application/template_glassfish_webserver)
         * [JVM Generic](Applications/Java_Application/template_jvm_and_g1_gc_monitoring_with_jmx)
+    * [Job_Schedulers](Applications/Job_Schedulers)
+        * [IBM Tivoli Workload Scheduler](Applications/Job_Schedulers/template_ibm_tws_tivoli_workload_scheduler)
     * [Mail_servers](Applications/Mail_servers)
         * [ESA-CISCO XML Status](Applications/Mail_servers/template_cisco_esa_(_ironport_)_additional_monitoring)
         * [Exchange Mailbox Servers_RU](Applications/Mail_servers/template_exchange_2010_client_access_performance_monitoring_(rus))


### PR DESCRIPTION
Monitor TWS jobs parsing the application event.log as documented in [console-job-scheduling-events-format](https://www.ibm.com/docs/en/workload-automation/9.4.0?topic=console-job-scheduling-events-format)

Parsing the event.log is the most simple and common way to monitor the TWS Jobs status.