### PR TITLE
Update template_unifi_ap_snmpv3.yaml

### DIFF
--- a/Network_Devices/Ubiquiti/template_unifi_ap_snmpv3/6.0/template_unifi_ap_snmpv3.yaml
+++ b/Network_Devices/Ubiquiti/template_unifi_ap_snmpv3/6.0/template_unifi_ap_snmpv3.yaml
@@ -437,7 +437,7 @@ zabbix_export:
           item_prototypes:
             -
               uuid: d2279ac27bba4c2abbca52dc3218ca7d
-              name: 'WIFI Channel $2 on $1'
+              name: 'WIFI Channel {#UNIFIVAPESSID} on {#UNIVAPRADIO}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.41112.1.6.1.2.1.4.{#SNMPINDEX}'
               key: 'unifiVapChannel[{#UNIFIVAPESSID},{#UNIVAPRADIO}]'
@@ -448,7 +448,7 @@ zabbix_export:
                   value: 'Virtual Interfaces'
             -
               uuid: 8b2ff05b149b4dfda7c5587e3e4d8f6f
-              name: 'Users $2 on $1'
+              name: 'Users {#UNIFIVAPESSID} on {#UNIVAPRADIO}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.41112.1.6.1.2.1.8.{#SNMPINDEX}'
               key: 'unifiVapNumStations[{#UNIFIVAPESSID},{#UNIVAPRADIO}]'
@@ -461,7 +461,7 @@ zabbix_export:
                   value: 'Virtual Interfaces'
             -
               uuid: f40514a52c8a4c86bfb88d129700b246
-              name: 'Traffic Incoming $2 on $1'
+              name: 'Traffic Incoming {#UNIFIVAPESSID} on {#UNIVAPRADIO}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.41112.1.6.1.2.1.10.{#SNMPINDEX}'
               key: 'unifiVapRxBytes[{#UNIFIVAPESSID},{#UNIVAPRADIO}]'
@@ -479,7 +479,7 @@ zabbix_export:
                   value: 'Virtual Interfaces'
             -
               uuid: cd3b5e71497c41f895731179ae7ba59a
-              name: 'Traffic Incoming Errors per Second $2 on $1'
+              name: 'Traffic Incoming Errors per Second {#UNIFIVAPESSID} on {#UNIVAPRADIO}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.41112.1.6.1.2.1.13.{#SNMPINDEX}'
               key: 'unifiVapRxErrors[{#UNIFIVAPESSID},{#UNIVAPRADIO}]'
@@ -497,7 +497,7 @@ zabbix_export:
                   value: 'Virtual Interfaces'
             -
               uuid: 58ec96db72484ae2a7e596dcd644c1d5
-              name: 'Traffic Outgoing $2 on $1'
+              name: 'Traffic Outgoing {#UNIFIVAPESSID} on {#UNIVAPRADIO}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.41112.1.6.1.2.1.16.{#SNMPINDEX}'
               key: 'unifiVapTxBytes[{#UNIFIVAPESSID},{#UNIVAPRADIO}]'
@@ -515,7 +515,7 @@ zabbix_export:
                   value: 'Virtual Interfaces'
             -
               uuid: a9fc1cfe399e483eaa8305a56ad9b20a
-              name: 'Traffic Outgoing Errors per Second $2 on $1'
+              name: 'Traffic Outgoing Errors per Second {#UNIFIVAPESSID} on {#UNIVAPRADIO}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.41112.1.6.1.2.1.18.{#SNMPINDEX}'
               key: 'unifiVapTxErrors[{#UNIFIVAPESSID},{#UNIVAPRADIO}]'


### PR DESCRIPTION
Edited the discovery item names which where showing $2 on $1 instead of the variable:  was:
name: 'Traffic Incoming $2 on $1
which showed up on the items as 
Traffic Incoming $2 on $1

changing to:
name: 'Traffic Incoming {#UNIFIVAPESSID} on {#UNIVAPRADIO}' corrects the item labels and shows up with the correct SSID and radio in the item list