### PR TITLE
zfs_on_linux 60 import fix

### DIFF
--- a/Operating_Systems/Linux/template_zfs_on_linux/6.0/template_zfs_on_linux.yaml
+++ b/Operating_Systems/Linux/template_zfs_on_linux/6.0/template_zfs_on_linux.yaml
@@ -1,10 +1,10 @@
 zabbix_export:
   version: '6.0'
   date: '2022-11-16T18:44:30Z'
-  template_groups:
+  groups:
     -
-      uuid: 7df96b18c230490a9a0a9e2307226338
-      name: Templates
+      uuid: 57b7ae836ca64446ba2c296389c009b7
+      name: Templates/Modules
   templates:
     -
       uuid: 47d3c2ff933947368d4bee4b1184d69b


### PR DESCRIPTION
File zfs_on_linux/6.0/template_zfs_on_linux.yaml can't be imported: Invalid tag "/zabbix_export": unexpected tag "template_groups".
Fix:
- change tag 'template_groups' to 'groups'

Optional:
- change group name from 'Template' to 'Template/Modules'