### PR TITLE
Adding MikroTik RB260 v1.17 template

### DIFF
--- a/Network_Devices/Mikrotik/template_mikrotik_rb260gs_v1.17/6.0/README.md
+++ b/Network_Devices/Mikrotik/template_mikrotik_rb260gs_v1.17/6.0/README.md
@@ -1,0 +1,36 @@
+# MikroTik RB260 v1.17
+
+## Overview
+
+MikroTik RB260 v1.17
+
+
+
+## Macros used
+
+{$IF.UTIL.MAX} - Set the maximum network utilization before trigger goes off (Default: 90%)
+
+## Template links
+
+There are no template links in this template.
+
+## Discovery rules
+
+Network interfaces will get discovered and triggers set.
+Items:
+- Admin status
+- Bits received
+- Bits Send
+- Inbound packets discarded
+- Inbound packets with errors
+- Outbound packets discarded
+- Outbound packets with errors
+- Interface type
+- Operational status
+- Interface speed
+
+## Triggers
+
+- Link down
+- Lower speed than previous
+- High bandwith usage

--- a/Network_Devices/Mikrotik/template_mikrotik_rb260gs_v1.17/6.0/mikrotik_rb260_v1_17.yaml
+++ b/Network_Devices/Mikrotik/template_mikrotik_rb260gs_v1.17/6.0/mikrotik_rb260_v1_17.yaml
@@ -1,6 +1,6 @@
 zabbix_export:
   version: '6.2'
-  date: '2023-01-25T08:37:04Z'
+  date: '2023-01-28T06:27:33Z'
   template_groups:
     -
       uuid: 36bff6c29af64692839d077febfc7079
@@ -460,7 +460,7 @@ zabbix_export:
                   uuid: d02e2b11451348d285adaef3a0dda16f
                   expression: '{$IFCONTROL:"{#IFDESCR}"}=1 and last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
                   recovery_mode: RECOVERY_EXPRESSION
-                  recovery_expression: 'last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+                  recovery_expression: 'last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFDESCR}"}=0'
                   name: 'Interface {#IFDESCR}: Link down'
                   opdata: 'Current state: {ITEM.LASTVALUE1}'
                   priority: AVERAGE
@@ -513,10 +513,14 @@ zabbix_export:
                 )
                 and
                 (last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2)
+                and
+                {$IFCONTROL:"{#IFDESCR}"}=1
               recovery_mode: RECOVERY_EXPRESSION
               recovery_expression: |
                 (change(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0 and last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}],#2)>0) or
                 (last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2)
+                or
+                {$IFCONTROL:"{#IFDESCR}"}=0
               name: 'Interface {#IFDESCR}: Ethernet has changed to lower speed than it was before'
               opdata: 'Current reported speed: {ITEM.LASTVALUE1}'
               priority: INFO
@@ -526,7 +530,7 @@ zabbix_export:
                 -
                   name: 'Interface {#IFDESCR}: Link down'
                   expression: '{$IFCONTROL:"{#IFDESCR}"}=1 and last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
-                  recovery_expression: 'last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+                  recovery_expression: 'last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFDESCR}"}=0'
               tags:
                 -
                   tag: scope
@@ -534,13 +538,13 @@ zabbix_export:
             -
               uuid: 6c7b1778f09c42348656bb1eb86b2580
               expression: |
