### PR TITLE
fix: correct icmp dependency for template_synology_diskstation_snmpv3 v 6.0

### DIFF
--- a/Storage_Devices/Synology/template_synology_diskstation_snmpv3/6.0/template_synology_diskstation_snmpv3.yaml
+++ b/Storage_Devices/Synology/template_synology_diskstation_snmpv3/6.0/template_synology_diskstation_snmpv3.yaml
@@ -12,7 +12,7 @@ zabbix_export:
       name: 'Synology DiskStation SNMPv3'
       templates:
         -
-          name: 'Template Module ICMP Ping'
+          name: 'ICMP Ping'
       groups:
         -
           name: Templates


### PR DESCRIPTION
# Problem

Importing the current version will cause an error and fail. This is due to Zabbix 6.0 not having a template 'Template Module ICMP Ping', which is listed as a dependency.

## Description 

The current [template_synology_diskstation_snmpv3](https://github.com/patrickstump/community-templates/tree/main/Storage_Devices/Synology/template_synology_diskstation_snmpv3) for version 6.0 has a dependency for the builtin zabbix template 'Template Module ICMP Ping'.  

This is incorrect.  'Template Module ICMP Ping' is the correct template name for 5.0 but not for 6.0.  For 6.0, the correct template name is [ICMP Ping](https://git.zabbix.com/projects/ZBX/repos/zabbix/browse/templates/module/icmp_ping/template_module_icmp_ping.yaml?at=refs%2Fheads%2Frelease%2F6.0).

## Fix

Changed the dependency name for zabbix 6.0 from 'Template Module ICMP Ping' to 'ICMP Ping'.
This merge corrects the reference for 6.0 only.

