### PR TITLE
Fix Item names for Eltex MES template

### DIFF
--- a/Network_Devices/Eltex/template_eltex_mes/6.0/README.md
+++ b/Network_Devices/Eltex/template_eltex_mes/6.0/README.md
@@ -51,26 +51,26 @@ There are no template links in this template.
 |Serial number|<p>Serial number</p>|`SNMP agent`|rlPhdUnitGenParamSerialNum<p>Update: 1h</p>|
 |Number of network interfaces|<p>The number of network interfaces (regardless of their current state) present on this system.</p>|`SNMP agent`|ifNumber<p>Update: 1h</p>|
 |CPU Utilization 5min|<p>-</p>|`SNMP agent`|rlCpuUtilDuringLast5Minutes<p>Update: 5m</p>|
-|Admin status of interface $1|<p>The desired state of the interface.</p>|`SNMP agent`|ifAdminStatus[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Inbound errors on interface $1|<p>For packet-oriented interfaces, the number of inbound packets that contained errors preventing them from being deliverable to a higher-layer protocol. For character-oriented or fixed-length interfaces, the number of inbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol.</p>|`SNMP agent`|ifInErrors[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Volt SFP of interface $1|<p>Volt on SFP interface.</p>|`SNMP agent`|rlPhyTestGetResult.v[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Temperature SFP of interface $1|<p>Temperature on SFP interface.</p>|`SNMP agent`|rlPhyTestGetResult.t[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Out power SFP of interface $1|<p>Out power on SFP interface.</p>|`SNMP agent`|rlPhyTestGetResult.OutPow[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|mA SFP of interface $1|<p>mA on SFP interface.</p>|`SNMP agent`|rlPhyTestGetResult.mA[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Input power SFP of interface $1|<p>Input power on SFP interface.</p>|`SNMP agent`|rlPhyTestGetResult.InPow[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Outbound errors on interface $1|<p>For packet-oriented interfaces, the number of outbound packets that could not be transmitted because of errors. For character-oriented or fixed-length interfaces, the number of outbound transmission units that could not be transmitted because of errors.</p>|`SNMP agent`|ifOutErrors[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Operational status of interface $1|<p>The current operational state of the interface.</p>|`SNMP agent`|ifOperStatus[{#SNMPVALUE}]<p>Update: 15m</p><p>LLD</p>|
-|Outgoing Unicast packets on interface $1|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCOutUcastPkts[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Alias of interface $1|<p>-</p>|`SNMP agent`|ifAlias[{#SNMPVALUE}]<p>Update: 1h</p><p>LLD</p>|
-|Outgoing traffic on interface $1|<p>The number of octets transmitted in MAC frames on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCOutOctets[{#SNMPVALUE}]<p>Update: 3m</p><p>LLD</p>|
-|Outgoing Multicast packets on interface $1|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCOutMulticastPkts[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Outgoing Broadcast packets on interface $1|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCOutBroadcastPkts[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Incoming Unicast packets on interface $1|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCInUcastPkts[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Incoming traffic on interface $1|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCInOctets[{#SNMPVALUE}]<p>Update: 3m</p><p>LLD</p>|
-|Incoming Multicast packets on interface $1|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCInMulticastPkts[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Incoming Broadcast packets on interface $1|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCInBroadcastPkts[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
-|Description of interface $1|<p>A textual string containing information about the interface. This string should include the name of the manufacturer, the product name and the version of the interface hardware/software.</p>|`SNMP agent`|ifDescr[{#SNMPVALUE}]<p>Update: 1h</p><p>LLD</p>|
-|Speed on interface $1|<p>Mode speed on interfece.</p>|`SNMP agent`|speed_on_[{#SNMPVALUE}]<p>Update: 1h</p><p>LLD</p>|
+|Admin status of interface {#SNMPVALUE}|<p>The desired state of the interface.</p>|`SNMP agent`|ifAdminStatus[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Inbound errors on interface {#SNMPVALUE}|<p>For packet-oriented interfaces, the number of inbound packets that contained errors preventing them from being deliverable to a higher-layer protocol. For character-oriented or fixed-length interfaces, the number of inbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol.</p>|`SNMP agent`|ifInErrors[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Volt SFP of interface {#SNMPVALUE}|<p>Volt on SFP interface.</p>|`SNMP agent`|rlPhyTestGetResult.v[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Temperature SFP of interface {#SNMPVALUE}|<p>Temperature on SFP interface.</p>|`SNMP agent`|rlPhyTestGetResult.t[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Out power SFP of interface {#SNMPVALUE}|<p>Out power on SFP interface.</p>|`SNMP agent`|rlPhyTestGetResult.OutPow[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|mA SFP of interface {#SNMPVALUE}|<p>mA on SFP interface.</p>|`SNMP agent`|rlPhyTestGetResult.mA[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Input power SFP of interface {#SNMPVALUE}|<p>Input power on SFP interface.</p>|`SNMP agent`|rlPhyTestGetResult.InPow[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Outbound errors on interface {#SNMPVALUE}|<p>For packet-oriented interfaces, the number of outbound packets that could not be transmitted because of errors. For character-oriented or fixed-length interfaces, the number of outbound transmission units that could not be transmitted because of errors.</p>|`SNMP agent`|ifOutErrors[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Operational status of interface {#SNMPVALUE}|<p>The current operational state of the interface.</p>|`SNMP agent`|ifOperStatus[{#SNMPVALUE}]<p>Update: 15m</p><p>LLD</p>|
+|Outgoing Unicast packets on interface {#SNMPVALUE}|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCOutUcastPkts[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Alias of interface {#SNMPVALUE}|<p>-</p>|`SNMP agent`|ifAlias[{#SNMPVALUE}]<p>Update: 1h</p><p>LLD</p>|
+|Outgoing traffic on interface {#SNMPVALUE}|<p>The number of octets transmitted in MAC frames on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCOutOctets[{#SNMPVALUE}]<p>Update: 3m</p><p>LLD</p>|
+|Outgoing Multicast packets on interface {#SNMPVALUE}|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCOutMulticastPkts[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Outgoing Broadcast packets on interface {#SNMPVALUE}|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCOutBroadcastPkts[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Incoming Unicast packets on interface {#SNMPVALUE}|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCInUcastPkts[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Incoming traffic on interface {#SNMPVALUE}|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCInOctets[{#SNMPVALUE}]<p>Update: 3m</p><p>LLD</p>|
+|Incoming Multicast packets on interface {#SNMPVALUE}|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCInMulticastPkts[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Incoming Broadcast packets on interface {#SNMPVALUE}|<p>The number of octets in valid MAC frames received on this interface, including the MAC header and FCS.</p>|`SNMP agent`|ifHCInBroadcastPkts[{#SNMPVALUE}]<p>Update: 10m</p><p>LLD</p>|
+|Description of interface {#SNMPVALUE}|<p>A textual string containing information about the interface. This string should include the name of the manufacturer, the product name and the version of the interface hardware/software.</p>|`SNMP agent`|ifDescr[{#SNMPVALUE}]<p>Update: 1h</p><p>LLD</p>|
+|Speed on interface {#SNMPVALUE}|<p>Mode speed on interfece.</p>|`SNMP agent`|speed_on_[{#SNMPVALUE}]<p>Update: 1h</p><p>LLD</p>|
 
 
 ## Triggers

--- a/Network_Devices/Eltex/template_eltex_mes/6.0/template_eltex_mes.yaml
+++ b/Network_Devices/Eltex/template_eltex_mes/6.0/template_eltex_mes.yaml
@@ -351,7 +351,7 @@ zabbix_export:
           item_prototypes:
             -
               uuid: 448679bd4c664884a47ed6867fc4af72
-              name: 'Admin status of interface $1'
+              name: 'Admin status of interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifAdminStatus.{#SNMPINDEX}'
               key: 'ifAdminStatus[{#SNMPVALUE}]'
@@ -367,7 +367,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: 2d6d4212811443c59a2d21e0b2c3e94c
-              name: 'Alias of interface $1'
+              name: 'Alias of interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifAlias.{#SNMPINDEX}'
               key: 'ifAlias[{#SNMPVALUE}]'
@@ -381,7 +381,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: dbb266a073114252b0b5311b7a8148ec
-              name: 'Description of interface $1'
+              name: 'Description of interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifDescr.{#SNMPINDEX}'
               key: 'ifDescr[{#SNMPVALUE}]'
@@ -397,7 +397,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: 2b47101b7e36409794d049870596a41e
-              name: 'Incoming Broadcast packets on interface $1'
+              name: 'Incoming Broadcast packets on interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifHCInBroadcastPkts.{#SNMPINDEX}'
               key: 'ifHCInBroadcastPkts[{#SNMPVALUE}]'
@@ -417,7 +417,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: bb3f82b86ad649749fb9031e96f37170
-              name: 'Incoming Multicast packets on interface $1'
+              name: 'Incoming Multicast packets on interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifHCInMulticastPkts.{#SNMPINDEX}'
               key: 'ifHCInMulticastPkts[{#SNMPVALUE}]'
@@ -437,7 +437,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: 9eec1f33e5274822b6a4a782220d854b
-              name: 'Incoming traffic on interface $1'
+              name: 'Incoming traffic on interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifHCInOctets.{#SNMPINDEX}'
               key: 'ifHCInOctets[{#SNMPVALUE}]'
@@ -461,7 +461,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: 8990b83b153a4477a8ac822ed7eef542
-              name: 'Incoming Unicast packets on interface $1'
+              name: 'Incoming Unicast packets on interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifHCInUcastPkts.{#SNMPINDEX}'
               key: 'ifHCInUcastPkts[{#SNMPVALUE}]'
@@ -481,7 +481,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: c486f47f2e1e4da5b2eb94275e5dff53
-              name: 'Outgoing Broadcast packets on interface $1'
+              name: 'Outgoing Broadcast packets on interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifHCOutBroadcastPkts.{#SNMPINDEX}'
               key: 'ifHCOutBroadcastPkts[{#SNMPVALUE}]'
@@ -501,7 +501,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: cb68bbc067c64f8bb39a102ec8e9d8ff
-              name: 'Outgoing Multicast packets on interface $1'
+              name: 'Outgoing Multicast packets on interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifHCOutMulticastPkts.{#SNMPINDEX}'
               key: 'ifHCOutMulticastPkts[{#SNMPVALUE}]'
@@ -521,7 +521,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: b8b5290309294527b66806c7b1c522ce
-              name: 'Outgoing traffic on interface $1'
+              name: 'Outgoing traffic on interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifHCOutOctets.{#SNMPINDEX}'
               key: 'ifHCOutOctets[{#SNMPVALUE}]'
@@ -545,7 +545,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: d8ab6f59928541b89f0fafb1d56bc556
-              name: 'Outgoing Unicast packets on interface $1'
+              name: 'Outgoing Unicast packets on interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifHCOutUcastPkts.{#SNMPINDEX}'
               key: 'ifHCOutUcastPkts[{#SNMPVALUE}]'
@@ -565,7 +565,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: 568ccceed5aa47eaa94a8ae571dc2894
-              name: 'Inbound errors on interface $1'
+              name: 'Inbound errors on interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifInErrors.{#SNMPINDEX}'
               key: 'ifInErrors[{#SNMPVALUE}]'
@@ -590,7 +590,7 @@ zabbix_export:
                   priority: WARNING
             -
               uuid: 8c3408be6c3645ed9252b7ceb780c7ae
-              name: 'Operational status of interface $1'
+              name: 'Operational status of interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifOperStatus.{#SNMPINDEX}'
               key: 'ifOperStatus[{#SNMPVALUE}]'
@@ -613,7 +613,7 @@ zabbix_export:
                   priority: INFO
             -
               uuid: a9a2191db6d748aa8dcb8b78f52c93c9
-              name: 'Outbound errors on interface $1'
+              name: 'Outbound errors on interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: 'IF-MIB::ifOutErrors.{#SNMPINDEX}'
               key: 'ifOutErrors[{#SNMPVALUE}]'
@@ -638,7 +638,7 @@ zabbix_export:
                   priority: WARNING
             -
               uuid: d63d3212bbda4a9bb0e221e581e098b1
-              name: 'Input power SFP of interface $1'
+              name: 'Input power SFP of interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '1.3.6.1.4.1.89.90.1.2.1.3.{#SNMPINDEX}.9'
               key: 'rlPhyTestGetResult.InPow[{#SNMPVALUE}]'
@@ -659,7 +659,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: db0ae53e066343d4bd9f69e6ba49669f
-              name: 'mA SFP of interface $1'
+              name: 'mA SFP of interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '1.3.6.1.4.1.89.90.1.2.1.3.{#SNMPINDEX}.7'
               key: 'rlPhyTestGetResult.mA[{#SNMPVALUE}]'
@@ -680,7 +680,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: 0002d1c094804707b401e98606ae41ca
-              name: 'Out power SFP of interface $1'
+              name: 'Out power SFP of interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '1.3.6.1.4.1.89.90.1.2.1.3.{#SNMPINDEX}.8'
               key: 'rlPhyTestGetResult.OutPow[{#SNMPVALUE}]'
@@ -701,7 +701,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: 266a07d3c4c3413e99fc816a5bd3b7a4
-              name: 'Temperature SFP of interface $1'
+              name: 'Temperature SFP of interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '1.3.6.1.4.1.89.90.1.2.1.3.{#SNMPINDEX}.5'
               key: 'rlPhyTestGetResult.t[{#SNMPVALUE}]'
@@ -716,7 +716,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: 9841d16d1692467588fa4b20146526b6
-              name: 'Volt SFP of interface $1'
+              name: 'Volt SFP of interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '1.3.6.1.4.1.89.90.1.2.1.3.{#SNMPINDEX}.6'
               key: 'rlPhyTestGetResult.v[{#SNMPVALUE}]'
@@ -737,7 +737,7 @@ zabbix_export:
                   value: Interfaces
             -
               uuid: 7610b2fce8194f408f3c645949316b78
-              name: 'Speed on interface $1'
+              name: 'Speed on interface {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '1.3.6.1.2.1.2.2.1.5.{#SNMPINDEX}'
               key: 'speed_on_[{#SNMPVALUE}]'


### PR DESCRIPTION
Fix Item names: previous template create items like  "Alias of interface $1" for any interface. Change fixes it, now items named like this "Alias of interface te1/0/32"