### PR TITLE
Update 6.0  zfs template to work with newer zfs

### DIFF
--- a/Operating_Systems/Linux/template_zfs_on_linux/6.0/README.md
+++ b/Operating_Systems/Linux/template_zfs_on_linux/6.0/README.md
@@ -11,6 +11,8 @@
 |{$ZPOOL_AVERAGE_ALERT}|<p>-</p>|`85`|Text macro|
 |{$ZPOOL_DISASTER_ALERT}|<p>-</p>|`99`|Text macro|
 |{$ZPOOL_HIGH_ALERT}|<p>-</p>|`90`|Text macro|
+|{$ZFS_FSNAME_MATCHES}|<p>Determine datasets to discover</p>|`/`|Text macro|
+|{$ZFS_FSNAME_NOTMATCHES}|<p>Determine datasets to ignore</p>|`([a-z-0-9]{64}$\|[a-z-0-9]{64}-init$)`|Text macro|
 
 
 ## Template links
@@ -60,7 +62,7 @@ There are no template links in this template.
 |Zfs dataset $1 $2|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#FILESETNAME},usedbydataset]<p>Update: 1h</p><p>LLD</p>|
 |Zfs dataset $1 $2|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#FILESETNAME},usedbysnapshots]<p>Update: 5m</p><p>LLD</p>|
 |Zfs dataset $1 $2|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#FILESETNAME},used]<p>Update: 5m</p><p>LLD</p>|
