### PR TITLE
Add template for monitoring IPFire

### DIFF
--- a/Network_Appliances/template_ipfire/6.0/README.md
+++ b/Network_Appliances/template_ipfire/6.0/README.md
@@ -1,0 +1,76 @@
+# IPFire by Zabbix Agent Active
+
+## Description
+
+This template monitors an [IPFire](https://www.ipfire.org/) [appliance](https://www.lightningwirelabs.com/products/ipfire/appliances) or [instance](https://www.ipfire.org/download)
+
+## Overview
+
+For Zabbix version: 6.0
+
+Supports monitoring of:
+- IPFire general stats (Number of current DHCPd clients)
+- IPFire services (default IPFire services and possible Addon services)
+- Pakfire status (Installed version, Available update(s))
+- Network stats (Line quality, Open Connections, Firewall hits)
+- OpenVPN clients and stats (OpenVPN client discovery, OpenVPN client properties, Traffic stats)
+
+Use in conjunction with a default Template OS Linux-template for CPU/Memory/Storage monitoring of the IPFire appliance/instance.
+
+This template was created for:
+
+- IPFire 2.27 - Core update 179
+
+**Warning**: This template will *NOT* work on earlier versions of IPFire due to changes to the Zabbix Agent addon.
+
+## Author
+
+Robin Roevens
+
+## Setup
+
+- Install and configure [IPFire addon `zabbix_agentd`](https://wiki.ipfire.org/addons/zabbix_agentd) using Pakfire
+- Make sure the IPFire builtin specific userparameters are enabled in `/etc/zabbix_agentd/zabbix_agentd.conf` (which should be by default)
+- Copy `template_ipfire_services.conf` into the folder with Zabbix agent configuration (`/etc/zabbix_agentd/zabbix_agentd.d/` on IPFire)
+- Copy `ipfire_services.pl` into the folder with Zabbix agent scripts (`/etc/zabbix_agentd/scripts/` on IPFire) and make it executable for user `root`.
+- Unless you have your own custom sudoers config for zabbix; Copy `zabbix_agentd_user` into the folder with sudoers configuration (`/etc/sudoers.d`) to allow Zabbix agent to run `ipfire_services.pl` as root user.
+  Otherwise, make sure the contents of `zabbix_agentd_user` from this template are added to your custom `/etc/sudoers.d/zabbix_agentd_user` file.
+- Restart Zabbix agent.
+
+## Zabbix configuration
+
+No specific Zabbix configuration is required
+
+### Macros used
+|Name|Description|Default|
+|----|-----------|-------|
+|{$IPFIRE.CONN.MAX.WARN} |<p>Max percentage of max open connections used before triggering warning</p>|`95` |
+|{$IPFIRE.CONN.MAX.RESOLVE} |<p>Percentage of max open connections used before resolving trigger</p>|`85` |
+|{$IPFIRE.FW_CHAIN.MATCHES} |<p>Only discover firewall chains matching this regex</p>|`^.*$` |
+|{$IPFIRE.FW_CHAIN.NOT_MATCHES} |<p>Do not discover firewall chains matching this regex</p>|`CHANGE_IF_NEEDED` |
+|{$IPFIRE.SERVICE.TRIGGER} |<p>Whether Zabbix needs to trigger when an IPFire service is down. This variable can be used with context to exclude specific services.</p>|`1` |
+|{$IPFIRE.SERVICENAME.MATCHES} |<p>All services matching this regex will be discovered</p>|`^.*$` |
+|{$IPFIRE.SERVICENAME.NOT_MATCHES} |<p>Services matching this regex will not be discovered</p>|`CHANGE_IF_NEEDED` |
+|{$IPFIRE.OVPN.COMMONNAME.MATCHES} |<p>OpenVPN clients with common name matching this regex will be discovered</p>|`^.*$` |
+|{$IPFIRE.OVPN.COMMONNAME.NOTMATCHES} |<p>OpenVPN clients with common name matching this regex will not be discovered</p>|`CHANGE_IF_NEEDED` |
+|{$IPFIRE.OVPN.STATE.MATCHES} |<p>OpenVPN clients with a state (on/off) matching this regex will be discovered.</p>|`on` |
+
+#### Notes about $IPFIRE.SERVICE.TRIGGER
+This template does not 'detect' if you have manually disabled a service in IPFire, so by default it will alarm you when any service is down. This is done on purpose so that you will also be notified if a service is unintentionly disabled.
+
+To disable the trigger for a specific service (because it is disabled or you just don't want notifications about that service) add a host macro `{$IPFIRE.SERVICE.TRIGGER:"<service>"}` to the IPFire host and set it to `0`. 
+
+For example to disable the OpenVPN service trigger add `{$IPFIRE.SERVICE.TRIGGER:"openvpn"}` to the host. Check the discovered IPFire service item-keys for the correct service-name of each service.
+
+Or you could opt to use the variables `{$IPFIRE.SERVICENAME.MATCHES}` and/or `{$IPFIRE.SERVICENAME.NOT_MATCHES}` to filter out services
+you don't want to be monitored at all.
+
+## Credits
+
+[Alexander Koch](https://community.ipfire.org/t/looking-for-the-zabbix-agent-template/1459/2) for the app Pakfire template.
+
+[IPFire Team](https://www.ipfire.org) for the IPFire distro and for accepting my contributions to allow easier/better monitoring using Zabbix Agent.
+
+## Feedback
+
+Please report any issues with the template at https://github.com/RobinR1/zbx-template-ipfire/issues

--- a/Network_Appliances/template_ipfire/6.0/files/scripts/ipfire_services.pl
+++ b/Network_Appliances/template_ipfire/6.0/files/scripts/ipfire_services.pl
@@ -1,0 +1,232 @@
+#!/usr/bin/perl
+###############################################################################
+# ipfire_services.pl - Retrieves available IPFire services information and 
+#                      return this as a JSON array suitable for easy processing 
+#                      by Zabbix server
+#
+# Author: robin.roevens (at) disroot.org
+# Version: 2.0
+#
+# Based on: services.cgi by IPFire Team
+# Copyright (C) 2007-2021  IPFire Team  <info@ipfire.org> 
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License 
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# 
+###############################################################################
+
+use strict;
+
+# enable only the following on debugging purpose
+# use warnings;
+
+# Load pakfire "library"
+require "/opt/pakfire/lib/functions.pl";
+
+# Maps a nice printable name to the changing part of the pid file, which
+# is also the name of the program
+my %servicenames = (
+        'DHCP Server' => 'dhcpd',
+        'Web Server' => 'httpd',
+        'CRON Server' => 'fcron',
+        'DNS Proxy Server' => 'unbound',
+        'Logging Server' => 'syslogd',
+        'Kernel Logging Server' => 'klogd',
+        'NTP Server' => 'ntpd',
+        'Secure Shell Server' => 'sshd',
+        'VPN' => 'charon',
+        'Web Proxy' => 'squid',
+        'Intrusion Detection System' => 'suricata',
+        'OpenVPN' => 'openvpn'
+);
+
+# Hash to overwrite the process name of a process if it differs from the launch command.
+my %overwrite_exename_hash = (
+        "suricata" => "Suricata-Main"
+);
+
+my $first = 1;
+
+print "[";
+
+# Built-in services
+my $key = '';
+foreach $key (sort keys %servicenames){
+	print "," if not $first;
+	$first = 0;
+
+	print "{";
+	print "\"service\":\"$key\",";
+
+	my $shortname = $servicenames{$key};
+	print &servicestats($shortname);
+	
+	print "}";
+}
+
+# Generate list of installed addon pak's
+my %paklist = &Pakfire::dblist("installed");
+
+foreach my $pak (keys %paklist) {
+        my %metadata = &Pakfire::getmetadata($pak, "installed");
+                
+        # If addon contains services
+        if ("$metadata{'Services'}") {
+                foreach my $service (split(/ /, "$metadata{'Services'}")) {
+                        print ",";
+                        print "{";
+
+                        print "\"service\":\"Addon: $metadata{'Name'}\",";
+                        print "\"servicename\":\"$service\",";
+
+                        my $onboot = isautorun($service);
+                        print "\"onboot\":$onboot,";
+
+                        print &addonservicestats($service);
+
+                        print "}";
+                }
+	}
+}	
+
+print "]";
+
+sub servicestats {
+	my $cmd = $_[0];
+	my $status = "\"servicename\":\"$cmd\",\"state\":\"0\"";
+	my $pid = '';
+	my $testcmd = '';
+        my $exename;
+        my $memory;
+
+
+	$cmd =~ /(^[a-z]+)/;
+	
+	# Check if the exename needs to be overwritten.
+        # This happens if the expected process name string
+        # differs from the real one. This may happened if
+        # a service uses multiple processes or threads.
+        if (exists($overwrite_exename_hash{$cmd})) {
+                # Grab the string which will be reported by
+                # the process from the corresponding hash.
+                $exename = $overwrite_exename_hash{$1};
+        } else {
+                # Directly expect the launched command as
+                # process name.
+                $exename = $1;
+        }
+	
+	if (open(FILE, "/var/run/${cmd}.pid")){
+                $pid = <FILE>; chomp $pid;
+                close FILE;
+                if (open(FILE, "/proc/${pid}/status")){
+                        while (<FILE>){
+                                if (/^Name:\W+(.*)/) {
+                                        $testcmd = $1;
+                                }
+                        }
+                        close FILE;
+                }
+                if (open(FILE, "/proc/${pid}/status")) {
+                        while (<FILE>) {
+                                my ($key, $val) = split(":", $_, 2);
+                                if ($key eq 'VmRSS') {
+					$val =~ /\s*([0-9]*)\s+kB/;
+					# Convert kB to B
+                                        $memory = $1*1024;
+                                        last;
+                                }
+                        }
+                        close(FILE);
+                }
+                if ($testcmd =~ /$exename/){
+			$status = "\"servicename\":\"$cmd\",\"state\":1,\"pid\":$pid,\"memory\":$memory";
+		}
+        }
+        return $status;
+}
+
+sub isautorun {
+        my $cmd = $_[0];
+
+        # Init directory.
+	my $initdir = "/etc/rc.d/rc3.d/";
+
+        return &find_init("$cmd", "$initdir") ? 1 : 0;
+}
+
+sub find_init {
+	my ($cmd, $dir) = @_;
+
+	# Open given init directory.
+	opendir (INITDIR, "$dir") || die "Cannot opendir $dir: $!";
+
+	# Read-in init files from directory.
+	my @inits = readdir(INITDIR);
+
+	# Close directory handle.
+	closedir(INITDIR);
+
+	# Loop through the directory.
+	foreach my $init (@inits) {
+		# Check if the current processed file belongs to the given command.
+		if ($init =~ /S\d+\d+$cmd\z/) {
+			# Found, return "1" - True.
+			return "1";
+		}
+        }
+
+	# Nothing found, return nothing.
+	return;
+}
+
+sub addonservicestats {
+        my $cmd = $_[0];
+        my $status = "0";
+        my $pid = '';
+        my $testcmd = '';
+        my $exename;
+        my @memory = (0);
+
+        $testcmd = `/usr/local/bin/addonctrl $cmd status 2>/dev/null`;
+
+        if ( $testcmd =~ /is\ running/ && $testcmd !~ /is\ not\ running/){
+                $status = "\"state\":1";
+
+                $testcmd =~ s/.* //gi;
+                $testcmd =~ s/[a-z_]//gi;
+                $testcmd =~ s/\[[0-1]\;[0-9]+//gi;
+                $testcmd =~ s/[\(\)\.]//gi;
+                $testcmd =~ s/  //gi;
+                $testcmd =~ s///gi;
+
+                my @pid = split(/\s/,$testcmd);
+                $status .=",\"pid\":\"$pid[0]\"";
+
+                my $memory = 0;
+
+                foreach (@pid){
+                        chomp($_);
+                        if (open(FILE, "/proc/$_/statm")){
+                                my $temp = <FILE>;
+                                @memory = split(/ /,$temp);
+                        }
+                        $memory+=$memory[0];
+                }
+		$memory*=1024;
+                $status .=",\"memory\":$memory";
+        }else{
+                $status = "\"state\":0";
+        }
+        return $status;
+}

--- a/Network_Appliances/template_ipfire/6.0/files/sudoers.d/zabbix_agentd_user
+++ b/Network_Appliances/template_ipfire/6.0/files/sudoers.d/zabbix_agentd_user
@@ -1,0 +1,15 @@
+# Include file for sudoers file
+#
+# This is needed for some userparameters to be able to execute commands that only run as root (using sudo)
+# e.g. /usr/bin/openssl or /usr/sbin/smartctl
+#
+# USE AT YOU'RE OWN RISK. USING THIS WRONG CAN RESULT IN A SECURITY BREACH!
+#
+# Some hints:
+# - It is strongly recommended to edit this file only using the visudo -f <filename> command. If you mess up this file,
+#   you might end up locking yourself out of your system!
+# - Append the full path incl. parameters to each command, using "," as separator.
+# - Only add commands you really need. Zabbix should not have more rights than it has to.
+#
+
+zabbix ALL=(ALL) NOPASSWD: /etc/zabbix_agentd/scripts/ipfire_services.pl

--- a/Network_Appliances/template_ipfire/6.0/files/zabbix_agentd.d/template_ipfire_services.conf
+++ b/Network_Appliances/template_ipfire/6.0/files/zabbix_agentd.d/template_ipfire_services.conf
@@ -1,0 +1,2 @@
+### Parameter for monitoring IPFire services
+UserParameter=ipfire.services,sudo /etc/zabbix_agentd/scripts/ipfire_services.pl

--- a/Network_Appliances/template_ipfire/6.0/ipfire_by_zabbix_agent_active.yaml
+++ b/Network_Appliances/template_ipfire/6.0/ipfire_by_zabbix_agent_active.yaml
@@ -1,0 +1,1335 @@
+zabbix_export:
+  version: '6.0'
+  date: '2023-10-11T19:48:42Z'
+  groups:
+    - uuid: 6a9e41a5ef934d2196aca8b4abdafff5
+      name: 'OpenVPN Clients'
+    - uuid: a571c0d144b14fd4a87a9d9b2aa9fcd6
+      name: Templates/Applications
+    - uuid: 57b7ae836ca64446ba2c296389c009b7
+      name: Templates/Modules
+  templates:
+    - uuid: 80543e3dcb9641a8a5a33554ad6638a9
+      template: 'IPFire by Zabbix agent active'
+      name: 'IPFire by Zabbix agent active'
+      description: |
+        Monitor an IPFire appliance
+        
+        Requirements for template operation:
+        1.Install Zabbix agent addon using Pakfire
+        2.Copy zabbix_agentd_user sudoers-file into /etc/sudoers.d
+        3.Copy ipfire_services.pl into /etc/zabbix_agentd/scripts and make sure it is executable by the root user.
+        4.Copy template_ipfire_services.conf into /etc/zabbix_agentd/zabbix_agentd.d/. 
+        Don't forget to restart zabbix-agent.
+        
+        Created by Robin Roevens (robin.roevens (at) disroot.org)
+      groups:
+        - name: Templates/Applications
+      items:
+        - uuid: 9be0495e730a476fac68b91583bb4146
+          name: 'Captive Portal: # of active clients'
+          type: ZABBIX_ACTIVE
+          key: ipfire.captive.clients
+          history: 7d
+          description: 'Number of active users on captive portal'
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: captive-portal
+        - uuid: da3ef4de97f343d4a3d0d420e4e0df36
+          name: 'DHCP Server: # of active leases'
+          type: ZABBIX_ACTIVE
+          key: ipfire.dhcpd.clients
+          history: 7d
+          description: 'Number of active dhcpd leases'
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: dhcpd
+        - uuid: d7752458935c4e40adaacd4e1107f40e
+          name: 'Firewall hits: Get'
+          type: ZABBIX_ACTIVE
+          key: ipfire.net.fw.hits.raw
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          description: 'Raw data item for retrieving firewall hits on all forwarding chains'
+          tags:
+            - tag: component
+              value: firewall
+            - tag: component
+              value: network
+            - tag: component
+              value: raw
+        - uuid: 2e0173990de34061b2e743ef22518c6a
+          name: 'Network: Internet gateway available'
+          type: ZABBIX_ACTIVE
+          key: ipfire.net.gateway.ping
+          history: 7d
+          description: 'Checks if the internet gateway on RED is reachable'
+          tags:
+            - tag: component
+              value: gateway
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 750db20bec7c46e6ab9943e516f52947
+              expression: 'last(/IPFire by Zabbix agent active/ipfire.net.gateway.ping)<>1'
+              name: 'Internet Gateway is not reachable'
+              priority: HIGH
+              description: 'Internet Gateway on interface RED is unreachable. Internet connection is lost or intermittent.'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: f548b019c57a42cd8b6d4cf0a244f098
+          name: 'Network: Internet gateway ping timings'
+          type: ZABBIX_ACTIVE
+          key: ipfire.net.gateway.pingtime
+          history: 7d
+          value_type: FLOAT
+          units: ms
+          description: 'Checks the response time of the internet gateway on RED indicating Line Quality.'
+          tags:
+            - tag: component
+              value: gateway
+            - tag: component
+              value: network
+        - uuid: a01561b00aab4406a38e34440658848d
+          name: 'IPFire Services: Get'
+          type: ZABBIX_ACTIVE
+          key: ipfire.services
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          description: 'Get a list of IPFire service using agent script ipfire_services.pl'
+          tags:
+            - tag: component
+              value: raw
+            - tag: component
+              value: service
+        - uuid: 45efac8b0c984815b9cf5c2790373911
+          name: 'System: Core-Update available'
+          type: DEPENDENT
+          key: pakfire.core-update-available
+          delay: '0'
+          history: 7d
+          valuemap:
+            name: 'Boolean Yes/no'
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - 'Core-Update available: (.*)'
+                - \1
+              error_handler: DISCARD_VALUE
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Convert Bool String to Bool Integer
+                  switch(value) {
+                     case "yes":
+                        return 1;
+                     case "no":
+                        return 0;
+                     default:
+                        return 99;
+                  }
+            - type: IN_RANGE
+              parameters:
+                - '0'
+                - '1'
+              error_handler: CUSTOM_ERROR
+              error_handler_params: 'Unknown value received'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pakfire.status
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 10fdaa47927d4638b62ec43deff34360
+              expression: 'last(/IPFire by Zabbix agent active/pakfire.core-update-available)=1'
+              name: 'Pakfire: Core-Update available'
+              url: 'https://{HOST.CONN}:444/cgi-bin/pakfire.cgi'
+              priority: INFO
+              description: 'A Core-Update for IPFire is available. Go to the IPFire webgui > IPFire Pakfire to perform an update.'
+              tags:
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+            - uuid: 059cebb808634b35a3c2f2304e8cfaf5
+              expression: 'nodata(/IPFire by Zabbix agent active/pakfire.core-update-available,4h)=1'
+              name: 'Pakfire: Last Pakfire status update > 4h ago'
+              priority: WARNING
+              description: 'Zabbix was unable to retrieve Pakfire status for more than 4h. Check if Pakfire is still correctly working.'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 3c87cd1c09ec4fc2910c2572d9a4f5e9
+          name: 'System: Core-Update level'
+          type: DEPENDENT
+          key: pakfire.core-update-level
+          delay: '0'
+          history: 7d
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - 'Core-Update-Level: ([0-9]*)'
+                - \1
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: pakfire.status
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 315ab087e6b3408eb463eaecbab289f7
+              expression: 'change(/IPFire by Zabbix agent active/pakfire.core-update-level)>0'
+              name: 'Pakfire: Core-Update-Level has changed'
+              priority: INFO
+              manual_close: 'YES'
+              dependencies:
+                - name: 'Pakfire: Core-Version has changed'
+                  expression: '(last(/IPFire by Zabbix agent active/pakfire.core-version,#1)<>last(/IPFire by Zabbix agent active/pakfire.core-version,#2))=1'
+              tags:
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 96e3883bf9784f45b5ff7a9acaeeb5a9
+          name: 'System: Core version'
+          type: DEPENDENT
+          key: pakfire.core-version
+          delay: '0'
+          history: 7d
+          value_type: FLOAT
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - 'Core-Version: ([0-9.]*)'
+                - \1
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: pakfire.status
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 743e14e27c1141cdb08c895e768e9931
+              expression: '(last(/IPFire by Zabbix agent active/pakfire.core-version,#1)<>last(/IPFire by Zabbix agent active/pakfire.core-version,#2))=1'
+              name: 'Pakfire: Core-Version has changed'
+              priority: INFO
+              tags:
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 299ed0d3aa97435088fd805646ffe649
+          name: 'System: # of addon updates available'
+          type: DEPENDENT
+          key: pakfire.package-updates-available
+          delay: '0'
+          history: 7d
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - 'Package-Updates available: ([0-9]*)'
+                - \1
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pakfire.status
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 39bc50b094cf40ab86588b909eef2db7
+              expression: 'last(/IPFire by Zabbix agent active/pakfire.package-updates-available)>0'
+              name: 'Pakfire: Package-Updates available'
+              priority: INFO
+              tags:
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 8dbec81630674c7c89a74ba12cdae84b
+          name: 'System: Reboot required'
+          type: DEPENDENT
+          key: pakfire.reboot-required
+          delay: '0'
+          history: 7d
+          valuemap:
+            name: 'Boolean Yes/no'
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - 'Reboot required: (.*)'
+                - \1
+              error_handler: DISCARD_VALUE
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Convert Bool String to Bool Integer
+                  switch(value) {
+                     case "yes":
+                        return 1;
+                     case "no":
+                        return 0;
+                     default:
+                        return 99;
+                  }
+            - type: IN_RANGE
+              parameters:
+                - '0'
+                - '1'
+              error_handler: CUSTOM_ERROR
+              error_handler_params: 'Unknown value received'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pakfire.status
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 5bf0656d2f9f46258ee36ca10096a9bb
+              expression: 'last(/IPFire by Zabbix agent active/pakfire.reboot-required)=1'
+              name: 'Pakfire: Reboot required'
+              url: 'https://{HOST.CONN}:444/cgi-bin/shutdown.cgi'
+              priority: INFO
+              description: 'An update requires a reboot of IPFire to complete. Please reboot the host as soon as possible. Go to the IPFire webgui > System > Shutdown to perform a reboot.'
+              tags:
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 0593a390fa7f40e1b23c94fe845eff09
+          name: 'Pakfire Status: Get'
+          type: ZABBIX_ACTIVE
+          key: pakfire.status
+          delay: 10m
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: raw
+            - tag: component
+              value: system
+        - uuid: 7349c0e5921440f5bf1e8be3111acb7f
+          name: 'Network: # of open connections'
+          type: ZABBIX_ACTIVE
+          key: 'vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_count"]'
+          history: 7d
+          tags:
+            - tag: component
+              value: network
+        - uuid: aaa91f7fdd3949d0adf4a6f90e9ddc87
+          name: 'Network: Max # of open connections'
+          type: ZABBIX_ACTIVE
+          key: 'vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_max"]'
+          delay: 1h
+          history: 7d
+          tags:
+            - tag: component
+              value: network
+        - uuid: cdc1d6590ab044cc8e9684119238c1db
+          name: 'System: Last update'
+          type: ZABBIX_ACTIVE
+          key: 'vfs.file.time["/opt/pakfire/db/core/mine",modify]'
+          delay: 10m
+          history: 7d
+          units: unixtime
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+        - uuid: 8614cc5f14364b8d851631850a0d0ce9
+          name: 'Pakfire: Last core-list update'
+          type: ZABBIX_ACTIVE
+          key: 'vfs.file.time["/opt/pakfire/db/lists/core-list.db",modify]'
+          delay: 10m
+          history: 7d
+          units: unixtime
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          tags:
+            - tag: component
+              value: application
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: a490e3a3d0be4fd88f6890afc61e4826
+              expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/core-list.db",modify],49h)=0'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/core-list.db",modify],1h)=1'
+              name: 'Pakfire: Last core-list update > 49h ago'
+              priority: WARNING
+              description: 'Auslösung bei Delta > 49h / Recovery bei Delta < 1h'
+              dependencies:
+                - name: 'Pakfire: Last server-list update > 49h ago'
+                  expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify],49h)=0'
+                  recovery_expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify],1h)=1'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 72d6284952044ff58795e6076e6ad3c8
+          name: 'Pakfire: Last packages-list update'
+          type: ZABBIX_ACTIVE
+          key: 'vfs.file.time["/opt/pakfire/db/lists/packages_list.db",modify]'
+          delay: 10m
+          history: 7d
+          units: unixtime
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          tags:
+            - tag: component
+              value: application
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 9a7dfe94a226472bb36f9d1c4f5a86e6
+              expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/packages_list.db",modify],49h)=0'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/packages_list.db",modify],1h)=1'
+              name: 'Pakfire: Last packages-list update > 49h ago'
+              priority: WARNING
+              description: 'Auslösung bei Delta > 49h / Recovery bei Delta < 1h'
+              dependencies:
+                - name: 'Pakfire: Last server-list update > 49h ago'
+                  expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify],49h)=0'
+                  recovery_expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify],1h)=1'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 0dd0776c8b91489784d45bf06893d1c3
+          name: 'Pakfire: Last server-list update'
+          type: ZABBIX_ACTIVE
+          key: 'vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify]'
+          delay: 10m
+          history: 7d
+          units: unixtime
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          tags:
+            - tag: component
+              value: application
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: da2d132b5dd142a2a047413fc2ed3bc7
+              expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify],49h)=0'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify],1h)=1'
+              name: 'Pakfire: Last server-list update > 49h ago'
+              priority: WARNING
+              description: 'Auslösung bei Delta > 49h / Recovery bei Delta < 1h'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+      discovery_rules:
+        - uuid: 61c015898168475892226c0d1cc752d8
+          name: 'Firewall chains discovery'
+          type: DEPENDENT
+          key: ipfire.net.fw.hits.discovery
+          delay: '0'
+          filter:
+            conditions:
+              - macro: '{#FW_CHAIN}'
+                value: '{$IPFIRE.FW_CHAIN.MATCHES}'
+                formulaid: A
+              - macro: '{#FW_CHAIN}'
+                value: '{$IPFIRE.FW_CHAIN.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: B
+          description: 'Discovery of firewall chains in filter table to create "firewall hits" items/chain'
+          item_prototypes:
+            - uuid: e754323822f04c6b9e2e77bca43344fe
+              name: 'Firewall: Hits on chain {#FW_CHAIN}'
+              type: DEPENDENT
+              key: 'ipfire.net.fw.hits[{#FW_CHAIN}]'
+              delay: '0'
+              history: 7d
+              units: bps
+              description: 'Bytes dropped on firewall chain {#FW_CHAIN} of the Filter table'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$[?(@.chain=="{#FW_CHAIN}")].bytes.first()'
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              master_item:
+                key: ipfire.net.fw.hits.raw
+              tags:
+                - tag: component
+                  value: firewall
+                - tag: component
+                  value: network
+                - tag: component
+                  value: os
+                - tag: firewall-chain
+                  value: '{#FW_CHAIN}'
+          master_item:
+            key: ipfire.net.fw.hits.raw
+          lld_macro_paths:
+            - lld_macro: '{#FW_CHAIN}'
+              path: $.chain
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Filter out toggling part: bytes
+                  discovery_items = JSON.parse(value);
+                  discovery_items.map(function (item) { delete item['bytes']; });
+                  return JSON.stringify(discovery_items);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+        - uuid: 4255351b82de467ea643cb15b5f2297e
+          name: 'OpenVPN clients discovery'
+          type: ZABBIX_ACTIVE
+          key: ipfire.ovpn.clients.discovery
+          delay: 1h
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#COMMONNAME}'
+                value: '{$IPFIRE.OVPN.COMMONNAME.MATCHES}'
+                formulaid: A
+              - macro: '{#COMMONNAME}'
+                value: '{$IPFIRE.OVPN.COMMONNAME.NOTMATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: B
+              - macro: '{#STATE}'
+                value: '{$IPFIRE.OVPN.STATE.MATCHES}'
+                formulaid: C
+          description: 'Discovers configured OpenVPN clients'
+          host_prototypes:
+            - uuid: 37dc62b5f94c4979bfca33e8ab7ae7cb
+              host: '{#COMMONNAME}'
+              name: '{#NAME}'
+              group_links:
+                - group:
+                    name: 'OpenVPN Clients'
+              templates:
+                - name: 'IPFire OpenVPN Client by Zabbix agent'
+              macros:
+                - macro: '{$IPFIRE.OVPN.CLIENT.COMMONNAME}'
+                  value: '{#COMMONNAME}'
+                  description: 'OpenVPN client Common Name'
+                - macro: '{$IPFIRE.OVPN.CLIENT.NAME}'
+                  value: '{#NAME}'
+                  description: 'OpenVPN client Name'
+                - macro: '{$IPFIRE.OVPN.CLIENT.REMARK}'
+                  value: '{#REMARK}'
+                  description: 'OpenVPN client remark'
+                - macro: '{$IPFIRE.OVPN.CLIENT.STATE}'
+                  value: '{#STATE}'
+                  description: 'OpenVPN client state'
+                - macro: '{$IPFIRE.OVPN.CLIENT.TYPE}'
+                  value: '{#TYPE}'
+                  description: 'OpenVPN client type'
+              tags:
+                - tag: type
+                  value: '{#TYPE}'
+        - uuid: 0724a9154c924222a1495a4665929039
+          name: 'IPFire Services discovery'
+          type: DEPENDENT
+          key: ipfire.services.discovery
+          delay: '0'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#SERVICENAME}'
+                value: '{$IPFIRE.SERVICENAME.MATCHES}'
+                formulaid: A
+              - macro: '{#SERVICENAME}'
+                value: '{$IPFIRE.SERVICENAME.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: B
+          item_prototypes:
+            - uuid: bd1d7dfffc65492fb3eb7ade56c07bf8
+              name: 'OpenVPN: # clients connected'
+              type: DEPENDENT
+              key: 'ipfire.ovpn.clients.count[{#SINGLETON}]'
+              delay: '0'
+              description: 'Number of clients currently connected with OpenVPN'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.clients.length()
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: 'ipfire.ovpn.statusreport.get[{#SINGLETON}]'
+              tags:
+                - tag: component
+                  value: network
+                - tag: component
+                  value: service
+                - tag: service
+                  value: openvpn
+            - uuid: 17b4f2e8a9b944c7b09f81c6b6f8699b
+              name: 'OpenVPN: Statusreport: Get'
+              type: ZABBIX_ACTIVE
+              key: 'ipfire.ovpn.statusreport.get[{#SINGLETON}]'
+              history: '0'
+              trends: '0'
+              value_type: TEXT
+              description: 'Get OpenVPN status report containing list of connected clients and routing tables'
+              preprocessing:
+                - type: DISCARD_UNCHANGED
+                  parameters:
+                    - ''
+              tags:
+                - tag: component
+                  value: network
+                - tag: component
+                  value: raw
+                - tag: component
+                  value: service
+                - tag: service
+                  value: openvpn
+            - uuid: 9f207a283c4347569f02374f8e548b69
+              name: 'OpenVPN: Last status report update'
+              type: DEPENDENT
+              key: 'ipfire.ovpn.statusreport.timestamp[{#SINGLETON}]'
+              delay: '0'
+              history: 1d
+              units: unixtime
+              description: 'Timestamp of last OpenVPN server statusreport update'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.timestamp
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: 'ipfire.ovpn.statusreport.get[{#SINGLETON}]'
+              tags:
+                - tag: component
+                  value: network
+                - tag: component
+                  value: service
+                - tag: service
+                  value: openvpn
+            - uuid: 64ab99104e5c4a748745fbc1d02b1803
+              name: '{#SERVICE}: Memory usage'
+              type: DEPENDENT
+              key: 'ipfire.services.memory[{#SERVICENAME}]'
+              delay: '0'
+              history: 7d
+              units: b
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$[?(@.servicename == "{#SERVICENAME}")].memory.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: ipfire.services
+              tags:
+                - tag: component
+                  value: memory
+                - tag: component
+                  value: service
+                - tag: service
+                  value: '{#SERVICENAME}'
+            - uuid: 3d679fd91a334de1949e5cc5afdcc8a3
+              name: '{#SERVICE}: Start on boot'
+              type: DEPENDENT
+              key: 'ipfire.services.onboot[{#SERVICENAME}]'
+              delay: '0'
+              history: 7d
+              valuemap:
+                name: 'Boolean Yes/no'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$[?(@.servicename == "{#SERVICENAME}")].onboot.first()'
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '1'
+              master_item:
+                key: ipfire.services
+              tags:
+                - tag: component
+                  value: service
+                - tag: service
+                  value: '{#SERVICENAME}'
+            - uuid: 865fe738cfb34752b83605930b3cf180
+              name: '{#SERVICE}: Pid'
+              type: DEPENDENT
+              key: 'ipfire.services.pid[{#SERVICENAME}]'
+              delay: '0'
+              history: 7d
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$[?(@.servicename == "{#SERVICENAME}")].pid.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: ipfire.services
+              tags:
+                - tag: component
+                  value: os
+                - tag: component
+                  value: service
+                - tag: service
+                  value: '{#SERVICENAME}'
+            - uuid: 7fa6c6e4b6cf4a018ac3002122b0e0e5
+              name: '{#SERVICE}: State'
+              type: DEPENDENT
+              key: 'ipfire.services.state[{#SERVICENAME}]'
+              delay: '0'
+              history: 7d
+              valuemap:
+                name: 'Service state'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$[?(@.servicename == "{#SERVICENAME}")].state.first()'
+              master_item:
+                key: ipfire.services
+              tags:
+                - tag: component
+                  value: service
+                - tag: service
+                  value: '{#SERVICENAME}'
+              trigger_prototypes:
+                - uuid: 71d4baaa724140179fbde0bbdd170dfa
+                  expression: '{$IPFIRE.SERVICE.TRIGGER:"{#SERVICENAME}"} and last(/IPFire by Zabbix agent active/ipfire.services.state[{#SERVICENAME}])<>1'
+                  name: '{#SERVICE}: Service not running'
+                  priority: HIGH
+                  description: 'The IPFire service {#SERVICE} is not running. If this service is manually disabled, set host macro $IPFIRE.SERVICE.TRIGGER:"{#SERVICENAME}" to 0 to disable this trigger.'
+                  tags:
+                    - tag: scope
+                      value: availability
+          trigger_prototypes:
+            - uuid: adf12fb393704b90b3bd5541a447e2a1
+              expression: |
+                last(/IPFire by Zabbix agent active/ipfire.services.onboot[{#SERVICENAME}])=1 and 
+                (nodata(/IPFire by Zabbix agent active/ipfire.ovpn.statusreport.get[{#SINGLETON}],5m)=1 or
+                 time()-last(/IPFire by Zabbix agent active/ipfire.ovpn.statusreport.timestamp[{#SINGLETON}])>5m)
+              name: 'OpenVPN: Statusreport outdated'
+              priority: AVERAGE
+              description: |
+                Did not receive a recent OpenVPN status report. OpenVPN client data is probably outdated and/or inaccurate.
+                Check if Zabbix Agent is running and properly configured to send OpenVPN status reports (UserParameter: ipfire.ovpn.statusreport.get) and/or OpenVPN server configuration is the IPFire default.
+              dependencies:
+                - name: '{#SERVICE}: Service not running'
+                  expression: '{$IPFIRE.SERVICE.TRIGGER:"{#SERVICENAME}"} and last(/IPFire by Zabbix agent active/ipfire.services.state[{#SERVICENAME}])<>1'
+              tags:
+                - tag: scope
+                  value: availability
+          master_item:
+            key: ipfire.services
+          lld_macro_paths:
+            - lld_macro: '{#SERVICENAME}'
+              path: $.servicename
+            - lld_macro: '{#SERVICE}'
+              path: $.service
+            - lld_macro: '{#SINGLETON}'
+              path: $.singleton
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Filter out toggling parts: state, pid, memory, onboot & add singleton
+                  discovery_items = JSON.parse(value);
+                  discovery_items.map(function (item) { ['state','pid','memory', 'onboot'].forEach(function(key) { delete item[key] }); item['singleton'] = "" });
+                  return JSON.stringify(discovery_items);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          overrides:
+            - name: 'Don''t discover OpenVPN specific items/triggers on other services'
+              step: '1'
+              filter:
+                conditions:
+                  - macro: '{#SERVICENAME}'
+                    value: openvpn
+                    operator: NOT_MATCHES_REGEX
+                    formulaid: A
+              operations:
+                - operationobject: ITEM_PROTOTYPE
+                  operator: REGEXP
+                  value: '^OpenVPN: .*'
+                  discover: NO_DISCOVER
+                - operationobject: TRIGGER_PROTOTYPE
+                  operator: REGEXP
+                  value: '^OpenVPN: .*'
+                  discover: NO_DISCOVER
+      tags:
+        - tag: class
+          value: software
+        - tag: target
+          value: ipfire
+      macros:
+        - macro: '{$IPFIRE.CONN.MAX.RESOLVE}'
+          value: '85'
+          description: 'Percentage of max open connections used before resolving trigger'
+        - macro: '{$IPFIRE.CONN.MAX.WARN}'
+          value: '95'
+          description: 'Max percentage of max open connections used before triggering warning'
+        - macro: '{$IPFIRE.FW_CHAIN.MATCHES}'
+          value: '^.*$'
+          description: 'Only discover firewall chains matching this regex'
+        - macro: '{$IPFIRE.FW_CHAIN.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+          description: 'Do not discover firewall chains matching this regex'
+        - macro: '{$IPFIRE.OVPN.COMMONNAME.MATCHES}'
+          value: '^.*$'
+          description: 'OpenVPN clients with common name matching this regex will be discovered'
+        - macro: '{$IPFIRE.OVPN.COMMONNAME.NOTMATCHES}'
+          value: CHANGE_IF_NEEDED
+          description: 'OpenVPN clients with common name matching this regex will not be discovered'
+        - macro: '{$IPFIRE.OVPN.STATE.MATCHES}'
+          value: 'on'
+          description: 'OpenVPN clients with a state (on/off) matching this regex will be discovered.'
+        - macro: '{$IPFIRE.SERVICE.TRIGGER}'
+          value: '1'
+          description: 'Whether Zabbix needs to trigger when an IPFire service is down. This variable can be used with context to exclude specific services.'
+        - macro: '{$IPFIRE.SERVICENAME.MATCHES}'
+          value: '^.*$'
+          description: 'All services matching this regex will be discovered'
+        - macro: '{$IPFIRE.SERVICENAME.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+          description: 'Services matching this regex will not be discovered'
+      valuemaps:
+        - uuid: 57ac5ee3ecd34a36a30119db05e5a738
+          name: 'Boolean Yes/no'
+          mappings:
+            - value: '0'
+              newvalue: 'No'
+            - value: '1'
+              newvalue: 'Yes'
+        - uuid: 9f0de9d59823477b9e8788e0c4b100d2
+          name: 'OpenVPN Connection state'
+          mappings:
+            - value: '0'
+              newvalue: 'not connected'
+            - value: '1'
+              newvalue: connected
+        - uuid: 7517e6ba802e42abaf567ae383a32414
+          name: 'Service state'
+          mappings:
+            - value: '0'
+              newvalue: Down
+            - value: '1'
+              newvalue: Up
+    - uuid: 52850149b8ad443184ee95d3da3cd195
+      template: 'IPFire OpenVPN Client by Zabbix agent'
+      name: 'IPFire OpenVPN Client by Zabbix agent'
+      description: |
+        Monitor an IPFire OpenVPN client
+        
+        This template is applied to discovered OpenVPN client hosts by the template IPFire by Zabbix agent and is not meant to be applied manually to any hosts.
+      groups:
+        - name: Templates/Modules
+      items:
+        - uuid: bead53bd8f1f4382b4c36733db3ab0f3
+          name: 'OpenVPN: Client common name'
+          type: SCRIPT
+          key: ipfire.ovpn.client.commonname
+          history: 7d
+          trends: '0'
+          value_type: CHAR
+          params: 'return "{$IPFIRE.OVPN.CLIENT.COMMONNAME}";'
+          description: 'OpenVPN Client connection name as configured in IPFire WUI'
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: add7fbf01d384c0bab9ded620fa9f958
+          name: 'OpenVPN: Last connection duration'
+          type: CALCULATED
+          key: 'ipfire.ovpn.client.connection[{$IPFIRE.OVPN.CLIENT.COMMONNAME},duration]'
+          history: 7d
+          units: s
+          params: 'last(//ipfire.ovpn.routing_table[{$IPFIRE.OVPN.CLIENT.COMMONNAME},last_ref])-last(//ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},connected_since])'
+          description: 'Duration of current or last connection'
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 12b42114672c4f698fa3e9407d0f0346
+          name: 'OpenVPN: Client name'
+          type: SCRIPT
+          key: ipfire.ovpn.client.name
+          history: 7d
+          trends: '0'
+          value_type: CHAR
+          params: 'return "{$IPFIRE.OVPN.CLIENT.NAME}";'
+          description: 'OpenVPN Client name as configured in IPFire WUI'
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 7eeabe63f0ba4f3dbd32403ed37c5acb
+          name: 'OpenVPN: Client remark'
+          type: SCRIPT
+          key: ipfire.ovpn.client.remark
+          history: 7d
+          trends: '0'
+          value_type: TEXT
+          params: 'return "{$IPFIRE.OVPN.CLIENT.REMARK}";'
+          description: 'OpenVPN Client remark as configured in IPFire WUI'
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 108aef4c2b184624a00961f5b64500c4
+          name: 'OpenVPN: Client access status'
+          type: SCRIPT
+          key: ipfire.ovpn.client.state
+          history: 7d
+          params: 'return "{$IPFIRE.OVPN.CLIENT.STATE}";'
+          description: 'Whether the client is enabled to access the IPFire OpenVPN server.'
+          preprocessing:
+            - type: STR_REPLACE
+              parameters:
+                - 'off'
+                - '0'
+            - type: STR_REPLACE
+              parameters:
+                - 'on'
+                - '1'
+            - type: IN_RANGE
+              parameters:
+                - '0'
+                - '1'
+              error_handler: CUSTOM_ERROR
+              error_handler_params: 'Unknown client state'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 08411efa83e3490da6858c96fe8e406f
+          name: 'OpenVPN: Client type'
+          type: SCRIPT
+          key: ipfire.ovpn.client.type
+          history: 7d
+          trends: '0'
+          value_type: CHAR
+          params: 'return "{$IPFIRE.OVPN.CLIENT.TYPE}";'
+          description: 'OpenVPN Client type'
+          valuemap:
+            name: 'OpenVPN Client type'
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 713f21c4059a452d8aa6746dbb4c024d
+          name: 'OpenVPN: Bytes received'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},bytes_in]'
+          delay: '0'
+          history: 7d
+          units: b
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].bytes_in.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 57993d21e1d04b319b4adc5f70385a30
+          name: 'OpenVPN: Bytes received total'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},bytes_in_total]'
+          delay: '0'
+          history: 7d
+          units: b
+          description: 'Total amount of bytes received during current/last connection'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].bytes_in.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 130de3a8a8bf4e4987ac563eabb88602
+          name: 'OpenVPN: Bytes sent'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},bytes_out]'
+          delay: '0'
+          history: 7d
+          units: b
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].bytes_out.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 81bdb6e42bdd46a58308531d0cffac32
+          name: 'OpenVPN: Bytes sent total'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},bytes_out_total]'
+          delay: '0'
+          history: 7d
+          units: b
+          description: 'Total amount of bytes sent during current/last connection'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].bytes_out.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: e035d6315a7e4403a25185d17bbe6489
+          name: 'OpenVPN: Connection state'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},connected]'
+          delay: '0'
+          history: 7d
+          description: 'Whether the client is currently connected'
+          valuemap:
+            name: 'OpenVPN Connection state'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].length()'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 8b0ba4b88ae549a0a4a2346e1cf40133
+          name: 'OpenVPN: Last connection time'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},connected_since]'
+          delay: '0'
+          history: 7d
+          units: unixtime
+          description: 'Timestamp of last client connection initiation'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].connected_since.first()'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: fd22e3d29b4c4c358c77d100cd412990
+          name: 'OpenVPN: Remote IP Address'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},real_address]'
+          delay: '0'
+          history: 7d
+          trends: '0'
+          value_type: CHAR
+          description: 'Real IP address of client'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].real_address.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0.0.0.0:0'
+            - type: REGEX
+              parameters:
+                - '^(\d+\.\d+\.\d+\.\d+):\d+$'
+                - \1
+            - type: STR_REPLACE
+              parameters:
+                - 0.0.0.0
+                - ''
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 175a8220c2e04e42884e1a5b67de263f
+          name: 'OpenVPN: Last activity'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.routing_table[{$IPFIRE.OVPN.CLIENT.COMMONNAME},last_ref]'
+          delay: '0'
+          history: 7d
+          units: unixtime
+          description: 'Timestamp of last client network activity'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.routing_table[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].last_ref.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: c1c65e8f92b84008a69eb40db7907d61
+          name: 'OpenVPN: VPN IP Address'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.routing_table[{$IPFIRE.OVPN.CLIENT.COMMONNAME},virtual_address]'
+          delay: '0'
+          history: 7d
+          trends: '0'
+          value_type: CHAR
+          description: 'Virtual IP address of client'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.routing_table[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].virtual_address.first()'
+              error_handler: CUSTOM_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 5c6b95eedb1a47d99dfba1bb092d56bf
+          name: 'OpenVPN statusreport: Get'
+          key: ipfire.ovpn.statusreport.get
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          description: 'Get OpenVPN status report containing list of connected clients and routing tables'
+          preprocessing:
+            - type: DISCARD_UNCHANGED
+              parameters:
+                - ''
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: raw
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+      tags:
+        - tag: class
+          value: device
+        - tag: target
+          value: ipfire
+        - tag: target
+          value: openvpn-client
+      macros:
+        - macro: '{$IPFIRE.OVPN.CLIENT.COMMONNAME}'
+          value: FILLED_IN_BY_HOST_DISCOVERY
+          description: 'OpenVPN client Common Name'
+        - macro: '{$IPFIRE.OVPN.CLIENT.NAME}'
+          value: FILLED_IN_BY_HOST_DISCOVERY
+          description: 'OpenVPN client Name'
+        - macro: '{$IPFIRE.OVPN.CLIENT.REMARK}'
+          value: FILLED_IN_BY_HOST_DISCOVERY
+          description: 'OpenVPN client remark'
+        - macro: '{$IPFIRE.OVPN.CLIENT.STATE}'
+          value: FILLED_IN_BY_HOST_DISCOVERY
+          description: 'OpenVPN client state'
+        - macro: '{$IPFIRE.OVPN.CLIENT.TYPE}'
+          value: FILLED_IN_BY_HOST_DISCOVERY
+          description: 'OpenVPN client type'
+      valuemaps:
+        - uuid: 87dfebb2a9784886b12efe44d8044ee3
+          name: 'OpenVPN Client access status'
+          mappings:
+            - value: '0'
+              newvalue: disabled
+            - value: '1'
+              newvalue: enabled
+        - uuid: 142e2748979147cb8b8f887825575a72
+          name: 'OpenVPN Client type'
+          mappings:
+            - value: host
+              newvalue: Roadwarior
+            - type: REGEXP
+              value: '^net.*'
+              newvalue: 'Remote network'
+        - uuid: 486bcaed8ba049c7b9b7c811482b6ad8
+          name: 'OpenVPN Connection state'
+          mappings:
+            - value: '0'
+              newvalue: 'not connected'
+            - value: '1'
+              newvalue: connected
+  triggers:
+    - uuid: ed954859a31b4e658e1c1ac42545a6f6
+      expression: 'last(/IPFire by Zabbix agent active/vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_count"])/last(/IPFire by Zabbix agent active/vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_max"])*100>{$IPFIRE.CONN.MAX.WARN}'
+      recovery_mode: RECOVERY_EXPRESSION
+      recovery_expression: 'last(/IPFire by Zabbix agent active/vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_count"])/last(/IPFire by Zabbix agent active/vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_max"])*100<={$IPFIRE.CONN.MAX.RESOLVE}'
+      name: 'Number of open connection is too high (> 90% of max open connections)'
+      opdata: 'Open connections: {ITEM.LASTVALUE1}, Max open connections: {ITEM.LASTVALUE2}'
+      priority: WARNING
+      description: |
+        The current number of open connections is at {$IPFIRE.CONN.MAX}% of the max allowed number of open connections. When the max allowed number of open connections is reached, new connections will be dropped. 
+        Consider increasing the net.netfilter.nf_conntrack_max system variable.
+      tags:
+        - tag: scope
+          value: availability
+        - tag: scope
+          value: capacity
+  graphs:
+    - uuid: f9acf1d3482f4af3b619a649eb81b844
+      name: 'Line Quality'
+      graph_items:
+        - sortorder: '1'
+          drawtype: GRADIENT_LINE
+          color: 1A7C11
+          item:
+            host: 'IPFire by Zabbix agent active'
+            key: ipfire.net.gateway.pingtime
+    - uuid: f4bf7726c930427aa2a99bad42d7fa7f
+      name: 'Open Connections'
+      graph_items:
+        - sortorder: '1'
+          color: FF0000
+          item:
+            host: 'IPFire by Zabbix agent active'
+            key: 'vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_count"]'

