### PR TITLE
Create Aruba-1930-Switch-SNMP (20230404).xml

### DIFF
--- a/Network_Devices/Aruba/template_aruba_1930_switch/6.0/Aruba-1930-Switch-SNMP (20230404).xml
+++ b/Network_Devices/Aruba/template_aruba_1930_switch/6.0/Aruba-1930-Switch-SNMP (20230404).xml
@@ -1,0 +1,3269 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>6.2</version>
+    <date>2023-04-05T00:57:55Z</date>
+    <template_groups>
+        <template_group>
+            <uuid>36bff6c29af64692839d077febfc7079</uuid>
+            <name>Templates/Network devices</name>
+        </template_group>
+    </template_groups>
+    <templates>
+        <template>
+            <uuid>3a458a77d38744cb9babfec69d431e33</uuid>
+            <template>Aruba 1930 Switch SNMP</template>
+            <name>Aruba 1930 Switch SNMP</name>
+            <description>Template Net HP Enterprise Switch
+
+MIBs used:
+NETSWITCH-MIB
+HP-ICF-CHASSIS
+ENTITY-SENSORS-MIB
+IF-MIB
+EtherLike-MIB
+SEMI-MIB
+SNMPv2-MIB
+ENTITY-MIB
+STATISTICS-MIB
+
+Template tooling version used: 0.41</description>
+            <groups>
+                <group>
+                    <name>Templates/Network devices</name>
+                </group>
+            </groups>
+            <items>
+                <item>
+                    <uuid>171a7ef5105e47068da921f4a20a3824</uuid>
+                    <name>ICMP ping</name>
+                    <type>SIMPLE</type>
+                    <key>icmpping</key>
+                    <history>1w</history>
+                    <valuemap>
+                        <name>Service state</name>
+                    </valuemap>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>health</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>network</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>4c733e467f03440a858587f942beeefa</uuid>
+                            <expression>max(/Aruba 1930 Switch SNMP/icmpping,#3)=0</expression>
+                            <name>Unavailable by ICMP ping</name>
+                            <priority>HIGH</priority>
+                            <description>Last three attempts returned timeout.  Please check device connectivity.</description>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>availability</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>6022ff699267497b900bbadea21c6b7a</uuid>
+                    <name>ICMP loss</name>
+                    <type>SIMPLE</type>
+                    <key>icmppingloss</key>
+                    <history>1w</history>
+                    <value_type>FLOAT</value_type>
+                    <units>%</units>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>health</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>network</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>3117fce5ba3c4549876d196c4ce0056f</uuid>
+                            <expression>min(/Aruba 1930 Switch SNMP/icmppingloss,5m)&gt;{$ICMP_LOSS_WARN} and min(/Aruba 1930 Switch SNMP/icmppingloss,5m)&lt;100</expression>
+                            <name>High ICMP ping loss</name>
+                            <opdata>Loss: {ITEM.LASTVALUE1}</opdata>
+                            <priority>WARNING</priority>
+                            <dependencies>
+                                <dependency>
+                                    <name>Unavailable by ICMP ping</name>
+                                    <expression>max(/Aruba 1930 Switch SNMP/icmpping,#3)=0</expression>
+                                </dependency>
+                            </dependencies>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>availability</value>
+                                </tag>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>performance</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>8bb8243a88b8429586921709288c6559</uuid>
+                    <name>ICMP response time</name>
+                    <type>SIMPLE</type>
+                    <key>icmppingsec</key>
+                    <history>1w</history>
+                    <value_type>FLOAT</value_type>
+                    <units>s</units>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>health</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>network</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>b4c0ca4fb93145caab3281d88d504a40</uuid>
+                            <expression>avg(/Aruba 1930 Switch SNMP/icmppingsec,5m)&gt;{$ICMP_RESPONSE_TIME_WARN}</expression>
+                            <name>High ICMP ping response time</name>
+                            <opdata>Value: {ITEM.LASTVALUE1}</opdata>
+                            <priority>WARNING</priority>
+                            <dependencies>
+                                <dependency>
+                                    <name>High ICMP ping loss</name>
+                                    <expression>min(/Aruba 1930 Switch SNMP/icmppingloss,5m)&gt;{$ICMP_LOSS_WARN} and min(/Aruba 1930 Switch SNMP/icmppingloss,5m)&lt;100</expression>
+                                </dependency>
+                                <dependency>
+                                    <name>Unavailable by ICMP ping</name>
+                                    <expression>max(/Aruba 1930 Switch SNMP/icmpping,#3)=0</expression>
+                                </dependency>
+                            </dependencies>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>availability</value>
+                                </tag>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>performance</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>22013d5a42ab40aab564457a5de05fdf</uuid>
+                    <name>SNMP traps (fallback)</name>
+                    <type>SNMP_TRAP</type>
+                    <key>snmptrap.fallback</key>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>LOG</value_type>
+                    <description>The item is used to collect all SNMP traps unmatched by other snmptrap items</description>
+                    <logtimefmt>hh:mm:sszyyyy/MM/dd</logtimefmt>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>network</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>8aaeaaed3c534802ae120cf096e3cfcd</uuid>
+                    <name>System contact details</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.1.4.0</snmp_oid>
+                    <key>system.contact[sysContact.0]</key>
+                    <delay>15m</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <description>MIB: SNMPv2-MIB
+The textual identification of the contact person for this managed node, together with information on how to contact this person.  If no contact information is known, the value is the zero-length string.</description>
+                    <inventory_link>CONTACT</inventory_link>
+                    <preprocessing>
+                        <step>
+                            <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                            <parameters>
+                                <parameter>12h</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>3ec61a677bb54a42a6a6af740981adf2</uuid>
+                    <name>CPU utilization</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>.1.3.6.1.4.1.11.2.1.8.0</snmp_oid>
+                    <key>system.cpu.util[hpSwitchCpuStat.0]</key>
+                    <history>7d</history>
+                    <value_type>FLOAT</value_type>
+                    <units>%</units>
+                    <description>MIB: STATISTICS-MIB
+The CPU utilization in percent(%).
+Reference: http://h20564.www2.hpe.com/hpsc/doc/public/display?docId=emr_na-c02597344&amp;sp4ts.oid=51079</description>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>cpu</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>4de5a9cc6ee74adebe6b805273366b9d</uuid>
+                            <expression>min(/Aruba 1930 Switch SNMP/system.cpu.util[hpSwitchCpuStat.0],5m)&gt;{$CPU.UTIL.CRIT}</expression>
+                            <name>High CPU utilization (over {$CPU.UTIL.CRIT}% for 5m)</name>
+                            <opdata>Current utilization: {ITEM.LASTVALUE1}</opdata>
+                            <priority>WARNING</priority>
+                            <description>CPU utilization is too high. The system might be slow to respond.</description>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>performance</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>921e76caab0b426aac521842d4600fb2</uuid>
+                    <name>System description</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.1.1.0</snmp_oid>
+                    <key>system.descr[sysDescr.0]</key>
+                    <delay>15m</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <description>MIB: SNMPv2-MIB
+A textual description of the entity. This value should
+include the full name and version identification of the system's hardware type, software operating-system, and
+networking software.</description>
+                    <preprocessing>
+                        <step>
+                            <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                            <parameters>
+                                <parameter>12h</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>c37a70aac7034950af3e9e52e4b30934</uuid>
+                    <name>Firmware version</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>.1.3.6.1.4.1.11.2.53.4.1.5.1</snmp_oid>
+                    <key>system.hw.firmware</key>
+                    <delay>1h</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <description>MIB: NETSWITCH-MIB
+Contains the operating code version number (also known as software or firmware).
+For example, a software version such as A.08.01 is described as follows:
+A    the function set available in your router
+08   the common release number
+01   updates to the current common release</description>
+                    <preprocessing>
+                        <step>
+                            <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                            <parameters>
+                                <parameter>1d</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>78f8c05914214375a71dd7b84fb254ec</uuid>
+                            <expression>last(/Aruba 1930 Switch SNMP/system.hw.firmware,#1)&lt;&gt;last(/Aruba 1930 Switch SNMP/system.hw.firmware,#2) and length(last(/Aruba 1930 Switch SNMP/system.hw.firmware))&gt;0</expression>
+                            <name>Firmware has changed</name>
+                            <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
+                            <priority>INFO</priority>
+                            <description>Firmware version has changed. Ack to close</description>
+                            <manual_close>YES</manual_close>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>notice</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>378d2be777af413a8d4310dabadf9e28</uuid>
+                    <name>Hardware serial number</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.11.2.36.1.1.2.9.0</snmp_oid>
+                    <key>system.hw.serialnumber</key>
+                    <delay>1h</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <description>MIB: SEMI-MIB</description>
+                    <inventory_link>SERIALNO_A</inventory_link>
+                    <preprocessing>
+                        <step>
+                            <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                            <parameters>
+                                <parameter>1d</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>f754763b58be4aea93987b4c466045fd</uuid>
+                            <expression>last(/Aruba 1930 Switch SNMP/system.hw.serialnumber,#1)&lt;&gt;last(/Aruba 1930 Switch SNMP/system.hw.serialnumber,#2) and length(last(/Aruba 1930 Switch SNMP/system.hw.serialnumber))&gt;0</expression>
+                            <name>Device has been replaced (new serial number received)</name>
+                            <priority>INFO</priority>
+                            <description>Device serial number has changed. Ack to close</description>
+                            <manual_close>YES</manual_close>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>notice</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>502eeb1b48444a50b3a1ef3fead83b9c</uuid>
+                    <name>System location</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.1.6.0</snmp_oid>
+                    <key>system.location[sysLocation.0]</key>
+                    <delay>15m</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <description>MIB: SNMPv2-MIB
+The physical location of this node (e.g., `telephone closet, 3rd floor').  If the location is unknown, the value is the zero-length string.</description>
+                    <inventory_link>LOCATION</inventory_link>
+                    <preprocessing>
+                        <step>
+                            <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                            <parameters>
+                                <parameter>12h</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>9edb539eb7c2497d9c309b5b590a6087</uuid>
+                    <name>System name</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.1.5.0</snmp_oid>
+                    <key>system.name</key>
+                    <delay>15m</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <description>MIB: SNMPv2-MIB
+An administratively-assigned name for this managed node.By convention, this is the node's fully-qualified domain name.  If the name is unknown, the value is the zero-length string.</description>
+                    <inventory_link>NAME</inventory_link>
+                    <preprocessing>
+                        <step>
+                            <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                            <parameters>
+                                <parameter>12h</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>c094b85a54774cca9bffe089d4cb968d</uuid>
+                            <expression>last(/Aruba 1930 Switch SNMP/system.name,#1)&lt;&gt;last(/Aruba 1930 Switch SNMP/system.name,#2) and length(last(/Aruba 1930 Switch SNMP/system.name))&gt;0</expression>
+                            <name>System name has changed (new name: {ITEM.VALUE})</name>
+                            <priority>INFO</priority>
+                            <description>System name has changed. Ack to close.</description>
+                            <manual_close>YES</manual_close>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>notice</value>
+                                </tag>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>security</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>5a465ca2377948d3a10a230c78f69825</uuid>
+                    <name>System object ID</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.1.2.0</snmp_oid>
+                    <key>system.objectid[sysObjectID.0]</key>
+                    <delay>15m</delay>
+                    <history>2w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <description>MIB: SNMPv2-MIB
+The vendor's authoritative identification of the network management subsystem contained in the entity.  This value is allocated within the SMI enterprises subtree (1.3.6.1.4.1) and provides an easy and unambiguous means for determining`what kind of box' is being managed.  For example, if vendor`Flintstones, Inc.' was assigned the subtree1.3.6.1.4.1.4242, it could assign the identifier 1.3.6.1.4.1.4242.1.1 to its `Fred Router'.</description>
+                    <preprocessing>
+                        <step>
+                            <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                            <parameters>
+                                <parameter>12h</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
+                        </tag>
+                    </tags>
+                </item>
+                <item>
+                    <uuid>5b10c9a613ce475b89c7a46437061e0c</uuid>
+                    <name>Uptime</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.1.3.0</snmp_oid>
+                    <key>system.uptime[sysUpTime.0]</key>
+                    <delay>30s</delay>
+                    <history>2w</history>
+                    <trends>0d</trends>
+                    <units>uptime</units>
+                    <description>MIB: SNMPv2-MIB
+The time (in hundredths of a second) since the network management portion of the system was last re-initialized.</description>
+                    <preprocessing>
+                        <step>
+                            <type>MULTIPLIER</type>
+                            <parameters>
+                                <parameter>0.01</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>system</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>9c41a9ef6d734aa3a355220d05bf2831</uuid>
+                            <expression>last(/Aruba 1930 Switch SNMP/system.uptime[sysUpTime.0])&lt;10m</expression>
+                            <name>{HOST.NAME} has been restarted (uptime &lt; 10m)</name>
+                            <priority>WARNING</priority>
+                            <description>Uptime is less than 10 minutes</description>
+                            <manual_close>YES</manual_close>
+                            <dependencies>
+                                <dependency>
+                                    <name>No SNMP data collection</name>
+                                    <expression>max(/Aruba 1930 Switch SNMP/zabbix[host,snmp,available],{$SNMP.TIMEOUT})=0</expression>
+                                </dependency>
+                            </dependencies>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>notice</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>309714d978b1483196ed7bb47ebd190e</uuid>
+                    <name>SNMP agent availability</name>
+                    <type>INTERNAL</type>
+                    <key>zabbix[host,snmp,available]</key>
+                    <history>7d</history>
+                    <description>Availability of SNMP checks on the host. The value of this item corresponds to availability icons in the host list.
+Possible value:
+0 - not available
+1 - available
+2 - unknown</description>
+                    <valuemap>
+                        <name>zabbix.host.available</name>
+                    </valuemap>
+                    <tags>
+                        <tag>
+                            <tag>component</tag>
+                            <value>health</value>
+                        </tag>
+                        <tag>
+                            <tag>component</tag>
+                            <value>network</value>
+                        </tag>
+                    </tags>
+                    <triggers>
+                        <trigger>
+                            <uuid>5a3f77183b1441bdb8fa1112e53303ce</uuid>
+                            <expression>max(/Aruba 1930 Switch SNMP/zabbix[host,snmp,available],{$SNMP.TIMEOUT})=0</expression>
+                            <name>No SNMP data collection</name>
+                            <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
+                            <priority>WARNING</priority>
+                            <description>SNMP is not available for polling. Please check device connectivity and SNMP settings.</description>
+                            <dependencies>
+                                <dependency>
+                                    <name>Unavailable by ICMP ping</name>
+                                    <expression>max(/Aruba 1930 Switch SNMP/icmpping,#3)=0</expression>
+                                </dependency>
+                            </dependencies>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>availability</value>
+                                </tag>
+                            </tags>
+                        </trigger>
+                    </triggers>
+                </item>
+            </items>
+            <discovery_rules>
+                <discovery_rule>
+                    <uuid>99b170c2782c4a9da6a9fc8195f3c2d7</uuid>
+                    <name>Entity Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#ENT_CLASS},1.3.6.1.2.1.47.1.1.1.1.5,{#ENT_NAME},1.3.6.1.2.1.47.1.1.1.1.7]</snmp_oid>
+                    <key>entity.discovery</key>
+                    <delay>1h</delay>
+                    <filter>
+                        <conditions>
+                            <condition>
+                                <macro>{#ENT_CLASS}</macro>
+                                <value>3</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>bdca88db94ff445a9b8dba75515defbf</uuid>
+                            <name>{#ENT_NAME}: Hardware model name</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.47.1.1.1.1.2.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.model[entPhysicalDescr.{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>2w</history>
+                            <trends>0</trends>
+                            <value_type>CHAR</value_type>
+                            <description>MIB: ENTITY-MIB</description>
+                            <preprocessing>
+                                <step>
+                                    <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                                    <parameters>
+                                        <parameter>1d</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>system</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>fb311e5d042a41968841eab3e8acdf96</uuid>
+                            <name>{#ENT_NAME}: Hardware version(revision)</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.47.1.1.1.1.8.{#SNMPINDEX}</snmp_oid>
+                            <key>system.hw.version[entPhysicalHardwareRev.{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>2w</history>
+                            <trends>0</trends>
+                            <value_type>CHAR</value_type>
+                            <description>MIB: ENTITY-MIB</description>
+                            <preprocessing>
+                                <step>
+                                    <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                                    <parameters>
+                                        <parameter>1d</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>system</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>310d3fecb80842d6b304fa93b7be1c94</uuid>
+                    <name>FAN Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#ENT_CLASS},1.3.6.1.4.1.11.2.14.11.1.2.6.1.2,{#ENT_DESCR},1.3.6.1.4.1.11.2.14.11.1.2.6.1.7,{#ENT_STATUS},1.3.6.1.4.1.11.2.14.11.1.2.6.1.4]</snmp_oid>
+                    <key>fan.discovery</key>
+                    <delay>1h</delay>
+                    <filter>
+                        <evaltype>AND</evaltype>
+                        <conditions>
+                            <condition>
+                                <macro>{#ENT_CLASS}</macro>
+                                <value>.+8.3.2$</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#ENT_STATUS}</macro>
+                                <value>(1|2|3|4)</value>
+                                <formulaid>B</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
+                    <description>Discovering all entities of hpicfSensorObjectId that ends with: 11.2.3.7.8.3.2 - fans and are present</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>5129b16b6bd549b6b31778f2381329c2</uuid>
+                            <name>{#ENT_DESCR}: Fan status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.11.2.14.11.1.2.6.1.4.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.fan.status[hpicfSensorStatus.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <description>MIB: HP-ICF-CHASSIS
+Actual status indicated by the sensor: {#ENT_DESCR}</description>
+                            <valuemap>
+                                <name>HP-ICF-CHASSIS::hpicfSensorStatus</name>
+                            </valuemap>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>fan</value>
+                                </tag>
+                            </tags>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>9559390cb9cd4bfda80170306ebd429e</uuid>
+                                    <expression>count(/Aruba 1930 Switch SNMP/sensor.fan.status[hpicfSensorStatus.{#SNMPINDEX}],#1,&quot;eq&quot;,&quot;{$FAN_CRIT_STATUS:\&quot;bad\&quot;}&quot;)=1</expression>
+                                    <name>{#ENT_DESCR}: Fan is in critical state</name>
+                                    <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
+                                    <priority>AVERAGE</priority>
+                                    <description>Please check the fan unit</description>
+                                    <tags>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>availability</value>
+                                        </tag>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>performance</value>
+                                        </tag>
+                                    </tags>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>8b089ca2569f49789c1d6caae5d475c1</uuid>
+                                    <expression>count(/Aruba 1930 Switch SNMP/sensor.fan.status[hpicfSensorStatus.{#SNMPINDEX}],#1,&quot;eq&quot;,&quot;{$FAN_WARN_STATUS:\&quot;warning\&quot;}&quot;)=1</expression>
+                                    <name>{#ENT_DESCR}: Fan is in warning state</name>
+                                    <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
+                                    <priority>WARNING</priority>
+                                    <description>Please check the fan unit</description>
+                                    <dependencies>
+                                        <dependency>
+                                            <name>{#ENT_DESCR}: Fan is in critical state</name>
+                                            <expression>count(/Aruba 1930 Switch SNMP/sensor.fan.status[hpicfSensorStatus.{#SNMPINDEX}],#1,&quot;eq&quot;,&quot;{$FAN_CRIT_STATUS:\&quot;bad\&quot;}&quot;)=1</expression>
+                                        </dependency>
+                                    </dependencies>
+                                    <tags>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>availability</value>
+                                        </tag>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>performance</value>
+                                        </tag>
+                                    </tags>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>8fbee0ad395f4113b8616f96aa2d34ce</uuid>
+                    <name>Memory Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.4.1.11.2.14.11.5.1.1.2.1.1.1.1]</snmp_oid>
+                    <key>memory.discovery</key>
+                    <delay>1h</delay>
+                    <description>Discovery of NETSWITCH-MIB::hpLocalMemTable, A table that contains information on all the local memory for each slot.</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>191adcb1f2204de3b7ce4b59fb83bb16</uuid>
+                            <name>#{#SNMPVALUE}: Available memory</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.11.2.14.11.5.1.1.2.1.1.1.6.{#SNMPINDEX}</snmp_oid>
+                            <key>vm.memory.available[hpLocalMemFreeBytes.{#SNMPINDEX}]</key>
+                            <history>7d</history>
+                            <units>B</units>
+                            <description>MIB: NETSWITCH-MIB
+The number of available (unallocated) bytes.</description>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>memory</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>c5672acc911c4840a30b564324f1793e</uuid>
+                            <name>#{#SNMPVALUE}: Total memory</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.11.2.14.11.5.1.1.2.1.1.1.5.{#SNMPINDEX}</snmp_oid>
+                            <key>vm.memory.total[hpLocalMemTotalBytes.{#SNMPINDEX}]</key>
+                            <history>7d</history>
+                            <units>B</units>
+                            <description>MIB: NETSWITCH-MIB
+The number of currently installed bytes.</description>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>memory</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>77bddbffdb7b47748957a02629139020</uuid>
+                            <name>#{#SNMPVALUE}: Used memory</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.11.2.14.11.5.1.1.2.1.1.1.7.{#SNMPINDEX}</snmp_oid>
+                            <key>vm.memory.used[hpLocalMemAllocBytes.{#SNMPINDEX}]</key>
+                            <history>7d</history>
+                            <units>B</units>
+                            <description>MIB: NETSWITCH-MIB
+The number of currently allocated bytes.</description>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>memory</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>fe1848bad9fa43458d7fde49795ebf0a</uuid>
+                            <name>#{#SNMPVALUE}: Memory utilization</name>
+                            <type>CALCULATED</type>
+                            <key>vm.memory.util[snmp.{#SNMPINDEX}]</key>
+                            <history>7d</history>
+                            <value_type>FLOAT</value_type>
+                            <units>%</units>
+                            <params>last(//vm.memory.used[hpLocalMemAllocBytes.{#SNMPINDEX}])/last(//vm.memory.total[hpLocalMemTotalBytes.{#SNMPINDEX}])*100</params>
+                            <description>Memory utilization in %</description>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>memory</value>
+                                </tag>
+                            </tags>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>9b3842e032a34656b8dffb26c01c4ae7</uuid>
+                                    <expression>min(/Aruba 1930 Switch SNMP/vm.memory.util[snmp.{#SNMPINDEX}],5m)&gt;{$MEMORY.UTIL.MAX}</expression>
+                                    <name>#{#SNMPVALUE}: High memory utilization (&gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+                                    <priority>AVERAGE</priority>
+                                    <description>The system is running out of free memory.</description>
+                                    <tags>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>capacity</value>
+                                        </tag>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>performance</value>
+                                        </tag>
+                                    </tags>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <uuid>6c5d994229e84befaffa628910d5ca2c</uuid>
+                            <name>#{#SNMPVALUE}: Memory usage</name>
+                            <ymin_type_1>FIXED</ymin_type_1>
+                            <graph_items>
+                                <graph_item>
+                                    <drawtype>BOLD_LINE</drawtype>
+                                    <color>1A7C11</color>
+                                    <item>
+                                        <host>Aruba 1930 Switch SNMP</host>
+                                        <key>vm.memory.total[hpLocalMemTotalBytes.{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>1</sortorder>
+                                    <drawtype>GRADIENT_LINE</drawtype>
+                                    <color>2774A4</color>
+                                    <item>
+                                        <host>Aruba 1930 Switch SNMP</host>
+                                        <key>vm.memory.available[hpLocalMemFreeBytes.{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                        <graph_prototype>
+                            <uuid>fec9cab97ec0464e8515e82e968907f5</uuid>
+                            <name>#{#SNMPVALUE}: Memory utilization</name>
+                            <ymin_type_1>FIXED</ymin_type_1>
+                            <ymax_type_1>FIXED</ymax_type_1>
+                            <graph_items>
+                                <graph_item>
+                                    <drawtype>GRADIENT_LINE</drawtype>
+                                    <color>1A7C11</color>
+                                    <item>
+                                        <host>Aruba 1930 Switch SNMP</host>
+                                        <key>vm.memory.util[snmp.{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>55cc69927aab49e7b4733dda4af5bc0c</uuid>
+                    <name>Network interfaces discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#IFOPERSTATUS},1.3.6.1.2.1.2.2.1.8,{#IFADMINSTATUS},1.3.6.1.2.1.2.2.1.7,{#IFALIAS},1.3.6.1.2.1.31.1.1.1.18,{#IFNAME},1.3.6.1.2.1.31.1.1.1.1,{#IFDESCR},1.3.6.1.2.1.2.2.1.2,{#IFTYPE},1.3.6.1.2.1.2.2.1.3]</snmp_oid>
+                    <key>net.if.discovery</key>
+                    <delay>1h</delay>
+                    <filter>
+                        <evaltype>AND</evaltype>
+                        <conditions>
+                            <condition>
+                                <macro>{#IFADMINSTATUS}</macro>
+                                <value>{$NET.IF.IFADMINSTATUS.MATCHES}</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#IFADMINSTATUS}</macro>
+                                <value>{$NET.IF.IFADMINSTATUS.NOT_MATCHES}</value>
+                                <operator>NOT_MATCHES_REGEX</operator>
+                                <formulaid>B</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#IFOPERSTATUS}</macro>
+                                <value>{$NET.IF.IFOPERSTATUS.MATCHES}</value>
+                                <formulaid>I</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#IFOPERSTATUS}</macro>
+                                <value>{$NET.IF.IFOPERSTATUS.NOT_MATCHES}</value>
+                                <operator>NOT_MATCHES_REGEX</operator>
+                                <formulaid>J</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#IFNAME}</macro>
+                                <value>{$NET.IF.IFNAME.MATCHES}</value>
+                                <formulaid>G</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#IFNAME}</macro>
+                                <value>{$NET.IF.IFNAME.NOT_MATCHES}</value>
+                                <operator>NOT_MATCHES_REGEX</operator>
+                                <formulaid>H</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#IFDESCR}</macro>
+                                <value>{$NET.IF.IFDESCR.MATCHES}</value>
+                                <formulaid>E</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#IFDESCR}</macro>
+                                <value>{$NET.IF.IFDESCR.NOT_MATCHES}</value>
+                                <operator>NOT_MATCHES_REGEX</operator>
+                                <formulaid>F</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#IFALIAS}</macro>
+                                <value>{$NET.IF.IFALIAS.MATCHES}</value>
+                                <formulaid>C</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#IFALIAS}</macro>
+                                <value>{$NET.IF.IFALIAS.NOT_MATCHES}</value>
+                                <operator>NOT_MATCHES_REGEX</operator>
+                                <formulaid>D</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#IFTYPE}</macro>
+                                <value>{$NET.IF.IFTYPE.MATCHES}</value>
+                                <formulaid>K</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#IFTYPE}</macro>
+                                <value>{$NET.IF.IFTYPE.NOT_MATCHES}</value>
+                                <operator>NOT_MATCHES_REGEX</operator>
+                                <formulaid>L</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
+                    <description>Discovering interfaces from IF-MIB.</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>4c00e8f86d18490ca2a2cba7c79b9b6f</uuid>
+                            <name>Interface {#IFNAME}({#IFALIAS}): Inbound packets discarded</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.2.2.1.13.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.in.discards[ifInDiscards.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>7d</history>
+                            <description>MIB: IF-MIB
+The number of inbound packets which were chosen to be discarded
+even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.
+One possible reason for discarding such a packet could be to free up buffer space.
+Discontinuities in the value of this counter can occur at re-initialization of the management system,
+and at other times as indicated by the value of ifCounterDiscontinuityTime.</description>
+                            <preprocessing>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <parameters>
+                                        <parameter/>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
+                                </tag>
+                                <tag>
+                                    <tag>description</tag>
+                                    <value>{#IFALIAS}</value>
+                                </tag>
+                                <tag>
+                                    <tag>interface</tag>
+                                    <value>{#IFNAME}</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>b26cc2ed978044779cb5f6495a20e69e</uuid>
+                            <name>Interface {#IFNAME}({#IFALIAS}): Inbound packets with errors</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.2.2.1.14.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.in.errors[ifInErrors.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>7d</history>
+                            <description>MIB: IF-MIB
+For packet-oriented interfaces, the number of inbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of inbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.</description>
+                            <preprocessing>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <parameters>
+                                        <parameter/>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
+                                </tag>
+                                <tag>
+                                    <tag>description</tag>
+                                    <value>{#IFALIAS}</value>
+                                </tag>
+                                <tag>
+                                    <tag>interface</tag>
+                                    <value>{#IFNAME}</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>d8a289d5b23b4ff2a52c5dd91d5bfb88</uuid>
+                            <name>Interface {#IFNAME}({#IFALIAS}): Bits received</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.31.1.1.1.6.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.in[ifHCInOctets.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>7d</history>
+                            <units>bps</units>
+                            <description>MIB: IF-MIB
+The total number of octets received on the interface, including framing characters. This object is a 64-bit version of ifInOctets. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.</description>
+                            <preprocessing>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <parameters>
+                                        <parameter/>
+                                    </parameters>
+                                </step>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <parameters>
+                                        <parameter>8</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
+                                </tag>
+                                <tag>
+                                    <tag>description</tag>
+                                    <value>{#IFALIAS}</value>
+                                </tag>
+                                <tag>
+                                    <tag>interface</tag>
+                                    <value>{#IFNAME}</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>2465940b973b492cb2f9bdc5eadc1892</uuid>
+                            <name>Interface {#IFNAME}({#IFALIAS}): Outbound packets discarded</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.2.2.1.19.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.out.discards[ifOutDiscards.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>7d</history>
+                            <description>MIB: IF-MIB
+The number of outbound packets which were chosen to be discarded
+even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.
+One possible reason for discarding such a packet could be to free up buffer space.
+Discontinuities in the value of this counter can occur at re-initialization of the management system,
+and at other times as indicated by the value of ifCounterDiscontinuityTime.</description>
+                            <preprocessing>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <parameters>
+                                        <parameter/>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
+                                </tag>
+                                <tag>
+                                    <tag>description</tag>
+                                    <value>{#IFALIAS}</value>
+                                </tag>
+                                <tag>
+                                    <tag>interface</tag>
+                                    <value>{#IFNAME}</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>41aaeee21a6e4372a7f88ac28e3dac12</uuid>
+                            <name>Interface {#IFNAME}({#IFALIAS}): Outbound packets with errors</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.2.2.1.20.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.out.errors[ifOutErrors.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>7d</history>
+                            <description>MIB: IF-MIB
+For packet-oriented interfaces, the number of outbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of outbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.</description>
+                            <preprocessing>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <parameters>
+                                        <parameter/>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
+                                </tag>
+                                <tag>
+                                    <tag>description</tag>
+                                    <value>{#IFALIAS}</value>
+                                </tag>
+                                <tag>
+                                    <tag>interface</tag>
+                                    <value>{#IFNAME}</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>e7002686e3b8477981e68f0623180247</uuid>
+                            <name>Interface {#IFNAME}({#IFALIAS}): Bits sent</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.31.1.1.1.10.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.out[ifHCOutOctets.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>7d</history>
+                            <units>bps</units>
+                            <description>MIB: IF-MIB
+The total number of octets transmitted out of the interface, including framing characters. This object is a 64-bit version of ifOutOctets.Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.</description>
+                            <preprocessing>
+                                <step>
+                                    <type>CHANGE_PER_SECOND</type>
+                                    <parameters>
+                                        <parameter/>
+                                    </parameters>
+                                </step>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <parameters>
+                                        <parameter>8</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
+                                </tag>
+                                <tag>
+                                    <tag>description</tag>
+                                    <value>{#IFALIAS}</value>
+                                </tag>
+                                <tag>
+                                    <tag>interface</tag>
+                                    <value>{#IFNAME}</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>50f5f4f2f5db43e6becd6693be0f9a93</uuid>
+                            <name>Interface {#IFNAME}({#IFALIAS}): Speed</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.31.1.1.1.15.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.speed[ifHighSpeed.{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>7d</history>
+                            <trends>0d</trends>
+                            <units>bps</units>
+                            <description>MIB: IF-MIB
+An estimate of the interface's current bandwidth in units of 1,000,000 bits per second. If this object reports a value of `n' then the speed of the interface is somewhere in the range of `n-500,000' to`n+499,999'.  For interfaces which do not vary in bandwidth or for those where no accurate estimation can be made, this object should contain the nominal bandwidth. For a sub-layer which has no concept of bandwidth, this object should be zero.</description>
+                            <preprocessing>
+                                <step>
+                                    <type>MULTIPLIER</type>
+                                    <parameters>
+                                        <parameter>1000000</parameter>
+                                    </parameters>
+                                </step>
+                                <step>
+                                    <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                                    <parameters>
+                                        <parameter>1h</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
+                                </tag>
+                                <tag>
+                                    <tag>description</tag>
+                                    <value>{#IFALIAS}</value>
+                                </tag>
+                                <tag>
+                                    <tag>interface</tag>
+                                    <value>{#IFNAME}</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>162736fb3de74450b97a4fa1adedaaff</uuid>
+                            <name>Interface {#IFNAME}({#IFALIAS}): Operational status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.2.2.1.8.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.status[ifOperStatus.{#SNMPINDEX}]</key>
+                            <history>7d</history>
+                            <trends>0</trends>
+                            <description>MIB: IF-MIB
+The current operational state of the interface.
+- The testing(3) state indicates that no operational packet scan be passed
+- If ifAdminStatus is down(2) then ifOperStatus should be down(2)
+- If ifAdminStatus is changed to up(1) then ifOperStatus should change to up(1) if the interface is ready to transmit and receive network traffic
+- It should change todormant(5) if the interface is waiting for external actions (such as a serial line waiting for an incoming connection)
+- It should remain in the down(2) state if and only if there is a fault that prevents it from going to the up(1) state
+- It should remain in the notPresent(6) state if the interface has missing(typically, hardware) components.</description>
+                            <valuemap>
+                                <name>IF-MIB::ifOperStatus</name>
+                            </valuemap>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
+                                </tag>
+                                <tag>
+                                    <tag>description</tag>
+                                    <value>{#IFALIAS}</value>
+                                </tag>
+                                <tag>
+                                    <tag>interface</tag>
+                                    <value>{#IFNAME}</value>
+                                </tag>
+                            </tags>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>50187eb4428b4166b5357dd5e675d470</uuid>
+                                    <expression>{$IFCONTROL:&quot;{#IFNAME}&quot;}=1 and last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)&lt;&gt;last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])&lt;&gt;2 or {$IFCONTROL:&quot;{#IFNAME}&quot;}=0</recovery_expression>
+                                    <name>Interface {#IFNAME}({#IFALIAS}): Link down</name>
+                                    <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
+                                    <priority>AVERAGE</priority>
+                                    <description>This trigger expression works as follows:
+1. Can be triggered if operations status is down.
+2. {$IFCONTROL:&quot;{#IFNAME}&quot;}=1 - user can redefine Context macro to value - 0. That marks this interface as not important. No new trigger will be fired if this interface is down.
+3. {TEMPLATE_NAME:METRIC.diff()}=1) - trigger fires only if operational status was up(1) sometime before. (So, do not fire 'ethernal off' interfaces.)
+
+WARNING: if closed manually - won't fire again on next poll, because of .diff.</description>
+                                    <tags>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>availability</value>
+                                        </tag>
+                                    </tags>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>ab69c7bcacbe42c2afd7f4a52f3ce91e</uuid>
+                            <name>Interface {#IFNAME}({#IFALIAS}): Interface type</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.2.2.1.3.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.type[ifType.{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>7d</history>
+                            <trends>0d</trends>
+                            <description>MIB: IF-MIB
+The type of interface.
+Additional values for ifType are assigned by the Internet Assigned NumbersAuthority (IANA),
+through updating the syntax of the IANAifType textual convention.</description>
+                            <valuemap>
+                                <name>IF-MIB::ifType</name>
+                            </valuemap>
+                            <preprocessing>
+                                <step>
+                                    <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                                    <parameters>
+                                        <parameter>1d</parameter>
+                                    </parameters>
+                                </step>
+                            </preprocessing>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
+                                </tag>
+                                <tag>
+                                    <tag>description</tag>
+                                    <value>{#IFALIAS}</value>
+                                </tag>
+                                <tag>
+                                    <tag>interface</tag>
+                                    <value>{#IFNAME}</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                    </item_prototypes>
+                    <trigger_prototypes>
+                        <trigger_prototype>
+                            <uuid>25d05d521df04d1da6089c8cdfcfdf86</uuid>
+                            <expression>change(/Aruba 1930 Switch SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])&lt;0 and last(/Aruba 1930 Switch SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])&gt;0
+and (
+last(/Aruba 1930 Switch SNMP/net.if.type[ifType.{#SNMPINDEX}])=6 or
+last(/Aruba 1930 Switch SNMP/net.if.type[ifType.{#SNMPINDEX}])=7 or
+last(/Aruba 1930 Switch SNMP/net.if.type[ifType.{#SNMPINDEX}])=11 or
+last(/Aruba 1930 Switch SNMP/net.if.type[ifType.{#SNMPINDEX}])=62 or
+last(/Aruba 1930 Switch SNMP/net.if.type[ifType.{#SNMPINDEX}])=69 or
+last(/Aruba 1930 Switch SNMP/net.if.type[ifType.{#SNMPINDEX}])=117
+)
+and
+(last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])&lt;&gt;2)</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>(change(/Aruba 1930 Switch SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])&gt;0 and last(/Aruba 1930 Switch SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}],#2)&gt;0) or
+(last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2)</recovery_expression>
+                            <name>Interface {#IFNAME}({#IFALIAS}): Ethernet has changed to lower speed than it was before</name>
+                            <opdata>Current reported speed: {ITEM.LASTVALUE1}</opdata>
+                            <priority>INFO</priority>
+                            <description>This Ethernet connection has transitioned down from its known maximum speed. This might be a sign of autonegotiation issues. Ack to close.</description>
+                            <dependencies>
+                                <dependency>
+                                    <name>Interface {#IFNAME}({#IFALIAS}): Link down</name>
+                                    <expression>{$IFCONTROL:&quot;{#IFNAME}&quot;}=1 and last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)&lt;&gt;last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))</expression>
+                                    <recovery_expression>last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])&lt;&gt;2 or {$IFCONTROL:&quot;{#IFNAME}&quot;}=0</recovery_expression>
+                                </dependency>
+                            </dependencies>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>performance</value>
+                                </tag>
+                            </tags>
+                        </trigger_prototype>
+                        <trigger_prototype>
+                            <uuid>a1eb66fa58894bb798067b1e42afb771</uuid>
+                            <expression>(avg(/Aruba 1930 Switch SNMP/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)&gt;({$IF.UTIL.MAX:&quot;{#IFNAME}&quot;}/100)*last(/Aruba 1930 Switch SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) or
+avg(/Aruba 1930 Switch SNMP/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)&gt;({$IF.UTIL.MAX:&quot;{#IFNAME}&quot;}/100)*last(/Aruba 1930 Switch SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])) and
+last(/Aruba 1930 Switch SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])&gt;0</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>avg(/Aruba 1930 Switch SNMP/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)&lt;(({$IF.UTIL.MAX:&quot;{#IFNAME}&quot;}-3)/100)*last(/Aruba 1930 Switch SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) and
+avg(/Aruba 1930 Switch SNMP/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)&lt;(({$IF.UTIL.MAX:&quot;{#IFNAME}&quot;}-3)/100)*last(/Aruba 1930 Switch SNMP/net.if.speed[ifHighSpeed.{#SNMPINDEX}])</recovery_expression>
+                            <name>Interface {#IFNAME}({#IFALIAS}): High bandwidth usage (&gt;{$IF.UTIL.MAX:&quot;{#IFNAME}&quot;}%)</name>
+                            <opdata>In: {ITEM.LASTVALUE1}, out: {ITEM.LASTVALUE3}, speed: {ITEM.LASTVALUE2}</opdata>
+                            <priority>WARNING</priority>
+                            <description>The network interface utilization is close to its estimated maximum bandwidth.</description>
+                            <dependencies>
+                                <dependency>
+                                    <name>Interface {#IFNAME}({#IFALIAS}): Link down</name>
+                                    <expression>{$IFCONTROL:&quot;{#IFNAME}&quot;}=1 and last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)&lt;&gt;last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))</expression>
+                                    <recovery_expression>last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])&lt;&gt;2 or {$IFCONTROL:&quot;{#IFNAME}&quot;}=0</recovery_expression>
+                                </dependency>
+                            </dependencies>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>performance</value>
+                                </tag>
+                            </tags>
+                        </trigger_prototype>
+                        <trigger_prototype>
+                            <uuid>def69d78f8144f0588736b73d41e03fa</uuid>
+                            <expression>min(/Aruba 1930 Switch SNMP/net.if.in.errors[ifInErrors.{#SNMPINDEX}],5m)&gt;{$IF.ERRORS.WARN:&quot;{#IFNAME}&quot;}
+or min(/Aruba 1930 Switch SNMP/net.if.out.errors[ifOutErrors.{#SNMPINDEX}],5m)&gt;{$IF.ERRORS.WARN:&quot;{#IFNAME}&quot;}</expression>
+                            <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                            <recovery_expression>max(/Aruba 1930 Switch SNMP/net.if.in.errors[ifInErrors.{#SNMPINDEX}],5m)&lt;{$IF.ERRORS.WARN:&quot;{#IFNAME}&quot;}*0.8
+and max(/Aruba 1930 Switch SNMP/net.if.out.errors[ifOutErrors.{#SNMPINDEX}],5m)&lt;{$IF.ERRORS.WARN:&quot;{#IFNAME}&quot;}*0.8</recovery_expression>
+                            <name>Interface {#IFNAME}({#IFALIAS}): High error rate (&gt;{$IF.ERRORS.WARN:&quot;{#IFNAME}&quot;} for 5m)</name>
+                            <opdata>errors in: {ITEM.LASTVALUE1}, errors out: {ITEM.LASTVALUE2}</opdata>
+                            <priority>WARNING</priority>
+                            <description>Recovers when below 80% of {$IF.ERRORS.WARN:&quot;{#IFNAME}&quot;} threshold</description>
+                            <dependencies>
+                                <dependency>
+                                    <name>Interface {#IFNAME}({#IFALIAS}): Link down</name>
+                                    <expression>{$IFCONTROL:&quot;{#IFNAME}&quot;}=1 and last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)&lt;&gt;last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))</expression>
+                                    <recovery_expression>last(/Aruba 1930 Switch SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])&lt;&gt;2 or {$IFCONTROL:&quot;{#IFNAME}&quot;}=0</recovery_expression>
+                                </dependency>
+                            </dependencies>
+                            <tags>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>availability</value>
+                                </tag>
+                                <tag>
+                                    <tag>scope</tag>
+                                    <value>performance</value>
+                                </tag>
+                            </tags>
+                        </trigger_prototype>
+                    </trigger_prototypes>
+                    <graph_prototypes>
+                        <graph_prototype>
+                            <uuid>b48cd483e77c4f03847bd1c212e316ca</uuid>
+                            <name>Interface {#IFNAME}({#IFALIAS}): Network traffic</name>
+                            <graph_items>
+                                <graph_item>
+                                    <drawtype>GRADIENT_LINE</drawtype>
+                                    <color>1A7C11</color>
+                                    <item>
+                                        <host>Aruba 1930 Switch SNMP</host>
+                                        <key>net.if.in[ifHCInOctets.{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>1</sortorder>
+                                    <drawtype>BOLD_LINE</drawtype>
+                                    <color>2774A4</color>
+                                    <item>
+                                        <host>Aruba 1930 Switch SNMP</host>
+                                        <key>net.if.out[ifHCOutOctets.{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>2</sortorder>
+                                    <color>F63100</color>
+                                    <yaxisside>RIGHT</yaxisside>
+                                    <item>
+                                        <host>Aruba 1930 Switch SNMP</host>
+                                        <key>net.if.out.errors[ifOutErrors.{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>3</sortorder>
+                                    <color>A54F10</color>
+                                    <yaxisside>RIGHT</yaxisside>
+                                    <item>
+                                        <host>Aruba 1930 Switch SNMP</host>
+                                        <key>net.if.in.errors[ifInErrors.{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>4</sortorder>
+                                    <color>FC6EA3</color>
+                                    <yaxisside>RIGHT</yaxisside>
+                                    <item>
+                                        <host>Aruba 1930 Switch SNMP</host>
+                                        <key>net.if.out.discards[ifOutDiscards.{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                                <graph_item>
+                                    <sortorder>5</sortorder>
+                                    <color>6C59DC</color>
+                                    <yaxisside>RIGHT</yaxisside>
+                                    <item>
+                                        <host>Aruba 1930 Switch SNMP</host>
+                                        <key>net.if.in.discards[ifInDiscards.{#SNMPINDEX}]</key>
+                                    </item>
+                                </graph_item>
+                            </graph_items>
+                        </graph_prototype>
+                    </graph_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>cd60ab8ac00541ecb0879fe44293e10e</uuid>
+                    <name>EtherLike-MIB Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SNMPVALUE},1.3.6.1.2.1.10.7.2.1.19,{#IFOPERSTATUS},1.3.6.1.2.1.2.2.1.8,{#IFALIAS},1.3.6.1.2.1.31.1.1.1.18,{#IFNAME},1.3.6.1.2.1.31.1.1.1.1,{#IFDESCR},1.3.6.1.2.1.2.2.1.2]</snmp_oid>
+                    <key>net.if.duplex.discovery</key>
+                    <delay>1h</delay>
+                    <filter>
+                        <evaltype>AND</evaltype>
+                        <conditions>
+                            <condition>
+                                <macro>{#IFOPERSTATUS}</macro>
+                                <value>1</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#SNMPVALUE}</macro>
+                                <value>(2|3)</value>
+                                <formulaid>B</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
+                    <description>Discovering interfaces from IF-MIB and EtherLike-MIB. Interfaces with up(1) Operational Status are discovered.</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>603a0d5b41874efda22a62b1ac058457</uuid>
+                            <name>Interface {#IFNAME}({#IFALIAS}): Duplex status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.10.7.2.1.19.{#SNMPINDEX}</snmp_oid>
+                            <key>net.if.duplex[dot3StatsDuplexStatus.{#SNMPINDEX}]</key>
+                            <history>7d</history>
+                            <description>MIB: EtherLike-MIB
+The current mode of operation of the MAC
+entity.  'unknown' indicates that the current
+duplex mode could not be determined.
+
+Management control of the duplex mode is
+accomplished through the MAU MIB.  When
+an interface does not support autonegotiation,
+or when autonegotiation is not enabled, the
+duplex mode is controlled using
+ifMauDefaultType.  When autonegotiation is
+supported and enabled, duplex mode is controlled
+using ifMauAutoNegAdvertisedBits.  In either
+case, the currently operating duplex mode is
+reflected both in this object and in ifMauType.
+
+Note that this object provides redundant
+information with ifMauType.  Normally, redundant
+objects are discouraged.  However, in this
+instance, it allows a management application to
+determine the duplex status of an interface
+without having to know every possible value of
+ifMauType.  This was felt to be sufficiently
+valuable to justify the redundancy.
+Reference: [IEEE 802.3 Std.], 30.3.1.1.32,aDuplexStatus.</description>
+                            <valuemap>
+                                <name>EtherLike-MIB::dot3StatsDuplexStatus</name>
+                            </valuemap>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>network</value>
+                                </tag>
+                                <tag>
+                                    <tag>description</tag>
+                                    <value>{#IFALIAS}</value>
+                                </tag>
+                                <tag>
+                                    <tag>interface</tag>
+                                    <value>{#IFNAME}</value>
+                                </tag>
+                            </tags>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>e07f535078ce4c4e8b1bc184430d3d88</uuid>
+                                    <expression>last(/Aruba 1930 Switch SNMP/net.if.duplex[dot3StatsDuplexStatus.{#SNMPINDEX}])=2</expression>
+                                    <name>Interface {#IFNAME}({#IFALIAS}): In half-duplex mode</name>
+                                    <priority>WARNING</priority>
+                                    <description>Please check autonegotiation settings and cabling</description>
+                                    <tags>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>performance</value>
+                                        </tag>
+                                    </tags>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                    <preprocessing>
+                        <step>
+                            <type>JAVASCRIPT</type>
+                            <parameters>
+                                <parameter>try {
+    var data = JSON.parse(value);
+}
+catch (error) {
+    throw 'Failed to parse JSON of EtherLike-MIB discovery.';
+}
+var fields = ['{#SNMPVALUE}','{#IFOPERSTATUS}','{#IFALIAS}','{#IFNAME}','{#IFDESCR}'];
+data.forEach(function (element) {
+    fields.forEach(function (field) {
+        element[field] = element[field] || '';
+    });
+});
+return JSON.stringify(data);</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>969c444a61b74aabacfde3f66cfd0528</uuid>
+                    <name>PSU Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#ENT_CLASS},1.3.6.1.4.1.11.2.14.11.1.2.6.1.2,{#ENT_DESCR},1.3.6.1.4.1.11.2.14.11.1.2.6.1.7,{#ENT_STATUS},1.3.6.1.4.1.11.2.14.11.1.2.6.1.4]</snmp_oid>
+                    <key>psu.discovery</key>
+                    <delay>1h</delay>
+                    <filter>
+                        <evaltype>AND</evaltype>
+                        <conditions>
+                            <condition>
+                                <macro>{#ENT_CLASS}</macro>
+                                <value>.+8.3.1$</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#ENT_STATUS}</macro>
+                                <value>(1|2|3|4)</value>
+                                <formulaid>B</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
+                    <description>Discovering all entities of hpicfSensorObjectId that ends with: 11.2.3.7.8.3.1 - power supplies and are present</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>3cde89e7d39941308d761f2f64b2fe3b</uuid>
+                            <name>{#ENT_DESCR}: Power supply status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.11.2.14.11.1.2.6.1.4.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.psu.status[hpicfSensorStatus.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <description>MIB: HP-ICF-CHASSIS
+Actual status indicated by the sensor: {#ENT_DESCR}</description>
+                            <valuemap>
+                                <name>HP-ICF-CHASSIS::hpicfSensorStatus</name>
+                            </valuemap>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>power</value>
+                                </tag>
+                            </tags>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>d59f83607f9a489b8130167bcfac5aeb</uuid>
+                                    <expression>count(/Aruba 1930 Switch SNMP/sensor.psu.status[hpicfSensorStatus.{#SNMPINDEX}],#1,&quot;eq&quot;,&quot;{$PSU_CRIT_STATUS:\&quot;bad\&quot;}&quot;)=1</expression>
+                                    <name>{#ENT_DESCR}: Power supply is in critical state</name>
+                                    <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
+                                    <priority>AVERAGE</priority>
+                                    <description>Please check the power supply unit for errors</description>
+                                    <tags>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>availability</value>
+                                        </tag>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>performance</value>
+                                        </tag>
+                                    </tags>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>4ae4fe87974444568f4e426364569edc</uuid>
+                                    <expression>count(/Aruba 1930 Switch SNMP/sensor.psu.status[hpicfSensorStatus.{#SNMPINDEX}],#1,&quot;eq&quot;,&quot;{$PSU_WARN_STATUS:\&quot;warning\&quot;}&quot;)=1</expression>
+                                    <name>{#ENT_DESCR}: Power supply is in warning state</name>
+                                    <opdata>Current state: {ITEM.LASTVALUE1}</opdata>
+                                    <priority>WARNING</priority>
+                                    <description>Please check the power supply unit for errors</description>
+                                    <dependencies>
+                                        <dependency>
+                                            <name>{#ENT_DESCR}: Power supply is in critical state</name>
+                                            <expression>count(/Aruba 1930 Switch SNMP/sensor.psu.status[hpicfSensorStatus.{#SNMPINDEX}],#1,&quot;eq&quot;,&quot;{$PSU_CRIT_STATUS:\&quot;bad\&quot;}&quot;)=1</expression>
+                                        </dependency>
+                                    </dependencies>
+                                    <tags>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>availability</value>
+                                        </tag>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>performance</value>
+                                        </tag>
+                                    </tags>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>a8d8f4dc440949e485f379285f0cffc0</uuid>
+                    <name>Temperature Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SENSOR_TYPE},1.3.6.1.2.1.99.1.1.1.1,{#SENSOR_INFO},1.3.6.1.2.1.47.1.1.1.1.2,{#SENSOR_PRECISION},1.3.6.1.2.1.99.1.1.1.3]</snmp_oid>
+                    <key>temp.precision0.discovery</key>
+                    <delay>1h</delay>
+                    <filter>
+                        <evaltype>AND</evaltype>
+                        <conditions>
+                            <condition>
+                                <macro>{#SENSOR_TYPE}</macro>
+                                <value>8</value>
+                                <formulaid>B</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#SENSOR_PRECISION}</macro>
+                                <value>0</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
+                    <description>ENTITY-SENSORS-MIB::EntitySensorDataType discovery with temperature filter</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>d3235679d1e74b69a060580b0d5db89f</uuid>
+                            <name>{#SENSOR_INFO}: Temperature</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.99.1.1.1.4.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.temp.value[entPhySensorValue.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <value_type>FLOAT</value_type>
+                            <units>°C</units>
+                            <description>MIB: ENTITY-SENSORS-MIB
+The most recent measurement obtained by the agent for this sensor.
+To correctly interpret the value of this object, the associated entPhySensorType,
+entPhySensorScale, and entPhySensorPrecision objects must also be examined.</description>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>temperature</value>
+                                </tag>
+                            </tags>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>71a576bb6f7744b3a7f8769d890bce00</uuid>
+                                    <expression>avg(/Aruba 1930 Switch SNMP/sensor.temp.value[entPhySensorValue.{#SNMPINDEX}],5m)&gt;{$TEMP_CRIT:&quot;&quot;}</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>max(/Aruba 1930 Switch SNMP/sensor.temp.value[entPhySensorValue.{#SNMPINDEX}],5m)&lt;{$TEMP_CRIT:&quot;&quot;}-3</recovery_expression>
+                                    <name>{#SENSOR_INFO}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:&quot;&quot;}</name>
+                                    <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
+                                    <priority>HIGH</priority>
+                                    <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
+                                    <tags>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>availability</value>
+                                        </tag>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>performance</value>
+                                        </tag>
+                                    </tags>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>b6d5187615ff471baf9551bb200eb198</uuid>
+                                    <expression>avg(/Aruba 1930 Switch SNMP/sensor.temp.value[entPhySensorValue.{#SNMPINDEX}],5m)&gt;{$TEMP_WARN:&quot;&quot;}</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>max(/Aruba 1930 Switch SNMP/sensor.temp.value[entPhySensorValue.{#SNMPINDEX}],5m)&lt;{$TEMP_WARN:&quot;&quot;}-3</recovery_expression>
+                                    <name>{#SENSOR_INFO}: Temperature is above warning threshold: &gt;{$TEMP_WARN:&quot;&quot;}</name>
+                                    <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
+                                    <priority>WARNING</priority>
+                                    <description>This trigger uses temperature sensor values as well as temperature sensor status if available</description>
+                                    <dependencies>
+                                        <dependency>
+                                            <name>{#SENSOR_INFO}: Temperature is above critical threshold: &gt;{$TEMP_CRIT:&quot;&quot;}</name>
+                                            <expression>avg(/Aruba 1930 Switch SNMP/sensor.temp.value[entPhySensorValue.{#SNMPINDEX}],5m)&gt;{$TEMP_CRIT:&quot;&quot;}</expression>
+                                            <recovery_expression>max(/Aruba 1930 Switch SNMP/sensor.temp.value[entPhySensorValue.{#SNMPINDEX}],5m)&lt;{$TEMP_CRIT:&quot;&quot;}-3</recovery_expression>
+                                        </dependency>
+                                    </dependencies>
+                                    <tags>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>availability</value>
+                                        </tag>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>performance</value>
+                                        </tag>
+                                    </tags>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>60bbe6c329e7408f8b0cb3397f06e049</uuid>
+                                    <expression>avg(/Aruba 1930 Switch SNMP/sensor.temp.value[entPhySensorValue.{#SNMPINDEX}],5m)&lt;{$TEMP_CRIT_LOW:&quot;&quot;}</expression>
+                                    <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+                                    <recovery_expression>min(/Aruba 1930 Switch SNMP/sensor.temp.value[entPhySensorValue.{#SNMPINDEX}],5m)&gt;{$TEMP_CRIT_LOW:&quot;&quot;}+3</recovery_expression>
+                                    <name>{#SENSOR_INFO}: Temperature is too low: &lt;{$TEMP_CRIT_LOW:&quot;&quot;}</name>
+                                    <opdata>Current value: {ITEM.LASTVALUE1}</opdata>
+                                    <priority>AVERAGE</priority>
+                                    <tags>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>availability</value>
+                                        </tag>
+                                        <tag>
+                                            <tag>scope</tag>
+                                            <value>performance</value>
+                                        </tag>
+                                    </tags>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>83c378e2f27c4b6bb5249baca280c37c</uuid>
+                    <name>Temp Status Discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#ENT_CLASS},1.3.6.1.4.1.11.2.14.11.1.2.6.1.2,{#ENT_DESCR},1.3.6.1.4.1.11.2.14.11.1.2.6.1.7,{#ENT_STATUS},1.3.6.1.4.1.11.2.14.11.1.2.6.1.4]</snmp_oid>
+                    <key>temp.status.discovery</key>
+                    <delay>1h</delay>
+                    <filter>
+                        <evaltype>AND</evaltype>
+                        <conditions>
+                            <condition>
+                                <macro>{#ENT_CLASS}</macro>
+                                <value>.+8.3.3$</value>
+                                <formulaid>A</formulaid>
+                            </condition>
+                            <condition>
+                                <macro>{#ENT_STATUS}</macro>
+                                <value>(1|2|3|4)</value>
+                                <formulaid>B</formulaid>
+                            </condition>
+                        </conditions>
+                    </filter>
+                    <description>Discovering all entities of hpicfSensorObjectId that ends with: 11.2.3.7.8.3.3 - over temp status and are present</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>25a36119aa1f4361bc7259b6d5d6bac4</uuid>
+                            <name>{#ENT_DESCR}: Temperature status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.4.1.11.2.14.11.1.2.6.1.4.{#SNMPINDEX}</snmp_oid>
+                            <key>sensor.temp.status[hpicfSensorStatus.{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>2w</history>
+                            <trends>0d</trends>
+                            <description>MIB: HP-ICF-CHASSIS
+Actual status indicated by the sensor: {#ENT_DESCR}</description>
+                            <valuemap>
+                                <name>HP-ICF-CHASSIS::hpicfSensorStatus</name>
+                            </valuemap>
+                            <tags>
+                                <tag>
+                                    <tag>component</tag>
+                                    <value>temperature</value>
+                                </tag>
+                            </tags>
+                        </item_prototype>
+                    </item_prototypes>
+                </discovery_rule>
+            </discovery_rules>
+            <tags>
+                <tag>
+                    <tag>class</tag>
+                    <value>network</value>
+                </tag>
+                <tag>
+                    <tag>target</tag>
+                    <value>hp</value>
+                </tag>
+                <tag>
+                    <tag>target</tag>
+                    <value>hp-enterprise</value>
+                </tag>
+            </tags>
+            <macros>
+                <macro>
+                    <macro>{$CPU.UTIL.CRIT}</macro>
+                    <value>90</value>
+                </macro>
+                <macro>
+                    <macro>{$FAN_CRIT_STATUS:&quot;bad&quot;}</macro>
+                    <value>2</value>
+                </macro>
+                <macro>
+                    <macro>{$FAN_WARN_STATUS:&quot;warning&quot;}</macro>
+                    <value>3</value>
+                </macro>
+                <macro>
+                    <macro>{$ICMP_LOSS_WARN}</macro>
+                    <value>20</value>
+                </macro>
+                <macro>
+                    <macro>{$ICMP_RESPONSE_TIME_WARN}</macro>
+                    <value>0.15</value>
+                </macro>
+                <macro>
+                    <macro>{$IF.ERRORS.WARN}</macro>
+                    <value>2</value>
+                </macro>
+                <macro>
+                    <macro>{$IF.UTIL.MAX}</macro>
+                    <value>90</value>
+                </macro>
+                <macro>
+                    <macro>{$IFCONTROL}</macro>
+                    <value>1</value>
+                </macro>
+                <macro>
+                    <macro>{$MEMORY.UTIL.MAX}</macro>
+                    <value>90</value>
+                </macro>
+                <macro>
+                    <macro>{$NET.IF.IFADMINSTATUS.MATCHES}</macro>
+                    <value>^.*</value>
+                    <description>Ignore notPresent(6)</description>
+                </macro>
+                <macro>
+                    <macro>{$NET.IF.IFADMINSTATUS.NOT_MATCHES}</macro>
+                    <value>^2$</value>
+                    <description>Ignore down(2) administrative status</description>
+                </macro>
+                <macro>
+                    <macro>{$NET.IF.IFALIAS.MATCHES}</macro>
+                    <value>.*</value>
+                </macro>
+                <macro>
+                    <macro>{$NET.IF.IFALIAS.NOT_MATCHES}</macro>
+                    <value>CHANGE_IF_NEEDED</value>
+                </macro>
+                <macro>
+                    <macro>{$NET.IF.IFDESCR.MATCHES}</macro>
+                    <value>.*</value>
+                </macro>
+                <macro>
+                    <macro>{$NET.IF.IFDESCR.NOT_MATCHES}</macro>
+                    <value>CHANGE_IF_NEEDED</value>
+                </macro>
+                <macro>
+                    <macro>{$NET.IF.IFNAME.MATCHES}</macro>
+                    <value>^.*$</value>
+                </macro>
+                <macro>
+                    <macro>{$NET.IF.IFNAME.NOT_MATCHES}</macro>
+                    <value>(^Software Loopback Interface|^NULL[0-9.]*$|^[Ll]o[0-9.]*$|^[Ss]ystem$|^Nu[0-9.]*$|^veth[0-9a-z]+$|docker[0-9]+|br-[a-z0-9]{12})</value>
+                    <description>Filter out loopbacks, nulls, docker veth links and docker0 bridge by default</description>
+                </macro>
+                <macro>
+                    <macro>{$NET.IF.IFOPERSTATUS.MATCHES}</macro>
+                    <value>^.*$</value>
+                </macro>
+                <macro>
+                    <macro>{$NET.IF.IFOPERSTATUS.NOT_MATCHES}</macro>
+                    <value>^6$</value>
+                    <description>Ignore notPresent(6)</description>
+                </macro>
+                <macro>
+                    <macro>{$NET.IF.IFTYPE.MATCHES}</macro>
+                    <value>.*</value>
+                </macro>
+                <macro>
+                    <macro>{$NET.IF.IFTYPE.NOT_MATCHES}</macro>
+                    <value>CHANGE_IF_NEEDED</value>
+                </macro>
+                <macro>
+                    <macro>{$PSU_CRIT_STATUS:&quot;bad&quot;}</macro>
+                    <value>2</value>
+                </macro>
+                <macro>
+                    <macro>{$PSU_WARN_STATUS:&quot;warning&quot;}</macro>
+                    <value>3</value>
+                </macro>
+                <macro>
+                    <macro>{$SNMP.TIMEOUT}</macro>
+                    <value>5m</value>
+                </macro>
+                <macro>
+                    <macro>{$TEMP_CRIT}</macro>
+                    <value>60</value>
+                </macro>
+                <macro>
+                    <macro>{$TEMP_CRIT_LOW}</macro>
+                    <value>5</value>
+                </macro>
+                <macro>
+                    <macro>{$TEMP_WARN}</macro>
+                    <value>50</value>
+                </macro>
+            </macros>
+            <dashboards>
+                <dashboard>
+                    <uuid>6c9034c2f9c14a469610f3c30713aa52</uuid>
+                    <name>Network interfaces</name>
+                    <pages>
+                        <page>
+                            <widgets>
+                                <widget>
+                                    <type>GRAPH_PROTOTYPE</type>
+                                    <width>24</width>
+                                    <height>5</height>
+                                    <fields>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>source_type</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>columns</name>
+                                            <value>1</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>rows</name>
+                                            <value>1</value>
+                                        </field>
+                                        <field>
+                                            <type>GRAPH_PROTOTYPE</type>
+                                            <name>graphid</name>
+                                            <value>
+                                                <host>Aruba 1930 Switch SNMP</host>
+                                                <name>Interface {#IFNAME}({#IFALIAS}): Network traffic</name>
+                                            </value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                            </widgets>
+                        </page>
+                    </pages>
+                </dashboard>
+            </dashboards>
+            <valuemaps>
+                <valuemap>
+                    <uuid>2bebea4d3486484383492cb97db23a66</uuid>
+                    <name>EtherLike-MIB::dot3StatsDuplexStatus</name>
+                    <mappings>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>unknown</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>halfDuplex</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>fullDuplex</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+                <valuemap>
+                    <uuid>26b1fb1229124da5831bcf2c0389d5a0</uuid>
+                    <name>HP-ICF-CHASSIS::hpicfSensorStatus</name>
+                    <mappings>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>unknown</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>bad</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>warning</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>4</value>
+                            <newvalue>good</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>5</value>
+                            <newvalue>notPresent</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+                <valuemap>
+                    <uuid>230db317826e4dcaa489dbce7f6ddfae</uuid>
+                    <name>IF-MIB::ifOperStatus</name>
+                    <mappings>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>up</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>down</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>4</value>
+                            <newvalue>unknown</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>5</value>
+                            <newvalue>dormant</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>6</value>
+                            <newvalue>notPresent</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>7</value>
+                            <newvalue>lowerLayerDown</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+                <valuemap>
+                    <uuid>fec08ae31d134630a4cea14889dba010</uuid>
+                    <name>IF-MIB::ifType</name>
+                    <mappings>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>other</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>regular1822</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>hdh1822</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>4</value>
+                            <newvalue>ddnX25</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>5</value>
+                            <newvalue>rfc877x25</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>6</value>
+                            <newvalue>ethernetCsmacd</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>7</value>
+                            <newvalue>iso88023Csmacd</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>8</value>
+                            <newvalue>iso88024TokenBus</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>9</value>
+                            <newvalue>iso88025TokenRing</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>10</value>
+                            <newvalue>iso88026Man</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>11</value>
+                            <newvalue>starLan</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>12</value>
+                            <newvalue>proteon10Mbit</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>13</value>
+                            <newvalue>proteon80Mbit</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>14</value>
+                            <newvalue>hyperchannel</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>15</value>
+                            <newvalue>fddi</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>16</value>
+                            <newvalue>lapb</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>17</value>
+                            <newvalue>sdlc</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>18</value>
+                            <newvalue>ds1</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>19</value>
+                            <newvalue>e1</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>20</value>
+                            <newvalue>basicISDN</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>21</value>
+                            <newvalue>primaryISDN</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>22</value>
+                            <newvalue>propPointToPointSerial</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>23</value>
+                            <newvalue>ppp</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>24</value>
+                            <newvalue>softwareLoopback</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>25</value>
+                            <newvalue>eon</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>26</value>
+                            <newvalue>ethernet3Mbit</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>27</value>
+                            <newvalue>nsip</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>28</value>
+                            <newvalue>slip</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>29</value>
+                            <newvalue>ultra</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>30</value>
+                            <newvalue>ds3</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>31</value>
+                            <newvalue>sip</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>32</value>
+                            <newvalue>frameRelay</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>33</value>
+                            <newvalue>rs232</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>34</value>
+                            <newvalue>para</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>35</value>
+                            <newvalue>arcnet</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>36</value>
+                            <newvalue>arcnetPlus</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>37</value>
+                            <newvalue>atm</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>38</value>
+                            <newvalue>miox25</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>39</value>
+                            <newvalue>sonet</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>40</value>
+                            <newvalue>x25ple</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>41</value>
+                            <newvalue>iso88022llc</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>42</value>
+                            <newvalue>localTalk</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>43</value>
+                            <newvalue>smdsDxi</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>44</value>
+                            <newvalue>frameRelayService</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>45</value>
+                            <newvalue>v35</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>46</value>
+                            <newvalue>hssi</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>47</value>
+                            <newvalue>hippi</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>48</value>
+                            <newvalue>modem</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>49</value>
+                            <newvalue>aal5</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>50</value>
+                            <newvalue>sonetPath</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>51</value>
+                            <newvalue>sonetVT</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>52</value>
+                            <newvalue>smdsIcip</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>53</value>
+                            <newvalue>propVirtual</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>54</value>
+                            <newvalue>propMultiplexor</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>55</value>
+                            <newvalue>ieee80212</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>56</value>
+                            <newvalue>fibreChannel</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>57</value>
+                            <newvalue>hippiInterface</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>58</value>
+                            <newvalue>frameRelayInterconnect</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>59</value>
+                            <newvalue>aflane8023</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>60</value>
+                            <newvalue>aflane8025</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>61</value>
+                            <newvalue>cctEmul</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>62</value>
+                            <newvalue>fastEther</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>63</value>
+                            <newvalue>isdn</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>64</value>
+                            <newvalue>v11</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>65</value>
+                            <newvalue>v36</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>66</value>
+                            <newvalue>g703at64k</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>67</value>
+                            <newvalue>g703at2mb</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>68</value>
+                            <newvalue>qllc</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>69</value>
+                            <newvalue>fastEtherFX</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>70</value>
+                            <newvalue>channel</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>71</value>
+                            <newvalue>ieee80211</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>72</value>
+                            <newvalue>ibm370parChan</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>73</value>
+                            <newvalue>escon</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>74</value>
+                            <newvalue>dlsw</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>75</value>
+                            <newvalue>isdns</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>76</value>
+                            <newvalue>isdnu</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>77</value>
+                            <newvalue>lapd</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>78</value>
+                            <newvalue>ipSwitch</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>79</value>
+                            <newvalue>rsrb</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>80</value>
+                            <newvalue>atmLogical</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>81</value>
+                            <newvalue>ds0</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>82</value>
+                            <newvalue>ds0Bundle</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>83</value>
+                            <newvalue>bsc</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>84</value>
+                            <newvalue>async</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>85</value>
+                            <newvalue>cnr</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>86</value>
+                            <newvalue>iso88025Dtr</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>87</value>
+                            <newvalue>eplrs</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>88</value>
+                            <newvalue>arap</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>89</value>
+                            <newvalue>propCnls</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>90</value>
+                            <newvalue>hostPad</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>91</value>
+                            <newvalue>termPad</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>92</value>
+                            <newvalue>frameRelayMPI</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>93</value>
+                            <newvalue>x213</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>94</value>
+                            <newvalue>adsl</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>95</value>
+                            <newvalue>radsl</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>96</value>
+                            <newvalue>sdsl</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>97</value>
+                            <newvalue>vdsl</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>98</value>
+                            <newvalue>iso88025CRFPInt</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>99</value>
+                            <newvalue>myrinet</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>100</value>
+                            <newvalue>voiceEM</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>101</value>
+                            <newvalue>voiceFXO</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>102</value>
+                            <newvalue>voiceFXS</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>103</value>
+                            <newvalue>voiceEncap</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>104</value>
+                            <newvalue>voiceOverIp</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>105</value>
+                            <newvalue>atmDxi</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>106</value>
+                            <newvalue>atmFuni</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>107</value>
+                            <newvalue>atmIma</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>108</value>
+                            <newvalue>pppMultilinkBundle</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>109</value>
+                            <newvalue>ipOverCdlc</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>110</value>
+                            <newvalue>ipOverClaw</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>111</value>
+                            <newvalue>stackToStack</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>112</value>
+                            <newvalue>virtualIpAddress</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>113</value>
+                            <newvalue>mpc</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>114</value>
+                            <newvalue>ipOverAtm</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>115</value>
+                            <newvalue>iso88025Fiber</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>116</value>
+                            <newvalue>tdlc</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>117</value>
+                            <newvalue>gigabitEthernet</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>118</value>
+                            <newvalue>hdlc</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>119</value>
+                            <newvalue>lapf</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>120</value>
+                            <newvalue>v37</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>121</value>
+                            <newvalue>x25mlp</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>122</value>
+                            <newvalue>x25huntGroup</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>123</value>
+                            <newvalue>trasnpHdlc</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>124</value>
+                            <newvalue>interleave</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>125</value>
+                            <newvalue>fast</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>126</value>
+                            <newvalue>ip</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>127</value>
+                            <newvalue>docsCableMaclayer</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>128</value>
+                            <newvalue>docsCableDownstream</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>129</value>
+                            <newvalue>docsCableUpstream</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>130</value>
+                            <newvalue>a12MppSwitch</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>131</value>
+                            <newvalue>tunnel</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>132</value>
+                            <newvalue>coffee</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>133</value>
+                            <newvalue>ces</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>134</value>
+                            <newvalue>atmSubInterface</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>135</value>
+                            <newvalue>l2vlan</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>136</value>
+                            <newvalue>l3ipvlan</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>137</value>
+                            <newvalue>l3ipxvlan</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>138</value>
+                            <newvalue>digitalPowerline</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>139</value>
+                            <newvalue>mediaMailOverIp</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>140</value>
+                            <newvalue>dtm</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>141</value>
+                            <newvalue>dcn</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>142</value>
+                            <newvalue>ipForward</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>143</value>
+                            <newvalue>msdsl</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>144</value>
+                            <newvalue>ieee1394</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>145</value>
+                            <newvalue>if-gsn</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>146</value>
+                            <newvalue>dvbRccMacLayer</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>147</value>
+                            <newvalue>dvbRccDownstream</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>148</value>
+                            <newvalue>dvbRccUpstream</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>149</value>
+                            <newvalue>atmVirtual</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>150</value>
+                            <newvalue>mplsTunnel</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>151</value>
+                            <newvalue>srp</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>152</value>
+                            <newvalue>voiceOverAtm</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>153</value>
+                            <newvalue>voiceOverFrameRelay</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>154</value>
+                            <newvalue>idsl</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>155</value>
+                            <newvalue>compositeLink</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>156</value>
+                            <newvalue>ss7SigLink</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>157</value>
+                            <newvalue>propWirelessP2P</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>158</value>
+                            <newvalue>frForward</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>159</value>
+                            <newvalue>rfc1483</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>160</value>
+                            <newvalue>usb</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>161</value>
+                            <newvalue>ieee8023adLag</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>162</value>
+                            <newvalue>bgppolicyaccounting</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>163</value>
+                            <newvalue>frf16MfrBundle</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>164</value>
+                            <newvalue>h323Gatekeeper</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>165</value>
+                            <newvalue>h323Proxy</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>166</value>
+                            <newvalue>mpls</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>167</value>
+                            <newvalue>mfSigLink</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>168</value>
+                            <newvalue>hdsl2</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>169</value>
+                            <newvalue>shdsl</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>170</value>
+                            <newvalue>ds1FDL</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>171</value>
+                            <newvalue>pos</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>172</value>
+                            <newvalue>dvbAsiIn</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>173</value>
+                            <newvalue>dvbAsiOut</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>174</value>
+                            <newvalue>plc</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>175</value>
+                            <newvalue>nfas</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>176</value>
+                            <newvalue>tr008</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>177</value>
+                            <newvalue>gr303RDT</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>178</value>
+                            <newvalue>gr303IDT</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>179</value>
+                            <newvalue>isup</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>180</value>
+                            <newvalue>propDocsWirelessMaclayer</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>181</value>
+                            <newvalue>propDocsWirelessDownstream</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>182</value>
+                            <newvalue>propDocsWirelessUpstream</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>183</value>
+                            <newvalue>hiperlan2</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>184</value>
+                            <newvalue>propBWAp2Mp</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>185</value>
+                            <newvalue>sonetOverheadChannel</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>186</value>
+                            <newvalue>digitalWrapperOverheadChannel</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>187</value>
+                            <newvalue>aal2</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>188</value>
+                            <newvalue>radioMAC</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>189</value>
+                            <newvalue>atmRadio</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>190</value>
+                            <newvalue>imt</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>191</value>
+                            <newvalue>mvl</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>192</value>
+                            <newvalue>reachDSL</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>193</value>
+                            <newvalue>frDlciEndPt</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>194</value>
+                            <newvalue>atmVciEndPt</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>195</value>
+                            <newvalue>opticalChannel</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>196</value>
+                            <newvalue>opticalTransport</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>197</value>
+                            <newvalue>propAtm</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>198</value>
+                            <newvalue>voiceOverCable</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>199</value>
+                            <newvalue>infiniband</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>200</value>
+                            <newvalue>teLink</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>201</value>
+                            <newvalue>q2931</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>202</value>
+                            <newvalue>virtualTg</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>203</value>
+                            <newvalue>sipTg</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>204</value>
+                            <newvalue>sipSig</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>205</value>
+                            <newvalue>docsCableUpstreamChannel</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>206</value>
+                            <newvalue>econet</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>207</value>
+                            <newvalue>pon155</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>208</value>
+                            <newvalue>pon622</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>209</value>
+                            <newvalue>bridge</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>210</value>
+                            <newvalue>linegroup</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>211</value>
+                            <newvalue>voiceEMFGD</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>212</value>
+                            <newvalue>voiceFGDEANA</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>213</value>
+                            <newvalue>voiceDID</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>214</value>
+                            <newvalue>mpegTransport</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>215</value>
+                            <newvalue>sixToFour</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>216</value>
+                            <newvalue>gtp</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>217</value>
+                            <newvalue>pdnEtherLoop1</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>218</value>
+                            <newvalue>pdnEtherLoop2</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>219</value>
+                            <newvalue>opticalChannelGroup</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>220</value>
+                            <newvalue>homepna</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>221</value>
+                            <newvalue>gfp</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>222</value>
+                            <newvalue>ciscoISLvlan</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>223</value>
+                            <newvalue>actelisMetaLOOP</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>224</value>
+                            <newvalue>fcipLink</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>225</value>
+                            <newvalue>rpr</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>226</value>
+                            <newvalue>qam</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>227</value>
+                            <newvalue>lmp</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>228</value>
+                            <newvalue>cblVectaStar</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>229</value>
+                            <newvalue>docsCableMCmtsDownstream</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>230</value>
+                            <newvalue>adsl2</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>231</value>
+                            <newvalue>macSecControlledIF</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>232</value>
+                            <newvalue>macSecUncontrolledIF</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>233</value>
+                            <newvalue>aviciOpticalEther</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>234</value>
+                            <newvalue>atmbond</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>235</value>
+                            <newvalue>voiceFGDOS</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>236</value>
+                            <newvalue>mocaVersion1</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>237</value>
+                            <newvalue>ieee80216WMAN</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>238</value>
+                            <newvalue>adsl2plus</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>239</value>
+                            <newvalue>dvbRcsMacLayer</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>240</value>
+                            <newvalue>dvbTdm</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>241</value>
+                            <newvalue>dvbRcsTdma</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>242</value>
+                            <newvalue>x86Laps</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>243</value>
+                            <newvalue>wwanPP</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>244</value>
+                            <newvalue>wwanPP2</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>245</value>
+                            <newvalue>voiceEBS</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>246</value>
+                            <newvalue>ifPwType</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>247</value>
+                            <newvalue>ilan</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>248</value>
+                            <newvalue>pip</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>249</value>
+                            <newvalue>aluELP</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>250</value>
+                            <newvalue>gpon</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>251</value>
+                            <newvalue>vdsl2</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>252</value>
+                            <newvalue>capwapDot11Profile</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>253</value>
+                            <newvalue>capwapDot11Bss</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>254</value>
+                            <newvalue>capwapWtpVirtualRadio</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>255</value>
+                            <newvalue>bits</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>256</value>
+                            <newvalue>docsCableUpstreamRfPort</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>257</value>
+                            <newvalue>cableDownstreamRfPort</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>258</value>
+                            <newvalue>vmwareVirtualNic</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>259</value>
+                            <newvalue>ieee802154</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>260</value>
+                            <newvalue>otnOdu</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>261</value>
+                            <newvalue>otnOtu</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>262</value>
+                            <newvalue>ifVfiType</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>263</value>
+                            <newvalue>g9981</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>264</value>
+                            <newvalue>g9982</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>265</value>
+                            <newvalue>g9983</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>266</value>
+                            <newvalue>aluEpon</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>267</value>
+                            <newvalue>aluEponOnu</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>268</value>
+                            <newvalue>aluEponPhysicalUni</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>269</value>
+                            <newvalue>aluEponLogicalLink</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>270</value>
+                            <newvalue>aluGponOnu</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>271</value>
+                            <newvalue>aluGponPhysicalUni</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>272</value>
+                            <newvalue>vmwareNicTeam</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>277</value>
+                            <newvalue>docsOfdmDownstream</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>278</value>
+                            <newvalue>docsOfdmaUpstream</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>279</value>
+                            <newvalue>gfast</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>280</value>
+                            <newvalue>sdci</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>281</value>
+                            <newvalue>xboxWireless</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>282</value>
+                            <newvalue>fastdsl</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>283</value>
+                            <newvalue>docsCableScte55d1FwdOob</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>284</value>
+                            <newvalue>docsCableScte55d1RetOob</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>285</value>
+                            <newvalue>docsCableScte55d2DsOob</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>286</value>
+                            <newvalue>docsCableScte55d2UsOob</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>287</value>
+                            <newvalue>docsCableNdf</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>288</value>
+                            <newvalue>docsCableNdr</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>289</value>
+                            <newvalue>ptm</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>290</value>
+                            <newvalue>ghn</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+                <valuemap>
+                    <uuid>2aab3a9eeb6e44bc9f609d7da0dc173e</uuid>
+                    <name>Service state</name>
+                    <mappings>
+                        <mapping>
+                            <value>0</value>
+                            <newvalue>Down</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>Up</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+                <valuemap>
+                    <uuid>6ed6db00ccbf4529b694228a91927d2f</uuid>
+                    <name>zabbix.host.available</name>
+                    <mappings>
+                        <mapping>
+                            <value>0</value>
+                            <newvalue>not available</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>available</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>unknown</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+            </valuemaps>
+        </template>
+    </templates>
+    <graphs>
+        <graph>
+            <uuid>a5f1b63228b544699fe2794b58135c1a</uuid>
+            <name>CPU utilization</name>
+            <ymin_type_1>FIXED</ymin_type_1>
+            <ymax_type_1>FIXED</ymax_type_1>
+            <graph_items>
+                <graph_item>
+                    <drawtype>GRADIENT_LINE</drawtype>
+                    <color>1A7C11</color>
+                    <item>
+                        <host>Aruba 1930 Switch SNMP</host>
+                        <key>system.cpu.util[hpSwitchCpuStat.0]</key>
+                    </item>
+                </graph_item>
+            </graph_items>
+        </graph>
+    </graphs>
+</zabbix_export>


### PR DESCRIPTION
Cloned from [HP Enterprise Switch SNMP] and then updated OID's for CPU Utilization and Firmware version to work with Aruba 1930 Instant On switches. 