### PR TITLE
added templates for xcp-ng/xenorchestra monitoring

### DIFF
--- a/Virtualization/xcp-ng/6.0/template_app_xenorchestra.yaml
+++ b/Virtualization/xcp-ng/6.0/template_app_xenorchestra.yaml
@@ -1,0 +1,1112 @@
+zabbix_export:
+  version: '6.0'
+  date: '2024-01-24T10:01:43Z'
+  groups:
+    - uuid: 1b837a3c078647049a0c00c61b4d57b5
+      name: Hypervisors
+    - uuid: 7df96b18c230490a9a0a9e2307226338
+      name: Templates
+    - uuid: 137f19e6e2dc4219b33553b812627bc2
+      name: 'Virtual machines'
+  templates:
+    - uuid: 8d4ad92902e6440ca14dfa5256d8bf82
+      template: 'XCP-NG Host via Xen Orchestra'
+      name: 'XCP-NG Host via Xen Orchestra'
+      groups:
+        - name: Templates
+      items:
+        - uuid: d137a2d23e554eb7b98d1de0ce26dfb6
+          name: 'CPU Cores'
+          type: DEPENDENT
+          key: xoa.host.cpu.cores
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.CPUs.cpu_count
+          master_item:
+            key: xoa.host.raw
+        - uuid: 0a1e66d4f0a4455abcfd9317c4c973b1
+          name: 'CPU Sockets'
+          type: DEPENDENT
+          key: xoa.host.cpu.sockets
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.CPUs.socket_count
+          master_item:
+            key: xoa.host.raw
+        - uuid: 702c08f7b6d94be49fbfaef45b1b4174
+          name: 'Host description'
+          type: DEPENDENT
+          key: xoa.host.description
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.name_description
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          master_item:
+            key: xoa.host.raw
+        - uuid: a6343812baea4750b24def6a3ef71f70
+          name: Enabled
+          type: DEPENDENT
+          key: xoa.host.enabled
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.enabled
+          master_item:
+            key: xoa.host.raw
+        - uuid: 604ae2b2e6b943c387edd492eddc8beb
+          name: 'Hypervisor brand'
+          type: DEPENDENT
+          key: xoa.host.hv.brand
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.productBrand
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          master_item:
+            key: xoa.host.raw
+        - uuid: 494f4ddea1cf40398641295be217878a
+          name: 'Hypervisor version'
+          type: DEPENDENT
+          key: xoa.host.hv.version
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.version
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          master_item:
+            key: xoa.host.raw
+        - uuid: c1c9cee844f34ff289b32559493af04f
+          name: 'Hypervisor version build'
+          type: DEPENDENT
+          key: xoa.host.hv.version.build
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.build
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          master_item:
+            key: xoa.host.raw
+        - uuid: ecf042cea23e45e89954fe6fc499be86
+          name: 'HVM capable'
+          type: DEPENDENT
+          key: xoa.host.hvm.capabale
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.hvmCapable
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: xoa.host.raw
+        - uuid: 4026336d2d97475e9019522c73535574
+          name: 'Memory total'
+          type: DEPENDENT
+          key: xoa.host.memory.total
+          delay: '0'
+          units: B
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.memory.size
+          master_item:
+            key: xoa.host.raw
+        - uuid: 6181620d670c4e3cbeaad0babe89fc1b
+          name: 'Memory used'
+          type: DEPENDENT
+          key: xoa.host.memory.used
+          delay: '0'
+          units: B
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.memory.usage
+          master_item:
+            key: xoa.host.raw
+        - uuid: ed5fe0b877ed469ebc0d4e4b32ff8a87
+          name: 'Memory used percent'
+          type: CALCULATED
+          key: xoa.host.memory.used.percent
+          delay: 5m
+          value_type: FLOAT
+          units: '%'
+          params: 'last(//xoa.host.memory.used)/last(//xoa.host.memory.total)*100'
+          triggers:
+            - uuid: 29677931a1b944038a687c8c28c4d015
+              expression: 'last(/XCP-NG Host via Xen Orchestra/xoa.host.memory.used.percent)>{$XOA.MEMORY.CRIT}'
+              name: 'Memory usage critical high'
+              priority: HIGH
+            - uuid: 9de3ff6c29d945a7b8ca5a2bb0a78493
+              expression: 'last(/XCP-NG Host via Xen Orchestra/xoa.host.memory.used.percent)>{$XOA.MEMORY.WARN}'
+              name: 'Memory usage exceeds {$XOA.MEMORY.WARN}'
+              priority: WARNING
+              dependencies:
+                - name: 'Memory usage critical high'
+                  expression: 'last(/XCP-NG Host via Xen Orchestra/xoa.host.memory.used.percent)>{$XOA.MEMORY.CRIT}'
+        - uuid: 81a949d8376b43b0b620de6bcbe3d525
+          name: 'XCP-NG Hosts: Get Missing Patches'
+          type: HTTP_AGENT
+          key: xoa.host.missingpatches.raw
+          delay: 15m
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          url: '{$XOA.URL}/rest/v0/hosts/{$XOA.HOST.UUID}/missing_patches'
+          headers:
+            - name: Cookie
+              value: 'authenticationToken={$XOA.AUTH.TOKEN}'
+            - name: Accept
+              value: application/json
+        - uuid: 3725dfaac75643fcb3cfe0b852a26f70
+          name: Hostname
+          type: DEPENDENT
+          key: xoa.host.name
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.name_label
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          master_item:
+            key: xoa.host.raw
+        - uuid: 5b2435e1c5dd49c7be4b7cc1dc31e64d
+          name: 'Power State'
+          type: DEPENDENT
+          key: xoa.host.power.state
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.power_state
+          master_item:
+            key: xoa.host.raw
+          triggers:
+            - uuid: 484c668a58c54317a61a405b52cc43ec
+              expression: 'last(/XCP-NG Host via Xen Orchestra/xoa.host.power.state)<>last(/XCP-NG Host via Xen Orchestra/xoa.host.power.state,#2)'
+              recovery_mode: NONE
+              name: 'Power state changed'
+              priority: INFO
+              manual_close: 'YES'
+        - uuid: 11c547b55c424e26bb02d87266980a6f
+          name: 'XCP-NG Hosts: Get Values'
+          type: HTTP_AGENT
+          key: xoa.host.raw
+          delay: 5m
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          url: '{$XOA.URL}/rest/v0/hosts/{$XOA.HOST.UUID}'
+          headers:
+            - name: Cookie
+              value: 'authenticationToken={$XOA.AUTH.TOKEN}'
+            - name: Accept
+              value: application/json
+        - uuid: ee2ab8db1e0f4d1f88df5fe6892eaf73
+          name: 'Reboot required'
+          type: DEPENDENT
+          key: xoa.host.reboot.required
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rebootRequired
+          master_item:
+            key: xoa.host.raw
+          triggers:
+            - uuid: 06a3b195183a49d9ac6f37afa802e5a9
+              expression: 'last(/XCP-NG Host via Xen Orchestra/xoa.host.reboot.required)="true"'
+              name: 'Reboot required for hosts'
+              priority: WARNING
+        - uuid: 077fd836ae1c420792fcf368fa43e8a3
+          name: 'Number of running VMs'
+          type: DEPENDENT
+          key: xoa.host.runningvms
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.residentVms
+            - type: JAVASCRIPT
+              parameters:
+                - 'return JSON.parse(value).length'
+          master_item:
+            key: xoa.host.raw
+        - uuid: 745f6fb406c34e3b8ec313a54b2c85cc
+          name: 'Host start time'
+          type: DEPENDENT
+          key: xoa.host.starttime
+          delay: '0'
+          units: unixtime
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.startTime
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: xoa.host.raw
+        - uuid: dab4f3b69f5141048e914d87ed23dd69
+          name: 'Number of Missing Patches'
+          type: DEPENDENT
+          key: xoa.hosts.missingpatches.count
+          delay: '0'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - 'return JSON.parse(value).length'
+          master_item:
+            key: xoa.host.missingpatches.raw
+          triggers:
+            - uuid: b4f671bc3ab8442c87147db31e815ffe
+              expression: 'last(/XCP-NG Host via Xen Orchestra/xoa.hosts.missingpatches.count)>{$XOA.HOST.MISSING.PATCHES.MAX}'
+              name: 'Number of {$XOA.HOST.MISSING.PATCHES.MAX} missing patches exceeded'
+              priority: WARNING
+      tags:
+        - tag: component
+          value: hypervisor
+        - tag: target
+          value: xcp-ng
+      macros:
+        - macro: '{$XOA.AUTH.TOKEN}'
+          value: CHANGE_IF_NEEDED
+          description: 'Authentication Token generated on XOA UI'
+        - macro: '{$XOA.HOST.MISSING.PATCHES.MAX}'
+          value: '1'
+          description: 'Maximum Number of missing patches allowed'
+        - macro: '{$XOA.HOST.UUID}'
+          value: CHANGE_IF_NEEDED
+          description: 'Host UUID'
+        - macro: '{$XOA.MEMORY.CRIT}'
+          value: '90'
+          description: 'Critical memory usage'
+        - macro: '{$XOA.MEMORY.WARN}'
+          value: '75'
+          description: 'Warn when memory usage is above'
+        - macro: '{$XOA.URL}'
+          value: CHANGE_IF_NEEDED
+          description: 'URL where XOA can be reached'
+      valuemaps:
+        - uuid: 7de0ad540b0f4fd5ab2b33ef9f79d440
+          name: 'XOA Boolean'
+          mappings:
+            - value: '1'
+              newvalue: 'true'
+            - value: '0'
+              newvalue: 'false'
+    - uuid: b1aa3ddc4db246c3a5e71658dd5a9601
+      template: 'XCP-NG VM via Xen Orchestra'
+      name: 'XCP-NG VM via Xen Orchestra'
+      groups:
+        - name: Templates
+      items:
+        - uuid: 6a01a4edf2364313a72939d2dfb7789c
+          name: 'vCPU active'
+          type: DEPENDENT
+          key: xoa.vm.cpu.active
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.CPUs.number
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 2149aaf9d7904bf4b28f4aaa943f120e
+          name: 'vCPU max'
+          type: DEPENDENT
+          key: xoa.vm.cpu.max
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.CPUs.max
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 2bd0262b02754c49bf1388e392bff454
+          name: 'VM description'
+          type: DEPENDENT
+          key: xoa.vm.description
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.name_description
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 011d9425a4bc4b4cb3cba08d878c0f83
+          name: 'Xen PV driver version'
+          type: DEPENDENT
+          key: xoa.vm.driver.version
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.pvDriversVersion
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 86a3094485084862a3a2d4d1bd9333b2
+          name: 'VM install time'
+          type: DEPENDENT
+          key: xoa.vm.installtime
+          delay: '0'
+          units: unixtime
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.installTime
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 37d6d0b60c654490b5d360b194538f15
+          name: 'Management agent detected'
+          type: DEPENDENT
+          key: xoa.vm.management.agent
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.managementAgentDetected
+          master_item:
+            key: xoa.vms.raw
+          triggers:
+            - uuid: 90dd8a29cfc3457aabb35ce8527683d4
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false"'
+              name: 'No management agent install on VM'
+              priority: INFO
+              manual_close: 'YES'
+        - uuid: e72db9c5c0474d099be380a577aafd23
+          name: 'Memory total'
+          type: DEPENDENT
+          key: xoa.vm.memory.total
+          delay: '0'
+          units: B
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.memory.size
+          master_item:
+            key: xoa.vms.raw
+        - uuid: c319917b771c46afbf2fdacf217216d1
+          name: 'Virtualization mode'
+          type: DEPENDENT
+          key: xoa.vm.mode
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.virtualizationMode
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: xoa.vms.raw
+        - uuid: e5f39794e08c4aeb9b2f96abf5dc58dc
+          name: 'VM name'
+          type: DEPENDENT
+          key: xoa.vm.name
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.name_label
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 24h
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 5397b9f0460742899d91a127b52f2020
+          name: 'OS Distribution'
+          type: DEPENDENT
+          key: xoa.vm.os.distro
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.os_version.distro
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 4126bf9d15464ecea0f7a0d0fe8fd8b8
+          name: 'OS version'
+          type: DEPENDENT
+          key: xoa.vm.os.version
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.os_version.name
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 2415c2f666e64438ae682c0855c2831b
+          name: 'Power State'
+          type: DEPENDENT
+          key: xoa.vm.power.state
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.power_state
+          master_item:
+            key: xoa.vms.raw
+          triggers:
+            - uuid: 4f938791d96b4898860edf870a1bc72e
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2)'
+              recovery_mode: NONE
+              name: 'State of VM changed'
+              priority: AVERAGE
+              manual_close: 'YES'
+        - uuid: d3da95b5b2c64e5e82c893e9fbd82743
+          name: 'Number of snapshots'
+          type: DEPENDENT
+          key: xoa.vm.snapshot
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.snapshots
+            - type: JAVASCRIPT
+              parameters:
+                - 'return JSON.parse(value).length'
+          master_item:
+            key: xoa.vms.raw
+          triggers:
+            - uuid: 353d88c34edc4ea3957a4ecc12e6db7b
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.snapshot)>{$XOA.VM.NO.SNAPSHOTS.MAX}'
+              name: 'Number of Snapshots exceeds {$XOA.VM.NO.SNAPSHOTS.MAX}'
+              priority: WARNING
+        - uuid: 889bc4bcaf0744f7ac14c36f45139cc8
+          name: 'VM start time'
+          type: DEPENDENT
+          key: xoa.vm.starttime
+          delay: '0'
+          units: unixtime
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.startTime
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: xoa.vms.raw
+        - uuid: cb8d4b3b8a0442c2aa48853c6ab45af3
+          name: 'Xen Tool Version'
+          type: DEPENDENT
+          key: xoa.vm.tools.version
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.xenTools.version
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 27f086c8cf754b789daf6868cf394172
+          name: 'XCP-NG VMS: Get Values'
+          type: HTTP_AGENT
+          key: xoa.vms.raw
+          delay: 5m
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          url: '{$XOA.URL}/rest/v0/vms/{$XOA.VM.UUID}'
+          headers:
+            - name: Cookie
+              value: 'authenticationToken={$XOA.AUTH.TOKEN}'
+            - name: Accept
+              value: application/json
+      tags:
+        - tag: component
+          value: hypervisor
+        - tag: target
+          value: guests
+      macros:
+        - macro: '{$XOA.AUTH.TOKEN}'
+          value: CHANGE_IF_NEEDED
+          description: 'Authentication Token generated on XOA UI'
+        - macro: '{$XOA.HOST.UUID}'
+          value: CHANGE_IF_NEEDED
+          description: 'Host UUID'
+        - macro: '{$XOA.URL}'
+          value: CHANGE_IF_NEEDED
+          description: 'URL where XOA can be reached'
+        - macro: '{$XOA.VM.NO.SNAPSHOTS.MAX}'
+          value: '1'
+          description: 'Max number of snapshots allowed'
+        - macro: '{$XOA.VM.UUID}'
+      valuemaps:
+        - uuid: 546880e65268446ba8d3b319f837b7eb
+          name: 'XOA Boolean'
+          mappings:
+            - value: '1'
+              newvalue: 'true'
+            - value: '0'
+              newvalue: 'false'
+    - uuid: 5f69e71a0ed1418da4daf08e4dc22b7c
+      template: 'Xen Orchestra by HTTP'
+      name: 'Xen Orchestra by HTTP'
+      groups:
+        - name: Templates
+      discovery_rules:
+        - uuid: 4f543445aeb1465ebb10fe09d895c661
+          name: 'Discovery Backups'
+          type: SCRIPT
+          key: xoa.backup.discovery
+          delay: 1h
+          status: DISABLED
+          params: |
+            try {
+            var params = JSON.parse(value);
+            var req = new HttpRequest();
+            req.addHeader('Cookie: authenticationToken=' + params.token);
+            var response = req.get(encodeURI(params.url + '/rest/v0/backup/jobs/vm'));
+            } catch(error) {
+             Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/backup/jobs/vm Error: " + error);
+             if (!Number.isInteger(error))
+                return 520;
+            }
+            var retVal = []
+            for (r=0; r < JSON.parse(response).length; r++) {
+              resp = req.get(encodeURI(params.url + JSON.parse(response)[r]));
+              srInfo = JSON.parse(resp);
+              retVal.push({"url": JSON.parse(response)[r], "uuid": srInfo.uuid, 'name': srInfo.name_label});
+            }
+            return JSON.stringify(retVal);
+          lifetime: 1d
+          item_prototypes:
+            - uuid: b16275be3b5741d9b199b3965856c86f
+              name: 'SR {#BACKUP.NAME} ({#BACKUP.UUID}): Get Values'
+              type: HTTP_AGENT
+              key: 'xoa.backup.raw[{#BACKUP.UUID}]'
+              delay: 15m
+              history: '0'
+              trends: '0'
+              value_type: TEXT
+              url: '{$XOA.URL}{#BACKUP.URL}'
+              headers:
+                - name: Cookie
+                  value: 'authenticationToken={$XOA.AUTH.TOKEN}'
+                - name: Accept
+                  value: application/json
+          parameters:
+            - name: token
+              value: '{$XOA.AUTH.TOKEN}'
+            - name: url
+              value: '{$XOA.URL}'
+          lld_macro_paths:
+            - lld_macro: '{#BACKUP.NAME}'
+              path: $.name
+            - lld_macro: '{#BACKUP.URL}'
+              path: $.url
+            - lld_macro: '{#BACKUP.UUID}'
+              path: $.uuid
+        - uuid: 0f0abc26d9884936ad59800f1e2778a0
+          name: 'Discovery Hosts'
+          type: SCRIPT
+          key: xoa.hosts.discovery
+          delay: 1h
+          params: |
+            try {
+            var params = JSON.parse(value);
+            var req = new HttpRequest();
+            req.addHeader('Cookie: authenticationToken=' + params.token);
+            var response = req.get(encodeURI(params.url + '/rest/v0/hosts'));
+            } catch(error) {
+             Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/hosts Error: " + error);
+             if (!Number.isInteger(error))
+                return 520;
+            }
+            var retVal = []
+            for (r=0; r < JSON.parse(response).length; r++) {
+              try {
+                resp = req.get(encodeURI(params.url + JSON.parse(response)[r]));
+                hostInfo = JSON.parse(resp);
+                retVal.push({"url": JSON.parse(response)[r], "uuid": hostInfo.uuid, 'name': hostInfo.name_label});
+              } catch(error) {
+                Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/hosts Error: " + error);
+                if(!Number.isInteger(error))
+                  return 500;
+            }
+            }
+            return JSON.stringify(retVal);
+          lifetime: 1d
+          host_prototypes:
+            - uuid: 49e0b0dee6964027907b68867bd0bada
+              host: '{#HOSTS.UUID}'
+              name: 'HV-{#HOSTS.NAME}'
+              group_links:
+                - group:
+                    name: Hypervisors
+              templates:
+                - name: 'XCP-NG Host via Xen Orchestra'
+              macros:
+                - macro: '{$XOA.HOST.NAME}'
+                  value: '{#HOSTS.NAME}'
+                - macro: '{$XOA.HOST.PATH}'
+                  value: '{#HOSTS.URL}'
+                - macro: '{$XOA.HOST.UUID}'
+                  value: '{#HOSTS.UUID}'
+              tags:
+                - tag: componenet
+                  value: Hypervisors
+                - tag: target
+                  value: XCP-NG
+          parameters:
+            - name: token
+              value: '{$XOA.AUTH.TOKEN}'
+            - name: url
+              value: '{$XOA.URL}'
+          lld_macro_paths:
+            - lld_macro: '{#HOSTS.NAME}'
+              path: $.name
+            - lld_macro: '{#HOSTS.URL}'
+              path: $.url
+            - lld_macro: '{#HOSTS.UUID}'
+              path: $.uuid
+        - uuid: ba152d09c30a48fda5e2385615ebe76d
+          name: 'Discovery Pools'
+          type: SCRIPT
+          key: xoa.pool.discovery
+          delay: 1h
+          params: |
+            try {
+            var params = JSON.parse(value);
+            var req = new HttpRequest();
+            req.addHeader('Cookie: authenticationToken=' + params.token);
+            var response = req.get(encodeURI(params.url + '/rest/v0/pools'));
+            } catch(error) {
+             Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/pools Error: " + error);
+             if (!Number.isInteger(error))
+                return 520;
+            }
+            var retVal = []
+            for (r=0; r < JSON.parse(response).length; r++) {
+              try {
+                resp = req.get(encodeURI(params.url + JSON.parse(response)[r]));
+                poolInfo = JSON.parse(resp);
+                retVal.push({"url": JSON.parse(response)[r], "uuid": poolInfo.uuid, 'name': poolInfo.name_label});
+              } catch(error) {
+                 Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/pools Error: " + error);
+                 if (!Number.isInteger(error))
+                   return 520;
+              }
+            }
+            return JSON.stringify(retVal);
+          lifetime: 1d
+          item_prototypes:
+            - uuid: 7f4a8af6115b4128afb280c678bc4db9
+              name: 'Pool {#POOL.NAME} ({#POOL.UUID}): CPU Cores'
+              type: DEPENDENT
+              key: 'xoa.pool.cpu.cores[{#POOL.URL}]'
+              delay: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.cpus.cores
+              master_item:
+                key: 'xoa.pool[{#POOL.URL}]'
+            - uuid: f6d83eef5fd9449d97ac649bb0f6e40e
+              name: 'Pool{#POOL.NAME} ({#POOL.UUID}): CPU Sockets'
+              type: DEPENDENT
+              key: 'xoa.pool.cpu.sockets[{#POOL.URL}]'
+              delay: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.cpus.sockets
+              master_item:
+                key: 'xoa.pool[{#POOL.URL}]'
+            - uuid: 46a2c37e887a44af831a95b2962ee8c4
+              name: 'Pool {#POOL.NAME} ({#POOL.UUID}): Descriptipn'
+              type: DEPENDENT
+              key: 'xoa.pool.description[{#POOL.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.name_description
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 12h
+              master_item:
+                key: 'xoa.pool[{#POOL.URL}]'
+            - uuid: 64981b8e1f7f49e7a4941ab0866df905
+              name: 'Pool {#POOL.NAME} ({#POOL.UUID}): HA enabled'
+              type: DEPENDENT
+              key: 'xoa.pool.ha.enabled[{#POOL.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.HA_enabled
+              master_item:
+                key: 'xoa.pool[{#POOL.URL}]'
+            - uuid: bb14638e591940389e2ee1b437fa428f
+              name: 'Pool {#POOL.NAME} ({#POOL.UUID}): Name'
+              type: DEPENDENT
+              key: 'xoa.pool.name[{#POOL.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.name_label
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'xoa.pool[{#POOL.URL}]'
+            - uuid: d119af9ee0794efa9c5a93ef01301a1a
+              name: 'Pool {#POOL.NAME} ({#POOL.UUID}): Get Values'
+              type: HTTP_AGENT
+              key: 'xoa.pool[{#POOL.URL}]'
+              delay: 15m
+              history: '0'
+              trends: '0'
+              value_type: TEXT
+              url: '{$XOA.URL}{#POOL.URL}'
+              headers:
+                - name: Cookie
+                  value: 'authenticationToken={$XOA.AUTH.TOKEN}'
+                - name: Accept
+                  value: application/json
+          parameters:
+            - name: token
+              value: '{$XOA.AUTH.TOKEN}'
+            - name: url
+              value: '{$XOA.URL}'
+          lld_macro_paths:
+            - lld_macro: '{#POOL.NAME}'
+              path: $.name
+            - lld_macro: '{#POOL.URL}'
+              path: $.url
+            - lld_macro: '{#POOL.UUID}'
+              path: $.uuid
+        - uuid: 59ad3f67fa2644be8f8a63ceb7dd1039
+          name: 'Discovery SRs'
+          type: SCRIPT
+          key: xoa.sr.discovery
+          delay: 1h
+          params: |
+            try {
+            var params = JSON.parse(value);
+            var req = new HttpRequest();
+            req.addHeader('Cookie: authenticationToken=' + params.token);
+            var response = req.get(encodeURI(params.url + '/rest/v0/srs'));
+            } catch(error) {
+             Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/srs Error: " + error);
+             if (!Number.isInteger(error))
+                return 520;
+            }
+            var retVal = []
+            for (r=0; r < JSON.parse(response).length; r++) {
+              try {
+                resp = req.get(encodeURI(params.url + JSON.parse(response)[r]));
+                srInfo = JSON.parse(resp);
+                retVal.push({"url": JSON.parse(response)[r], "uuid": srInfo.uuid, 'name': srInfo.name_label});
+              } catch(error) {
+                 Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/srs Error: " + error);
+                 if (!Number.isInteger(error))
+                   return 520;
+              }
+            }
+            return JSON.stringify(retVal);
+          lifetime: 1d
+          item_prototypes:
+            - uuid: 2c7ddde760c7485fbfd5afd06c0ca9f6
+              name: 'SR {#SR.NAME} ({#SR.UUID}): In maintenance mode'
+              type: DEPENDENT
+              key: 'xoa.sr.maintenance[{#SR.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.inMaintenanceMode
+              master_item:
+                key: 'xoa.sr.raw[{#SR.URL}]'
+            - uuid: ac01c8b01494403797fbdf84657ecbc1
+              name: 'SR {#SR.NAME} ({#SR.UUID}): Name'
+              type: DEPENDENT
+              key: 'xoa.sr.name[{#SR.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.name_label
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 12h
+              master_item:
+                key: 'xoa.sr.raw[{#SR.URL}]'
+            - uuid: a9c8007dfb15454da2ec7d3b2ef78c36
+              name: 'SR {#SR.NAME} ({#SR.UUID}): Get Values'
+              type: HTTP_AGENT
+              key: 'xoa.sr.raw[{#SR.URL}]'
+              delay: 5m
+              history: '0'
+              trends: '0'
+              value_type: TEXT
+              url: '{$XOA.URL}{#SR.URL}'
+              headers:
+                - name: Cookie
+                  value: 'authenticationToken={$XOA.AUTH.TOKEN}'
+                - name: Accept
+                  value: application/json
+            - uuid: c3d42712ef4c4941b5d6dcf301abd4f5
+              name: 'SR {#SR.NAME} ({#SR.UUID}): Size'
+              type: DEPENDENT
+              key: 'xoa.sr.size[{#SR.URL}]'
+              delay: '0'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.size
+              master_item:
+                key: 'xoa.sr.raw[{#SR.URL}]'
+            - uuid: 5c9753ddfd4040a4b2f09bee5b218f37
+              name: 'SR {#SR.NAME} ({#SR.UUID}) Content Type'
+              type: DEPENDENT
+              key: 'xoa.sr.type.content[{#SR.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.content_type
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'xoa.sr.raw[{#SR.URL}]'
+            - uuid: 09c0b4829e674fbaa3b80ce030f311f3
+              name: 'SR {#SR.NAME} ({#SR.UUID}): Type'
+              type: DEPENDENT
+              key: 'xoa.sr.type[{#SR.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.SR_type
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'xoa.sr.raw[{#SR.URL}]'
+            - uuid: 3f678af9e8fc4c0dbfab055155749c2c
+              name: 'SR {#SR.NAME} ({#SR.UUID}): Used percentage'
+              type: CALCULATED
+              key: 'xoa.sr.used.percentage[{#SR.URL}]'
+              delay: 5m
+              value_type: FLOAT
+              units: '%'
+              params: 'last(//xoa.sr.used.physical[{#SR.URL}])/last(//xoa.sr.size[{#SR.URL}])*100'
+              trigger_prototypes:
+                - uuid: fb16b143e0ef45ea91eb423f2530cdd0
+                  expression: 'last(/Xen Orchestra by HTTP/xoa.sr.used.percentage[{#SR.URL}])>{$XOA.SR.THRESHOLD.CRIT}'
+                  name: 'Free space on SR {#SR.NAME} ({#SR.UUID}) is critical low'
+                  priority: HIGH
+                - uuid: 087dcb24233f4f3c8a88bc7d01abe3a4
+                  expression: 'last(/Xen Orchestra by HTTP/xoa.sr.used.percentage[{#SR.URL}])>{$XOA.SR.THRESHOLD.WARN}'
+                  name: 'Free space on SR {#SR.NAME} ({#SR.UUID}) is low'
+                  priority: WARNING
+                  dependencies:
+                    - name: 'Free space on SR {#SR.NAME} ({#SR.UUID}) is critical low'
+                      expression: 'last(/Xen Orchestra by HTTP/xoa.sr.used.percentage[{#SR.URL}])>{$XOA.SR.THRESHOLD.CRIT}'
+            - uuid: 57b22801aba547bfa90a3304a59f53dc
+              name: 'SR {#SR.NAME} ({#SR.UUID}): Physical Usage'
+              type: DEPENDENT
+              key: 'xoa.sr.used.physical[{#SR.URL}]'
+              delay: '0'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.physical_usage
+              master_item:
+                key: 'xoa.sr.raw[{#SR.URL}]'
+          parameters:
+            - name: token
+              value: '{$XOA.AUTH.TOKEN}'
+            - name: url
+              value: '{$XOA.URL}'
+          lld_macro_paths:
+            - lld_macro: '{#SR.NAME}'
+              path: $.name
+            - lld_macro: '{#SR.URL}'
+              path: $.url
+            - lld_macro: '{#SR.UUID}'
+              path: $.uuid
+        - uuid: 5485ca1d330d4dffa4a03579729428e6
+          name: 'Discovery VMs'
+          type: SCRIPT
+          key: xoa.vms.discovery
+          delay: 1h
+          params: |
+            try {
+            var params = JSON.parse(value);
+            var req = new HttpRequest();
+            req.addHeader('Cookie: authenticationToken=' + params.token);
+            var response = req.get(encodeURI(params.url + '/rest/v0/vms'));
+            } catch(error) {
+             Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/vms Error: " + error);
+             if (!Number.isInteger(error))
+                return 520;
+            }
+            var retVal = []
+            for (r=0; r < JSON.parse(response).length; r++) {
+              try {
+                resp = req.get(encodeURI(params.url + JSON.parse(response)[r]));
+                vmsInfo = JSON.parse(resp);
+                retVal.push({"url": JSON.parse(response)[r], "uuid": vmsInfo.uuid, 'name': vmsInfo.name_label});
+              } catch(error) {
+                 Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/vms Error: " + error);
+                 if (!Number.isInteger(error))
+                   return 520;
+              }
+            }
+            return JSON.stringify(retVal);
+          lifetime: 1d
+          host_prototypes:
+            - uuid: 78bf8b747c7547f2990fcf9f4bac56ae
+              host: '{#VMS.UUID}'
+              name: 'VM-{#VMS.NAME}'
+              group_links:
+                - group:
+                    name: 'Virtual machines'
+              templates:
+                - name: 'XCP-NG VM via Xen Orchestra'
+              macros:
+                - macro: '{$XOA.VM.NAME}'
+                  value: '{#VMS.NAME}'
+                - macro: '{$XOA.VM.PATH}'
+                  value: '{#VMS.URL}'
+                - macro: '{$XOA.VM.UUID}'
+                  value: '{#VMS.UUID}'
+              tags:
+                - tag: component
+                  value: hypervisor
+                - tag: target
+                  value: guest
+          parameters:
+            - name: token
+              value: '{$XOA.AUTH.TOKEN}'
+            - name: url
+              value: '{$XOA.URL}'
+          lld_macro_paths:
+            - lld_macro: '{#VMS.NAME}'
+              path: $.name
+            - lld_macro: '{#VMS.URL}'
+              path: $.url
+            - lld_macro: '{#VMS.UUID}'
+              path: $.uuid
+      tags:
+        - tag: component
+          value: hypervisor
+        - tag: target
+          value: xen
+      macros:
+        - macro: '{$XOA.AUTH.TOKEN}'
+          value: CHANGE_IF_NEEDED
+          description: 'Authentication Token generated on XOA UI'
+        - macro: '{$XOA.SR.THRESHOLD.CRIT}'
+          value: '95'
+          description: 'Critical threshold for SR usage'
+        - macro: '{$XOA.SR.THRESHOLD.WARN}'
+          value: '75'
+          description: 'Warn threshold for SR usage'
+        - macro: '{$XOA.URL}'
+          value: CHANGE_IF_NEEDED
+          description: 'URL where XOA can be reached'
+      valuemaps:
+        - uuid: 0ec95555cba645f796a21bdece34349c
+          name: 'XOA Boolean'
+          mappings:
+            - value: '1'
+              newvalue: 'true'
+            - value: '0'
+              newvalue: 'false'

