### PR TITLE
Added the output source to the items monitored

### DIFF
--- a/Power_(UPS)/UPS_Templates/template_network_ups-three-phase_(generic)/6.0/template_network_ups-three-phase_(generic).yaml
+++ b/Power_(UPS)/UPS_Templates/template_network_ups-three-phase_(generic)/6.0/template_network_ups-three-phase_(generic).yaml
@@ -481,6 +481,26 @@ zabbix_export:
             -
               tag: Application
               value: Operational
+        -
+          uuid: 85d41ae965c747cc8ceacb36b621cd60
+          name: 'UPS Output Source'
+          type: SNMP_AGENT
+          snmp_oid: 'UPS-MIB::upsOutputSource.0'
+          key: upsOutputSource
+          delay: '60'
+          history: 7d
+          value_type: FLOAT
+          tags:
+            -
+              tag: Application
+              value: Operational
+          triggers:
+            -
+              uuid: e5b7ec0e7d074cf4bb596b9f1e168088
+              expression: 'last(/UPS TRIPH - diogont/upsOutputSource)<>3'
+              name: 'Output Not Normal'
+              priority: DISASTER
+              description: 'The source of output is not normal (3) instead it is on one of other(1), none(2), bypass(4), battery(5), booster(6), reducer(7) that are considered problems'
       valuemaps:
         -
           uuid: 8b454f5fe9b54ca2af30d586716fda9d


### PR DESCRIPTION
There's the snmp OID upsOutputSource that returns the current output source for an UPS system ([reference](https://www.circitor.fr/Mibs/Html/U/UPS-MIB.php#upsOutputSource)).
I added an item track this value and a trigger with the level disaster when the value is not 3 (normal)
Other values are other(1), none(2), normal(3), bypass(4), battery(5), booster(6), reducer(7)