-                (avg(/Mikrotik RB260 v1.17 by SNMP/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) or
-                avg(/Mikrotik RB260 v1.17 by SNMP/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])) and
+                (avg(/Mikrotik RB260 v1.17 by SNMP/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFDESCR}"}/100)*last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) or
+                avg(/Mikrotik RB260 v1.17 by SNMP/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFDESCR}"}/100)*last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])) and
                 last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0
               recovery_mode: RECOVERY_EXPRESSION
               recovery_expression: |
-                avg(/Mikrotik RB260 v1.17 by SNMP/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) and
-                avg(/Mikrotik RB260 v1.17 by SNMP/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])
+                avg(/Mikrotik RB260 v1.17 by SNMP/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFDESCR}"}-3)/100)*last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) and
+                avg(/Mikrotik RB260 v1.17 by SNMP/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFDESCR}"}-3)/100)*last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])
               name: 'Interface {#IFDESCR}: High bandwidth usage'
               opdata: 'Current state: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -550,7 +554,7 @@ zabbix_export:
                 -
                   name: 'Interface {#IFDESCR}: Link down'
                   expression: '{$IFCONTROL:"{#IFDESCR}"}=1 and last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
-                  recovery_expression: 'last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+                  recovery_expression: 'last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFDESCR}"}=0'
               tags:
                 -
                   tag: scope
@@ -590,6 +594,7 @@ zabbix_export:
         -
           macro: '{$IFCONTROL}'
           value: '1'
+          description: 'Use {$IFCONTROL:Port1..5}=0 to stop triggers from link down or speed change.'
       dashboards:
         -
           uuid: 43719abfadb74fda98d35727b4972c34

--- a/Network_Devices/Mikrotik/template_mikrotik_rb260gs_v1.17/6.0/mikrotik_rb260_v1_17.yaml
+++ b/Network_Devices/Mikrotik/template_mikrotik_rb260gs_v1.17/6.0/mikrotik_rb260_v1_17.yaml
@@ -1,6 +1,6 @@
 zabbix_export:
   version: '6.2'
-  date: '2023-01-25T06:05:01Z'
+  date: '2023-01-25T08:37:04Z'
   template_groups:
     -
       uuid: 36bff6c29af64692839d077febfc7079
@@ -8,8 +8,8 @@ zabbix_export:
   templates:
     -
       uuid: 0de648facfa14d89b3bcff20e81fae6d
-      template: 'Mikrotik RB260 v1.17'
-      name: 'Mikrotik RB260 v1.17'
+      template: 'Mikrotik RB260 v1.17 by SNMP'
+      name: 'Mikrotik RB260 v1.17 by SNMP'
       description: 'Monitor the old Mikrotik RB260 (fw1.17) switches'
       groups:
         -
@@ -458,9 +458,9 @@ zabbix_export:
               trigger_prototypes:
                 -
                   uuid: d02e2b11451348d285adaef3a0dda16f
-                  expression: '{$IFCONTROL:"{#IFDESCR}"}=1 and last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
+                  expression: '{$IFCONTROL:"{#IFDESCR}"}=1 and last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
                   recovery_mode: RECOVERY_EXPRESSION
-                  recovery_expression: 'last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+                  recovery_expression: 'last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
                   name: 'Interface {#IFDESCR}: Link down'
                   opdata: 'Current state: {ITEM.LASTVALUE1}'
                   priority: AVERAGE
@@ -502,21 +502,21 @@ zabbix_export:
             -
               uuid: 6fbc44f0298149b398cf8d28052fb9c9
               expression: |