--- a/Virtualization/xcp-ng/6.4/template_app_xenorchestra.yaml
+++ b/Virtualization/xcp-ng/6.4/template_app_xenorchestra.yaml
@@ -1,0 +1,1112 @@
+zabbix_export:
+  version: '6.4'
+  template_groups:
+    - uuid: 7df96b18c230490a9a0a9e2307226338
+      name: Templates
+  host_groups:
+    - uuid: 1b837a3c078647049a0c00c61b4d57b5
+      name: Hypervisors
+    - uuid: 137f19e6e2dc4219b33553b812627bc2
+      name: 'Virtual machines'
+  templates:
+    - uuid: 8d4ad92902e6440ca14dfa5256d8bf82
+      template: 'XCP-NG Host via Xen Orchestra'
+      name: 'XCP-NG Host via Xen Orchestra'
+      groups:
+        - name: Templates
+      items:
+        - uuid: d137a2d23e554eb7b98d1de0ce26dfb6
+          name: 'CPU Cores'
+          type: DEPENDENT
+          key: xoa.host.cpu.cores
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.CPUs.cpu_count
+          master_item:
+            key: xoa.host.raw
+        - uuid: 0a1e66d4f0a4455abcfd9317c4c973b1
+          name: 'CPU Sockets'
+          type: DEPENDENT
+          key: xoa.host.cpu.sockets
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.CPUs.socket_count
+          master_item:
+            key: xoa.host.raw
+        - uuid: 702c08f7b6d94be49fbfaef45b1b4174
+          name: 'Host description'
+          type: DEPENDENT
+          key: xoa.host.description
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.name_description
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          master_item:
+            key: xoa.host.raw
+        - uuid: a6343812baea4750b24def6a3ef71f70
+          name: Enabled
+          type: DEPENDENT
+          key: xoa.host.enabled
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.enabled
+          master_item:
+            key: xoa.host.raw
+        - uuid: 604ae2b2e6b943c387edd492eddc8beb
+          name: 'Hypervisor brand'
+          type: DEPENDENT
+          key: xoa.host.hv.brand
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.productBrand
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          master_item:
+            key: xoa.host.raw
+        - uuid: 494f4ddea1cf40398641295be217878a
+          name: 'Hypervisor version'
+          type: DEPENDENT
+          key: xoa.host.hv.version
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.version
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          master_item:
+            key: xoa.host.raw
+        - uuid: c1c9cee844f34ff289b32559493af04f
+          name: 'Hypervisor version build'
+          type: DEPENDENT
+          key: xoa.host.hv.version.build
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.build
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          master_item:
+            key: xoa.host.raw
+        - uuid: ecf042cea23e45e89954fe6fc499be86
+          name: 'HVM capable'
+          type: DEPENDENT
+          key: xoa.host.hvm.capabale
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.hvmCapable
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: xoa.host.raw
+        - uuid: 4026336d2d97475e9019522c73535574
+          name: 'Memory total'
+          type: DEPENDENT
+          key: xoa.host.memory.total
+          delay: '0'
+          units: B
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.memory.size
+          master_item:
+            key: xoa.host.raw
+        - uuid: 6181620d670c4e3cbeaad0babe89fc1b
+          name: 'Memory used'
+          type: DEPENDENT
+          key: xoa.host.memory.used
+          delay: '0'
+          units: B
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.memory.usage
+          master_item:
+            key: xoa.host.raw
+        - uuid: ed5fe0b877ed469ebc0d4e4b32ff8a87
+          name: 'Memory used percent'
+          type: CALCULATED
+          key: xoa.host.memory.used.percent
+          delay: 5m
+          value_type: FLOAT
+          units: '%'
+          params: 'last(//xoa.host.memory.used)/last(//xoa.host.memory.total)*100'
+          triggers:
+            - uuid: 29677931a1b944038a687c8c28c4d015
+              expression: 'last(/XCP-NG Host via Xen Orchestra/xoa.host.memory.used.percent)>{$XOA.MEMORY.CRIT}'
+              name: 'Memory usage critical high'
+              priority: HIGH
+            - uuid: 9de3ff6c29d945a7b8ca5a2bb0a78493
+              expression: 'last(/XCP-NG Host via Xen Orchestra/xoa.host.memory.used.percent)>{$XOA.MEMORY.WARN}'
+              name: 'Memory usage exceeds {$XOA.MEMORY.WARN}'
+              priority: WARNING
+              dependencies:
+                - name: 'Memory usage critical high'
+                  expression: 'last(/XCP-NG Host via Xen Orchestra/xoa.host.memory.used.percent)>{$XOA.MEMORY.CRIT}'
+        - uuid: 81a949d8376b43b0b620de6bcbe3d525
+          name: 'XCP-NG Hosts: Get Missing Patches'
+          type: HTTP_AGENT
+          key: xoa.host.missingpatches.raw
+          delay: 15m
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          url: '{$XOA.URL}/rest/v0/hosts/{$XOA.HOST.UUID}/missing_patches'
+          headers:
+            - name: Cookie
+              value: 'authenticationToken={$XOA.AUTH.TOKEN}'
+            - name: Accept
+              value: application/json
+        - uuid: 3725dfaac75643fcb3cfe0b852a26f70
+          name: Hostname
+          type: DEPENDENT
+          key: xoa.host.name
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.name_label
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          master_item:
+            key: xoa.host.raw
+        - uuid: 5b2435e1c5dd49c7be4b7cc1dc31e64d
+          name: 'Power State'
+          type: DEPENDENT
+          key: xoa.host.power.state
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.power_state
+          master_item:
+            key: xoa.host.raw
+          triggers:
+            - uuid: 484c668a58c54317a61a405b52cc43ec
+              expression: 'last(/XCP-NG Host via Xen Orchestra/xoa.host.power.state)<>last(/XCP-NG Host via Xen Orchestra/xoa.host.power.state,#2)'
+              recovery_mode: NONE
+              name: 'Power state changed'
+              priority: INFO
+              manual_close: 'YES'
+        - uuid: 11c547b55c424e26bb02d87266980a6f
+          name: 'XCP-NG Hosts: Get Values'
+          type: HTTP_AGENT
+          key: xoa.host.raw
+          delay: 5m
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          url: '{$XOA.URL}/rest/v0/hosts/{$XOA.HOST.UUID}'
+          headers:
+            - name: Cookie
+              value: 'authenticationToken={$XOA.AUTH.TOKEN}'
+            - name: Accept
+              value: application/json
+        - uuid: ee2ab8db1e0f4d1f88df5fe6892eaf73
+          name: 'Reboot required'
+          type: DEPENDENT
+          key: xoa.host.reboot.required
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rebootRequired
+          master_item:
+            key: xoa.host.raw
+          triggers:
+            - uuid: 06a3b195183a49d9ac6f37afa802e5a9
+              expression: 'last(/XCP-NG Host via Xen Orchestra/xoa.host.reboot.required)="true"'
+              name: 'Reboot required for hosts'
+              priority: WARNING
+        - uuid: 077fd836ae1c420792fcf368fa43e8a3
+          name: 'Number of running VMs'
+          type: DEPENDENT
+          key: xoa.host.runningvms
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.residentVms
+            - type: JAVASCRIPT
+              parameters:
+                - 'return JSON.parse(value).length'
+          master_item:
+            key: xoa.host.raw
+        - uuid: 745f6fb406c34e3b8ec313a54b2c85cc
+          name: 'Host start time'
+          type: DEPENDENT
+          key: xoa.host.starttime
+          delay: '0'
+          units: unixtime
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.startTime
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: xoa.host.raw
+        - uuid: dab4f3b69f5141048e914d87ed23dd69
+          name: 'Number of Missing Patches'
+          type: DEPENDENT
+          key: xoa.hosts.missingpatches.count
+          delay: '0'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - 'return JSON.parse(value).length'
+          master_item:
+            key: xoa.host.missingpatches.raw
+          triggers:
+            - uuid: b4f671bc3ab8442c87147db31e815ffe
+              expression: 'last(/XCP-NG Host via Xen Orchestra/xoa.hosts.missingpatches.count)>{$XOA.HOST.MISSING.PATCHES.MAX}'
+              name: 'Number of {$XOA.HOST.MISSING.PATCHES.MAX} missing patches exceeded'
+              priority: WARNING
+      tags:
+        - tag: component
+          value: hypervisor
+        - tag: target
+          value: xcp-ng
+      macros:
+        - macro: '{$XOA.AUTH.TOKEN}'
+          value: CHANGE_IF_NEEDED
+          description: 'Authentication Token generated on XOA UI'
+        - macro: '{$XOA.HOST.MISSING.PATCHES.MAX}'
+          value: '1'
+          description: 'Maximum Number of missing patches allowed'
+        - macro: '{$XOA.HOST.UUID}'
+          value: CHANGE_IF_NEEDED
+          description: 'Host UUID'
+        - macro: '{$XOA.MEMORY.CRIT}'
+          value: '90'
+          description: 'Critical memory usage'
+        - macro: '{$XOA.MEMORY.WARN}'
+          value: '75'
+          description: 'Warn when memory usage is above'
+        - macro: '{$XOA.URL}'
+          value: CHANGE_IF_NEEDED
+          description: 'URL where XOA can be reached'
+      valuemaps:
+        - uuid: 7de0ad540b0f4fd5ab2b33ef9f79d440
+          name: 'XOA Boolean'
+          mappings:
+            - value: '1'
+              newvalue: 'true'
+            - value: '0'
+              newvalue: 'false'
+    - uuid: b1aa3ddc4db246c3a5e71658dd5a9601
+      template: 'XCP-NG VM via Xen Orchestra'
+      name: 'XCP-NG VM via Xen Orchestra'
+      groups:
+        - name: Templates
+      items:
+        - uuid: 6a01a4edf2364313a72939d2dfb7789c
+          name: 'vCPU active'
+          type: DEPENDENT
+          key: xoa.vm.cpu.active
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.CPUs.number
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 2149aaf9d7904bf4b28f4aaa943f120e
+          name: 'vCPU max'
+          type: DEPENDENT
+          key: xoa.vm.cpu.max
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.CPUs.max
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 2bd0262b02754c49bf1388e392bff454
+          name: 'VM description'
+          type: DEPENDENT
+          key: xoa.vm.description
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.name_description
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 011d9425a4bc4b4cb3cba08d878c0f83
+          name: 'Xen PV driver version'
+          type: DEPENDENT
+          key: xoa.vm.driver.version
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.pvDriversVersion
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 86a3094485084862a3a2d4d1bd9333b2
+          name: 'VM install time'
+          type: DEPENDENT
+          key: xoa.vm.installtime
+          delay: '0'
+          units: unixtime
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.installTime
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 37d6d0b60c654490b5d360b194538f15
+          name: 'Management agent detected'
+          type: DEPENDENT
+          key: xoa.vm.management.agent
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.managementAgentDetected
+          master_item:
+            key: xoa.vms.raw
+          triggers:
+            - uuid: 90dd8a29cfc3457aabb35ce8527683d4
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.management.agent)="false"'
+              name: 'No management agent install on VM'
+              priority: INFO
+              manual_close: 'YES'
+        - uuid: e72db9c5c0474d099be380a577aafd23
+          name: 'Memory total'
+          type: DEPENDENT
+          key: xoa.vm.memory.total
+          delay: '0'
+          units: B
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.memory.size
+          master_item:
+            key: xoa.vms.raw
+        - uuid: c319917b771c46afbf2fdacf217216d1
+          name: 'Virtualization mode'
+          type: DEPENDENT
+          key: xoa.vm.mode
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.virtualizationMode
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: xoa.vms.raw
+        - uuid: e5f39794e08c4aeb9b2f96abf5dc58dc
+          name: 'VM name'
+          type: DEPENDENT
+          key: xoa.vm.name
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.name_label
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 24h
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 5397b9f0460742899d91a127b52f2020
+          name: 'OS Distribution'
+          type: DEPENDENT
+          key: xoa.vm.os.distro
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.os_version.distro
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 4126bf9d15464ecea0f7a0d0fe8fd8b8
+          name: 'OS version'
+          type: DEPENDENT
+          key: xoa.vm.os.version
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.os_version.name
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 2415c2f666e64438ae682c0855c2831b
+          name: 'Power State'
+          type: DEPENDENT
+          key: xoa.vm.power.state
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.power_state
+          master_item:
+            key: xoa.vms.raw
+          triggers:
+            - uuid: 4f938791d96b4898860edf870a1bc72e
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state)<>last(/XCP-NG VM via Xen Orchestra/xoa.vm.power.state,#2)'
+              recovery_mode: NONE
+              name: 'State of VM changed'
+              priority: AVERAGE
+              manual_close: 'YES'
+        - uuid: d3da95b5b2c64e5e82c893e9fbd82743
+          name: 'Number of snapshots'
+          type: DEPENDENT
+          key: xoa.vm.snapshot
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.snapshots
+            - type: JAVASCRIPT
+              parameters:
+                - 'return JSON.parse(value).length'
+          master_item:
+            key: xoa.vms.raw
+          triggers:
+            - uuid: 353d88c34edc4ea3957a4ecc12e6db7b
+              expression: 'last(/XCP-NG VM via Xen Orchestra/xoa.vm.snapshot)>{$XOA.VM.NO.SNAPSHOTS.MAX}'
+              name: 'Number of Snapshots exceeds {$XOA.VM.NO.SNAPSHOTS.MAX}'
+              priority: WARNING
+        - uuid: 889bc4bcaf0744f7ac14c36f45139cc8
+          name: 'VM start time'
+          type: DEPENDENT
+          key: xoa.vm.starttime
+          delay: '0'
+          units: unixtime
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.startTime
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: xoa.vms.raw
+        - uuid: cb8d4b3b8a0442c2aa48853c6ab45af3
+          name: 'Xen Tool Version'
+          type: DEPENDENT
+          key: xoa.vm.tools.version
+          delay: '0'
+          trends: '0'
+          value_type: CHAR
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.xenTools.version
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: xoa.vms.raw
+        - uuid: 27f086c8cf754b789daf6868cf394172
+          name: 'XCP-NG VMS: Get Values'
+          type: HTTP_AGENT
+          key: xoa.vms.raw
+          delay: 5m
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          url: '{$XOA.URL}/rest/v0/vms/{$XOA.VM.UUID}'
+          headers:
+            - name: Cookie
+              value: 'authenticationToken={$XOA.AUTH.TOKEN}'
+            - name: Accept
+              value: application/json
+      tags:
+        - tag: component
+          value: hypervisor
+        - tag: target
+          value: guests
+      macros:
+        - macro: '{$XOA.AUTH.TOKEN}'
+          value: CHANGE_IF_NEEDED
+          description: 'Authentication Token generated on XOA UI'
+        - macro: '{$XOA.HOST.UUID}'
+          value: CHANGE_IF_NEEDED
+          description: 'Host UUID'
+        - macro: '{$XOA.URL}'
+          value: CHANGE_IF_NEEDED
+          description: 'URL where XOA can be reached'
+        - macro: '{$XOA.VM.NO.SNAPSHOTS.MAX}'
+          value: '1'
+          description: 'Max number of snapshots allowed'
+        - macro: '{$XOA.VM.UUID}'
+      valuemaps:
+        - uuid: 546880e65268446ba8d3b319f837b7eb
+          name: 'XOA Boolean'
+          mappings:
+            - value: '1'
+              newvalue: 'true'
+            - value: '0'
+              newvalue: 'false'
+    - uuid: 5f69e71a0ed1418da4daf08e4dc22b7c
+      template: 'Xen Orchestra by HTTP'
+      name: 'Xen Orchestra by HTTP'
+      groups:
+        - name: Templates
+      discovery_rules:
+        - uuid: 4f543445aeb1465ebb10fe09d895c661
+          name: 'Discovery Backups'
+          type: SCRIPT
+          key: xoa.backup.discovery
+          delay: 1h
+          status: DISABLED
+          params: |
+            try {
+            var params = JSON.parse(value);
+            var req = new HttpRequest();
+            req.addHeader('Cookie: authenticationToken=' + params.token);
+            var response = req.get(encodeURI(params.url + '/rest/v0/backup/jobs/vm'));
+            } catch(error) {
+             Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/backup/jobs/vm Error: " + error);
+             if (!Number.isInteger(error))
+                return 520;
+            }
+            var retVal = []
+            for (r=0; r < JSON.parse(response).length; r++) {
+              resp = req.get(encodeURI(params.url + JSON.parse(response)[r]));
+              srInfo = JSON.parse(resp);
+              retVal.push({"url": JSON.parse(response)[r], "uuid": srInfo.uuid, 'name': srInfo.name_label});
+            }
+            return JSON.stringify(retVal);
+          lifetime: 1d
+          item_prototypes:
+            - uuid: b16275be3b5741d9b199b3965856c86f
+              name: 'SR {#BACKUP.NAME} ({#BACKUP.UUID}): Get Values'
+              type: HTTP_AGENT
+              key: 'xoa.backup.raw[{#BACKUP.UUID}]'
+              delay: 15m
+              history: '0'
+              trends: '0'
+              value_type: TEXT
+              url: '{$XOA.URL}{#BACKUP.URL}'
+              headers:
+                - name: Cookie
+                  value: 'authenticationToken={$XOA.AUTH.TOKEN}'
+                - name: Accept
+                  value: application/json
+          parameters:
+            - name: token
+              value: '{$XOA.AUTH.TOKEN}'
+            - name: url
+              value: '{$XOA.URL}'
+          lld_macro_paths:
+            - lld_macro: '{#BACKUP.NAME}'
+              path: $.name
+            - lld_macro: '{#BACKUP.URL}'
+              path: $.url
+            - lld_macro: '{#BACKUP.UUID}'
+              path: $.uuid
+        - uuid: 0f0abc26d9884936ad59800f1e2778a0
+          name: 'Discovery Hosts'
+          type: SCRIPT
+          key: xoa.hosts.discovery
+          delay: 1h
+          params: |
+            try {
+            var params = JSON.parse(value);
+            var req = new HttpRequest();
+            req.addHeader('Cookie: authenticationToken=' + params.token);
+            var response = req.get(encodeURI(params.url + '/rest/v0/hosts'));
+            } catch(error) {
+             Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/hosts Error: " + error);
+             if (!Number.isInteger(error))
+                return 520;
+            }
+            var retVal = []
+            for (r=0; r < JSON.parse(response).length; r++) {
+              try {
+                resp = req.get(encodeURI(params.url + JSON.parse(response)[r]));
+                hostInfo = JSON.parse(resp);
+                retVal.push({"url": JSON.parse(response)[r], "uuid": hostInfo.uuid, 'name': hostInfo.name_label});
+              } catch(error) {
+                Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/hosts Error: " + error);
+                if(!Number.isInteger(error))
+                  return 500;
+            }
+            }
+            return JSON.stringify(retVal);
+          lifetime: 1d
+          host_prototypes:
+            - uuid: 49e0b0dee6964027907b68867bd0bada
+              host: '{#HOSTS.UUID}'
+              name: 'HV-{#HOSTS.NAME}'
+              group_links:
+                - group:
+                    name: Hypervisors
+              templates:
+                - name: 'XCP-NG Host via Xen Orchestra'
+              macros:
+                - macro: '{$XOA.HOST.NAME}'
+                  value: '{#HOSTS.NAME}'
+                - macro: '{$XOA.HOST.PATH}'
+                  value: '{#HOSTS.URL}'
+                - macro: '{$XOA.HOST.UUID}'
+                  value: '{#HOSTS.UUID}'
+              tags:
+                - tag: componenet
+                  value: Hypervisors
+                - tag: target
+                  value: XCP-NG
+          parameters:
+            - name: token
+              value: '{$XOA.AUTH.TOKEN}'
+            - name: url
+              value: '{$XOA.URL}'
+          lld_macro_paths:
+            - lld_macro: '{#HOSTS.NAME}'
+              path: $.name
+            - lld_macro: '{#HOSTS.URL}'
+              path: $.url
+            - lld_macro: '{#HOSTS.UUID}'
+              path: $.uuid
+        - uuid: ba152d09c30a48fda5e2385615ebe76d
+          name: 'Discovery Pools'
+          type: SCRIPT
+          key: xoa.pool.discovery
+          delay: 1h
+          params: |
+            try {
+            var params = JSON.parse(value);
+            var req = new HttpRequest();
+            req.addHeader('Cookie: authenticationToken=' + params.token);
+            var response = req.get(encodeURI(params.url + '/rest/v0/pools'));
+            } catch(error) {
+             Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/pools Error: " + error);
+             if (!Number.isInteger(error))
+                return 520;
+            }
+            var retVal = []
+            for (r=0; r < JSON.parse(response).length; r++) {
+              try {
+                resp = req.get(encodeURI(params.url + JSON.parse(response)[r]));
+                poolInfo = JSON.parse(resp);
+                retVal.push({"url": JSON.parse(response)[r], "uuid": poolInfo.uuid, 'name': poolInfo.name_label});
+              } catch(error) {
+                 Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/pools Error: " + error);
+                 if (!Number.isInteger(error))
+                   return 520;
+              }
+            }
+            return JSON.stringify(retVal);
+          lifetime: 1d
+          item_prototypes:
+            - uuid: 7f4a8af6115b4128afb280c678bc4db9
+              name: 'Pool {#POOL.NAME} ({#POOL.UUID}): CPU Cores'
+              type: DEPENDENT
+              key: 'xoa.pool.cpu.cores[{#POOL.URL}]'
+              delay: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.cpus.cores
+              master_item:
+                key: 'xoa.pool[{#POOL.URL}]'
+            - uuid: f6d83eef5fd9449d97ac649bb0f6e40e
+              name: 'Pool{#POOL.NAME} ({#POOL.UUID}): CPU Sockets'
+              type: DEPENDENT
+              key: 'xoa.pool.cpu.sockets[{#POOL.URL}]'
+              delay: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.cpus.sockets
+              master_item:
+                key: 'xoa.pool[{#POOL.URL}]'
+            - uuid: 46a2c37e887a44af831a95b2962ee8c4
+              name: 'Pool {#POOL.NAME} ({#POOL.UUID}): Descriptipn'
+              type: DEPENDENT
+              key: 'xoa.pool.description[{#POOL.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.name_description
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 12h
+              master_item:
+                key: 'xoa.pool[{#POOL.URL}]'
+            - uuid: 64981b8e1f7f49e7a4941ab0866df905
+              name: 'Pool {#POOL.NAME} ({#POOL.UUID}): HA enabled'
+              type: DEPENDENT
+              key: 'xoa.pool.ha.enabled[{#POOL.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.HA_enabled
+              master_item:
+                key: 'xoa.pool[{#POOL.URL}]'
+            - uuid: bb14638e591940389e2ee1b437fa428f
+              name: 'Pool {#POOL.NAME} ({#POOL.UUID}): Name'
+              type: DEPENDENT
+              key: 'xoa.pool.name[{#POOL.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.name_label
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'xoa.pool[{#POOL.URL}]'
+            - uuid: d119af9ee0794efa9c5a93ef01301a1a
+              name: 'Pool {#POOL.NAME} ({#POOL.UUID}): Get Values'
+              type: HTTP_AGENT
+              key: 'xoa.pool[{#POOL.URL}]'
+              delay: 15m
+              history: '0'
+              trends: '0'
+              value_type: TEXT
+              url: '{$XOA.URL}{#POOL.URL}'
+              headers:
+                - name: Cookie
+                  value: 'authenticationToken={$XOA.AUTH.TOKEN}'
+                - name: Accept
+                  value: application/json
+          parameters:
+            - name: token
+              value: '{$XOA.AUTH.TOKEN}'
+            - name: url
+              value: '{$XOA.URL}'
+          lld_macro_paths:
+            - lld_macro: '{#POOL.NAME}'
+              path: $.name
+            - lld_macro: '{#POOL.URL}'
+              path: $.url
+            - lld_macro: '{#POOL.UUID}'
+              path: $.uuid
+        - uuid: 59ad3f67fa2644be8f8a63ceb7dd1039
+          name: 'Discovery SRs'
+          type: SCRIPT
+          key: xoa.sr.discovery
+          delay: 1h
+          params: |
+            try {
+            var params = JSON.parse(value);
+            var req = new HttpRequest();
+            req.addHeader('Cookie: authenticationToken=' + params.token);
+            var response = req.get(encodeURI(params.url + '/rest/v0/srs'));
+            } catch(error) {
+             Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/srs Error: " + error);
+             if (!Number.isInteger(error))
+                return 520;
+            }
+            var retVal = []
+            for (r=0; r < JSON.parse(response).length; r++) {
+              try {
+                resp = req.get(encodeURI(params.url + JSON.parse(response)[r]));
+                srInfo = JSON.parse(resp);
+                retVal.push({"url": JSON.parse(response)[r], "uuid": srInfo.uuid, 'name': srInfo.name_label});
+              } catch(error) {
+                 Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/srs Error: " + error);
+                 if (!Number.isInteger(error))
+                   return 520;
+              }
+            }
+            return JSON.stringify(retVal);
+          lifetime: 1d
+          item_prototypes:
+            - uuid: 2c7ddde760c7485fbfd5afd06c0ca9f6
+              name: 'SR {#SR.NAME} ({#SR.UUID}): In maintenance mode'
+              type: DEPENDENT
+              key: 'xoa.sr.maintenance[{#SR.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.inMaintenanceMode
+              master_item:
+                key: 'xoa.sr.raw[{#SR.URL}]'
+            - uuid: ac01c8b01494403797fbdf84657ecbc1
+              name: 'SR {#SR.NAME} ({#SR.UUID}): Name'
+              type: DEPENDENT
+              key: 'xoa.sr.name[{#SR.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.name_label
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 12h
+              master_item:
+                key: 'xoa.sr.raw[{#SR.URL}]'
+            - uuid: a9c8007dfb15454da2ec7d3b2ef78c36
+              name: 'SR {#SR.NAME} ({#SR.UUID}): Get Values'
+              type: HTTP_AGENT
+              key: 'xoa.sr.raw[{#SR.URL}]'
+              delay: 5m
+              history: '0'
+              trends: '0'
+              value_type: TEXT
+              url: '{$XOA.URL}{#SR.URL}'
+              headers:
+                - name: Cookie
+                  value: 'authenticationToken={$XOA.AUTH.TOKEN}'
+                - name: Accept
+                  value: application/json
+            - uuid: c3d42712ef4c4941b5d6dcf301abd4f5
+              name: 'SR {#SR.NAME} ({#SR.UUID}): Size'
+              type: DEPENDENT
+              key: 'xoa.sr.size[{#SR.URL}]'
+              delay: '0'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.size
+              master_item:
+                key: 'xoa.sr.raw[{#SR.URL}]'
+            - uuid: 5c9753ddfd4040a4b2f09bee5b218f37
+              name: 'SR {#SR.NAME} ({#SR.UUID}) Content Type'
+              type: DEPENDENT
+              key: 'xoa.sr.type.content[{#SR.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.content_type
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'xoa.sr.raw[{#SR.URL}]'
+            - uuid: 09c0b4829e674fbaa3b80ce030f311f3
+              name: 'SR {#SR.NAME} ({#SR.UUID}): Type'
+              type: DEPENDENT
+              key: 'xoa.sr.type[{#SR.URL}]'
+              delay: '0'
+              trends: '0'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.SR_type
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'xoa.sr.raw[{#SR.URL}]'
+            - uuid: 3f678af9e8fc4c0dbfab055155749c2c
+              name: 'SR {#SR.NAME} ({#SR.UUID}): Used percentage'
+              type: CALCULATED
+              key: 'xoa.sr.used.percentage[{#SR.URL}]'
+              delay: 5m
+              value_type: FLOAT
+              units: '%'
+              params: 'last(//xoa.sr.used.physical[{#SR.URL}])/last(//xoa.sr.size[{#SR.URL}])*100'
+              trigger_prototypes:
+                - uuid: fb16b143e0ef45ea91eb423f2530cdd0
+                  expression: 'last(/Xen Orchestra by HTTP/xoa.sr.used.percentage[{#SR.URL}])>{$XOA.SR.THRESHOLD.CRIT}'
+                  name: 'Free space on SR {#SR.NAME} ({#SR.UUID}) is critical low'
+                  priority: HIGH
+                - uuid: 087dcb24233f4f3c8a88bc7d01abe3a4
+                  expression: 'last(/Xen Orchestra by HTTP/xoa.sr.used.percentage[{#SR.URL}])>{$XOA.SR.THRESHOLD.WARN}'
+                  name: 'Free space on SR {#SR.NAME} ({#SR.UUID}) is low'
+                  priority: WARNING
+                  dependencies:
+                    - name: 'Free space on SR {#SR.NAME} ({#SR.UUID}) is critical low'
+                      expression: 'last(/Xen Orchestra by HTTP/xoa.sr.used.percentage[{#SR.URL}])>{$XOA.SR.THRESHOLD.CRIT}'
+            - uuid: 57b22801aba547bfa90a3304a59f53dc
+              name: 'SR {#SR.NAME} ({#SR.UUID}): Physical Usage'
+              type: DEPENDENT
+              key: 'xoa.sr.used.physical[{#SR.URL}]'
+              delay: '0'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.physical_usage
+              master_item:
+                key: 'xoa.sr.raw[{#SR.URL}]'
+          parameters:
+            - name: token
+              value: '{$XOA.AUTH.TOKEN}'
+            - name: url
+              value: '{$XOA.URL}'
+          lld_macro_paths:
+            - lld_macro: '{#SR.NAME}'
+              path: $.name
+            - lld_macro: '{#SR.URL}'
+              path: $.url
+            - lld_macro: '{#SR.UUID}'
+              path: $.uuid
+        - uuid: 5485ca1d330d4dffa4a03579729428e6
+          name: 'Discovery VMs'
+          type: SCRIPT
+          key: xoa.vms.discovery
+          delay: 1h
+          params: |
+            try {
+            var params = JSON.parse(value);
+            var req = new HttpRequest();
+            req.addHeader('Cookie: authenticationToken=' + params.token);
+            var response = req.get(encodeURI(params.url + '/rest/v0/vms'));
+            } catch(error) {
+             Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/vms Error: " + error);
+             if (!Number.isInteger(error))
+                return 520;
+            }
+            var retVal = []
+            for (r=0; r < JSON.parse(response).length; r++) {
+              try {
+                resp = req.get(encodeURI(params.url + JSON.parse(response)[r]));
+                vmsInfo = JSON.parse(resp);
+                retVal.push({"url": JSON.parse(response)[r], "uuid": vmsInfo.uuid, 'name': vmsInfo.name_label});
+              } catch(error) {
+                 Zabbix.log(3, "XenOrchestra API failes" + params.url + "/rest/v0/vms Error: " + error);
+                 if (!Number.isInteger(error))
+                   return 520;
+              }
+            }
+            return JSON.stringify(retVal);
+          lifetime: 1d
+          host_prototypes:
+            - uuid: 78bf8b747c7547f2990fcf9f4bac56ae
+              host: '{#VMS.UUID}'
+              name: 'VM-{#VMS.NAME}'
+              group_links:
+                - group:
+                    name: 'Virtual machines'
+              templates:
+                - name: 'XCP-NG VM via Xen Orchestra'
+              macros:
+                - macro: '{$XOA.VM.NAME}'
+                  value: '{#VMS.NAME}'
+                - macro: '{$XOA.VM.PATH}'
+                  value: '{#VMS.URL}'
+                - macro: '{$XOA.VM.UUID}'
+                  value: '{#VMS.UUID}'
+              tags:
+                - tag: component
+                  value: hypervisor
+                - tag: target
+                  value: guest
+          parameters:
+            - name: token
+              value: '{$XOA.AUTH.TOKEN}'
+            - name: url
+              value: '{$XOA.URL}'
+          lld_macro_paths:
+            - lld_macro: '{#VMS.NAME}'
+              path: $.name
+            - lld_macro: '{#VMS.URL}'
+              path: $.url
+            - lld_macro: '{#VMS.UUID}'
+              path: $.uuid
+      tags:
+        - tag: component
+          value: hypervisor
+        - tag: target
+          value: xen
+      macros:
+        - macro: '{$XOA.AUTH.TOKEN}'
+          value: CHANGE_IF_NEEDED
+          description: 'Authentication Token generated on XOA UI'
+        - macro: '{$XOA.SR.THRESHOLD.CRIT}'
+          value: '95'
+          description: 'Critical threshold for SR usage'
+        - macro: '{$XOA.SR.THRESHOLD.WARN}'
+          value: '75'
+          description: 'Warn threshold for SR usage'
+        - macro: '{$XOA.URL}'
+          value: CHANGE_IF_NEEDED
+          description: 'URL where XOA can be reached'
+      valuemaps:
+        - uuid: 0ec95555cba645f796a21bdece34349c
+          name: 'XOA Boolean'
+          mappings:
+            - value: '1'
+              newvalue: 'true'
+            - value: '0'
+              newvalue: 'false'

--- a/Virtualization/xcp-ng/Readme.md
+++ b/Virtualization/xcp-ng/Readme.md
@@ -33,6 +33,8 @@ Thorsten Liepert
 |----|-----------|-------|
 |{$XOA.AUTH.TOKEN}|<p>authentication token for XenOrchestra API</p>||
 |{$XOA.URL}|<p>URL to XenOrchestra (https://xen.mydomain.com)</p>||
+|{$XOA.SR.THRESHOLD.CRIT}|<p>Critical threshold for storage repository usage in percent</p>||
+|{$XOA.SR.THRESHOLD.WARN}|<p>Warning threshold for storage repository usage in percent</p>||
 
 ## Feedback
 

--- a/Virtualization/xcp-ng/Readme.md
+++ b/Virtualization/xcp-ng/Readme.md
@@ -1,0 +1,39 @@
+
+# XenOrchestra
+
+## Overview
+
+This template is designed for the effortless deployment of both XenOrchestra and XCP-NG monitoring and doesn't require any external scripts.
+
+The "XCP-NG Host via Xen Orchestra" and "XCP-NG VM via Xen Orchestra" templates are used by discovery and normally should not be manually linked to a host.
+
+## Requirements
+
+Zabbix version: 6.0 and higher.
+
+## Tested versions
+
+This template has been tested on:
+- XenOrchestra CE
+
+## Author
+
+Thorsten Liepert
+
+## Setup
+
+1. Generate an access token at XenOrchestra for aa user with read access.
+2. Create a host for the XenOrchestra host and link template "Xen Orchestra by HTTP"
+3. Configure macro "{$XOA.AUTH.TOKEN}" with generated access token
+4. Configure macro "{$XOA.URL}" with url to XenOrchestra e.g. https://xen.mydomain.com
+
+### Macros used
+
+|Name|Description|Default|
+|----|-----------|-------|
+|{$XOA.AUTH.TOKEN}|<p>authentication token for XenOrchestra API</p>||
+|{$XOA.URL}|<p>URL to XenOrchestra (https://xen.mydomain.com)</p>||
+
+## Feedback
+
+Please report any issues with the template at [`https://github.com/bufanda/zabbix--template-xenorchestra`](https://github.com/bufanda/zabbix--template-xenorchestra)


### PR DESCRIPTION
These Templates are inspired by the VMWare template and will monitor an XCP-NG/Xen Installation via the management appliance XenOrchestra. The XenOrchestra Template will discover pools, hypervisor and vms present in the pools. Hypervisor and VMs will be created as host and their state will be monitored. 

No external scripts are needed. All Monitoring is done via the REST API of XenOrchestra and either HTTP-Agent Items or Script Items. 