### PR TITLE
Bind statistic channels improved template

### DIFF
--- a/Applications/DNS/template_bind_stat/6.4/README.md
+++ b/Applications/DNS/template_bind_stat/6.4/README.md
@@ -1,0 +1,85 @@
+# DNS bind statistics
+
+## Overview
+
+**Requirements**  
+ Bind Server 9 and above  
+ Zabbix Server 4+ and above  
+ Zabbix Agent on monitored host
+ Installed jq and curl utility 
+  
+  
+**How it works**  
+Include statistics in named.conf  
+  
+/etc/named.conf
+
+statistics-channels {
+	inet 127.0.0.1 port 8053 allow { 127.0.0.1; };
+};
+
+
+semanage port --add -t dns_port_t -p tcp 8053
+systemctl restart named
+dnf install jq curl
+
+Include - zabbix\_agentd.d/bind_jq.conf 
+UserParameter=bind.queries.jq[*],curl $3 2>/dev/null | jq ".$1.$2"
+
+## Macros used
+
+|Name|Description|
+|----|-----------|
+|{$BIND_STAT_URL}|URL of bind statistic-channels, default http://127.0.0.1:8053/json|
+
+## Template links
+
+There are no template links in this template.
+
+## Discovery rules
+
+There are no discovery rules in this template.
+
+## Items collected
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|Port 53BIND|<p>-</p>|`Zabbix agent`|net.udp.listen[53]<p>Update: 5m</p>|
+|Queries A|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,A,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries AAAA|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,AAAA,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries ANY|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,ANY,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries AuthAns|<p>-</p>|`Zabbix agent`|bind.queries.jq[nsstats,QryAuthAns,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries AXFR|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,AXFR,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries CDNSKEY|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,CDNSKEY,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries CNAME|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,CNAME,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries DNSKEY|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,DNSKEY,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries Dropped|<p>-</p>|`Zabbix agent`|bind.queries.jq[nsstats,QryDropped,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries DS|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,DS,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries Failure|<p>-</p>|`Zabbix agent`|bind.queries.jq[nsstats,QryFailure,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries HTTPS|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,HTTPS,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries MX|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,MX,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries NS|<p>-</p>|`Zabbix agent`|	bind.queries.jq[qtypes,NS,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries NXDOMAIN|<p>-</p>|`Zabbix agent`|bind.queries.jq[nsstats,QryNXDOMAIN,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries Nxrrset|<p>-</p>|`Zabbix agent`|bind.queries.jq[nsstats,QryNxrrset,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries Others|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,Others,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries PTR|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,PTR,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries Requestv4|<p>-</p>|`Zabbix agent`|bind.queries.jq[nsstats,Requestv4,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries Requestv6|<p>-</p>|`Zabbix agent`|bind.queries.jq[nsstats,Requestv6,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries RRSIG|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,RRSIG,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries SOA|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,SOA,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries SPF|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,SPF,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries SRV|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,SRV,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries Success|<p>-</p>|`Zabbix agent`|bind.queries.jq[nsstats,QrySuccess,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries TCP|<p>-</p>|`Zabbix agent`|bind.queries.jq[nsstats,QryTCP,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries TLSA|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,TLSA,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries TXT|<p>-</p>|`Zabbix agent`|bind.queries.jq[qtypes,TXT,{$BIND_STAT_URL}]<p>Update: 30</p>|
+|Queries UDP|<p>-</p>|`Zabbix agent`|bind.queries.jq[nsstats,QryUDP,{$BIND_STAT_URL}]<p>Update: 30</p>|
+
+
+## Triggers
+
+|Name|Description|Expression|Recovery Expression|Severity|Dependencies and additional info|
+|----|-----------|----------|--------|--------------------------------|
+|BIND: Port not opened (UDP 53) at {HOST.HOST}||`min(/DNS-bind stat jq/net.udp.listen[53],#3)<>1`|`min(/DNS-bind stat jq/net.udp.listen[53],#10)=1`|Disaster||
+
+

--- a/Applications/DNS/template_bind_stat/6.4/README.md
+++ b/Applications/DNS/template_bind_stat/6.4/README.md
@@ -79,7 +79,7 @@ There are no discovery rules in this template.
 ## Triggers
 
 |Name|Description|Expression|Recovery Expression|Severity|Dependencies and additional info|
-|----|-----------|----------|--------|--------------------------------|
+|----|-----------|----------|--------------------|--------|--------------------------------|
 |BIND: Port not opened (UDP 53) at {HOST.HOST}||`min(/DNS-bind stat jq/net.udp.listen[53],#3)<>1`|`min(/DNS-bind stat jq/net.udp.listen[53],#10)=1`|Disaster||
 
 

--- a/Applications/DNS/template_bind_stat/6.4/README.md
+++ b/Applications/DNS/template_bind_stat/6.4/README.md
@@ -4,7 +4,7 @@
 
 **Requirements**  
 
-Instead xml2 command, which was used in previous template version, which is not present at EL8 and newer RHEL based systems this template uses jq command and parses directly Json output of Bind statistic-channels. Added more values, Graphs and Dashboard.
+Instead xml2 command, which was used in previous template version and unfortunately is not present at EL8 and newer RHEL based systems this template uses jq command and parses directly Json output of Bind statistic-channels. Added more values, Graphs and Dashboard.
 
  Bind Server 9 and above  
  Zabbix Server 4+ and above  

--- a/Applications/DNS/template_bind_stat/6.4/README.md
+++ b/Applications/DNS/template_bind_stat/6.4/README.md
@@ -3,6 +3,9 @@
 ## Overview
 
 **Requirements**  
+
+Instead xml2 command, which was used in previous template version, which is not present at EL8 and newer RHEL based systems this template uses jq command and parses directly Json output of Bind statistic-channels. Added more values, Graphs and Dashboard.
+
  Bind Server 9 and above  
  Zabbix Server 4+ and above  
  Zabbix Agent on monitored host

--- a/Applications/DNS/template_bind_stat/6.4/bind_jq.conf
+++ b/Applications/DNS/template_bind_stat/6.4/bind_jq.conf
@@ -1,0 +1,1 @@
+UserParameter=bind.queries.jq[*],curl $3 2>/dev/null | jq ".$1.$2"

--- a/Applications/DNS/template_bind_stat/6.4/template_bind_stat_jq.yaml
+++ b/Applications/DNS/template_bind_stat/6.4/template_bind_stat_jq.yaml
@@ -1,0 +1,729 @@
+zabbix_export:
+  version: '6.4'
+  template_groups:
+    - uuid: b76718fd5ddc44af9bd1252ae4b66012
+      name: Templates/Custom/kotlinj
+  templates:
+    - uuid: 0b25e80bf8d44fe1bc3ae2a164c29234
+      template: 'DNS-bind stat jq'
+      name: 'DNS-bind stat jq'
+      description: |
+        Bind DNS server statistics template.
+        Uses jq to process bind statistics-channels output instead of xml2 which is not present in EL8 systems and newer.
+        
+        Imeplementation:
+        
+        yum install jq
+        
+        BIND:
+        /etc/named.conf
+        
+        statistics-channels {
+        	inet 127.0.0.1 port 8053 allow { 127.0.0.1; };
+        };
+        
+        semanage port --add -t dns_port_t -p tcp 8053
+        systemctl restart named
+        
+        ZABBIX agent:
+        UserParameter=bind.queries.jq[*],curl $3 2>/dev/null | jq ".$1.$2"
+      groups:
+        - name: Templates/Custom/kotlinj
+      items:
+        - uuid: 535d2542e42a43a489c4d6c2d9a2f2e0
+          name: 'Queries AuthAns'
+          key: 'bind.queries.jq[nsstats,QryAuthAns,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 284dfda4c4b541fdbf34e4b6aebb784c
+          name: 'Queries Dropped'
+          key: 'bind.queries.jq[nsstats,QryDropped,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 206131188aa7432492c82d893ba51a21
+          name: 'Queries Failure'
+          key: 'bind.queries.jq[nsstats,QryFailure,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 9457ee92d6b34e0884ba0f9654f0bf3e
+          name: 'Queries NXDOMAIN'
+          key: 'bind.queries.jq[nsstats,QryNXDOMAIN,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 9a2caf32211240a48d5879979d7bcbc3
+          name: 'Queries Nxrrset'
+          key: 'bind.queries.jq[nsstats,QryNxrrset,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: bef79a0a75b5409295841e86ea71ee75
+          name: 'Queries Success'
+          key: 'bind.queries.jq[nsstats,QrySuccess,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: f15fda4837be48b4a1fe7a6e753e0eb9
+          name: 'Queries TCP'
+          key: 'bind.queries.jq[nsstats,QryTCP,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: b2f2b88d510240ba8519a95833454ba9
+          name: 'Queries UDP'
+          key: 'bind.queries.jq[nsstats,QryUDP,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: f5456eb558eb49c3aa4932d89ffb8fca
+          name: 'Queries Requestv4'
+          key: 'bind.queries.jq[nsstats,Requestv4,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 8ce6737c00584916941fc16da1c93588
+          name: 'Queries Requestv6'
+          key: 'bind.queries.jq[nsstats,Requestv6,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: d8f173de178946d787841fc5dc5c36c0
+          name: 'Queries A'
+          key: 'bind.queries.jq[qtypes,A,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: bb96bb4bc84544c9881e9414a1c20deb
+          name: 'Queries AAAA'
+          key: 'bind.queries.jq[qtypes,AAAA,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 5fa1c1331fa34db5965214eab4d97489
+          name: 'Queries ANY'
+          key: 'bind.queries.jq[qtypes,ANY,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 21d29e8fdd714749bf7181c2bdf40d95
+          name: 'Queries AXFR'
+          key: 'bind.queries.jq[qtypes,AXFR,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 4307a8433d65478588029d6d16c8b577
+          name: 'Queries CDNSKEY'
+          key: 'bind.queries.jq[qtypes,CDNSKEY,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 9c701b7777c94f5f869db79fe041d8bf
+          name: 'Queries CNAME'
+          key: 'bind.queries.jq[qtypes,CNAME,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 1e66461907704bf9b975856644a2558f
+          name: 'Queries DNSKEY'
+          key: 'bind.queries.jq[qtypes,DNSKEY,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 961937f4d9674791a8b33520c56bd8e8
+          name: 'Queries DS'
+          key: 'bind.queries.jq[qtypes,DS,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 2acbc0cd4f4e4f2e8ea8a223345b48ae
+          name: 'Queries HTTPS'
+          key: 'bind.queries.jq[qtypes,HTTPS,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 53256b06727b433384f5853bc85c9428
+          name: 'Queries MX'
+          key: 'bind.queries.jq[qtypes,MX,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: d24c3a7a54ee4fda835f5732e651759a
+          name: 'Queries NS'
+          key: 'bind.queries.jq[qtypes,NS,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: dd6aa0b7b64846c1a69347457bb59fb4
+          name: 'Queries Others'
+          key: 'bind.queries.jq[qtypes,Others,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 41d708823e5a407a8b51eafc29aed8e6
+          name: 'Queries PTR'
+          key: 'bind.queries.jq[qtypes,PTR,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 92b1bfad0a2e4f4c8e369f81a8f02267
+          name: 'Queries RRSIG'
+          key: 'bind.queries.jq[qtypes,RRSIG,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 454ebc0d594e415baa344d5cd16beb27
+          name: 'Queries SOA'
+          key: 'bind.queries.jq[qtypes,SOA,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 39816441a7b24f0ba9fe7c2712cbb37c
+          name: 'Queries SPF'
+          key: 'bind.queries.jq[qtypes,SPF,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: ffa17dde365f440885ce13ac30fcd62a
+          name: 'Queries SRV'
+          key: 'bind.queries.jq[qtypes,SRV,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 7038830300ed4575bfb03c5a3b9aa767
+          name: 'Queries TLSA'
+          key: 'bind.queries.jq[qtypes,TLSA,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 74fead404804494885d3e1b83fc8ba2b
+          name: 'Queries TXT'
+          key: 'bind.queries.jq[qtypes,TXT,{$BIND_STAT_URL}]'
+          delay: 30s
+          trends: 120d
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - ''
+            - type: SIMPLE_CHANGE
+              parameters:
+                - ''
+              error_handler: DISCARD_VALUE
+          tags:
+            - tag: DNS
+        - uuid: 080dd0ae255d4a2e9cd4aaa5f1d69b26
+          name: 'Port 53BIND'
+          key: 'net.udp.listen[53]'
+          delay: 5m
+          history: 30d
+          trends: '0'
+          tags:
+            - tag: DNS
+          triggers:
+            - uuid: d0eb12aba0e24fa8a3023dcf5d18a4d8
+              expression: 'min(/DNS-bind stat jq/net.udp.listen[53],#3)<>1'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'min(/DNS-bind stat jq/net.udp.listen[53],#10)=1'
+              name: 'BIND: Port not opened (UDP 53) at {HOST.HOST}'
+              priority: DISASTER
+              tags:
+                - tag: DNS
+      macros:
+        - macro: '{$BIND_STAT_URL}'
+          value: 'http://127.0.0.1:8053/json'
+      dashboards:
+        - uuid: 0813b189ef9a4bf59aa134d5ba82bb84
+          name: 'DNS Bind'
+          pages:
+            - widgets:
+                - type: graph
+                  width: '12'
+                  height: '8'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'DNS-bind stat jq'
+                        name: 'Queries by type'
+                - type: graph
+                  'y': '8'
+                  width: '12'
+                  height: '6'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'DNS-bind stat jq'
+                        name: 'Queries by protocol'
+                - type: graph
+                  x: '12'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'DNS-bind stat jq'
+                        name: 'Queries by response'
+                - type: graph
+                  x: '12'
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'DNS-bind stat jq'
+                        name: 'Port 53 UDP'
+                - type: graph
+                  x: '12'
+                  'y': '8'
+                  width: '12'
+                  height: '6'
+                  fields:
+                    - type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'DNS-bind stat jq'
+                        name: 'Queries by IP version'
+  graphs:
+    - uuid: 25593d5ed2124dccbb590cc42bb4063b
+      name: 'Port 53 UDP'
+      graph_items:
+        - color: 1A7C11
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'net.udp.listen[53]'
+    - uuid: 52846ea303b6445c9d7df2cf63706dbe
+      name: 'Queries by IP version'
+      graph_items:
+        - color: 1A7C11
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[nsstats,Requestv4,{$BIND_STAT_URL}]'
+        - sortorder: '1'
+          color: 0040FF
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[nsstats,Requestv6,{$BIND_STAT_URL}]'
+    - uuid: 08b6f90d7bde4f0ea1c48f3564131553
+      name: 'Queries by protocol'
+      graph_items:
+        - color: 1A7C11
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[nsstats,QryTCP,{$BIND_STAT_URL}]'
+        - sortorder: '1'
+          color: '274482'
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[nsstats,QryUDP,{$BIND_STAT_URL}]'
+    - uuid: 99c6cf3bc7e8481093ecc69e4b04b797
+      name: 'Queries by response'
+      graph_items:
+        - color: 546E7A
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[nsstats,QryDropped,{$BIND_STAT_URL}]'
+        - sortorder: '1'
+          color: FF0000
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[nsstats,QryFailure,{$BIND_STAT_URL}]'
+        - sortorder: '2'
+          color: FF6F00
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[nsstats,QryNXDOMAIN,{$BIND_STAT_URL}]'
+        - sortorder: '3'
+          color: 2774A4
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[nsstats,QryNxrrset,{$BIND_STAT_URL}]'
+        - sortorder: '4'
+          color: 43A047
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[nsstats,QrySuccess,{$BIND_STAT_URL}]'
+    - uuid: 6ca443fdd0a54f96a01ba3c45bdb6c56
+      name: 'Queries by type'
+      graph_items:
+        - color: 1A7C11
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,A,{$BIND_STAT_URL}]'
+        - sortorder: '1'
+          color: '274482'
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,AAAA,{$BIND_STAT_URL}]'
+        - sortorder: '2'
+          color: F63100
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,ANY,{$BIND_STAT_URL}]'
+        - sortorder: '3'
+          color: 2774A4
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,AXFR,{$BIND_STAT_URL}]'
+        - sortorder: '4'
+          color: A54F10
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,CDNSKEY,{$BIND_STAT_URL}]'
+        - sortorder: '5'
+          color: FC6EA3
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,CNAME,{$BIND_STAT_URL}]'
+        - sortorder: '6'
+          color: 6C59DC
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,DNSKEY,{$BIND_STAT_URL}]'
+        - sortorder: '7'
+          color: AC8C14
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,DS,{$BIND_STAT_URL}]'
+        - sortorder: '8'
+          color: 611F27
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,HTTPS,{$BIND_STAT_URL}]'
+        - sortorder: '9'
+          color: F230E0
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,MX,{$BIND_STAT_URL}]'
+        - sortorder: '10'
+          color: 5CCD18
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,NS,{$BIND_STAT_URL}]'
+        - sortorder: '11'
+          color: BB2A02
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,Others,{$BIND_STAT_URL}]'
+        - sortorder: '12'
+          color: 5A2B57
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,PTR,{$BIND_STAT_URL}]'
+        - sortorder: '13'
+          color: 89ABF8
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,RRSIG,{$BIND_STAT_URL}]'
+        - sortorder: '14'
+          color: 7EC25C
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,SOA,{$BIND_STAT_URL}]'
+        - sortorder: '15'
+          color: 2B5429
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,SPF,{$BIND_STAT_URL}]'
+        - sortorder: '16'
+          color: 8048B4
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,TLSA,{$BIND_STAT_URL}]'
+        - sortorder: '17'
+          color: FD5434
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,TXT,{$BIND_STAT_URL}]'
+        - sortorder: '18'
+          color: 790E1F
+          calc_fnc: ALL
+          item:
+            host: 'DNS-bind stat jq'
+            key: 'bind.queries.jq[qtypes,SRV,{$BIND_STAT_URL}]'
+


### PR DESCRIPTION
Instead xml2 command, which was used in previous template version and unfortunately is not present at EL8 and newer RHEL based systems this template uses jq command and parses directly Json output of Bind statistic-channels. 

Added more values, Graphs and Dashboard.