--- a/Network_Appliances/template_ipfire/6.4/README.md
+++ b/Network_Appliances/template_ipfire/6.4/README.md
@@ -1,0 +1,76 @@
+# IPFire by Zabbix Agent Active
+
+## Description
+
+This template monitors an [IPFire](https://www.ipfire.org/) [appliance](https://www.lightningwirelabs.com/products/ipfire/appliances) or [instance](https://www.ipfire.org/download)
+
+## Overview
+
+For Zabbix version: 6.4
+
+Supports monitoring of:
+- IPFire general stats (Number of current DHCPd clients)
+- IPFire services (default IPFire services and possible Addon services)
+- Pakfire status (Installed version, Available update(s))
+- Network stats (Line quality, Open Connections, Firewall hits)
+- OpenVPN clients and stats (OpenVPN client discovery, OpenVPN client properties, Traffic stats)
+
+Use in conjunction with a default Template OS Linux-template for CPU/Memory/Storage monitoring of the IPFire appliance/instance.
+
+This template was created for:
+
+- IPFire 2.27 - Core update 179
+
+**Warning**: This template will *NOT* work on earlier versions of IPFire due to changes to the Zabbix Agent addon.
+
+## Author
+
+Robin Roevens
+
+## Setup
+
+- Install and configure [IPFire addon `zabbix_agentd`](https://wiki.ipfire.org/addons/zabbix_agentd) using Pakfire
+- Make sure the IPFire builtin specific userparameters are enabled in `/etc/zabbix_agentd/zabbix_agentd.conf` (which should be by default)
+- Copy `template_ipfire_services.conf` into the folder with Zabbix agent configuration (`/etc/zabbix_agentd/zabbix_agentd.d/` on IPFire)
+- Copy `ipfire_services.pl` into the folder with Zabbix agent scripts (`/etc/zabbix_agentd/scripts/` on IPFire) and make it executable for user `root`.
+- Unless you have your own custom sudoers config for zabbix; Copy `zabbix_agentd_user` into the folder with sudoers configuration (`/etc/sudoers.d`) to allow Zabbix agent to run `ipfire_services.pl` as root user.
+  Otherwise, make sure the contents of `zabbix_agentd_user` from this template are added to your custom `/etc/sudoers.d/zabbix_agentd_user` file.
+- Restart Zabbix agent.
+
+## Zabbix configuration
+
+No specific Zabbix configuration is required
+
+### Macros used
+|Name|Description|Default|
+|----|-----------|-------|
+|{$IPFIRE.CONN.MAX.WARN} |<p>Max percentage of max open connections used before triggering warning</p>|`95` |
+|{$IPFIRE.CONN.MAX.RESOLVE} |<p>Percentage of max open connections used before resolving trigger</p>|`85` |
+|{$IPFIRE.FW_CHAIN.MATCHES} |<p>Only discover firewall chains matching this regex</p>|`^.*$` |
+|{$IPFIRE.FW_CHAIN.NOT_MATCHES} |<p>Do not discover firewall chains matching this regex</p>|`CHANGE_IF_NEEDED` |
+|{$IPFIRE.SERVICE.TRIGGER} |<p>Whether Zabbix needs to trigger when an IPFire service is down. This variable can be used with context to exclude specific services.</p>|`1` |
+|{$IPFIRE.SERVICENAME.MATCHES} |<p>All services matching this regex will be discovered</p>|`^.*$` |
+|{$IPFIRE.SERVICENAME.NOT_MATCHES} |<p>Services matching this regex will not be discovered</p>|`CHANGE_IF_NEEDED` |
+|{$IPFIRE.OVPN.COMMONNAME.MATCHES} |<p>OpenVPN clients with common name matching this regex will be discovered</p>|`^.*$` |
+|{$IPFIRE.OVPN.COMMONNAME.NOTMATCHES} |<p>OpenVPN clients with common name matching this regex will not be discovered</p>|`CHANGE_IF_NEEDED` |
+|{$IPFIRE.OVPN.STATE.MATCHES} |<p>OpenVPN clients with a state (on/off) matching this regex will be discovered.</p>|`on` |
+
+#### Notes about $IPFIRE.SERVICE.TRIGGER
+This template does not 'detect' if you have manually disabled a service in IPFire, so by default it will alarm you when any service is down. This is done on purpose so that you will also be notified if a service is unintentionly disabled.
+
+To disable the trigger for a specific service (because it is disabled or you just don't want notifications about that service) add a host macro `{$IPFIRE.SERVICE.TRIGGER:"<service>"}` to the IPFire host and set it to `0`. 
+
+For example to disable the OpenVPN service trigger add `{$IPFIRE.SERVICE.TRIGGER:"openvpn"}` to the host. Check the discovered IPFire service item-keys for the correct service-name of each service.
+
+Or you could opt to use the variables `{$IPFIRE.SERVICENAME.MATCHES}` and/or `{$IPFIRE.SERVICENAME.NOT_MATCHES}` to filter out services
+you don't want to be monitored at all.
+
+## Credits
+
+[Alexander Koch](https://community.ipfire.org/t/looking-for-the-zabbix-agent-template/1459/2) for the app Pakfire template.
+
+[IPFire Team](https://www.ipfire.org) for the IPFire distro and for accepting my contributions to allow easier/better monitoring using Zabbix Agent.
+
+## Feedback
+
+Please report any issues with the template at https://github.com/RobinR1/zbx-template-ipfire/issues

--- a/Network_Appliances/template_ipfire/6.4/files/scripts/ipfire_services.pl
+++ b/Network_Appliances/template_ipfire/6.4/files/scripts/ipfire_services.pl
@@ -1,0 +1,232 @@
+#!/usr/bin/perl
+###############################################################################
+# ipfire_services.pl - Retrieves available IPFire services information and 
+#                      return this as a JSON array suitable for easy processing 
+#                      by Zabbix server
+#
+# Author: robin.roevens (at) disroot.org
+# Version: 2.0
+#
+# Based on: services.cgi by IPFire Team
+# Copyright (C) 2007-2021  IPFire Team  <info@ipfire.org> 
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the 
+# GNU General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License 
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# 
+###############################################################################
+
+use strict;
+
+# enable only the following on debugging purpose
+# use warnings;
+
+# Load pakfire "library"
+require "/opt/pakfire/lib/functions.pl";
+
+# Maps a nice printable name to the changing part of the pid file, which
+# is also the name of the program
+my %servicenames = (
+        'DHCP Server' => 'dhcpd',
+        'Web Server' => 'httpd',
+        'CRON Server' => 'fcron',
+        'DNS Proxy Server' => 'unbound',
+        'Logging Server' => 'syslogd',
+        'Kernel Logging Server' => 'klogd',
+        'NTP Server' => 'ntpd',
+        'Secure Shell Server' => 'sshd',
+        'VPN' => 'charon',
+        'Web Proxy' => 'squid',
+        'Intrusion Detection System' => 'suricata',
+        'OpenVPN' => 'openvpn'
+);
+
+# Hash to overwrite the process name of a process if it differs from the launch command.
+my %overwrite_exename_hash = (
+        "suricata" => "Suricata-Main"
+);
+
+my $first = 1;
+
+print "[";
+
+# Built-in services
+my $key = '';
+foreach $key (sort keys %servicenames){
+	print "," if not $first;
+	$first = 0;
+
+	print "{";
+	print "\"service\":\"$key\",";
+
+	my $shortname = $servicenames{$key};
+	print &servicestats($shortname);
+	
+	print "}";
+}
+
+# Generate list of installed addon pak's
+my %paklist = &Pakfire::dblist("installed");
+
+foreach my $pak (keys %paklist) {
+        my %metadata = &Pakfire::getmetadata($pak, "installed");
+                
+        # If addon contains services
+        if ("$metadata{'Services'}") {
+                foreach my $service (split(/ /, "$metadata{'Services'}")) {
+                        print ",";
+                        print "{";
+
+                        print "\"service\":\"Addon: $metadata{'Name'}\",";
+                        print "\"servicename\":\"$service\",";
+
+                        my $onboot = isautorun($service);
+                        print "\"onboot\":$onboot,";
+
+                        print &addonservicestats($service);
+
+                        print "}";
+                }
+	}
+}	
+
+print "]";
+
+sub servicestats {
+	my $cmd = $_[0];
+	my $status = "\"servicename\":\"$cmd\",\"state\":\"0\"";
+	my $pid = '';
+	my $testcmd = '';
+        my $exename;
+        my $memory;
+
+
+	$cmd =~ /(^[a-z]+)/;
+	
+	# Check if the exename needs to be overwritten.
+        # This happens if the expected process name string
+        # differs from the real one. This may happened if
+        # a service uses multiple processes or threads.
+        if (exists($overwrite_exename_hash{$cmd})) {
+                # Grab the string which will be reported by
+                # the process from the corresponding hash.
+                $exename = $overwrite_exename_hash{$1};
+        } else {
+                # Directly expect the launched command as
+                # process name.
+                $exename = $1;
+        }
+	
+	if (open(FILE, "/var/run/${cmd}.pid")){
+                $pid = <FILE>; chomp $pid;
+                close FILE;
+                if (open(FILE, "/proc/${pid}/status")){
+                        while (<FILE>){
+                                if (/^Name:\W+(.*)/) {
+                                        $testcmd = $1;
+                                }
+                        }
+                        close FILE;
+                }
+                if (open(FILE, "/proc/${pid}/status")) {
+                        while (<FILE>) {
+                                my ($key, $val) = split(":", $_, 2);
+                                if ($key eq 'VmRSS') {
+					$val =~ /\s*([0-9]*)\s+kB/;
+					# Convert kB to B
+                                        $memory = $1*1024;
+                                        last;
+                                }
+                        }
+                        close(FILE);
+                }
+                if ($testcmd =~ /$exename/){
+			$status = "\"servicename\":\"$cmd\",\"state\":1,\"pid\":$pid,\"memory\":$memory";
+		}
+        }
+        return $status;
+}
+
+sub isautorun {
+        my $cmd = $_[0];
+
+        # Init directory.
+	my $initdir = "/etc/rc.d/rc3.d/";
+
+        return &find_init("$cmd", "$initdir") ? 1 : 0;
+}
+
+sub find_init {
+	my ($cmd, $dir) = @_;
+
+	# Open given init directory.
+	opendir (INITDIR, "$dir") || die "Cannot opendir $dir: $!";
+
+	# Read-in init files from directory.
+	my @inits = readdir(INITDIR);
+
+	# Close directory handle.
+	closedir(INITDIR);
+
+	# Loop through the directory.
+	foreach my $init (@inits) {
+		# Check if the current processed file belongs to the given command.
+		if ($init =~ /S\d+\d+$cmd\z/) {
+			# Found, return "1" - True.
+			return "1";
+		}
+        }
+
+	# Nothing found, return nothing.
+	return;
+}
+
+sub addonservicestats {
+        my $cmd = $_[0];
+        my $status = "0";
+        my $pid = '';
+        my $testcmd = '';
+        my $exename;
+        my @memory = (0);
+
+        $testcmd = `/usr/local/bin/addonctrl $cmd status 2>/dev/null`;
+
+        if ( $testcmd =~ /is\ running/ && $testcmd !~ /is\ not\ running/){
+                $status = "\"state\":1";
+
+                $testcmd =~ s/.* //gi;
+                $testcmd =~ s/[a-z_]//gi;
+                $testcmd =~ s/\[[0-1]\;[0-9]+//gi;
+                $testcmd =~ s/[\(\)\.]//gi;
+                $testcmd =~ s/  //gi;
+                $testcmd =~ s///gi;
+
+                my @pid = split(/\s/,$testcmd);
+                $status .=",\"pid\":\"$pid[0]\"";
+
+                my $memory = 0;
+
+                foreach (@pid){
+                        chomp($_);
+                        if (open(FILE, "/proc/$_/statm")){
+                                my $temp = <FILE>;
+                                @memory = split(/ /,$temp);
+                        }
+                        $memory+=$memory[0];
+                }
+		$memory*=1024;
+                $status .=",\"memory\":$memory";
+        }else{
+                $status = "\"state\":0";
+        }
+        return $status;
+}

--- a/Network_Appliances/template_ipfire/6.4/files/sudoers.d/zabbix_agentd_user
+++ b/Network_Appliances/template_ipfire/6.4/files/sudoers.d/zabbix_agentd_user
@@ -1,0 +1,15 @@
+# Include file for sudoers file
+#
+# This is needed for some userparameters to be able to execute commands that only run as root (using sudo)
+# e.g. /usr/bin/openssl or /usr/sbin/smartctl
+#
+# USE AT YOU'RE OWN RISK. USING THIS WRONG CAN RESULT IN A SECURITY BREACH!
+#
+# Some hints:
+# - It is strongly recommended to edit this file only using the visudo -f <filename> command. If you mess up this file,
+#   you might end up locking yourself out of your system!
+# - Append the full path incl. parameters to each command, using "," as separator.
+# - Only add commands you really need. Zabbix should not have more rights than it has to.
+#
+
+zabbix ALL=(ALL) NOPASSWD: /etc/zabbix_agentd/scripts/ipfire_services.pl

--- a/Network_Appliances/template_ipfire/6.4/files/zabbix_agentd.d/template_ipfire_services.conf
+++ b/Network_Appliances/template_ipfire/6.4/files/zabbix_agentd.d/template_ipfire_services.conf
@@ -1,0 +1,2 @@
+### Parameter for monitoring IPFire services
+UserParameter=ipfire.services,sudo /etc/zabbix_agentd/scripts/ipfire_services.pl

--- a/Network_Appliances/template_ipfire/6.4/ipfire_by_zabbix_agent_active.yaml
+++ b/Network_Appliances/template_ipfire/6.4/ipfire_by_zabbix_agent_active.yaml
@@ -1,0 +1,1341 @@
+zabbix_export:
+  version: '6.4'
+  template_groups:
+    - uuid: a571c0d144b14fd4a87a9d9b2aa9fcd6
+      name: Templates/Applications
+    - uuid: 57b7ae836ca64446ba2c296389c009b7
+      name: Templates/Modules
+  host_groups:
+    - uuid: 6a9e41a5ef934d2196aca8b4abdafff5
+      name: 'OpenVPN Clients'
+  templates:
+    - uuid: 80543e3dcb9641a8a5a33554ad6638a9
+      template: 'IPFire by Zabbix agent active'
+      name: 'IPFire by Zabbix agent active'
+      description: |
+        Monitor an IPFire appliance
+        
+        Requirements for template operation:
+        1.Install Zabbix agent addon using Pakfire
+        2.Copy zabbix_agentd_user sudoers-file into /etc/sudoers.d
+        3.Copy ipfire_services.pl into /etc/zabbix_agentd/scripts and make sure it is executable by the root user.
+        4.Copy template_ipfire_services.conf into /etc/zabbix_agentd/zabbix_agentd.d/. 
+        Don't forget to restart zabbix-agent.
+        
+        Created by Robin Roevens (robin.roevens (at) disroot.org)
+      vendor:
+        name: RobinR1
+        version: 6.4-0.3
+      groups:
+        - name: Templates/Applications
+      items:
+        - uuid: 9be0495e730a476fac68b91583bb4146
+          name: 'Captive Portal: # of active clients'
+          type: ZABBIX_ACTIVE
+          key: ipfire.captive.clients
+          history: 7d
+          description: 'Number of active users on captive portal'
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: captive-portal
+        - uuid: da3ef4de97f343d4a3d0d420e4e0df36
+          name: 'DHCP Server: # of active leases'
+          type: ZABBIX_ACTIVE
+          key: ipfire.dhcpd.clients
+          history: 7d
+          description: 'Number of active dhcpd leases'
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: dhcpd
+        - uuid: d7752458935c4e40adaacd4e1107f40e
+          name: 'Firewall hits: Get'
+          type: ZABBIX_ACTIVE
+          key: ipfire.net.fw.hits.raw
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          description: 'Raw data item for retrieving firewall hits on all forwarding chains'
+          tags:
+            - tag: component
+              value: firewall
+            - tag: component
+              value: network
+            - tag: component
+              value: raw
+        - uuid: 2e0173990de34061b2e743ef22518c6a
+          name: 'Network: Internet gateway available'
+          type: ZABBIX_ACTIVE
+          key: ipfire.net.gateway.ping
+          history: 7d
+          description: 'Checks if the internet gateway on RED is reachable'
+          tags:
+            - tag: component
+              value: gateway
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 750db20bec7c46e6ab9943e516f52947
+              expression: 'last(/IPFire by Zabbix agent active/ipfire.net.gateway.ping)<>1'
+              name: 'Internet Gateway is not reachable'
+              priority: HIGH
+              description: 'Internet Gateway on interface RED is unreachable. Internet connection is lost or intermittent.'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: f548b019c57a42cd8b6d4cf0a244f098
+          name: 'Network: Internet gateway ping timings'
+          type: ZABBIX_ACTIVE
+          key: ipfire.net.gateway.pingtime
+          history: 7d
+          value_type: FLOAT
+          units: ms
+          description: 'Checks the response time of the internet gateway on RED indicating Line Quality.'
+          tags:
+            - tag: component
+              value: gateway
+            - tag: component
+              value: network
+        - uuid: a01561b00aab4406a38e34440658848d
+          name: 'IPFire Services: Get'
+          type: ZABBIX_ACTIVE
+          key: ipfire.services
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          description: 'Get a list of IPFire service using agent script ipfire_services.pl'
+          tags:
+            - tag: component
+              value: raw
+            - tag: component
+              value: service
+        - uuid: 45efac8b0c984815b9cf5c2790373911
+          name: 'System: Core-Update available'
+          type: DEPENDENT
+          key: pakfire.core-update-available
+          delay: '0'
+          history: 7d
+          valuemap:
+            name: 'Boolean Yes/no'
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - 'Core-Update available: (.*)'
+                - \1
+              error_handler: DISCARD_VALUE
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Convert Bool String to Bool Integer
+                  switch(value) {
+                     case "yes":
+                        return 1;
+                     case "no":
+                        return 0;
+                     default:
+                        return 99;
+                  }
+            - type: IN_RANGE
+              parameters:
+                - '0'
+                - '1'
+              error_handler: CUSTOM_ERROR
+              error_handler_params: 'Unknown value received'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pakfire.status
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 10fdaa47927d4638b62ec43deff34360
+              expression: 'last(/IPFire by Zabbix agent active/pakfire.core-update-available)=1'
+              name: 'Pakfire: Core-Update available'
+              url: 'https://{HOST.CONN}:444/cgi-bin/pakfire.cgi'
+              priority: INFO
+              description: 'A Core-Update for IPFire is available. Go to the IPFire webgui > IPFire Pakfire to perform an update.'
+              tags:
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+            - uuid: 059cebb808634b35a3c2f2304e8cfaf5
+              expression: 'nodata(/IPFire by Zabbix agent active/pakfire.core-update-available,4h)=1'
+              name: 'Pakfire: Last Pakfire status update > 4h ago'
+              priority: WARNING
+              description: 'Zabbix was unable to retrieve Pakfire status for more than 4h. Check if Pakfire is still correctly working.'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 3c87cd1c09ec4fc2910c2572d9a4f5e9
+          name: 'System: Core-Update level'
+          type: DEPENDENT
+          key: pakfire.core-update-level
+          delay: '0'
+          history: 7d
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - 'Core-Update-Level: ([0-9]*)'
+                - \1
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: pakfire.status
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 315ab087e6b3408eb463eaecbab289f7
+              expression: 'change(/IPFire by Zabbix agent active/pakfire.core-update-level)>0'
+              name: 'Pakfire: Core-Update-Level has changed'
+              priority: INFO
+              manual_close: 'YES'
+              dependencies:
+                - name: 'Pakfire: Core-Version has changed'
+                  expression: '(last(/IPFire by Zabbix agent active/pakfire.core-version,#1)<>last(/IPFire by Zabbix agent active/pakfire.core-version,#2))=1'
+              tags:
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 96e3883bf9784f45b5ff7a9acaeeb5a9
+          name: 'System: Core version'
+          type: DEPENDENT
+          key: pakfire.core-version
+          delay: '0'
+          history: 7d
+          value_type: FLOAT
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - 'Core-Version: ([0-9.]*)'
+                - \1
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: pakfire.status
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 743e14e27c1141cdb08c895e768e9931
+              expression: '(last(/IPFire by Zabbix agent active/pakfire.core-version,#1)<>last(/IPFire by Zabbix agent active/pakfire.core-version,#2))=1'
+              name: 'Pakfire: Core-Version has changed'
+              priority: INFO
+              tags:
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 299ed0d3aa97435088fd805646ffe649
+          name: 'System: # of addon updates available'
+          type: DEPENDENT
+          key: pakfire.package-updates-available
+          delay: '0'
+          history: 7d
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - 'Package-Updates available: ([0-9]*)'
+                - \1
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pakfire.status
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 39bc50b094cf40ab86588b909eef2db7
+              expression: 'last(/IPFire by Zabbix agent active/pakfire.package-updates-available)>0'
+              name: 'Pakfire: Package-Updates available'
+              priority: INFO
+              tags:
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 8dbec81630674c7c89a74ba12cdae84b
+          name: 'System: Reboot required'
+          type: DEPENDENT
+          key: pakfire.reboot-required
+          delay: '0'
+          history: 7d
+          valuemap:
+            name: 'Boolean Yes/no'
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - 'Reboot required: (.*)'
+                - \1
+              error_handler: DISCARD_VALUE
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Convert Bool String to Bool Integer
+                  switch(value) {
+                     case "yes":
+                        return 1;
+                     case "no":
+                        return 0;
+                     default:
+                        return 99;
+                  }
+            - type: IN_RANGE
+              parameters:
+                - '0'
+                - '1'
+              error_handler: CUSTOM_ERROR
+              error_handler_params: 'Unknown value received'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pakfire.status
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 5bf0656d2f9f46258ee36ca10096a9bb
+              expression: 'last(/IPFire by Zabbix agent active/pakfire.reboot-required)=1'
+              name: 'Pakfire: Reboot required'
+              url: 'https://{HOST.CONN}:444/cgi-bin/shutdown.cgi'
+              priority: INFO
+              description: 'An update requires a reboot of IPFire to complete. Please reboot the host as soon as possible. Go to the IPFire webgui > System > Shutdown to perform a reboot.'
+              tags:
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 0593a390fa7f40e1b23c94fe845eff09
+          name: 'Pakfire Status: Get'
+          type: ZABBIX_ACTIVE
+          key: pakfire.status
+          delay: 10m
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: raw
+            - tag: component
+              value: system
+        - uuid: 7349c0e5921440f5bf1e8be3111acb7f
+          name: 'Network: # of open connections'
+          type: ZABBIX_ACTIVE
+          key: 'vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_count"]'
+          history: 7d
+          tags:
+            - tag: component
+              value: network
+        - uuid: aaa91f7fdd3949d0adf4a6f90e9ddc87
+          name: 'Network: Max # of open connections'
+          type: ZABBIX_ACTIVE
+          key: 'vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_max"]'
+          delay: 1h
+          history: 7d
+          tags:
+            - tag: component
+              value: network
+        - uuid: cdc1d6590ab044cc8e9684119238c1db
+          name: 'System: Last update'
+          type: ZABBIX_ACTIVE
+          key: 'vfs.file.time["/opt/pakfire/db/core/mine",modify]'
+          delay: 10m
+          history: 7d
+          units: unixtime
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          tags:
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+        - uuid: 8614cc5f14364b8d851631850a0d0ce9
+          name: 'Pakfire: Last core-list update'
+          type: ZABBIX_ACTIVE
+          key: 'vfs.file.time["/opt/pakfire/db/lists/core-list.db",modify]'
+          delay: 10m
+          history: 7d
+          units: unixtime
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          tags:
+            - tag: component
+              value: application
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: a490e3a3d0be4fd88f6890afc61e4826
+              expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/core-list.db",modify],49h)=0'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/core-list.db",modify],1h)=1'
+              name: 'Pakfire: Last core-list update > 49h ago'
+              priority: WARNING
+              description: 'Auslösung bei Delta > 49h / Recovery bei Delta < 1h'
+              dependencies:
+                - name: 'Pakfire: Last server-list update > 49h ago'
+                  expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify],49h)=0'
+                  recovery_expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify],1h)=1'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 72d6284952044ff58795e6076e6ad3c8
+          name: 'Pakfire: Last packages-list update'
+          type: ZABBIX_ACTIVE
+          key: 'vfs.file.time["/opt/pakfire/db/lists/packages_list.db",modify]'
+          delay: 10m
+          history: 7d
+          units: unixtime
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          tags:
+            - tag: component
+              value: application
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 9a7dfe94a226472bb36f9d1c4f5a86e6
+              expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/packages_list.db",modify],49h)=0'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/packages_list.db",modify],1h)=1'
+              name: 'Pakfire: Last packages-list update > 49h ago'
+              priority: WARNING
+              description: 'Auslösung bei Delta > 49h / Recovery bei Delta < 1h'
+              dependencies:
+                - name: 'Pakfire: Last server-list update > 49h ago'
+                  expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify],49h)=0'
+                  recovery_expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify],1h)=1'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 0dd0776c8b91489784d45bf06893d1c3
+          name: 'Pakfire: Last server-list update'
+          type: ZABBIX_ACTIVE
+          key: 'vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify]'
+          delay: 10m
+          history: 7d
+          units: unixtime
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          tags:
+            - tag: component
+              value: application
+            - tag: component
+              value: pakfire
+            - tag: component
+              value: system
+          triggers:
+            - uuid: da2d132b5dd142a2a047413fc2ed3bc7
+              expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify],49h)=0'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'fuzzytime(/IPFire by Zabbix agent active/vfs.file.time["/opt/pakfire/db/lists/server-list.db",modify],1h)=1'
+              name: 'Pakfire: Last server-list update > 49h ago'
+              priority: WARNING
+              description: 'Auslösung bei Delta > 49h / Recovery bei Delta < 1h'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+      discovery_rules:
+        - uuid: 61c015898168475892226c0d1cc752d8
+          name: 'Firewall chains discovery'
+          type: DEPENDENT
+          key: ipfire.net.fw.hits.discovery
+          delay: '0'
+          filter:
+            conditions:
+              - macro: '{#FW_CHAIN}'
+                value: '{$IPFIRE.FW_CHAIN.MATCHES}'
+                formulaid: A
+              - macro: '{#FW_CHAIN}'
+                value: '{$IPFIRE.FW_CHAIN.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: B
+          description: 'Discovery of firewall chains in filter table to create "firewall hits" items/chain'
+          item_prototypes:
+            - uuid: e754323822f04c6b9e2e77bca43344fe
+              name: 'Firewall: Hits on chain {#FW_CHAIN}'
+              type: DEPENDENT
+              key: 'ipfire.net.fw.hits[{#FW_CHAIN}]'
+              delay: '0'
+              history: 7d
+              units: bps
+              description: 'Bytes dropped on firewall chain {#FW_CHAIN} of the Filter table'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$[?(@.chain=="{#FW_CHAIN}")].bytes.first()'
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              master_item:
+                key: ipfire.net.fw.hits.raw
+              tags:
+                - tag: component
+                  value: firewall
+                - tag: component
+                  value: network
+                - tag: component
+                  value: os
+                - tag: firewall-chain
+                  value: '{#FW_CHAIN}'
+          master_item:
+            key: ipfire.net.fw.hits.raw
+          lld_macro_paths:
+            - lld_macro: '{#FW_CHAIN}'
+              path: $.chain
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Filter out toggling part: bytes
+                  discovery_items = JSON.parse(value);
+                  discovery_items.map(function (item) { delete item['bytes']; });
+                  return JSON.stringify(discovery_items);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+        - uuid: 4255351b82de467ea643cb15b5f2297e
+          name: 'OpenVPN clients discovery'
+          type: ZABBIX_ACTIVE
+          key: ipfire.ovpn.clients.discovery
+          delay: 1h
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#COMMONNAME}'
+                value: '{$IPFIRE.OVPN.COMMONNAME.MATCHES}'
+                formulaid: A
+              - macro: '{#COMMONNAME}'
+                value: '{$IPFIRE.OVPN.COMMONNAME.NOTMATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: B
+              - macro: '{#STATE}'
+                value: '{$IPFIRE.OVPN.STATE.MATCHES}'
+                formulaid: C
+          description: 'Discovers configured OpenVPN clients'
+          host_prototypes:
+            - uuid: 37dc62b5f94c4979bfca33e8ab7ae7cb
+              host: '{#COMMONNAME}'
+              name: '{#NAME}'
+              group_links:
+                - group:
+                    name: 'OpenVPN Clients'
+              templates:
+                - name: 'IPFire OpenVPN Client by Zabbix agent'
+              macros:
+                - macro: '{$IPFIRE.OVPN.CLIENT.COMMONNAME}'
+                  value: '{#COMMONNAME}'
+                  description: 'OpenVPN client Common Name'
+                - macro: '{$IPFIRE.OVPN.CLIENT.NAME}'
+                  value: '{#NAME}'
+                  description: 'OpenVPN client Name'
+                - macro: '{$IPFIRE.OVPN.CLIENT.REMARK}'
+                  value: '{#REMARK}'
+                  description: 'OpenVPN client remark'
+                - macro: '{$IPFIRE.OVPN.CLIENT.STATE}'
+                  value: '{#STATE}'
+                  description: 'OpenVPN client state'
+                - macro: '{$IPFIRE.OVPN.CLIENT.TYPE}'
+                  value: '{#TYPE}'
+                  description: 'OpenVPN client type'
+              tags:
+                - tag: type
+                  value: '{#TYPE}'
+        - uuid: 0724a9154c924222a1495a4665929039
+          name: 'IPFire Services discovery'
+          type: DEPENDENT
+          key: ipfire.services.discovery
+          delay: '0'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#SERVICENAME}'
+                value: '{$IPFIRE.SERVICENAME.MATCHES}'
+                formulaid: A
+              - macro: '{#SERVICENAME}'
+                value: '{$IPFIRE.SERVICENAME.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: B
+          item_prototypes:
+            - uuid: bd1d7dfffc65492fb3eb7ade56c07bf8
+              name: 'OpenVPN: # clients connected'
+              type: DEPENDENT
+              key: 'ipfire.ovpn.clients.count[{#SINGLETON}]'
+              delay: '0'
+              description: 'Number of clients currently connected with OpenVPN'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.clients.length()
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: 'ipfire.ovpn.statusreport.get[{#SINGLETON}]'
+              tags:
+                - tag: component
+                  value: network
+                - tag: component
+                  value: service
+                - tag: service
+                  value: openvpn
+            - uuid: 17b4f2e8a9b944c7b09f81c6b6f8699b
+              name: 'OpenVPN: Statusreport: Get'
+              type: ZABBIX_ACTIVE
+              key: 'ipfire.ovpn.statusreport.get[{#SINGLETON}]'
+              history: '0'
+              trends: '0'
+              value_type: TEXT
+              description: 'Get OpenVPN status report containing list of connected clients and routing tables'
+              preprocessing:
+                - type: DISCARD_UNCHANGED
+                  parameters:
+                    - ''
+              tags:
+                - tag: component
+                  value: network
+                - tag: component
+                  value: raw
+                - tag: component
+                  value: service
+                - tag: service
+                  value: openvpn
+            - uuid: 9f207a283c4347569f02374f8e548b69
+              name: 'OpenVPN: Last status report update'
+              type: DEPENDENT
+              key: 'ipfire.ovpn.statusreport.timestamp[{#SINGLETON}]'
+              delay: '0'
+              history: 1d
+              units: unixtime
+              description: 'Timestamp of last OpenVPN server statusreport update'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.timestamp
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: 'ipfire.ovpn.statusreport.get[{#SINGLETON}]'
+              tags:
+                - tag: component
+                  value: network
+                - tag: component
+                  value: service
+                - tag: service
+                  value: openvpn
+            - uuid: 64ab99104e5c4a748745fbc1d02b1803
+              name: '{#SERVICE}: Memory usage'
+              type: DEPENDENT
+              key: 'ipfire.services.memory[{#SERVICENAME}]'
+              delay: '0'
+              history: 7d
+              units: b
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$[?(@.servicename == "{#SERVICENAME}")].memory.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: ipfire.services
+              tags:
+                - tag: component
+                  value: memory
+                - tag: component
+                  value: service
+                - tag: service
+                  value: '{#SERVICENAME}'
+            - uuid: 3d679fd91a334de1949e5cc5afdcc8a3
+              name: '{#SERVICE}: Start on boot'
+              type: DEPENDENT
+              key: 'ipfire.services.onboot[{#SERVICENAME}]'
+              delay: '0'
+              history: 7d
+              valuemap:
+                name: 'Boolean Yes/no'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$[?(@.servicename == "{#SERVICENAME}")].onboot.first()'
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '1'
+              master_item:
+                key: ipfire.services
+              tags:
+                - tag: component
+                  value: service
+                - tag: service
+                  value: '{#SERVICENAME}'
+            - uuid: 865fe738cfb34752b83605930b3cf180
+              name: '{#SERVICE}: Pid'
+              type: DEPENDENT
+              key: 'ipfire.services.pid[{#SERVICENAME}]'
+              delay: '0'
+              history: 7d
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$[?(@.servicename == "{#SERVICENAME}")].pid.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: ipfire.services
+              tags:
+                - tag: component
+                  value: os
+                - tag: component
+                  value: service
+                - tag: service
+                  value: '{#SERVICENAME}'
+            - uuid: 7fa6c6e4b6cf4a018ac3002122b0e0e5
+              name: '{#SERVICE}: State'
+              type: DEPENDENT
+              key: 'ipfire.services.state[{#SERVICENAME}]'
+              delay: '0'
+              history: 7d
+              valuemap:
+                name: 'Service state'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$[?(@.servicename == "{#SERVICENAME}")].state.first()'
+              master_item:
+                key: ipfire.services
+              tags:
+                - tag: component
+                  value: service
+                - tag: service
+                  value: '{#SERVICENAME}'
+              trigger_prototypes:
+                - uuid: 71d4baaa724140179fbde0bbdd170dfa
+                  expression: '{$IPFIRE.SERVICE.TRIGGER:"{#SERVICENAME}"} and last(/IPFire by Zabbix agent active/ipfire.services.state[{#SERVICENAME}])<>1'
+                  name: '{#SERVICE}: Service not running'
+                  priority: HIGH
+                  description: 'The IPFire service {#SERVICE} is not running. If this service is manually disabled, set host macro $IPFIRE.SERVICE.TRIGGER:"{#SERVICENAME}" to 0 to disable this trigger.'
+                  tags:
+                    - tag: scope
+                      value: availability
+          trigger_prototypes:
+            - uuid: adf12fb393704b90b3bd5541a447e2a1
+              expression: |
+                last(/IPFire by Zabbix agent active/ipfire.services.onboot[{#SERVICENAME}])=1 and 
+                (nodata(/IPFire by Zabbix agent active/ipfire.ovpn.statusreport.get[{#SINGLETON}],5m)=1 or
+                 time()-last(/IPFire by Zabbix agent active/ipfire.ovpn.statusreport.timestamp[{#SINGLETON}])>5m)
+              name: 'OpenVPN: Statusreport outdated'
+              priority: AVERAGE
+              description: |
+                Did not receive a recent OpenVPN status report. OpenVPN client data is probably outdated and/or inaccurate.
+                Check if Zabbix Agent is running and properly configured to send OpenVPN status reports (UserParameter: ipfire.ovpn.statusreport.get) and/or OpenVPN server configuration is the IPFire default.
+              dependencies:
+                - name: '{#SERVICE}: Service not running'
+                  expression: '{$IPFIRE.SERVICE.TRIGGER:"{#SERVICENAME}"} and last(/IPFire by Zabbix agent active/ipfire.services.state[{#SERVICENAME}])<>1'
+              tags:
+                - tag: scope
+                  value: availability
+          master_item:
+            key: ipfire.services
+          lld_macro_paths:
+            - lld_macro: '{#SERVICENAME}'
+              path: $.servicename
+            - lld_macro: '{#SERVICE}'
+              path: $.service
+            - lld_macro: '{#SINGLETON}'
+              path: $.singleton
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Filter out toggling parts: state, pid, memory, onboot & add singleton
+                  discovery_items = JSON.parse(value);
+                  discovery_items.map(function (item) { ['state','pid','memory', 'onboot'].forEach(function(key) { delete item[key] }); item['singleton'] = "" });
+                  return JSON.stringify(discovery_items);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          overrides:
+            - name: 'Don''t discover OpenVPN specific items/triggers on other services'
+              step: '1'
+              filter:
+                conditions:
+                  - macro: '{#SERVICENAME}'
+                    value: openvpn
+                    operator: NOT_MATCHES_REGEX
+                    formulaid: A
+              operations:
+                - operationobject: ITEM_PROTOTYPE
+                  operator: REGEXP
+                  value: '^OpenVPN: .*'
+                  discover: NO_DISCOVER
+                - operationobject: TRIGGER_PROTOTYPE
+                  operator: REGEXP
+                  value: '^OpenVPN: .*'
+                  discover: NO_DISCOVER
+      tags:
+        - tag: class
+          value: software
+        - tag: target
+          value: ipfire
+      macros:
+        - macro: '{$IPFIRE.CONN.MAX.RESOLVE}'
+          value: '85'
+          description: 'Percentage of max open connections used before resolving trigger'
+        - macro: '{$IPFIRE.CONN.MAX.WARN}'
+          value: '95'
+          description: 'Max percentage of max open connections used before triggering warning'
+        - macro: '{$IPFIRE.FW_CHAIN.MATCHES}'
+          value: '^.*$'
+          description: 'Only discover firewall chains matching this regex'
+        - macro: '{$IPFIRE.FW_CHAIN.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+          description: 'Do not discover firewall chains matching this regex'
+        - macro: '{$IPFIRE.OVPN.COMMONNAME.MATCHES}'
+          value: '^.*$'
+          description: 'OpenVPN clients with common name matching this regex will be discovered'
+        - macro: '{$IPFIRE.OVPN.COMMONNAME.NOTMATCHES}'
+          value: CHANGE_IF_NEEDED
+          description: 'OpenVPN clients with common name matching this regex will not be discovered'
+        - macro: '{$IPFIRE.OVPN.STATE.MATCHES}'
+          value: 'on'
+          description: 'OpenVPN clients with a state (on/off) matching this regex will be discovered.'
+        - macro: '{$IPFIRE.SERVICE.TRIGGER}'
+          value: '1'
+          description: 'Whether Zabbix needs to trigger when an IPFire service is down. This variable can be used with context to exclude specific services.'
+        - macro: '{$IPFIRE.SERVICENAME.MATCHES}'
+          value: '^.*$'
+          description: 'All services matching this regex will be discovered'
+        - macro: '{$IPFIRE.SERVICENAME.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+          description: 'Services matching this regex will not be discovered'
+      valuemaps:
+        - uuid: 57ac5ee3ecd34a36a30119db05e5a738
+          name: 'Boolean Yes/no'
+          mappings:
+            - value: '0'
+              newvalue: 'No'
+            - value: '1'
+              newvalue: 'Yes'
+        - uuid: 9f0de9d59823477b9e8788e0c4b100d2
+          name: 'OpenVPN Connection state'
+          mappings:
+            - value: '0'
+              newvalue: 'not connected'
+            - value: '1'
+              newvalue: connected
+        - uuid: 7517e6ba802e42abaf567ae383a32414
+          name: 'Service state'
+          mappings:
+            - value: '0'
+              newvalue: Down
+            - value: '1'
+              newvalue: Up
+    - uuid: 52850149b8ad443184ee95d3da3cd195
+      template: 'IPFire OpenVPN Client by Zabbix agent'
+      name: 'IPFire OpenVPN Client by Zabbix agent'
+      description: |
+        Monitor an IPFire OpenVPN client
+        
+        This template is applied to discovered OpenVPN client hosts by the template IPFire by Zabbix agent and is not meant to be applied manually to any hosts.
+      vendor:
+        name: RobinR1
+        version: 6.4-0.3
+      groups:
+        - name: Templates/Modules
+      items:
+        - uuid: bead53bd8f1f4382b4c36733db3ab0f3
+          name: 'OpenVPN: Client common name'
+          type: SCRIPT
+          key: ipfire.ovpn.client.commonname
+          history: 7d
+          trends: '0'
+          value_type: CHAR
+          params: 'return "{$IPFIRE.OVPN.CLIENT.COMMONNAME}";'
+          description: 'OpenVPN Client connection name as configured in IPFire WUI'
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: add7fbf01d384c0bab9ded620fa9f958
+          name: 'OpenVPN: Last connection duration'
+          type: CALCULATED
+          key: 'ipfire.ovpn.client.connection[{$IPFIRE.OVPN.CLIENT.COMMONNAME},duration]'
+          history: 7d
+          units: s
+          params: 'last(//ipfire.ovpn.routing_table[{$IPFIRE.OVPN.CLIENT.COMMONNAME},last_ref])-last(//ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},connected_since])'
+          description: 'Duration of current or last connection'
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 12b42114672c4f698fa3e9407d0f0346
+          name: 'OpenVPN: Client name'
+          type: SCRIPT
+          key: ipfire.ovpn.client.name
+          history: 7d
+          trends: '0'
+          value_type: CHAR
+          params: 'return "{$IPFIRE.OVPN.CLIENT.NAME}";'
+          description: 'OpenVPN Client name as configured in IPFire WUI'
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 7eeabe63f0ba4f3dbd32403ed37c5acb
+          name: 'OpenVPN: Client remark'
+          type: SCRIPT
+          key: ipfire.ovpn.client.remark
+          history: 7d
+          trends: '0'
+          value_type: TEXT
+          params: 'return "{$IPFIRE.OVPN.CLIENT.REMARK}";'
+          description: 'OpenVPN Client remark as configured in IPFire WUI'
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 108aef4c2b184624a00961f5b64500c4
+          name: 'OpenVPN: Client access status'
+          type: SCRIPT
+          key: ipfire.ovpn.client.state
+          history: 7d
+          params: 'return "{$IPFIRE.OVPN.CLIENT.STATE}";'
+          description: 'Whether the client is enabled to access the IPFire OpenVPN server.'
+          preprocessing:
+            - type: STR_REPLACE
+              parameters:
+                - 'off'
+                - '0'
+            - type: STR_REPLACE
+              parameters:
+                - 'on'
+                - '1'
+            - type: IN_RANGE
+              parameters:
+                - '0'
+                - '1'
+              error_handler: CUSTOM_ERROR
+              error_handler_params: 'Unknown client state'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 08411efa83e3490da6858c96fe8e406f
+          name: 'OpenVPN: Client type'
+          type: SCRIPT
+          key: ipfire.ovpn.client.type
+          history: 7d
+          trends: '0'
+          value_type: CHAR
+          params: 'return "{$IPFIRE.OVPN.CLIENT.TYPE}";'
+          description: 'OpenVPN Client type'
+          valuemap:
+            name: 'OpenVPN Client type'
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 713f21c4059a452d8aa6746dbb4c024d
+          name: 'OpenVPN: Bytes received'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},bytes_in]'
+          delay: '0'
+          history: 7d
+          units: b
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].bytes_in.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 57993d21e1d04b319b4adc5f70385a30
+          name: 'OpenVPN: Bytes received total'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},bytes_in_total]'
+          delay: '0'
+          history: 7d
+          units: b
+          description: 'Total amount of bytes received during current/last connection'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].bytes_in.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 130de3a8a8bf4e4987ac563eabb88602
+          name: 'OpenVPN: Bytes sent'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},bytes_out]'
+          delay: '0'
+          history: 7d
+          units: b
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].bytes_out.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 81bdb6e42bdd46a58308531d0cffac32
+          name: 'OpenVPN: Bytes sent total'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},bytes_out_total]'
+          delay: '0'
+          history: 7d
+          units: b
+          description: 'Total amount of bytes sent during current/last connection'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].bytes_out.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: e035d6315a7e4403a25185d17bbe6489
+          name: 'OpenVPN: Connection state'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},connected]'
+          delay: '0'
+          history: 7d
+          description: 'Whether the client is currently connected'
+          valuemap:
+            name: 'OpenVPN Connection state'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].length()'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 8b0ba4b88ae549a0a4a2346e1cf40133
+          name: 'OpenVPN: Last connection time'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},connected_since]'
+          delay: '0'
+          history: 7d
+          units: unixtime
+          description: 'Timestamp of last client connection initiation'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].connected_since.first()'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: fd22e3d29b4c4c358c77d100cd412990
+          name: 'OpenVPN: Remote IP Address'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.client[{$IPFIRE.OVPN.CLIENT.COMMONNAME},real_address]'
+          delay: '0'
+          history: 7d
+          trends: '0'
+          value_type: CHAR
+          description: 'Real IP address of client'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.clients[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].real_address.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0.0.0.0:0'
+            - type: REGEX
+              parameters:
+                - '^(\d+\.\d+\.\d+\.\d+):\d+$'
+                - \1
+            - type: STR_REPLACE
+              parameters:
+                - 0.0.0.0
+                - ''
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 175a8220c2e04e42884e1a5b67de263f
+          name: 'OpenVPN: Last activity'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.routing_table[{$IPFIRE.OVPN.CLIENT.COMMONNAME},last_ref]'
+          delay: '0'
+          history: 7d
+          units: unixtime
+          description: 'Timestamp of last client network activity'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.routing_table[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].last_ref.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: c1c65e8f92b84008a69eb40db7907d61
+          name: 'OpenVPN: VPN IP Address'
+          type: DEPENDENT
+          key: 'ipfire.ovpn.routing_table[{$IPFIRE.OVPN.CLIENT.COMMONNAME},virtual_address]'
+          delay: '0'
+          history: 7d
+          trends: '0'
+          value_type: CHAR
+          description: 'Virtual IP address of client'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.routing_table[?(@.common_name == "{$IPFIRE.OVPN.CLIENT.COMMONNAME}")].virtual_address.first()'
+              error_handler: CUSTOM_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: ipfire.ovpn.statusreport.get
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+        - uuid: 5c6b95eedb1a47d99dfba1bb092d56bf
+          name: 'OpenVPN statusreport: Get'
+          key: ipfire.ovpn.statusreport.get
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          description: 'Get OpenVPN status report containing list of connected clients and routing tables'
+          preprocessing:
+            - type: DISCARD_UNCHANGED
+              parameters:
+                - ''
+          tags:
+            - tag: component
+              value: network
+            - tag: component
+              value: raw
+            - tag: component
+              value: service
+            - tag: service
+              value: openvpn
+      tags:
+        - tag: class
+          value: device
+        - tag: target
+          value: ipfire
+        - tag: target
+          value: openvpn-client
+      macros:
+        - macro: '{$IPFIRE.OVPN.CLIENT.COMMONNAME}'
+          value: FILLED_IN_BY_HOST_DISCOVERY
+          description: 'OpenVPN client Common Name'
+        - macro: '{$IPFIRE.OVPN.CLIENT.NAME}'
+          value: FILLED_IN_BY_HOST_DISCOVERY
+          description: 'OpenVPN client Name'
+        - macro: '{$IPFIRE.OVPN.CLIENT.REMARK}'
+          value: FILLED_IN_BY_HOST_DISCOVERY
+          description: 'OpenVPN client remark'
+        - macro: '{$IPFIRE.OVPN.CLIENT.STATE}'
+          value: FILLED_IN_BY_HOST_DISCOVERY
+          description: 'OpenVPN client state'
+        - macro: '{$IPFIRE.OVPN.CLIENT.TYPE}'
+          value: FILLED_IN_BY_HOST_DISCOVERY
+          description: 'OpenVPN client type'
+      valuemaps:
+        - uuid: 87dfebb2a9784886b12efe44d8044ee3
+          name: 'OpenVPN Client access status'
+          mappings:
+            - value: '0'
+              newvalue: disabled
+            - value: '1'
+              newvalue: enabled
+        - uuid: 142e2748979147cb8b8f887825575a72
+          name: 'OpenVPN Client type'
+          mappings:
+            - value: host
+              newvalue: Roadwarior
+            - type: REGEXP
+              value: '^net.*'
+              newvalue: 'Remote network'
+        - uuid: 486bcaed8ba049c7b9b7c811482b6ad8
+          name: 'OpenVPN Connection state'
+          mappings:
+            - value: '0'
+              newvalue: 'not connected'
+            - value: '1'
+              newvalue: connected
+  triggers:
+    - uuid: ed954859a31b4e658e1c1ac42545a6f6
+      expression: 'last(/IPFire by Zabbix agent active/vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_count"])/last(/IPFire by Zabbix agent active/vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_max"])*100>{$IPFIRE.CONN.MAX.WARN}'
+      recovery_mode: RECOVERY_EXPRESSION
+      recovery_expression: 'last(/IPFire by Zabbix agent active/vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_count"])/last(/IPFire by Zabbix agent active/vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_max"])*100<={$IPFIRE.CONN.MAX.RESOLVE}'
+      name: 'Number of open connection is too high (> 90% of max open connections)'
+      opdata: 'Open connections: {ITEM.LASTVALUE1}, Max open connections: {ITEM.LASTVALUE2}'
+      priority: WARNING
+      description: |
+        The current number of open connections is at {$IPFIRE.CONN.MAX}% of the max allowed number of open connections. When the max allowed number of open connections is reached, new connections will be dropped. 
+        Consider increasing the net.netfilter.nf_conntrack_max system variable.
+      tags:
+        - tag: scope
+          value: availability
+        - tag: scope
+          value: capacity
+  graphs:
+    - uuid: f9acf1d3482f4af3b619a649eb81b844
+      name: 'Line Quality'
+      graph_items:
+        - sortorder: '1'
+          drawtype: GRADIENT_LINE
+          color: 1A7C11
+          item:
+            host: 'IPFire by Zabbix agent active'
+            key: ipfire.net.gateway.pingtime
+    - uuid: f4bf7726c930427aa2a99bad42d7fa7f
+      name: 'Open Connections'
+      graph_items:
+        - sortorder: '1'
+          color: FF0000
+          item:
+            host: 'IPFire by Zabbix agent active'
+            key: 'vfs.file.contents["/proc/sys/net/netfilter/nf_conntrack_count"]'


### PR DESCRIPTION
Adds a template for monitoring an IPFire opensource Firewall instance or appliance.
As maintainer of the zabbix-agent addon package for the IPFire distribution, I have added specific IPFire userparameters which can easily be monitored using this template. See also: https://wiki.ipfire.org/addons/zabbix_agentd