### PR TITLE
Update template_akcp_sensorprobe.yaml

### DIFF
--- a/SCADA_IoT_Energy_Home_Automation_Industrial_monitoring/Monitoring_Equipment/template_akcp_sensorprobe/6.0/template_akcp_sensorprobe.yaml
+++ b/SCADA_IoT_Energy_Home_Automation_Industrial_monitoring/Monitoring_Equipment/template_akcp_sensorprobe/6.0/template_akcp_sensorprobe.yaml
@@ -65,15 +65,15 @@ zabbix_export:
           uuid: ac3f37d6b04e4d7280bf82734232667f
           name: humiditysensor
           type: SNMP_AGENT
-          snmp_oid: 'discovery[{#SNMPVALUE},SNMPv2-SMI::enterprises.3854.1.2.2.1.17.1.1]'
+          snmp_oid: 'discovery[{#SNMPVALUE},1.3.6.1.4.1.3854.1.2.2.1.17.1.1]'
           key: HumiDescr
           delay: '60'
           item_prototypes:
             -
               uuid: da97c298138b40d0a431f731232bab30
-              name: 'humiditysensor $1'
+              name: 'humiditysensor {#SNMPVALUE}'
               type: SNMP_AGENT
-              snmp_oid: 'SNMPv2-SMI::enterprises.3854.1.2.2.1.17.1.1.{#SNMPINDEX}'
+              snmp_oid: '1.3.6.1.4.1.3854.1.2.2.1.17.1.1.{#SNMPINDEX}'
               key: 'HumiDescr[{#SNMPVALUE}]'
               delay: '60'
               trends: '0'
@@ -84,9 +84,9 @@ zabbix_export:
                   value: humidity
             -
               uuid: 9a46cdee5939484cad29a684c6e9cd20
-              name: 'humidity $1'
+              name: 'humidity {#SNMPVALUE}'
               type: SNMP_AGENT
-              snmp_oid: 'SNMPv2-SMI::enterprises.3854.1.2.2.1.17.1.3.{#SNMPINDEX}'
+              snmp_oid: '1.3.6.1.4.1.3854.1.2.2.1.17.1.3.{#SNMPINDEX}'
               key: 'HumiValue[{#SNMPVALUE}]'
               delay: '60'
               units: '%'
@@ -120,15 +120,15 @@ zabbix_export:
           uuid: 0d295089fd4a4e8182f6ca812b144026
           name: temperaturesensor
           type: SNMP_AGENT
-          snmp_oid: 'discovery[{#SNMPVALUE},SNMPv2-SMI::enterprises.3854.1.2.2.1.16.1.1]'
+          snmp_oid: 'discovery[{#SNMPVALUE},1.3.6.1.4.1.3854.1.2.2.1.16.1.1]'
           key: TempDescr
           delay: '60'
           item_prototypes:
             -
               uuid: da90731caa94451bb7a8f21c16f4bf4f
-              name: 'temperaturesensor $1'
+              name: 'temperaturesensor {#SNMPVALUE}'
               type: SNMP_AGENT
-              snmp_oid: 'SNMPv2-SMI::enterprises.3854.1.2.2.1.16.1.1.{#SNMPINDEX}'
+              snmp_oid: '1.3.6.1.4.1.3854.1.2.2.1.16.1.1.{#SNMPINDEX}'
               key: 'TempDescr[{#SNMPVALUE}]'
               delay: '60'
               trends: '0'
@@ -139,9 +139,9 @@ zabbix_export:
                   value: temperature
             -
               uuid: 8ead179397cc4054918d57bbe7fc5e15
-              name: 'temperature $1'
+              name: 'temperature {#SNMPVALUE}'
               type: SNMP_AGENT
-              snmp_oid: 'SNMPv2-SMI::enterprises.3854.1.2.2.1.16.1.3.{#SNMPINDEX}'
+              snmp_oid: '1.3.6.1.4.1.3854.1.2.2.1.16.1.3.{#SNMPINDEX}'
               key: 'TempValue[{#SNMPVALUE}]'
               delay: '60'
               units: °C


### PR DESCRIPTION
changing deprecated $1 to direct variable access
changing OID SNMPv2-SMI::enterprises.
-> 1.3.6.1.4.1.