### PR TITLE
Fix grafana dashboard link in template_linux_grafana

### DIFF
--- a/Operating_Systems/Linux/template_linux_grafana/6.0/README.md
+++ b/Operating_Systems/Linux/template_linux_grafana/6.0/README.md
@@ -17,7 +17,7 @@ Please, if have any suggestions or problems, please contact me: https://github.c
 Grafana Dashboard:
 
 
-<https://grafana.com/dashboards/5363>
+<https://grafana.com/grafana/dashboards/5363>
 
 
 


### PR DESCRIPTION
They moved grafana dashboards into a "grafana" directory, so this fixes the dashboard link.