### PR TITLE
Add template for monitoring Merox

### DIFF
--- a/Applications/DNS/template_merox/6.4/README.md
+++ b/Applications/DNS/template_merox/6.4/README.md
@@ -1,0 +1,44 @@
+# Merox
+
+## Description
+
+This template uses the [Merox](https://www.merox.io/) API to retrieve domain information and create alerts in the event of changes.
+
+## Overview
+
+For Zabbix version: 6.4
+
+Supports monitoring of:
+- Discovering domains configured in Merox
+- Retrieve statistics related to your domains in Merox
+- Retrieve information for each domain (Score, Status, etc.)
+- Execute DNS queries and monitor MX, DMARC, SPF and BIMI records
+
+## Author
+
+Romain Tiennot - ManoMano
+
+## Setup
+
+- Generate an API key from the Merox interface
+- Replace `{$MEROX.API.TOKEN}`, `{$MEROX.API.USER}` macros with API identifiers
+- You can replace the `{$DNS.IP}` macros if you wish to change the DNS server
+- You can override the Merox API version and URL from the `{$MEROX.API.VERSION}` and `{$MEROX.API.URL}` macros.
+- Assign the template to a host.
+
+## Zabbix configuration
+
+No specific Zabbix configuration is required
+
+### Macros used
+|Name|Description|Default|
+|----|-----------|-------|
+|{$DNS.IP} |<p>DNS server IP for retrieving MX, DMARC, SPF and BIMI record values</p>|`8.8.8.8` |
+|{$MEROX.API.URL} |<p>Base Merox API URL</p>|`https://api.merox.io` |
+|{$MEROX.API.VERSION} |<p>Merox API version</p>|`0.1` |
+|{$MEROX.API.USER} |<p>Email of Merox user who generated API key</p>||
+|{$MEROX.API.TOKEN} |<p>Merox API key token</p>||
+
+## Feedback
+
+Please report any issues with the template at https://github.com/ManoManoTech/zabbix_template_merox

--- a/Applications/DNS/template_merox/6.4/template_merox.yaml
+++ b/Applications/DNS/template_merox/6.4/template_merox.yaml
@@ -1,0 +1,963 @@
+zabbix_export:
+  version: '6.4'
+  template_groups:
+    - uuid: a571c0d144b14fd4a87a9d9b2aa9fcd6
+      name: Templates/Applications
+  templates:
+    - uuid: b21dc3f4eaf9499fa77a7d266effe2d4
+      template: Merox
+      name: Merox
+      description: |
+        Template for retrieving Merox application domain information via HTTP agent.
+        Metrics are collected by API requests.
+        It also retrieves information related to DNS SPF, DMARC and MX records.
+        
+        Don't forget to change macros {$MEROX.API.TOKEN}, {$MEROX.API.USER}
+        
+        {$DNS.IP} is the variable containing the DNS server that will query for SPF, DMARC and MX record values.
+      groups:
+        - name: Templates/Applications
+      items:
+        - uuid: d4c54bfd85324f358f24218a592a9913
+          name: 'Merox: Get domains'
+          type: HTTP_AGENT
+          key: merox.domains
+          delay: 1h
+          trends: '0'
+          value_type: TEXT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data.[*]'
+          timeout: 1m
+          url: '{$MEROX.API.URL}/domain?limit=1000'
+          headers:
+            - name: username
+              value: '{$MEROX.API.USER}'
+            - name: token
+              value: '{$MEROX.API.TOKEN}'
+            - name: v
+              value: '{$MEROX.API.VERSION}'
+            - name: content-type
+              value: application/json
+          tags:
+            - tag: component
+              value: domains
+        - uuid: c6ef21b074654629ba2e385f9a655d14
+          name: 'Merox: Get Statistics'
+          type: HTTP_AGENT
+          key: merox.statistics
+          delay: 1d
+          trends: '0'
+          value_type: TEXT
+          timeout: 1m
+          url: '{$MEROX.API.URL}/statistics/dashboard?nbDays=7&category=All'
+          headers:
+            - name: username
+              value: '{$MEROX.API.USER}'
+            - name: token
+              value: '{$MEROX.API.TOKEN}'
+            - name: v
+              value: '{$MEROX.API.VERSION}'
+            - name: content-type
+              value: application/json
+          tags:
+            - tag: component
+              value: statistics
+        - uuid: bb525f87055b4c1981929674bb4f2858
+          name: 'Merox: Statistics: analyzedMessages'
+          type: DEPENDENT
+          key: merox.statistics.analyzedMessages
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.analyzedMessages
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+          triggers:
+            - uuid: 3ffa4c21330a4a4e860d8bfbbf70fc2d
+              expression: 'last(/Merox/merox.statistics.analyzedMessages,#1)=0'
+              name: 'Merox: Statistics: analyzedMessages = 0'
+              priority: HIGH
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+        - uuid: 5643702dbd354a04a2e8a7084788d4c6
+          name: 'Merox: Statistics: averageScore'
+          type: DEPENDENT
+          key: merox.statistics.averageScore
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.averageScore
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+          triggers:
+            - uuid: 9578e9bbcb3743fdbad69ea148bca032
+              expression: change(/Merox/merox.statistics.averageScore)<0
+              name: 'Merox: Statistics: averageScore decrease'
+              priority: HIGH
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+            - uuid: d7fd3dc9d938405cb33ced2bafc1b5e5
+              expression: change(/Merox/merox.statistics.averageScore)>0
+              name: 'Merox: Statistics: averageScore increase'
+              priority: INFO
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+        - uuid: 86ba66e0b3bd4704b6218f5565260bdd
+          name: 'Merox: Statistics: blockedAnomalies'
+          type: DEPENDENT
+          key: merox.statistics.blockedAnomalies
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.blockedAnomalies
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+        - uuid: 06ab9c9151cf4d4992249b80b47cbb46
+          name: 'Merox: Statistics: detectedDNSChanges'
+          type: DEPENDENT
+          key: merox.statistics.detectedDNSChanges
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.detectedDNSChanges
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+          triggers:
+            - uuid: a2aebfe358634725835d68bc54a09393
+              expression: change(/Merox/merox.statistics.detectedDNSChanges)>0
+              name: 'Merox: Statistics: detectedDNSChanges increase'
+              priority: HIGH
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+        - uuid: 25d257768bb84c2495781970609b2024
+          name: 'Merox: Statistics: lowestScore'
+          type: DEPENDENT
+          key: merox.statistics.lowestScore
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.lowestScore
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+          triggers:
+            - uuid: 6e577744413343e090a0bb45002ac563
+              expression: change(/Merox/merox.statistics.lowestScore)<0
+              name: 'Merox: Statistics: lowestScore decrease'
+              priority: HIGH
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+            - uuid: 0558104f15fd4f748e5da382327eb477
+              expression: change(/Merox/merox.statistics.lowestScore)>0
+              name: 'Merox: Statistics: lowestScore increase'
+              priority: INFO
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+        - uuid: 33face3feb974e158d1bf04247edb628
+          name: 'Merox: Statistics: DomainsNb'
+          type: DEPENDENT
+          key: merox.statistics.nbDomains
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.nbDomains
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+            - tag: record
+              value: spf
+        - uuid: 77c7fbbeb0d94aa59b52481dd14bc816
+          name: 'Merox: Statistics: DKIMNbInvalidOrAbsent'
+          type: DEPENDENT
+          key: merox.statistics.nbInvalidOrAbsentDKIM
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.nbInvalidOrAbsentDKIM
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+            - tag: record
+              value: dkim
+          triggers:
+            - uuid: 0cdf8fe3e2db43799a00dae9f7bb8fbd
+              expression: change(/Merox/merox.statistics.nbInvalidOrAbsentDKIM)<0
+              name: 'Merox: Statistics: DKIMNbInvalidOrAbsent decrease'
+              priority: INFO
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+                - tag: record
+                  value: dkim
+            - uuid: db4ce231b05d4f6c9cf1c51b077b9618
+              expression: change(/Merox/merox.statistics.nbInvalidOrAbsentDKIM)>0
+              name: 'Merox: Statistics: DKIMNbInvalidOrAbsent increase'
+              priority: HIGH
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+                - tag: record
+                  value: dkim
+        - uuid: d7bcc8a81ed84cf08826e60b16e9244e
+          name: 'Merox: Statistics: DmarcNbProtected'
+          type: DEPENDENT
+          key: merox.statistics.nbProtectedDmarc
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.nbProtectedDmarc
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+            - tag: record
+              value: dmarc
+          triggers:
+            - uuid: 14069b523aa0481eb84c05d7ccb9b5f7
+              expression: change(/Merox/merox.statistics.nbProtectedDmarc)<0
+              name: 'Merox: Statistics: DmarcNbProtected decrease'
+              priority: HIGH
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+                - tag: record
+                  value: dmarc
+            - uuid: 427cd6155b6349e1a7a6cd3009faa947
+              expression: change(/Merox/merox.statistics.nbProtectedDmarc)>0
+              name: 'Merox: Statistics: DmarcNbProtected increase'
+              priority: INFO
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+                - tag: record
+                  value: dmarc
+        - uuid: e13557488b5e423daa94a02ca5fe39bb
+          name: 'Merox: Statistics: SPFnbProtected'
+          type: DEPENDENT
+          key: merox.statistics.nbProtectedSPF
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.nbProtectedSPF
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+            - tag: record
+              value: spf
+          triggers:
+            - uuid: 1fdae5463f9f4b7588c345483eb61268
+              expression: change(/Merox/merox.statistics.nbProtectedSPF)<0
+              name: 'Merox: Statistics: SPFnbProtected decrease'
+              priority: HIGH
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+                - tag: record
+                  value: spf
+            - uuid: 4d4c7ca4a9ed41c5986a3e28ee0056a5
+              expression: change(/Merox/merox.statistics.nbProtectedSPF)>0
+              name: 'Merox: Statistics: SPFnbProtected increase'
+              priority: INFO
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+                - tag: record
+                  value: spf
+        - uuid: 3345130beecf4d54866bb8d48d24a9db
+          name: 'Merox: Statistics: DmarcNbRisk'
+          type: DEPENDENT
+          key: merox.statistics.nbRiskDmarc
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.nbRiskDmarc
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+            - tag: record
+              value: dmarc
+        - uuid: 33f3f70517b74b8baa8500f72d6ce149
+          name: 'Merox: Statistics: SPFNbRisk'
+          type: DEPENDENT
+          key: merox.statistics.nbRiskSPF
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.nbRiskSPF
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+            - tag: record
+              value: spf
+        - uuid: 82c9006bdf664e85b46cdf9823c60801
+          name: 'Merox: Statistics: DmarcNbUnprotected'
+          type: DEPENDENT
+          key: merox.statistics.nbUnprotectedDmarc
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.nbUnprotectedDmarc
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+            - tag: record
+              value: dmarc
+        - uuid: d8df9b255c724b6bbc709f676897e326
+          name: 'Merox: Statistics: SPFNbUnprotected'
+          type: DEPENDENT
+          key: merox.statistics.nbUnprotectedSPF
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.nbUnprotectedSPF
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+            - tag: record
+              value: spf
+        - uuid: 725a7ca849d848c38b1381741f8da643
+          name: 'Merox: Statistics: BIMINbValid'
+          type: DEPENDENT
+          key: merox.statistics.nbValidBIMI
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.nbValidBIMI
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+            - tag: record
+              value: bimi
+          triggers:
+            - uuid: 83afe1fefc73416ca9090b028bd3b1be
+              expression: change(/Merox/merox.statistics.nbValidBIMI)<0
+              name: 'Merox: Statistics: BIMINbValid decrease'
+              priority: HIGH
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+                - tag: record
+                  value: bimi
+            - uuid: ba2d3f14a81d4004bc10dbb16dd6d593
+              expression: change(/Merox/merox.statistics.nbValidBIMI)>0
+              name: 'Merox: Statistics: BIMINbValid increase'
+              priority: INFO
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: statistics
+                - tag: record
+                  value: bimi
+        - uuid: 2f0dee09ce67461db23b919d1de7dd72
+          name: 'Merox: Statistics: DKIMnbValid'
+          type: DEPENDENT
+          key: merox.statistics.nbValidDKIM
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.nbValidDKIM
+          master_item:
+            key: merox.statistics
+          tags:
+            - tag: component
+              value: statistics
+            - tag: record
+              value: dkim
+      discovery_rules:
+        - uuid: cf7c43b3f8b6483ca2774ab75516bc2f
+          name: 'Domains discovery'
+          type: DEPENDENT
+          key: merox.domains.discovery
+          delay: '0'
+          item_prototypes:
+            - uuid: 2dc9118283ae4fb791faf0a11cb21042
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: DMARC Policy'
+              type: DEPENDENT
+              key: 'merox.domains.details.dmarc.policy[{#DOMAIN.NAME}]'
+              delay: '0'
+              trends: '0'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.currentStatus.dmarc.information
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              master_item:
+                key: 'merox.domains.details[{#DOMAIN.NAME}]'
+              tags:
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: record
+                  value: dmarc
+              trigger_prototypes:
+                - uuid: 04294f703e3f469e99088361ad1ca0a8
+                  expression: 'change(/Merox/merox.domains.details.dmarc.policy[{#DOMAIN.NAME}])<>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: DMARC Policy change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: dmarc
+            - uuid: ec8b30a26e02420a94bc64afa14fab91
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: Domain Name'
+              type: DEPENDENT
+              key: 'merox.domains.details.domainname[{#DOMAIN.NAME}]'
+              delay: '0'
+              trends: '0'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.name
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              master_item:
+                key: 'merox.domains.details[{#DOMAIN.NAME}]'
+              tags:
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: domainname
+            - uuid: e8ab945ee61a4493939d5394a5fb19a3
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: MX Infos'
+              type: DEPENDENT
+              key: 'merox.domains.details.mx.info[{#DOMAIN.NAME}]'
+              delay: '0'
+              trends: '0'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.currentStatus.mx.information
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              master_item:
+                key: 'merox.domains.details[{#DOMAIN.NAME}]'
+              tags:
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: record
+                  value: mx
+              trigger_prototypes:
+                - uuid: 13e541905d3244ddaee57b2fcdc1cd21
+                  expression: 'change(/Merox/merox.domains.details.mx.info[{#DOMAIN.NAME}])<>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: MX Infos change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: mx
+            - uuid: da0b83dae1cf4553adc8e5fd57802e0f
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: MX Status'
+              type: DEPENDENT
+              key: 'merox.domains.details.mx.status[{#DOMAIN.NAME}]'
+              delay: '0'
+              trends: '0'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.currentStatus.mx.status
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              master_item:
+                key: 'merox.domains.details[{#DOMAIN.NAME}]'
+              tags:
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: record
+                  value: mx
+              trigger_prototypes:
+                - uuid: 1321f68d7aec4acaa4c232ce8edba990
+                  expression: 'change(/Merox/merox.domains.details.mx.status[{#DOMAIN.NAME}])<>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: MX Status change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: mx
+            - uuid: 2bb5f28f6cb545a386c17bde767173ab
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: Registrar Infos'
+              type: DEPENDENT
+              key: 'merox.domains.details.registrar.infos[{#DOMAIN.NAME}]'
+              delay: '0'
+              trends: '0'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.currentStatus.registrar.information
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              master_item:
+                key: 'merox.domains.details[{#DOMAIN.NAME}]'
+              tags:
+                - tag: component
+                  value: registrar
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+              trigger_prototypes:
+                - uuid: c3ac3d18769b4ff4ab3ddbf930edff0c
+                  expression: 'change(/Merox/merox.domains.details.registrar.infos[{#DOMAIN.NAME}])<>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: Registrar Status change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: component
+                      value: registrar
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+            - uuid: a91628ea5bf3478cae34088200fbb22c
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: SMTP TLS Infos'
+              type: DEPENDENT
+              key: 'merox.domains.details.smtptls.info[{#DOMAIN.NAME}]'
+              delay: '0'
+              trends: '0'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.currentStatus.smtpTls.information
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              master_item:
+                key: 'merox.domains.details[{#DOMAIN.NAME}]'
+              tags:
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: record
+                  value: smtp
+              trigger_prototypes:
+                - uuid: 66a4f75cf1be48769a07de51f7f6a233
+                  expression: 'change(/Merox/merox.domains.details.smtptls.info[{#DOMAIN.NAME}])<>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: SMTP TLS Infos change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: smtp
+            - uuid: b692339b292d489e8e1083488574adec
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: SMTP TLS Status'
+              type: DEPENDENT
+              key: 'merox.domains.details.smtptls.status[{#DOMAIN.NAME}]'
+              delay: '0'
+              trends: '0'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.currentStatus.smtpTls.status
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              master_item:
+                key: 'merox.domains.details[{#DOMAIN.NAME}]'
+              tags:
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: record
+                  value: smtp
+              trigger_prototypes:
+                - uuid: ffb1f9c6a3c44c438c01e602acb0bd9f
+                  expression: 'change(/Merox/merox.domains.details.smtptls.status[{#DOMAIN.NAME}])<>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: SMTP TLS Status change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: smtp
+            - uuid: cdec325b54ab4e45b2d4175babb590f4
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: SPF Mechanisms'
+              type: DEPENDENT
+              key: 'merox.domains.details.spf.mechanisms[{#DOMAIN.NAME}]'
+              delay: '0'
+              trends: '0'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.currentStatus.spf.information
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              master_item:
+                key: 'merox.domains.details[{#DOMAIN.NAME}]'
+              tags:
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: record
+                  value: spf
+              trigger_prototypes:
+                - uuid: 65f7f8119e8848b0964aa61357fffa6d
+                  expression: 'change(/Merox/merox.domains.details.spf.mechanisms[{#DOMAIN.NAME}])<>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: SPF Mechanisms change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: spf
+            - uuid: 73d269769a24472ab44d3fc6d0e66021
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: SPF Status'
+              type: DEPENDENT
+              key: 'merox.domains.details.spf.status[{#DOMAIN.NAME}]'
+              delay: '0'
+              trends: '0'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.currentStatus.spf.status
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              master_item:
+                key: 'merox.domains.details[{#DOMAIN.NAME}]'
+              tags:
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: record
+                  value: spf
+              trigger_prototypes:
+                - uuid: 6f00b67abf7045e696247f27aeca0385
+                  expression: 'change(/Merox/merox.domains.details.spf.status[{#DOMAIN.NAME}])<>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: SPF Status change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: spf
+            - uuid: d6f280f4b876477595ec06b0ed4b07a6
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: details'
+              type: HTTP_AGENT
+              key: 'merox.domains.details[{#DOMAIN.NAME}]'
+              delay: 1h
+              trends: '0'
+              value_type: TEXT
+              preprocessing:
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              timeout: 1m
+              url: '{$MEROX.API.URL}/domain/{#DOMAIN.NAME}'
+              headers:
+                - name: username
+                  value: '{$MEROX.API.USER}'
+                - name: token
+                  value: '{$MEROX.API.TOKEN}'
+                - name: v
+                  value: '{$MEROX.API.VERSION}'
+                - name: content-type
+                  value: application/json
+              tags:
+                - tag: component
+                  value: raw
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: record
+                  value: smtp
+            - uuid: 6b89cdbcc51942b38abe45a82aa334d4
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: Score'
+              type: DEPENDENT
+              key: 'merox.domains.score[{#DOMAIN.NAME}]'
+              delay: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.name== "{#DOMAIN.NAME}")].score.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              master_item:
+                key: merox.domains
+              tags:
+                - tag: component
+                  value: score
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+              trigger_prototypes:
+                - uuid: 1f2490fc3e7a482099138c1d49499367
+                  expression: 'change(/Merox/merox.domains.score[{#DOMAIN.NAME}])<0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: Score change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: component
+                      value: score
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                - uuid: defd9954db0a43f0ac36bce0e6abeb85
+                  expression: 'change(/Merox/merox.domains.score[{#DOMAIN.NAME}])>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: Score change'
+                  priority: INFO
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: component
+                      value: score
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+            - uuid: b61e5c9856a44581aa7f926b461e3c42
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: BIMI DNS Value'
+              key: 'net.dns.record[{$DNS.IP},default._bimi.{#DOMAIN.NAME},TXT,2,1,tcp]'
+              delay: 1h
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              tags:
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: record
+                  value: bimi
+              trigger_prototypes:
+                - uuid: ce398591dd994287a8d334e3c847f048
+                  expression: 'change(/Merox/net.dns.record[{$DNS.IP},default._bimi.{#DOMAIN.NAME},TXT,2,1,tcp])<>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: BIMI DNS Value change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: bimi
+            - uuid: f8e00825a1d048508e075d9076621c16
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: DMARC DNS Value'
+              key: 'net.dns.record[{$DNS.IP},_dmarc.{#DOMAIN.NAME},TXT]'
+              delay: 1h
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              tags:
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: record
+                  value: dmarc
+              trigger_prototypes:
+                - uuid: d3c3d00ca78148a683172278ab5d19ef
+                  expression: 'change(/Merox/net.dns.record[{$DNS.IP},_dmarc.{#DOMAIN.NAME},TXT])<>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: DMARC DNS Value change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: dmarc
+                - uuid: f027ef41162f474496d2bb1da6e81fde
+                  expression: 'nodata(/Merox/net.dns.record[{$DNS.IP},_dmarc.{#DOMAIN.NAME},TXT],12h)=1'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: DMARC DNS Value empty'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: dmarc
+            - uuid: 401851c5d6b747498dd8118568ccee7e
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: MX DNS Value'
+              key: 'net.dns.record[{$DNS.IP},{#DOMAIN.NAME},MX]'
+              delay: 1h
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              tags:
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: record
+                  value: mx
+              trigger_prototypes:
+                - uuid: 4e0b0e44180146b6b5bc8083cdd6ec59
+                  expression: 'change(/Merox/net.dns.record[{$DNS.IP},{#DOMAIN.NAME},MX])<>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: MX DNS Value change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: mx
+                - uuid: ab2c91294f834214b52b8a51acf56edf
+                  expression: 'nodata(/Merox/net.dns.record[{$DNS.IP},{#DOMAIN.NAME},MX],12h)=1'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: MX DNS Value empty'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: mx
+            - uuid: 12251a747e9145dcbc02a7176d673f61
+              name: 'Merox: Domain [{#DOMAIN.NAME}]: SPF DNS Value'
+              key: 'net.dns.record[{$DNS.IP},{#DOMAIN.NAME},TXT,2,1,tcp]'
+              delay: 1h
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 8h
+              tags:
+                - tag: domain
+                  value: '{#DOMAIN.NAME}'
+                - tag: record
+                  value: spf
+              trigger_prototypes:
+                - uuid: d2e94ec0628242599e85e8bda8673251
+                  expression: 'change(/Merox/net.dns.record[{$DNS.IP},{#DOMAIN.NAME},TXT,2,1,tcp])<>0'
+                  name: 'Merox: Domain [{#DOMAIN.NAME}]: SPF DNS Value change'
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  tags:
+                    - tag: component
+                      value: domain
+                    - tag: domain
+                      value: '{#DOMAIN.NAME}'
+                    - tag: record
+                      value: spf
+          master_item:
+            key: merox.domains
+          lld_macro_paths:
+            - lld_macro: '{#DOMAIN.NAME}'
+              path: $.name
+            - lld_macro: '{#DOMAIN.SCORE}'
+              path: $.score
+      tags:
+        - tag: class
+          value: application
+        - tag: name
+          value: merox
+        - tag: target
+          value: merox
+      macros:
+        - macro: '{$DNS.IP}'
+          value: 8.8.8.8
+        - macro: '{$MEROX.API.TOKEN}'
+        - macro: '{$MEROX.API.URL}'
+          value: 'https://api.merox.io'
+        - macro: '{$MEROX.API.USER}'
+        - macro: '{$MEROX.API.VERSION}'
+          value: '0.1'


### PR DESCRIPTION
Adds a template for monitoring an [Merox application](https://www.merox.io/).
Merox is a web application that lets you monitor your domains, particularly from a messaging point of view (SPF, MX, DMARC, DKIM, BIMI). This application guides you in configuring your DNS records to secure your e-mail domains. It provides a score (0 to 100) per domain for best practices.
By using the API, we can retrieve this score and certain values enabling us to set alerts in the event of modification (DNS Record, Score, etc.).
From a Zabbix point of view, there's nothing specific to configure. Just HTTP and DNS requests. ([API Documentation](https://doc.api.merox.io/api-details#api=merox-api-production-azfn&operation=get-getdashboardstatistics))