-                change(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}])<0 and last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0
+                change(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])<0 and last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0
                 and (
-                last(/Mikrotik RB260 v1.17/net.if.type[ifType.{#SNMPINDEX}])=6 or
-                last(/Mikrotik RB260 v1.17/net.if.type[ifType.{#SNMPINDEX}])=7 or
-                last(/Mikrotik RB260 v1.17/net.if.type[ifType.{#SNMPINDEX}])=11 or
-                last(/Mikrotik RB260 v1.17/net.if.type[ifType.{#SNMPINDEX}])=62 or
-                last(/Mikrotik RB260 v1.17/net.if.type[ifType.{#SNMPINDEX}])=69 or
-                last(/Mikrotik RB260 v1.17/net.if.type[ifType.{#SNMPINDEX}])=117
+                last(/Mikrotik RB260 v1.17 by SNMP/net.if.type[ifType.{#SNMPINDEX}])=6 or
+                last(/Mikrotik RB260 v1.17 by SNMP/net.if.type[ifType.{#SNMPINDEX}])=7 or
+                last(/Mikrotik RB260 v1.17 by SNMP/net.if.type[ifType.{#SNMPINDEX}])=11 or
+                last(/Mikrotik RB260 v1.17 by SNMP/net.if.type[ifType.{#SNMPINDEX}])=62 or
+                last(/Mikrotik RB260 v1.17 by SNMP/net.if.type[ifType.{#SNMPINDEX}])=69 or
+                last(/Mikrotik RB260 v1.17 by SNMP/net.if.type[ifType.{#SNMPINDEX}])=117
                 )
                 and
-                (last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2)
+                (last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2)
               recovery_mode: RECOVERY_EXPRESSION
               recovery_expression: |
-                (change(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0 and last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}],#2)>0) or
-                (last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])=2)
+                (change(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0 and last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}],#2)>0) or
+                (last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2)
               name: 'Interface {#IFDESCR}: Ethernet has changed to lower speed than it was before'
               opdata: 'Current reported speed: {ITEM.LASTVALUE1}'
               priority: INFO
@@ -525,8 +525,8 @@ zabbix_export:
               dependencies:
                 -
                   name: 'Interface {#IFDESCR}: Link down'
-                  expression: '{$IFCONTROL:"{#IFDESCR}"}=1 and last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
-                  recovery_expression: 'last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+                  expression: '{$IFCONTROL:"{#IFDESCR}"}=1 and last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
+                  recovery_expression: 'last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
               tags:
                 -
                   tag: scope
@@ -534,13 +534,13 @@ zabbix_export:
             -
               uuid: 6c7b1778f09c42348656bb1eb86b2580
               expression: |
-                (avg(/Mikrotik RB260 v1.17/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) or
-                avg(/Mikrotik RB260 v1.17/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}])) and
-                last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0
+                (avg(/Mikrotik RB260 v1.17 by SNMP/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) or
+                avg(/Mikrotik RB260 v1.17 by SNMP/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])) and
+                last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0
               recovery_mode: RECOVERY_EXPRESSION
               recovery_expression: |
-                avg(/Mikrotik RB260 v1.17/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) and
-                avg(/Mikrotik RB260 v1.17/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}])
+                avg(/Mikrotik RB260 v1.17 by SNMP/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) and
+                avg(/Mikrotik RB260 v1.17 by SNMP/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Mikrotik RB260 v1.17 by SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])
               name: 'Interface {#IFDESCR}: High bandwidth usage'
               opdata: 'Current state: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -549,8 +549,8 @@ zabbix_export:
               dependencies:
                 -
                   name: 'Interface {#IFDESCR}: Link down'
-                  expression: '{$IFCONTROL:"{#IFDESCR}"}=1 and last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
-                  recovery_expression: 'last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+                  expression: '{$IFCONTROL:"{#IFDESCR}"}=1 and last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
+                  recovery_expression: 'last(/Mikrotik RB260 v1.17 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
               tags:
                 -
                   tag: scope
@@ -564,14 +564,14 @@ zabbix_export:
                   color: 1A7C11
                   calc_fnc: ALL
                   item:
-                    host: 'Mikrotik RB260 v1.17'
+                    host: 'Mikrotik RB260 v1.17 by SNMP'
                     key: 'net.if.in[ifHCInOctets.{#SNMPINDEX}]'
                 -
                   sortorder: '1'
                   color: 0288D1
                   calc_fnc: ALL
                   item:
-                    host: 'Mikrotik RB260 v1.17'
+                    host: 'Mikrotik RB260 v1.17 by SNMP'
                     key: 'net.if.out[ifHCOutOctets.{#SNMPINDEX}]'
       tags:
         -
@@ -610,7 +610,7 @@ zabbix_export:
                       type: GRAPH_PROTOTYPE
                       name: graphid
                       value:
-                        host: 'Mikrotik RB260 v1.17'
+                        host: 'Mikrotik RB260 v1.17 by SNMP'
                         name: 'Interface {#IFDESCR}: Network traffic'
       valuemaps:
         -

--- a/Network_Devices/Mikrotik/template_mikrotik_rb260gs_v1.17/6.0/mikrotik_rb260_v1_17.yaml
+++ b/Network_Devices/Mikrotik/template_mikrotik_rb260gs_v1.17/6.0/mikrotik_rb260_v1_17.yaml
@@ -1,0 +1,667 @@
+zabbix_export:
+  version: '6.2'
+  date: '2023-01-25T06:05:01Z'
+  template_groups:
+    -
+      uuid: 36bff6c29af64692839d077febfc7079
+      name: 'Templates/Network devices'
+  templates:
+    -
+      uuid: 0de648facfa14d89b3bcff20e81fae6d
+      template: 'Mikrotik RB260 v1.17'
+      name: 'Mikrotik RB260 v1.17'
+      description: 'Monitor the old Mikrotik RB260 (fw1.17) switches'
+      groups:
+        -
+          name: 'Templates/Network devices'
+      items:
+        -
+          uuid: 2f1c3a54e4cd465fb39ffe38a691a2ba
+          name: 'ICMP ping'
+          type: SIMPLE
+          key: icmpping
+          history: 1w
+          tags:
+            -
+              tag: component
+              value: health
+            -
+              tag: component
+              value: network
+        -
+          uuid: 00c716b1be8046d9851ac9b196905d40
+          name: 'ICMP loss'
+          type: SIMPLE
+          key: icmppingloss
+          history: 1w
+          value_type: FLOAT
+          units: '%'
+          tags:
+            -
+              tag: component
+              value: health
+            -
+              tag: component
+              value: network
+        -
+          uuid: f29d27dad6fd43d8a7f7eb2cd3331ba3
+          name: 'ICMP response time'
+          type: SIMPLE
+          key: icmppingsec
+          history: 1w
+          value_type: FLOAT
+          units: s
+          tags:
+            -
+              tag: component
+              value: health
+            -
+              tag: component
+              value: network
+        -
+          uuid: ab634ff918a046f3ab1637f6942ed2e9
+          name: 'System contact details'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.4.0
+          key: 'system.contact[sysContact.0]'
+          delay: 15m
+          history: 2w
+          trends: '0'
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            The textual identification of the contact person for this managed node, together with information on how to contact this person.  If no contact information is known, the value is the zero-length string.
+          inventory_link: CONTACT
+          preprocessing:
+            -
+              type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          tags:
+            -
+              tag: component
+              value: system
+        -
+          uuid: d64f2a95960049f68492bcb0899ef510
+          name: 'System description'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.1.0
+          key: 'system.descr[sysDescr.0]'
+          delay: 15m
+          history: 2w
+          trends: '0'
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            A textual description of the entity. This value should
+            include the full name and version identification of the system's hardware type, software operating-system, and
+            networking software.
+          preprocessing:
+            -
+              type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          tags:
+            -
+              tag: component
+              value: system
+        -
+          uuid: 5d41f8595a28477f87fe47e9fd64113e
+          name: 'Hardware model name'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.1.0
+          key: system.hw.model
+          delay: 1h
+          history: 2w
+          trends: '0'
+          value_type: CHAR
+          inventory_link: MODEL
+          preprocessing:
+            -
+              type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            -
+              tag: component
+              value: system
+        -
+          uuid: 08c0ab0526594d35b7d7679b17ff99f2
+          name: 'System location'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.6.0
+          key: 'system.location[sysLocation.0]'
+          delay: 15m
+          history: 2w
+          trends: '0'
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            The physical location of this node (e.g., `telephone closet, 3rd floor').  If the location is unknown, the value is the zero-length string.
+          inventory_link: LOCATION
+          preprocessing:
+            -
+              type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          tags:
+            -
+              tag: component
+              value: system
+        -
+          uuid: 7ec37d7255974446abd41ca2d1845bb5
+          name: 'System name'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.5.0
+          key: system.name
+          delay: 15m
+          history: 2w
+          trends: '0'
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            An administratively-assigned name for this managed node.By convention, this is the node's fully-qualified domain name.  If the name is unknown, the value is the zero-length string.
+          inventory_link: NAME
+          preprocessing:
+            -
+              type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          tags:
+            -
+              tag: component
+              value: system
+        -
+          uuid: 509fb1584e9a4353bbeaf37ad4f6ee34
+          name: Uptime
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.3.0
+          key: 'system.net.uptime[sysUpTime.0]'
+          delay: 30s
+          history: 2w
+          trends: '0'
+          units: uptime
+          description: |
+            MIB: SNMPv2-MIB
+            The time (in hundredths of a second)
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '0.01'
+          tags:
+            -
+              tag: component
+              value: system
+        -
+          uuid: 1e5fc579214147bf8f014af15c1773a4
+          name: 'System object ID'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.2.0
+          key: 'system.objectid[sysObjectID.0]'
+          delay: 15m
+          history: 2w
+          trends: '0'
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            The vendor's authoritative identification of the network management subsystem contained in the entity.  This value is allocated within the SMI enterprises subtree (1.3.6.1.4.1) and provides an easy and unambiguous means for determining`what kind of box' is being managed.  For example, if vendor`Flintstones, Inc.' was assigned the subtree1.3.6.1.4.1.4242, it could assign the identifier 1.3.6.1.4.1.4242.1.1 to its `Fred Router'.
+          preprocessing:
+            -
+              type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          tags:
+            -
+              tag: component
+              value: system
+        -
+          uuid: 677174f227e64a31911e08ab5f5f58c1
+          name: 'SNMP agent availability'
+          type: INTERNAL
+          key: 'zabbix[host,snmp,available]'
+          history: 7d
+          description: |
+            Availability of SNMP checks on the host. The value of this item corresponds to availability icons in the host list.
+            Possible value:
+            0 - not available
+            1 - available
+            2 - unknown
+          tags:
+            -
+              tag: component
+              value: health
+            -
+              tag: component
+              value: network
+      discovery_rules:
+        -
+          uuid: 4d12b8c4fcaf4f1ca9ab4ebedd8f8138
+          name: 'Network interfaces discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#IFOPERSTATUS},1.3.6.1.2.1.2.2.1.8,{#IFADMINSTATUS},1.3.6.1.2.1.2.2.1.7,{#IFDESCR},1.3.6.1.2.1.2.2.1.2,{#IFTYPE},1.3.6.1.2.1.2.2.1.3]'
+          key: net.if.discovery
+          delay: 1h
+          description: 'Discovering interfaces'
+          item_prototypes:
+            -
+              uuid: 18f653ddfdda4abd8d158b38bbba58f2
+              name: 'Interface {#IFDESCR}: Inbound packets discarded'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.2.1.2.2.1.13.{#SNMPINDEX}'
+              key: 'net.if.in.discards[ifInDiscards.{#SNMPINDEX}]'
+              delay: 15s
+              history: 7d
+              preprocessing:
+                -
+                  type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              tags:
+                -
+                  tag: component
+                  value: network
+                -
+                  tag: description
+                  value: '{#IFDESCR}'
+                -
+                  tag: interface
+                  value: '{#IFDESCR}'
+            -
+              uuid: d779b725bd2141db830eb617a963e6a3
+              name: 'Interface {#IFDESCR}: Inbound packets with errors'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.2.1.2.2.1.14.{#SNMPINDEX}'
+              key: 'net.if.in.errors[ifInErrors.{#SNMPINDEX}]'
+              delay: 15s
+              history: 7d
+              preprocessing:
+                -
+                  type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              tags:
+                -
+                  tag: component
+                  value: network
+                -
+                  tag: description
+                  value: '{#IFDESCR}'
+                -
+                  tag: interface
+                  value: '{#IFDESCR}'
+            -
+              uuid: d9a8b2c24ae2451a84ed12ccd98acf8d
+              name: 'Interface {#IFDESCR}: Bits received'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.2.1.2.2.1.10.{#SNMPINDEX}'
+              key: 'net.if.in[ifHCInOctets.{#SNMPINDEX}]'
+              delay: 15s
+              history: 7d
+              units: Bps
+              preprocessing:
+                -
+                  type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                -
+                  type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                -
+                  tag: component
+                  value: network
+                -
+                  tag: description
+                  value: '{#IFDESCR}'
+                -
+                  tag: interface
+                  value: '{#IFDESCR}'
+            -
+              uuid: 12e39c5bad5a49938307150a010a484a
+              name: 'Interface {#IFDESCR}: Outbound packets discarded'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.2.1.2.2.1.19.{#SNMPINDEX}'
+              key: 'net.if.out.discards[ifOutDiscards.{#SNMPINDEX}]'
+              delay: 15s
+              history: 7d
+              preprocessing:
+                -
+                  type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              tags:
+                -
+                  tag: component
+                  value: network
+                -
+                  tag: description
+                  value: '{#IFDESCR}'
+                -
+                  tag: interface
+                  value: '{#IFDESCR}'
+            -
+              uuid: cd08b9a0d8964625b224ac11788a77df
+              name: 'Interface {#IFDESCR}: Outbound packets with errors'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.2.1.2.2.1.20.{#SNMPINDEX}'
+              key: 'net.if.out.errors[ifOutErrors.{#SNMPINDEX}]'
+              delay: 15s
+              history: 7d
+              preprocessing:
+                -
+                  type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              tags:
+                -
+                  tag: component
+                  value: network
+                -
+                  tag: description
+                  value: '{#IFDESCR}'
+                -
+                  tag: interface
+                  value: '{#IFDESCR}'
+            -
+              uuid: 7713a2adafa34b5b819837d268ae8618
+              name: 'Interface {#IFDESCR}: Bits sent'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.2.1.2.2.1.16.{#SNMPINDEX}'
+              key: 'net.if.out[ifHCOutOctets.{#SNMPINDEX}]'
+              delay: 15s
+              history: 7d
+              units: bps
+              preprocessing:
+                -
+                  type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                -
+                  type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                -
+                  tag: component
+                  value: network
+                -
+                  tag: description
+                  value: '{#IFDESCR}'
+                -
+                  tag: interface
+                  value: '{#IFDESCR}'
+            -
+              uuid: 4f7036a3f9cb4f62bf662cd5d4d3e635
+              name: 'Interface {#IFDESCR}: Speed'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.5.{#SNMPINDEX}'
+              key: 'net.if.speed[ifHighSpeed.{#SNMPINDEX}]'
+              delay: 5m
+              history: 7d
+              trends: '0'
+              units: bps
+              preprocessing:
+                -
+                  type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              tags:
+                -
+                  tag: component
+                  value: network
+                -
+                  tag: description
+                  value: '{#IFDESCR}'
+                -
+                  tag: interface
+                  value: '{#IFDESCR}'
+            -
+              uuid: 22cd2c4e235e4253a37876e4e50b8bd0
+              name: 'Interface {#IFDESCR}: Admin status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.7.{#SNMPINDEX}'
+              key: 'net.if.status[ifAdminStatus.{#SNMPINDEX}]'
+              history: 7d
+              trends: '0'
+              tags:
+                -
+                  tag: component
+                  value: network
+                -
+                  tag: description
+                  value: '{#IFDESCR}'
+                -
+                  tag: interface
+                  value: '{#IFDESCR}'
+            -
+              uuid: 722d04fa347c4f65996ddd494478bbbd
+              name: 'Interface {#IFDESCR}: Operational status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.8.{#SNMPINDEX}'
+              key: 'net.if.status[ifOperStatus.{#SNMPINDEX}]'
+              history: 7d
+              trends: '0'
+              valuemap:
+                name: 'IF-MIB::ifOperStatus'
+              tags:
+                -
+                  tag: component
+                  value: network
+                -
+                  tag: description
+                  value: '{#IFDESCR}'
+                -
+                  tag: interface
+                  value: '{#IFDESCR}'
+              trigger_prototypes:
+                -
+                  uuid: d02e2b11451348d285adaef3a0dda16f
+                  expression: '{$IFCONTROL:"{#IFDESCR}"}=1 and last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+                  name: 'Interface {#IFDESCR}: Link down'
+                  opdata: 'Current state: {ITEM.LASTVALUE1}'
+                  priority: AVERAGE
+                  description: |
+                    This trigger expression works as follows:
+                    1. Can be triggered if operations status is down.
+                    2. {$IFCONTROL:"{#IFDESCR}"}=1 - user can redefine Context macro to value - 0. That marks this interface as not important. No new trigger will be fired if this interface is down.
+                    3. {TEMPLATE_NAME:METRIC.diff()}=1) - trigger fires only if operational status was up(1) sometime before. (So, do not fire 'ethernal off' interfaces.)
+                    
+                    WARNING: if closed manually - won't fire again on next poll, because of .diff.
+                  manual_close: 'YES'
+            -
+              uuid: bb3cdddc1bc44e40be84c6f4f447c1e6
+              name: 'Interface {#IFDESCR}: Interface type'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.3.{#SNMPINDEX}'
+              key: 'net.if.type[ifType.{#SNMPINDEX}]'
+              delay: 1h
+              history: 7d
+              trends: '0'
+              valuemap:
+                name: 'IF-MIB::ifType'
+              preprocessing:
+                -
+                  type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1d
+              tags:
+                -
+                  tag: component
+                  value: network
+                -
+                  tag: description
+                  value: '{#IFDESCR}'
+                -
+                  tag: interface
+                  value: '{#IFDESCR}'
+          trigger_prototypes:
+            -
+              uuid: 6fbc44f0298149b398cf8d28052fb9c9
+              expression: |
+                change(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}])<0 and last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0
+                and (
+                last(/Mikrotik RB260 v1.17/net.if.type[ifType.{#SNMPINDEX}])=6 or
+                last(/Mikrotik RB260 v1.17/net.if.type[ifType.{#SNMPINDEX}])=7 or
+                last(/Mikrotik RB260 v1.17/net.if.type[ifType.{#SNMPINDEX}])=11 or
+                last(/Mikrotik RB260 v1.17/net.if.type[ifType.{#SNMPINDEX}])=62 or
+                last(/Mikrotik RB260 v1.17/net.if.type[ifType.{#SNMPINDEX}])=69 or
+                last(/Mikrotik RB260 v1.17/net.if.type[ifType.{#SNMPINDEX}])=117
+                )
+                and
+                (last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2)
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: |
+                (change(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0 and last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}],#2)>0) or
+                (last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])=2)
+              name: 'Interface {#IFDESCR}: Ethernet has changed to lower speed than it was before'
+              opdata: 'Current reported speed: {ITEM.LASTVALUE1}'
+              priority: INFO
+              description: 'This Ethernet connection has transitioned down from its known maximum speed. This might be a sign of autonegotiation issues. Ack to close.'
+              manual_close: 'YES'
+              dependencies:
+                -
+                  name: 'Interface {#IFDESCR}: Link down'
+                  expression: '{$IFCONTROL:"{#IFDESCR}"}=1 and last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
+                  recovery_expression: 'last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+              tags:
+                -
+                  tag: scope
+                  value: performance
+            -
+              uuid: 6c7b1778f09c42348656bb1eb86b2580
+              expression: |
+                (avg(/Mikrotik RB260 v1.17/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) or
+                avg(/Mikrotik RB260 v1.17/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}])) and
+                last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: |
+                avg(/Mikrotik RB260 v1.17/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) and
+                avg(/Mikrotik RB260 v1.17/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Mikrotik RB260 v1.17/net.if.speed[ifHighSpeed.{#SNMPINDEX}])
+              name: 'Interface {#IFDESCR}: High bandwidth usage'
+              opdata: 'Current state: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'The network interface utilization is close to its estimated maximum bandwidth.'
+              manual_close: 'YES'
+              dependencies:
+                -
+                  name: 'Interface {#IFDESCR}: Link down'
+                  expression: '{$IFCONTROL:"{#IFDESCR}"}=1 and last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
+                  recovery_expression: 'last(/Mikrotik RB260 v1.17/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+              tags:
+                -
+                  tag: scope
+                  value: performance
+          graph_prototypes:
+            -
+              uuid: 406df4d30b074005a2edf0e6eca007f4
+              name: 'Interface {#IFDESCR}: Network traffic'
+              graph_items:
+                -
+                  color: 1A7C11
+                  calc_fnc: ALL
+                  item:
+                    host: 'Mikrotik RB260 v1.17'
+                    key: 'net.if.in[ifHCInOctets.{#SNMPINDEX}]'
+                -
+                  sortorder: '1'
+                  color: 0288D1
+                  calc_fnc: ALL
+                  item:
+                    host: 'Mikrotik RB260 v1.17'
+                    key: 'net.if.out[ifHCOutOctets.{#SNMPINDEX}]'
+      tags:
+        -
+          tag: class
+          value: network
+        -
+          tag: target
+          value: mikrotik
+        -
+          tag: target
+          value: rb260gs
+      macros:
+        -
+          macro: '{$IF.UTIL.MAX}'
+          value: '90'
+        -
+          macro: '{$IFCONTROL}'
+          value: '1'
+      dashboards:
+        -
+          uuid: 43719abfadb74fda98d35727b4972c34
+          name: 'Network interfaces'
+          pages:
+            -
+              widgets:
+                -
+                  type: GRAPH_PROTOTYPE
+                  width: '24'
+                  height: '5'
+                  fields:
+                    -
+                      type: INTEGER
+                      name: columns
+                      value: '1'
+                    -
+                      type: GRAPH_PROTOTYPE
+                      name: graphid
+                      value:
+                        host: 'Mikrotik RB260 v1.17'
+                        name: 'Interface {#IFDESCR}: Network traffic'
+      valuemaps:
+        -
+          uuid: 17c615a22d384380828aa4963fdf71fb
+          name: 'IF-MIB::ifOperStatus'
+          mappings:
+            -
+              value: '1'
+              newvalue: up
+            -
+              value: '2'
+              newvalue: down
+            -
+              value: '4'
+              newvalue: unknown
+            -
+              value: '5'
+              newvalue: dormant
+            -
+              value: '6'
+              newvalue: notPresent
+            -
+              value: '7'
+              newvalue: lowerLayerDown
+        -
+          uuid: 83852e5d503a426a99ee2c8af1b417ad
+          name: 'IF-MIB::ifType'
+          mappings:
+            -
+              value: '6'
+              newvalue: ethernetCsmacd
+        -
+          uuid: 055eb79065c74c00b059592f06066048
+          name: 'Service state'
+          mappings:
+            -
+              value: '0'
+              newvalue: Down
+            -
+              value: '1'
+              newvalue: Up
+        -
+          uuid: 40d1986314b141afb4201352c705152c
+          name: zabbix.host.available
+          mappings:
+            -
+              value: '0'
+              newvalue: 'not available'
+            -
+              value: '1'
+              newvalue: available
+            -
+              value: '2'
+              newvalue: unknown


### PR DESCRIPTION
The older RB260 model (Firmware v1.x) can't upgrade to v2, so we need a template to monitor older devices over snmp.