-|Zpool {#POOLNAME}: Get iostats|<p>-</p>|`Zabbix agent (active)`|vfs.file.contents[/proc/spl/kstat/zfs/{#POOLNAME}/io]<p>Update: 1m</p><p>LLD</p>|
+|Zpool {#POOLNAME}: Get iostats|<p>-</p>|`Zabbix agent (active)`|zfs.zpool.iostat[{#POOLNAME}]<p>Update: 1m</p><p>LLD</p>|
 |Zpool {#POOLNAME} available|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#POOLNAME},available]<p>Update: 5m</p><p>LLD</p>|
 |Zpool {#POOLNAME} used|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#POOLNAME},used]<p>Update: 5m</p><p>LLD</p>|
 |Zpool {#POOLNAME} Health|<p>-</p>|`Zabbix agent (active)`|zfs.zpool.health[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|

--- a/Operating_Systems/Linux/template_zfs_on_linux/6.0/template_zfs_on_linux_active.yaml
+++ b/Operating_Systems/Linux/template_zfs_on_linux/6.0/template_zfs_on_linux_active.yaml
@@ -1,6 +1,6 @@
 zabbix_export:
-  version: '6.0'
-  date: '2022-11-16T18:44:30Z'
+  version: '6.2'
+  date: '2022-11-16T19:00:14Z'
   template_groups:
     -
       uuid: 7df96b18c230490a9a0a9e2307226338
@@ -9,7 +9,7 @@ zabbix_export:
     -
       uuid: 47d3c2ff933947368d4bee4b1184d69b
       template: 'ZFS on Linux'
-      name: 'ZFS on Linux'
+      name: 'ZFS on Linux Active'
       groups:
         -
           name: Templates
@@ -17,6 +17,7 @@ zabbix_export:
         -
           uuid: 4ecabdcb2104460f83c2ad5f18fd98f9
           name: 'ZFS on Linux version'
+          type: ZABBIX_ACTIVE
           key: 'vfs.file.contents[/sys/module/zfs/version]'
           delay: 1h
           history: 30d
@@ -35,6 +36,7 @@ zabbix_export:
         -
           uuid: 6b5fc935fe194d30badea64eaf3f317f
           name: 'ZFS ARC stat "arc_dnode_limit"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[arc_dnode_limit]'
           history: 30d
           units: B
@@ -48,6 +50,7 @@ zabbix_export:
         -
           uuid: 0b7d673688e3429d92aa349762729f83
           name: 'ZFS ARC stat "arc_meta_limit"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[arc_meta_limit]'
           history: 30d
           units: B
@@ -61,6 +64,7 @@ zabbix_export:
         -
           uuid: b0b5004458494182bf874545f8eb4e41
           name: 'ZFS ARC stat "arc_meta_used"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[arc_meta_used]'
           history: 30d
           units: B
@@ -75,6 +79,7 @@ zabbix_export:
         -
           uuid: 795ab079ba13461c872ee1d5c0295704
           name: 'ZFS ARC stat "bonus_size"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[bonus_size]'
           history: 30d
           units: B
@@ -88,6 +93,7 @@ zabbix_export:
         -
           uuid: 34a1fb79b2b64ce08ec5b377211372d7
           name: 'ZFS ARC max size'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[c_max]'
           history: 30d
           units: B
@@ -101,6 +107,7 @@ zabbix_export:
         -
           uuid: d60b8e4f7a3d4bea972e7fe04c3bb5ca
           name: 'ZFS ARC minimum size'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[c_min]'
           history: 30d
           units: B
@@ -114,6 +121,7 @@ zabbix_export:
         -
           uuid: 5e12dd98f1644f5a87cc5ded5d2e55d8
           name: 'ZFS ARC stat "data_size"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[data_size]'
           history: 30d
           units: B
@@ -127,6 +135,7 @@ zabbix_export:
         -
           uuid: 522a0f33c90047bab4f55b7214f51dea
           name: 'ZFS ARC stat "dbuf_size"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[dbuf_size]'
           history: 30d
           units: B
@@ -140,6 +149,7 @@ zabbix_export:
         -
           uuid: a3d10ebb57984a829f780a229fc9617c
           name: 'ZFS ARC stat "dnode_size"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[dnode_size]'
           history: 30d
           units: B
@@ -153,6 +163,7 @@ zabbix_export:
         -
           uuid: 184eef57aa034cf8acaf6a8f0e02395b
           name: 'ZFS ARC stat "hdr_size"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[hdr_size]'
           history: 30d
           units: B
@@ -166,6 +177,7 @@ zabbix_export:
         -
           uuid: cb7bcc02dfc14329a361e194145871c0
           name: 'ZFS ARC stat "hits"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[hits]'
           history: 30d
           preprocessing:
@@ -183,6 +195,7 @@ zabbix_export:
         -
           uuid: 8df273b6e0904c9ab140f8f13f6ca973
           name: 'ZFS ARC stat "metadata_size"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[metadata_size]'
           history: 30d
           units: B
@@ -196,6 +209,7 @@ zabbix_export:
         -
           uuid: dcd96743ed984018bff5d16105693606
           name: 'ZFS ARC stat "mfu_hits"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[mfu_hits]'
           history: 30d
           preprocessing:
@@ -213,6 +227,7 @@ zabbix_export:
         -
           uuid: 1015ebe8ef6f4626ae7967bf6358f1b3
           name: 'ZFS ARC stat "mfu_size"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[mfu_size]'
           history: 30d
           units: B
@@ -226,6 +241,7 @@ zabbix_export:
         -
           uuid: 1298a265a6784e63a166b768e1faf67e
           name: 'ZFS ARC stat "misses"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[misses]'
           history: 30d
           preprocessing:
@@ -243,6 +259,7 @@ zabbix_export:
         -
           uuid: c85d0e9e1b464748a20148e2f2507609
           name: 'ZFS ARC stat "mru_hits"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[mru_hits]'
           history: 30d
           preprocessing:
@@ -260,6 +277,7 @@ zabbix_export:
         -
           uuid: 50954c7b43d745d09990011df4d7448c
           name: 'ZFS ARC stat "mru_size"'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[mru_size]'
           history: 30d
           units: B
@@ -273,6 +291,7 @@ zabbix_export:
         -
           uuid: cd225da5a02346a58dbe0c9808a628eb
           name: 'ZFS ARC current size'
+          type: ZABBIX_ACTIVE
           key: 'zfs.arcstats[size]'
           history: 30d
           units: B
@@ -317,6 +336,7 @@ zabbix_export:
         -
           uuid: ebfb742fb123451c9632d12bde0957c4
           name: 'ZFS parameter zfs_arc_dnode_limit_percent'
+          type: ZABBIX_ACTIVE
           key: 'zfs.get.param[zfs_arc_dnode_limit_percent]'
           delay: 1h
           history: 30d
@@ -331,6 +351,7 @@ zabbix_export:
         -
           uuid: 18d8b817852848929f4e0b421cb21532
           name: 'ZFS parameter zfs_arc_meta_limit_percent'
+          type: ZABBIX_ACTIVE
           key: 'zfs.get.param[zfs_arc_meta_limit_percent]'
           delay: 1h
           history: 30d
@@ -346,6 +367,7 @@ zabbix_export:
         -
           uuid: a82a1b7067904fecb06bcf5b88457192
           name: 'Zfs Dataset discovery'
+          type: ZABBIX_ACTIVE
           key: zfs.fileset.discovery
           delay: 30m
           filter:
@@ -366,6 +388,7 @@ zabbix_export:
             -
               uuid: 4d7c96bd10b44754b2c8790b90c12046
               name: 'Zfs dataset {#FILESETNAME} compressratio'
+              type: ZABBIX_ACTIVE
               key: 'zfs.get.compressratio[{#FILESETNAME}]'
               delay: 30m
               history: 30d
@@ -386,6 +409,7 @@ zabbix_export:
             -
               uuid: e9df401ae71e45c8a3fdbbd146cdd57b
               name: 'Zfs dataset {#FILESETNAME} available'
+              type: ZABBIX_ACTIVE
               key: 'zfs.get.fsinfo[{#FILESETNAME},available]'
               delay: 5m
               history: 30d
@@ -400,6 +424,7 @@ zabbix_export:
             -
               uuid: ed63bb6942364281bcea80c54b6f8fcc
               name: 'Zfs dataset {#FILESETNAME} referenced'
+              type: ZABBIX_ACTIVE
               key: 'zfs.get.fsinfo[{#FILESETNAME},referenced]'
               delay: 5m
               history: 30d
@@ -414,6 +439,7 @@ zabbix_export:
             -
               uuid: 7ef4530ddf464defb2a64ce674a82c8c
               name: 'Zfs dataset {#FILESETNAME} usedbychildren'
+              type: ZABBIX_ACTIVE
               key: 'zfs.get.fsinfo[{#FILESETNAME},usedbychildren]'
               delay: 5m
               history: 30d
@@ -428,6 +454,7 @@ zabbix_export:
             -
               uuid: 3c7f982147be49629c78aa67a1d8d56e
               name: 'Zfs dataset {#FILESETNAME} usedbydataset'
+              type: ZABBIX_ACTIVE
               key: 'zfs.get.fsinfo[{#FILESETNAME},usedbydataset]'
               delay: 1h
               history: 30d
@@ -442,6 +469,7 @@ zabbix_export:
             -
               uuid: cc0e02c58b28443eb78eeacc81095966
               name: 'Zfs dataset {#FILESETNAME} usedbysnapshots'
+              type: ZABBIX_ACTIVE
               key: 'zfs.get.fsinfo[{#FILESETNAME},usedbysnapshots]'
               delay: 5m
               history: 30d
@@ -456,6 +484,7 @@ zabbix_export:
             -
               uuid: a54feffafdb34ba08f1474ab4710088d
               name: 'Zfs dataset {#FILESETNAME} used'
+              type: ZABBIX_ACTIVE
               key: 'zfs.get.fsinfo[{#FILESETNAME},used]'
               delay: 5m
               history: 30d
@@ -525,6 +554,7 @@ zabbix_export:
         -
           uuid: 08039e570bd7417294d043f4f7bf960f
           name: 'Zfs Pool discovery'
+          type: ZABBIX_ACTIVE
           key: zfs.pool.discovery
           delay: 1h
           lifetime: 3d
@@ -532,6 +562,7 @@ zabbix_export:
             -
               uuid: 9f889e9529934fdfbf47a29de32468f0
               name: 'Zpool {#POOLNAME} available'
+              type: ZABBIX_ACTIVE
               key: 'zfs.get.fsinfo[{#POOLNAME},available]'
               delay: 5m
               history: 30d
@@ -546,6 +577,7 @@ zabbix_export:
             -
               uuid: 1993c04b00bc428bbdf43c909967afd2
               name: 'Zpool {#POOLNAME} used'
+              type: ZABBIX_ACTIVE
               key: 'zfs.get.fsinfo[{#POOLNAME},used]'
               delay: 5m
               history: 30d
@@ -560,6 +592,7 @@ zabbix_export:
             -
               uuid: 472e21c79759476984cbf4ce9f12580a
               name: 'Zpool {#POOLNAME} Health'
+              type: ZABBIX_ACTIVE
               key: 'zfs.zpool.health[{#POOLNAME}]'
               delay: 5m
               history: 30d
@@ -595,7 +628,7 @@ zabbix_export:
                       'use strict';
                       var text = value;
                       const myArray = text.split("	");
-                      return myArray[5]; 
+                      return myArray[5];
               master_item:
                 key: 'zfs.zpool.iostat[{#POOLNAME}]'
               tags:
@@ -622,7 +655,7 @@ zabbix_export:
                       'use strict';
                       var text = value;
                       const myArray = text.split("	");
-                      return myArray[6]; 
+                      return myArray[6];
               master_item:
                 key: 'zfs.zpool.iostat[{#POOLNAME}]'
               tags:
@@ -649,7 +682,7 @@ zabbix_export:
                       'use strict';
                       var text = value;
                       const myArray = text.split("	");
-                      return myArray[3]; 
+                      return myArray[3];
               master_item:
                 key: 'zfs.zpool.iostat[{#POOLNAME}]'
               tags:
@@ -676,7 +709,7 @@ zabbix_export:
                       'use strict';
                       var text = value;
                       const myArray = text.split("	");
-                      return myArray[4]; 
+                      return myArray[4];
               master_item:
                 key: 'zfs.zpool.iostat[{#POOLNAME}]'
               tags:
@@ -689,6 +722,7 @@ zabbix_export:
             -
               uuid: 7142e6f1eceb4dc29e3a03d494230564
               name: 'Zpool {#POOLNAME}: Get iostats'
+              type: ZABBIX_ACTIVE
               key: 'zfs.zpool.iostat[{#POOLNAME}]'
               history: '0'
               trends: '0'
@@ -703,6 +737,7 @@ zabbix_export:
             -
               uuid: 867075d6eb1743069be868007472192b
               name: 'Zpool {#POOLNAME} scrub status'
+              type: ZABBIX_ACTIVE
               key: 'zfs.zpool.scrub[{#POOLNAME}]'
               delay: 5m
               history: 30d
@@ -814,6 +849,7 @@ zabbix_export:
         -
           uuid: 6c96e092f08f4b98af9a377782180689
           name: 'Zfs vdev discovery'
+          type: ZABBIX_ACTIVE
           key: zfs.vdev.discovery
           delay: 1h
           lifetime: 3d
@@ -821,6 +857,7 @@ zabbix_export:
             -
               uuid: 9f63161726774a28905c87aac92cf1e9
               name: 'vdev {#VDEV}: CHECKSUM error counter'
+              type: ZABBIX_ACTIVE
               key: 'zfs.vdev.error_counter.cksum[{#VDEV}]'
               delay: 5m
               history: 30d
@@ -840,6 +877,7 @@ zabbix_export:
             -
               uuid: 48a02eb060fd4b73bdde08a2795c4717
               name: 'vdev {#VDEV}: READ error counter'
+              type: ZABBIX_ACTIVE
               key: 'zfs.vdev.error_counter.read[{#VDEV}]'
               delay: 5m
               history: 30d
@@ -859,6 +897,7 @@ zabbix_export:
             -
               uuid: 15953ba38fde4b8c8681955a27d9204a
               name: 'vdev {#VDEV}: WRITE error counter'
+              type: ZABBIX_ACTIVE
               key: 'zfs.vdev.error_counter.write[{#VDEV}]'
               delay: 5m
               history: 30d

--- a/Operating_Systems/Linux/template_zfs_on_linux/6.0/userparams_zol_with_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux/6.0/userparams_zol_with_sudo.conf
@@ -39,3 +39,6 @@ UserParameter=zfs.vdev.error_counter.read[*],/usr/bin/sudo /sbin/zpool status | 
 UserParameter=zfs.vdev.error_counter.write[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$4 }' | numfmt --from=si
 # vdev CHECKSUM error counter
 UserParameter=zfs.vdev.error_counter.cksum[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$5 }' | numfmt --from=si
+
+# Get zpool iostats 
+UserParameter=zfs.zpool.iostat[*],/sbin/zpool iostat $1 -H -p 1 2 | tail -n 1

--- a/Operating_Systems/Linux/template_zfs_on_linux/6.0/userparams_zol_with_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux/6.0/userparams_zol_with_sudo.conf
@@ -41,4 +41,4 @@ UserParameter=zfs.vdev.error_counter.write[*],/usr/bin/sudo /sbin/zpool status |
 UserParameter=zfs.vdev.error_counter.cksum[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$5 }' | numfmt --from=si
 
 # Get zpool iostats 
-UserParameter=zfs.zpool.iostat[*],/sbin/zpool iostat $1 -H -p 1 2 | tail -n 1
+UserParameter=zfs.zpool.iostat[*],/usr/bin/sudo /sbin/zpool iostat $1 -H -p 1 2 | tail -n 1

--- a/Operating_Systems/Linux/template_zfs_on_linux/6.0/userparams_zol_with_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux/6.0/userparams_zol_with_sudo.conf
@@ -32,13 +32,13 @@ UserParameter=zfs.arcstats[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/arcs
 UserParameter=zfs.zpool.scrub[*],/usr/bin/sudo /sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
 
 # vdev state
-UserParameter=zfs.vdev.state[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$2 }'
+UserParameter=zfs.vdev.state[*],/usr/bin/sudo /sbin/zpool status | grep -m 1 "$1" | awk '{ print $$2 }'
 # vdev READ error counter
-UserParameter=zfs.vdev.error_counter.read[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$3 }' | numfmt --from=si
+UserParameter=zfs.vdev.error_counter.read[*],/usr/bin/sudo /sbin/zpool status | grep -m 1 "$1" | awk '{ print $$3 }' | numfmt --from=si
 # vdev WRITE error counter
-UserParameter=zfs.vdev.error_counter.write[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$4 }' | numfmt --from=si
+UserParameter=zfs.vdev.error_counter.write[*],/usr/bin/sudo /sbin/zpool status | grep -m 1 "$1" | awk '{ print $$4 }' | numfmt --from=si
 # vdev CHECKSUM error counter
-UserParameter=zfs.vdev.error_counter.cksum[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$5 }' | numfmt --from=si
+UserParameter=zfs.vdev.error_counter.cksum[*],/usr/bin/sudo /sbin/zpool status | grep -m 1 "$1" | awk '{ print $$5 }' | numfmt --from=si
 
 # Get zpool iostats 
 UserParameter=zfs.zpool.iostat[*],/usr/bin/sudo /sbin/zpool iostat $1 -H -p 1 2 | tail -n 1

--- a/Operating_Systems/Linux/template_zfs_on_linux/6.0/userparams_zol_without_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux/6.0/userparams_zol_without_sudo.conf
@@ -32,13 +32,13 @@ UserParameter=zfs.arcstats[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/arcs
 UserParameter=zfs.zpool.scrub[*],/sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
 
 # vdev state
-UserParameter=zfs.vdev.state[*],/sbin/zpool status | grep "$1" | awk '{ print $$2 }'
+UserParameter=zfs.vdev.state[*],/sbin/zpool status | grep -m 1 "$1" | awk '{ print $$2 }'
 # vdev READ error counter
-UserParameter=zfs.vdev.error_counter.read[*],/sbin/zpool status | grep "$1" | awk '{ print $$3 }' | numfmt --from=si
+UserParameter=zfs.vdev.error_counter.read[*],/sbin/zpool status | grep -m 1 "$1" | awk '{ print $$3 }' | numfmt --from=si
 # vdev WRITE error counter
-UserParameter=zfs.vdev.error_counter.write[*],/sbin/zpool status | grep "$1" | awk '{ print $$4 }' | numfmt --from=si
+UserParameter=zfs.vdev.error_counter.write[*],/sbin/zpool status | grep -m 1 "$1" | awk '{ print $$4 }' | numfmt --from=si
 # vdev CHECKSUM error counter
-UserParameter=zfs.vdev.error_counter.cksum[*],/sbin/zpool status | grep "$1" | awk '{ print $$5 }' | numfmt --from=si
+UserParameter=zfs.vdev.error_counter.cksum[*],/sbin/zpool status | grep -m 1 "$1" | awk '{ print $$5 }' | numfmt --from=si
 
 # Get zpool iostats 
 UserParameter=zfs.zpool.iostat[*],/sbin/zpool iostat $1 -H -p 1 2 | tail -n 1

--- a/Operating_Systems/Linux/template_zfs_on_linux/6.0/userparams_zol_without_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux/6.0/userparams_zol_without_sudo.conf
@@ -39,3 +39,6 @@ UserParameter=zfs.vdev.error_counter.read[*],/sbin/zpool status | grep "$1" | aw
 UserParameter=zfs.vdev.error_counter.write[*],/sbin/zpool status | grep "$1" | awk '{ print $$4 }' | numfmt --from=si
 # vdev CHECKSUM error counter
 UserParameter=zfs.vdev.error_counter.cksum[*],/sbin/zpool status | grep "$1" | awk '{ print $$5 }' | numfmt --from=si
+
+# Get zpool iostats 
+UserParameter=zfs.zpool.iostat[*],/sbin/zpool iostat $1 -H -p 1 2 | tail -n 1


### PR DESCRIPTION
Changes io stats to look at zpool iostat instead of /proc/spl/kstat/zfs/{#POOLNAME}/io as this file no longer exists on newer version of openzfs.
Instead zpool iostat is polled to get stats as needed. 
Dependent items changed to use a javascript script to parse values for iops (read/write) bandwidth (read/write)

Separated out active and passive agent templates 

Updated userparameters to use zpool iostat 

Fixed Zfs dataset #FILESETNAME} used not using the macro due to a missed { on the variable name 

Updated the dataset matching filters to use macros similar to other fs discovery rules instead of non existent global macros
Creates {$ZFS_FSNAME_MATCHES} and {$ZFS_FSNAME_NOTMATCHES} 

