### PR TITLE
Update template_fortigate_snmp_v2019.yaml

### DIFF
--- a/Network_Devices/Fortigate/template_fortigate_snmp_v2019/6.0/template_fortigate_snmp_v2019.yaml
+++ b/Network_Devices/Fortigate/template_fortigate_snmp_v2019/6.0/template_fortigate_snmp_v2019.yaml
@@ -218,7 +218,7 @@ zabbix_export:
           item_prototypes:
             -
               uuid: 6cf869c445ba43bf8a7d147595116202
-              name: 'Link Speed $1'
+              name: 'Link Speed {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '1.3.6.1.2.1.2.2.1.5.{#SNMPINDEX}'
               key: 'ifHighSpeed[{#SNMPVALUE}]'
@@ -231,7 +231,7 @@ zabbix_export:
                   value: 'Link 10/100/1000'
             -
               uuid: c3818df2354142aa816827c1343b9a83
-              name: 'Download $1'
+              name: 'Download {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '1.3.6.1.2.1.2.2.1.10.{#SNMPINDEX}'
               key: 'ifInOctets[{#SNMPVALUE}]'
@@ -252,7 +252,7 @@ zabbix_export:
                   value: 'Network Traffic'
             -
               uuid: 9252196234d24e4bb295c139b503ebb5
-              name: 'Upload $1'
+              name: 'Upload {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '1.3.6.1.2.1.2.2.1.16.{#SNMPINDEX}'
               key: 'ifOutOctets[{#SNMPVALUE}]'


### PR DESCRIPTION
Fix discovered item names as positional argument support was removed in zabbix 6.0