### PR TITLE
Add Merox template to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This repository is dedicated to templates that are created and maintained by Zab
         * [Bind queries](Applications/DNS/template_bind_recursive_queries)
         * [DNS-bind](Applications/DNS/template_bind_stat)
         * [Knot Resolver Statistics](Applications/DNS/template_knot_resolver)
+        * [Merox](Applications/DNS/template_merox)
         * [net.dns.perf](Applications/DNS/template_net.dns.perf)
         * [pihole-FTL over zabbix active agent](Applications/DNS/template_pihole_daemon_check)
     * [Excel_Export](Applications/Excel_Export)


### PR DESCRIPTION
Hello,
[My previous MR](https://github.com/zabbix/community-templates/pull/302) was approved but I hadn't added the template in the README. Here is the correction