### PR TITLE
prettify MD RAID template XML (Closes: zabbix/community-templates#206)

### DIFF
--- a/Server_Hardware/Other/template_md_raid/5.0/template_md_raid.xml
+++ b/Server_Hardware/Other/template_md_raid/5.0/template_md_raid.xml
@@ -1,2 +1,110 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<zabbix_export><version>5.0</version><date>2021-11-25T12:36:13Z</date><groups><group><name>Templates</name></group></groups><templates><template><template>MD Soft RAID</template><name>MD Soft RAID</name><groups><group><name>Templates</name></group></groups><applications><application><name>MD</name></application></applications><discovery_rules><discovery_rule><name>MD Discovery</name><key>md.discover</key><delay>3600</delay><item_prototypes><item_prototype><name>MD {#MDNAME} degraded</name><key>md.degraded[{#MDNAME}]</key><delay>5m</delay><history>3600</history><trends>86400</trends><description>Get number of degraded disks</description><applications><application><name>MD</name></application></applications><trigger_prototypes><trigger_prototype><expression>{last()}&gt;0</expression><name>MD {#MDNAME} is degraded on {HOST.NAME}</name><priority>HIGH</priority></trigger_prototype></trigger_prototypes></item_prototype><item_prototype><name>MD {#MDNAME} raid disks</name><key>md.raid_disks[{#MDNAME}]</key><delay>3600</delay><history>3600</history><trends>86400</trends><description>Get number of all disks</description><applications><application><name>MD</name></application></applications><trigger_prototypes><trigger_prototype><expression>{diff()}&gt;0</expression><name>MD {#MDNAME} number of disks changed on {HOST.NAME}</name><priority>WARNING</priority></trigger_prototype></trigger_prototypes></item_prototype><item_prototype><name>MD {#MDNAME} sync action</name><key>md.sync_action[{#MDNAME}]</key><delay>300</delay><history>3600</history><trends>0</trends><value_type>TEXT</value_type><description>Get current sync action</description><applications><application><name>MD</name></application></applications><trigger_prototypes><trigger_prototype><expression>{str(recover)}=1</expression><name>MD {#MDNAME} in recovery mode on {HOST.NAME}</name><priority>INFO</priority></trigger_prototype></trigger_prototypes></item_prototype></item_prototypes><graph_prototypes><graph_prototype><name>MD {#MDNAME} degration</name><graph_items><graph_item><color>1A7C11</color><item><host>MD Soft RAID</host><key>md.degraded[{#MDNAME}]</key></item></graph_item></graph_items></graph_prototype></graph_prototypes></discovery_rule></discovery_rules></template></templates></zabbix_export>
+<zabbix_export>
+  <version>5.0</version>
+  <date>2021-11-25T12:36:13Z</date>
+  <groups>
+    <group>
+      <name>Templates</name>
+    </group>
+  </groups>
+  <templates>
+    <template>
+      <template>MD Soft RAID</template>
+      <name>MD Soft RAID</name>
+      <groups>
+        <group>
+          <name>Templates</name>
+        </group>
+      </groups>
+      <applications>
+        <application>
+          <name>MD</name>
+        </application>
+      </applications>
+      <discovery_rules>
+        <discovery_rule>
+          <name>MD Discovery</name>
+          <key>md.discover</key>
+          <delay>3600</delay>
+          <item_prototypes>
+            <item_prototype>
+              <name>MD {#MDNAME} degraded</name>
+              <key>md.degraded[{#MDNAME}]</key>
+              <delay>5m</delay>
+              <history>3600</history>
+              <trends>86400</trends>
+              <description>Get number of degraded disks</description>
+              <applications>
+                <application>
+                  <name>MD</name>
+                </application>
+              </applications>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <expression>{last()}&gt;0</expression>
+                  <name>MD {#MDNAME} is degraded on {HOST.NAME}</name>
+                  <priority>HIGH</priority>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>MD {#MDNAME} raid disks</name>
+              <key>md.raid_disks[{#MDNAME}]</key>
+              <delay>3600</delay>
+              <history>3600</history>
+              <trends>86400</trends>
+              <description>Get number of all disks</description>
+              <applications>
+                <application>
+                  <name>MD</name>
+                </application>
+              </applications>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <expression>{diff()}&gt;0</expression>
+                  <name>MD {#MDNAME} number of disks changed on {HOST.NAME}</name>
+                  <priority>WARNING</priority>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>MD {#MDNAME} sync action</name>
+              <key>md.sync_action[{#MDNAME}]</key>
+              <delay>300</delay>
+              <history>3600</history>
+              <trends>0</trends>
+              <value_type>TEXT</value_type>
+              <description>Get current sync action</description>
+              <applications>
+                <application>
+                  <name>MD</name>
+                </application>
+              </applications>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <expression>{str(recover)}=1</expression>
+                  <name>MD {#MDNAME} in recovery mode on {HOST.NAME}</name>
+                  <priority>INFO</priority>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <name>MD {#MDNAME} degration</name>
+              <graph_items>
+                <graph_item>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>MD Soft RAID</host>
+                    <key>md.degraded[{#MDNAME}]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+      </discovery_rules>
+    </template>
+  </templates>
+</zabbix_export>


### PR DESCRIPTION
Fixes diff and readability with `xmllint --format template_md_raid.xml`