### PR TITLE
Support Zabbiz 6.x and PX4 PDU

### DIFF
--- a/Power_(UPS)/Legrand_Inform/template_raritan_px_pdu/6.0/README.md
+++ b/Power_(UPS)/Legrand_Inform/template_raritan_px_pdu/6.0/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Works with Raritan PDU PX2 / PX3 and ATS PX3 products
+Works with Raritan PDU PX2 / PX3 / PX4 and ATS PX3 products
 
 
 Discovery rules:
@@ -18,9 +18,10 @@ With advanced power function (See <https://www.zabbix.com/forum/zabbix-help/3855
 
 
 
-## Author
+## Authors
 
 eric_at_2037
+abrenner
 
 ## Macros used
 
@@ -62,43 +63,43 @@ There are no template links in this template.
 |Outlet Controller number|<p>-</p>|`SNMP agent`|outletControllerCount<p>Update: 3600</p>|
 |Device Frequency|<p>-</p>|`SNMP agent`|pduRatedFrequency<p>Update: 3600</p>|
 |Contact|<p>-</p>|`SNMP agent`|sysContact<p>Update: 3600</p>|
-|OnOff Status of Outlet $1|<p>-</p>|`SNMP agent`|OnOffStatus[{#SNMPVALUE}]<p>Update: 300</p><p>LLD</p>|
-|Current Capability of Outlet $1|<p>-</p>|`SNMP agent`|OutletCurrent[{#SNMPVALUE}]<p>Update: 300</p><p>LLD</p>|
-|Name of Outlet $1|<p>-</p>|`SNMP agent`|OutletName[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|Type of Outlet $1|<p>-</p>|`SNMP agent`|outletReceptacleDescriptor[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|Voltage Capability of Outlet $1|<p>-</p>|`SNMP agent`|OutletVolts[{#SNMPVALUE}]<p>Update: 300</p><p>LLD</p>|
-|Name of Inlet $1|<p>-</p>|`SNMP agent`|InletName[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|State of powerFactor on Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorStatermspowerFactor[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|powerFactor of Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorValuermspowerFactor[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|apparentPower of Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorValuermsapparentPower[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|activePower of Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorValuermsactivePower[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|activeEnergy of Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorValuermsactiveEnergy[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|Frequency of Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorValueFrequency[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|Current of Inlet $1|<p>-</p>|`Calculated`|measurementsInletSensorUsableValuermsCurrent[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|State of Voltage on Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorStatermsVoltage[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|State of Current on Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorStatermsCurrent[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|Type of Inlet $1|<p>-</p>|`SNMP agent`|inletPlugDescriptor[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|State of apparentPower on Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorStatermsapparentPower[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|State of activePower on Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorStatermsactivePower[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|State of activeEnergy on Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorStatermsactiveEnergy[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|State of Frequency on Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorStateFrequency[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|RAW Current of Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorRAWValuermsCurrent[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|Current DecimalDigits of Inlet $1|<p>-</p>|`SNMP agent`|inletSensorDecimalDigitsrmsCurrent[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|Volatage Capability of Inlet $1|<p>-</p>|`SNMP agent`|inletRatedVoltage[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|Current Capability of Inlet $1|<p>-</p>|`SNMP agent`|inletRatedCurrent[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|Voltage of Inlet $1|<p>-</p>|`SNMP agent`|measurementsInletSensorValuermsVoltage[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|Sensor DecimalDigits of External Sensor $1|<p>-</p>|`SNMP agent`|externalSensorDecimalDigits[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|Serial Number of External Sensor $1|<p>-</p>|`SNMP agent`|externalSensorSerialNumber[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|Type of External Sensor $1|<p>-</p>|`SNMP agent`|externalSensorType[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|Unit of External Sensor $1|<p>-</p>|`SNMP agent`|externalSensorUnits[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|RAW Value of Sensor $1|<p>-</p>|`SNMP agent`|measurementsExternalSensorRAWValue[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|State of External Sensor $1|<p>-</p>|`SNMP agent`|measurementsExternalSensorState[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|OnOff Status of Outlet|<p>-</p>|`SNMP agent`|OnOffStatus[{#SNMPVALUE}]<p>Update: 300</p><p>LLD</p>|
+|Current Capability of Outlet|<p>-</p>|`SNMP agent`|OutletCurrent[{#SNMPVALUE}]<p>Update: 300</p><p>LLD</p>|
+|Name of Outlet|<p>-</p>|`SNMP agent`|OutletName[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|Type of Outlet|<p>-</p>|`SNMP agent`|outletReceptacleDescriptor[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|Voltage Capability of Outlet|<p>-</p>|`SNMP agent`|OutletVolts[{#SNMPVALUE}]<p>Update: 300</p><p>LLD</p>|
+|Name of Inlet|<p>-</p>|`SNMP agent`|InletName[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|State of powerFactor on Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorStatermspowerFactor[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|powerFactor of Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorValuermspowerFactor[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|apparentPower of Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorValuermsapparentPower[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|activePower of Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorValuermsactivePower[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|activeEnergy of Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorValuermsactiveEnergy[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|Frequency of Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorValueFrequency[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|Current of Inlet|<p>-</p>|`Calculated`|measurementsInletSensorUsableValuermsCurrent[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|State of Voltage on Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorStatermsVoltage[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|State of Current on Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorStatermsCurrent[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|Type of Inlet|<p>-</p>|`SNMP agent`|inletPlugDescriptor[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|State of apparentPower on Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorStatermsapparentPower[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|State of activePower on Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorStatermsactivePower[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|State of activeEnergy on Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorStatermsactiveEnergy[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|State of Frequency on Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorStateFrequency[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|RAW Current of Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorRAWValuermsCurrent[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|Current DecimalDigits of Inlet|<p>-</p>|`SNMP agent`|inletSensorDecimalDigitsrmsCurrent[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|Volatage Capability of Inlet|<p>-</p>|`SNMP agent`|inletRatedVoltage[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|Current Capability of Inlet|<p>-</p>|`SNMP agent`|inletRatedCurrent[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|Voltage of Inlet|<p>-</p>|`SNMP agent`|measurementsInletSensorValuermsVoltage[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|Sensor DecimalDigits of External Sensor|<p>-</p>|`SNMP agent`|externalSensorDecimalDigits[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|Serial Number of External Sensor|<p>-</p>|`SNMP agent`|externalSensorSerialNumber[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|Type of External Sensor|<p>-</p>|`SNMP agent`|externalSensorType[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|Unit of External Sensor|<p>-</p>|`SNMP agent`|externalSensorUnits[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|RAW Value of Sensor|<p>-</p>|`SNMP agent`|measurementsExternalSensorRAWValue[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|State of External Sensor|<p>-</p>|`SNMP agent`|measurementsExternalSensorState[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
 |Value of Sensor {#SNMPVALUE}|<p>-</p>|`Calculated`|measurementsExternalSensorUsableValue[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|State of  Overcurrent Protector $1|<p>-</p>|`SNMP agent`|measurementsOverCurrentProtectorSensorStatermsCurrent[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|Current of  Overcurrent Protector $1|<p>-</p>|`SNMP agent`|measurementsOverCurrentProtectorSensorValuermsCurrent[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
-|Name of Overcurrent Protector $1|<p>-</p>|`SNMP agent`|overCurrentProtectorName[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|Capability of  Overcurrent Protector  $1|<p>-</p>|`SNMP agent`|overCurrentProtectorRatedCurrent[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
-|Type of  Overcurrent Protector  $1|<p>-</p>|`SNMP agent`|overCurrentProtectorType[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|State of  Overcurrent Protector|<p>-</p>|`SNMP agent`|measurementsOverCurrentProtectorSensorStatermsCurrent[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|Current of  Overcurrent Protector|<p>-</p>|`SNMP agent`|measurementsOverCurrentProtectorSensorValuermsCurrent[{#SNMPVALUE}]<p>Update: 60</p><p>LLD</p>|
+|Name of Overcurrent Protector|<p>-</p>|`SNMP agent`|overCurrentProtectorName[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|Capability of Overcurrent Protector|<p>-</p>|`SNMP agent`|overCurrentProtectorRatedCurrent[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
+|Type of  Overcurrent Protector|<p>-</p>|`SNMP agent`|overCurrentProtectorType[{#SNMPVALUE}]<p>Update: 3600</p><p>LLD</p>|
 
 
 ## Triggers

--- a/Power_(UPS)/Legrand_Inform/template_raritan_px_pdu/6.0/template_raritan_px_pdu.yaml
+++ b/Power_(UPS)/Legrand_Inform/template_raritan_px_pdu/6.0/template_raritan_px_pdu.yaml
@@ -1,19 +1,16 @@
 zabbix_export:
-  version: '6.0'
-  date: '2021-11-21T21:50:28Z'
-  groups:
-    -
-      uuid: 7df96b18c230490a9a0a9e2307226338
+  version: '6.4'
+  template_groups:
+    - uuid: 7df96b18c230490a9a0a9e2307226338
       name: Templates
   templates:
-    -
-      uuid: f23c1bace4e54be6ac4d681d7a87179f
+    - uuid: f23c1bace4e54be6ac4d681d7a87179f
       template: 'Raritan PDU'
       name: 'Raritan PDU'
       description: |
         ## Overview
         
-        Works with Raritan PDU PX2 / PX3 and ATS PX3 products
+        Works with Raritan PDU PX2 / PX3 / PX4 and ATS PX3 products
         
         
         Discovery rules:
@@ -32,14 +29,11 @@ zabbix_export:
         ## Author
         
         eric_at_2037
-        
-        
+        abrenner
       groups:
-        -
-          name: Templates
+        - name: Templates
       items:
-        -
-          uuid: bf23bddae2a64284a3897ee799631914
+        - uuid: bf23bddae2a64284a3897ee799631914
           name: 'Device reachability using ICMP'
           type: SIMPLE
           key: icmpping
@@ -48,46 +42,38 @@ zabbix_export:
           valuemap:
             name: 'Host status'
           preprocessing:
-            -
-              type: BOOL_TO_DECIMAL
+            - type: BOOL_TO_DECIMAL
               parameters:
                 - ''
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
           triggers:
-            -
-              uuid: 6daff4b8812b4f3ebf0aa60dd9837f9c
+            - uuid: 6daff4b8812b4f3ebf0aa60dd9837f9c
               expression: 'last(/Raritan PDU/icmpping)=0'
               name: '{HOST.NAME} is UNREACHABLE or DOWN'
               priority: DISASTER
-        -
-          uuid: 5de26d0c865b479da6dd6c181ceb53b6
-          name: 'Inlet Controller number'
+        - uuid: 5de26d0c865b479da6dd6c181ceb53b6
+          name: 'Inlet Controller Count'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.2.1.5.1
           key: inletControllerCount
           delay: '3600'
           trends: 1825d
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: e7a3ef34ac644bad86c4f54fb2c65916
-          name: 'Inlet number'
+        - uuid: e7a3ef34ac644bad86c4f54fb2c65916
+          name: 'Inlet Count'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.2.1.2.1
           key: inletCount
           delay: '3600'
           trends: 1825d
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: f6818418baee4fa899ded803e053df52
+        - uuid: f6818418baee4fa899ded803e053df52
           name: 'Device Manufacter Name'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.1.1.2.1
@@ -97,47 +83,39 @@ zabbix_export:
           value_type: CHAR
           inventory_link: TAG
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: 6e84eddea980499096f5285a41b7febc
-          name: 'Outlet Controller number'
+        - uuid: 6e84eddea980499096f5285a41b7febc
+          name: 'Outlet Controller Count'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.2.1.6.1
           key: outletControllerCount
           delay: '3600'
           trends: 1825d
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: c6758093e8ee4d4abb143e83537a7259
-          name: 'Outlet number'
+        - uuid: c6758093e8ee4d4abb143e83537a7259
+          name: 'Outlet Count'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.2.1.4.1
           key: outletCount
           delay: '3600'
           trends: 1825d
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: 3a042a17641244e0a05bcf9274a1f44b
-          name: 'Overcurrent Protector number'
+        - uuid: 3a042a17641244e0a05bcf9274a1f44b
+          name: 'Overcurrent Protector Count'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.2.1.3.1
           key: overCurrentProtectorCount
           delay: '3600'
           trends: 1825d
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: 240a2df9a25a42379f6bf064e99cfed5
+        - uuid: 240a2df9a25a42379f6bf064e99cfed5
           name: 'Device Model Name'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.1.1.3.1
@@ -147,12 +125,10 @@ zabbix_export:
           value_type: CHAR
           inventory_link: TYPE
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: 499fda66622a4299bc0d3441aa122cb6
-          name: 'Device Current'
+        - uuid: 499fda66622a4299bc0d3441aa122cb6
+          name: 'Device Rated Current'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.1.1.6.1
           key: pduRatedCurrent
@@ -160,12 +136,10 @@ zabbix_export:
           trends: '0'
           value_type: CHAR
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: 68f03fa8b1ce4f81a66638f8127b5697
-          name: 'Device Frequency'
+        - uuid: 68f03fa8b1ce4f81a66638f8127b5697
+          name: 'Device Rated Frequency'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.1.1.7.1
           key: pduRatedFrequency
@@ -173,12 +147,10 @@ zabbix_export:
           trends: '0'
           value_type: CHAR
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: c0626e9ef6ef492b8413a69746d6bf78
-          name: 'Device Power Capability'
+        - uuid: c0626e9ef6ef492b8413a69746d6bf78
+          name: 'Device Rated Power Capability'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.1.1.8.1
           key: pduRatedVA
@@ -186,12 +158,10 @@ zabbix_export:
           trends: '0'
           value_type: CHAR
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: 80a439e281e341969938ff73b9ef96c7
-          name: 'Device Voltage'
+        - uuid: 80a439e281e341969938ff73b9ef96c7
+          name: 'Device Rated Voltage'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.1.1.5.1
           key: pduRatedVoltage
@@ -199,11 +169,9 @@ zabbix_export:
           trends: '0'
           value_type: CHAR
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: 07a4a70f5a12403084b969976be6bc97
+        - uuid: 07a4a70f5a12403084b969976be6bc97
           name: 'Device Serial Number'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.1.1.4.1
@@ -213,11 +181,9 @@ zabbix_export:
           value_type: CHAR
           inventory_link: SERIALNO_A
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: 7e18e85a230c46d3a3c8d1a7b03cc732
+        - uuid: 7e18e85a230c46d3a3c8d1a7b03cc732
           name: Contact
           type: SNMP_AGENT
           snmp_oid: 'SNMPv2-MIB::sysContact.0'
@@ -227,11 +193,9 @@ zabbix_export:
           value_type: CHAR
           inventory_link: CONTACT
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: 2c8bc8bcb1724dc09088fcb08f7092ce
+        - uuid: 2c8bc8bcb1724dc09088fcb08f7092ce
           name: 'Software version (full)'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.3.1.6.1.1.1
@@ -241,11 +205,9 @@ zabbix_export:
           value_type: CHAR
           inventory_link: OS_FULL
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: c7d5466676204b65b60aa3419325ec20
+        - uuid: c7d5466676204b65b60aa3419325ec20
           name: 'Device Location'
           type: SNMP_AGENT
           snmp_oid: 'SNMPv2-MIB::sysLocation.0'
@@ -255,11 +217,9 @@ zabbix_export:
           value_type: CHAR
           inventory_link: LOCATION
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: 30db102e247a4797a8f1d45446f03cac
+        - uuid: 30db102e247a4797a8f1d45446f03cac
           name: 'Device Name'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.13742.6.3.2.2.1.13.1
@@ -269,11 +229,9 @@ zabbix_export:
           value_type: CHAR
           inventory_link: NAME
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
-        -
-          uuid: ae9bd5a2c319491881f16904c79f2525
+        - uuid: ae9bd5a2c319491881f16904c79f2525
           name: Uptime
           type: SNMP_AGENT
           snmp_oid: 'SNMPv2-MIB::sysUpTime.0'
@@ -282,28 +240,23 @@ zabbix_export:
           trends: 1825d
           units: uptime
           preprocessing:
-            -
-              type: MULTIPLIER
+            - type: MULTIPLIER
               parameters:
                 - '0.01'
           tags:
-            -
-              tag: Application
+            - tag: Application
               value: Information(s)
           triggers:
-            -
-              uuid: 735532e6db414fa58b1a37d5a06404e1
+            - uuid: 735532e6db414fa58b1a37d5a06404e1
               expression: 'last(/Raritan PDU/sysUpTime)<86400'
               name: 'Uptime is too low on {HOST.NAME}'
               priority: INFO
-            -
-              uuid: adaa24260ee84b26b366b65f7acbf37b
+            - uuid: adaa24260ee84b26b366b65f7acbf37b
               expression: 'last(/Raritan PDU/sysUpTime)<3600'
               name: '{HOST.NAME} has just been restarted'
               priority: HIGH
       discovery_rules:
-        -
-          uuid: 499051dd71d344f3a02dd31410d92cea
+        - uuid: 499051dd71d344f3a02dd31410d92cea
           name: Sensors
           type: SNMP_AGENT
           snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.4.1.13742.6.3.6.3.1.4.1]'
@@ -311,32 +264,27 @@ zabbix_export:
           delay: '3600'
           filter:
             conditions:
-              -
-                macro: '{#SNMPVALUE}'
+              - macro: '{#SNMPVALUE}'
                 value: '.*'
                 formulaid: A
           lifetime: 7d
           item_prototypes:
-            -
-              uuid: f1cf39579f53463b929d2d6a2e51a745
-              name: 'Sensor DecimalDigits of External Sensor $1'
+            - uuid: f1cf39579f53463b929d2d6a2e51a745
+              name: 'External Sensor DecimalDigits #{#SNMPINDEX} - {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.6.3.1.17.1.{#SNMPINDEX}'
               key: 'externalSensorDecimalDigits[{#SNMPVALUE}]'
               delay: '3600'
               value_type: FLOAT
               preprocessing:
-                -
-                  type: JAVASCRIPT
+                - type: JAVASCRIPT
                   parameters:
                     - 'return  (Math.pow(0.1, value))'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Sensors
-            -
-              uuid: 73daac82d4c645c5bc273448d8cea32d
-              name: 'Serial Number of External Sensor $1'
+            - uuid: 73daac82d4c645c5bc273448d8cea32d
+              name: 'External Sensor Serial Number #{#SNMPINDEX} - {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.6.3.1.3.1.{#SNMPINDEX}'
               key: 'externalSensorSerialNumber[{#SNMPVALUE}]'
@@ -344,23 +292,21 @@ zabbix_export:
               trends: '0'
               value_type: CHAR
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Sensors
-            -
-              uuid: 4bb392bc361d4684b41542edd303fc30
-              name: 'Type of External Sensor $1'
+            - uuid: 4bb392bc361d4684b41542edd303fc30
+              name: 'External Sensor Type #{#SNMPINDEX} - {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.6.3.1.2.1.{#SNMPINDEX}'
               key: 'externalSensorType[{#SNMPVALUE}]'
               delay: '3600'
+              valuemap:
+                name: 'Raritan PDU Sensor Type Enumeration'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Sensors
-            -
-              uuid: ab5c6f42384749519ee366c659388959
-              name: 'Unit of External Sensor $1'
+            - uuid: ab5c6f42384749519ee366c659388959
+              name: 'External Sensor Unit #{#SNMPINDEX} - {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.6.3.1.16.1.{#SNMPINDEX}'
               key: 'externalSensorUnits[{#SNMPVALUE}]'
@@ -368,12 +314,10 @@ zabbix_export:
               valuemap:
                 name: 'Raritan PDU Units Enumeration'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Sensors
-            -
-              uuid: 54b40ba2822f473fb1645d2daf622f7f
-              name: 'RAW Value of Sensor $1'
+            - uuid: 54b40ba2822f473fb1645d2daf622f7f
+              name: 'External Sensor RAW #{#SNMPINDEX} - {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.5.3.1.4.1.{#SNMPINDEX}'
               key: 'measurementsExternalSensorRAWValue[{#SNMPVALUE}]'
@@ -381,12 +325,10 @@ zabbix_export:
               trends: 1825d
               value_type: FLOAT
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Sensors
-            -
-              uuid: 35c34a1df8d24bbd8e7b4b53e471a7e4
-              name: 'State of External Sensor $1'
+            - uuid: 35c34a1df8d24bbd8e7b4b53e471a7e4
+              name: 'External Sensor State #{#SNMPINDEX} - {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.5.3.1.3.1.{#SNMPINDEX}'
               key: 'measurementsExternalSensorState[{#SNMPVALUE}]'
@@ -395,49 +337,40 @@ zabbix_export:
               valuemap:
                 name: 'Raritan PDU State Enumeration'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Sensors
               trigger_prototypes:
-                -
-                  uuid: fb7f019f86db4151845cd127fc02217b
+                - uuid: fb7f019f86db4151845cd127fc02217b
                   expression: 'last(/Raritan PDU/measurementsExternalSensorState[{#SNMPVALUE}])<>4'
                   name: 'Sensor problem on {#SNMPVALUE}'
                   priority: AVERAGE
-                -
-                  uuid: 7f2fc06bd2ab4be7bb1911a8f5ba4c91
+                - uuid: 7f2fc06bd2ab4be7bb1911a8f5ba4c91
                   expression: 'last(/Raritan PDU/measurementsExternalSensorState[{#SNMPVALUE}])=6'
                   name: 'Sensor problem on {#SNMPVALUE} is too high'
                   priority: HIGH
-                -
-                  uuid: 66c18a64ecaf4fb8831de63d0272c9d2
+                - uuid: 66c18a64ecaf4fb8831de63d0272c9d2
                   expression: 'last(/Raritan PDU/measurementsExternalSensorState[{#SNMPVALUE}])=2'
                   name: 'Sensor problem on {#SNMPVALUE} is too low'
                   priority: HIGH
-            -
-              uuid: aff7b2e75c9d42238677fff011285c8d
-              name: 'Value of Sensor {#SNMPVALUE}'
+            - uuid: aff7b2e75c9d42238677fff011285c8d
+              name: 'External Sensor Value #{#SNMPINDEX} - {#SNMPVALUE}'
               type: CALCULATED
               key: 'measurementsExternalSensorUsableValue[{#SNMPVALUE}]'
               delay: '60'
               value_type: FLOAT
               params: 'last(//measurementsExternalSensorRAWValue[{#SNMPVALUE}])*last(//externalSensorDecimalDigits[{#SNMPVALUE}])'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Sensors
           graph_prototypes:
-            -
-              uuid: 3a2a02be2bc74acd883937058e17e0fa
-              name: 'Value of Sensor {#SNMPVALUE}'
+            - uuid: 3a2a02be2bc74acd883937058e17e0fa
+              name: 'External Sensor Value #{#SNMPINDEX} - {#SNMPVALUE}'
               graph_items:
-                -
-                  color: '000000'
+                - color: '000000'
                   item:
                     host: 'Raritan PDU'
                     key: 'measurementsExternalSensorUsableValue[{#SNMPVALUE}]'
-        -
-          uuid: c60e3d956ecd4ee29addc8f9cad865b9
+        - uuid: c60e3d956ecd4ee29addc8f9cad865b9
           name: 'Overcurrent Protectors'
           type: SNMP_AGENT
           snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.4.1.13742.6.3.4.3.1.2.1]'
@@ -445,15 +378,13 @@ zabbix_export:
           delay: '3600'
           filter:
             conditions:
-              -
-                macro: '{#SNMPVALUE}'
+              - macro: '{#SNMPVALUE}'
                 value: '.*'
                 formulaid: A
           lifetime: 7d
           item_prototypes:
-            -
-              uuid: 0a6e7f6c457642a1ac4dcaad5adeb619
-              name: 'State of  Overcurrent Protector $1'
+            - uuid: 0a6e7f6c457642a1ac4dcaad5adeb619
+              name: 'Overcurrent Protector State {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.3.3.1.3.1.{#SNMPINDEX}.1'
               key: 'measurementsOverCurrentProtectorSensorStatermsCurrent[{#SNMPVALUE}]'
@@ -461,45 +392,37 @@ zabbix_export:
               valuemap:
                 name: 'Raritan PDU State Enumeration'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: 'Overcurrent Protectors'
               trigger_prototypes:
-                -
-                  uuid: 29f1025ad83842f394c1f14323f0686a
+                - uuid: 29f1025ad83842f394c1f14323f0686a
                   expression: 'last(/Raritan PDU/measurementsOverCurrentProtectorSensorStatermsCurrent[{#SNMPVALUE}])=6'
                   name: 'Current problem too high on Overcurrent Protector {#SNMPVALUE}'
                   priority: HIGH
-                -
-                  uuid: 85defbe5183a4771baaab50aafd79d4f
+                - uuid: 85defbe5183a4771baaab50aafd79d4f
                   expression: 'last(/Raritan PDU/measurementsOverCurrentProtectorSensorStatermsCurrent[{#SNMPVALUE}])=2'
                   name: 'Current problem too low on Overcurrent Protector {#SNMPVALUE}'
                   priority: HIGH
-                -
-                  uuid: 6e51e79d39b143dda7d5a624292ca0db
+                - uuid: 6e51e79d39b143dda7d5a624292ca0db
                   expression: 'last(/Raritan PDU/measurementsOverCurrentProtectorSensorStatermsCurrent[{#SNMPVALUE}])<>4'
                   name: 'State of Overcurrent Protector {#SNMPVALUE}'
                   priority: AVERAGE
-            -
-              uuid: d4d4762697904430994d5a85b2d2a0aa
-              name: 'Current of  Overcurrent Protector $1'
+            - uuid: d4d4762697904430994d5a85b2d2a0aa
+              name: 'Overcurrent Protector Current {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.3.3.1.4.1.{#SNMPINDEX}.1'
               key: 'measurementsOverCurrentProtectorSensorValuermsCurrent[{#SNMPVALUE}]'
               delay: '60'
               value_type: FLOAT
               preprocessing:
-                -
-                  type: MULTIPLIER
+                - type: MULTIPLIER
                   parameters:
                     - '0.1'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: 'Overcurrent Protectors'
-            -
-              uuid: c9b1f2439e6e4f6cbc63307694ca33a9
-              name: 'Name of Overcurrent Protector $1'
+            - uuid: c9b1f2439e6e4f6cbc63307694ca33a9
+              name: 'Overcurrent Protector Name {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.4.3.1.3.1.{#SNMPINDEX}'
               key: 'overCurrentProtectorName[{#SNMPVALUE}]'
@@ -507,12 +430,10 @@ zabbix_export:
               trends: '0'
               value_type: CHAR
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: 'Overcurrent Protectors'
-            -
-              uuid: c2b2548ada134a7da77ead2c445e38de
-              name: 'Capability of  Overcurrent Protector  $1'
+            - uuid: c2b2548ada134a7da77ead2c445e38de
+              name: 'Overcurrent Protector Capability {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.4.3.1.5.1.{#SNMPINDEX}'
               key: 'overCurrentProtectorRatedCurrent[{#SNMPVALUE}]'
@@ -520,34 +441,30 @@ zabbix_export:
               trends: '0'
               value_type: CHAR
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: 'Overcurrent Protectors'
-            -
-              uuid: 65e38bacb5204d7b90d91a7f3e3b85a0
-              name: 'Type of  Overcurrent Protector  $1'
+            - uuid: 65e38bacb5204d7b90d91a7f3e3b85a0
+              name: 'Overcurrent Protector Type {#SNMPVALUE}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.4.3.1.4.1.{#SNMPINDEX}'
               key: 'overCurrentProtectorType[{#SNMPVALUE}]'
               delay: '3600'
+              valuemap:
+                name: 'Raritan PDU OverCurrent Protector Type Enumeration'
               trends: '0'
               value_type: CHAR
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: 'Overcurrent Protectors'
           graph_prototypes:
-            -
-              uuid: 056e331f8d3e467ba5d909d74ddaf6f5
-              name: 'Current of Overcurrent Protector {#SNMPVALUE}'
+            - uuid: 056e331f8d3e467ba5d909d74ddaf6f5
+              name: 'Overcurrent Protector Current {#SNMPVALUE}'
               graph_items:
-                -
-                  color: FF0000
+                - color: FF0000
                   item:
                     host: 'Raritan PDU'
                     key: 'measurementsOverCurrentProtectorSensorValuermsCurrent[{#SNMPVALUE}]'
-        -
-          uuid: 37108349f92b4f678d04aedaae55f09d
+        - uuid: 37108349f92b4f678d04aedaae55f09d
           name: Inlets
           type: SNMP_AGENT
           snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.4.1.13742.6.3.3.3.1.2.1]'
@@ -555,15 +472,13 @@ zabbix_export:
           delay: '3600'
           filter:
             conditions:
-              -
-                macro: '{#SNMPVALUE}'
+              - macro: '{#SNMPVALUE}'
                 value: '.*'
                 formulaid: A
           lifetime: 7d
           item_prototypes:
-            -
-              uuid: 93c0b5abc6d74d68b8797df1d0c54946
-              name: 'Name of Inlet $1'
+            - uuid: 93c0b5abc6d74d68b8797df1d0c54946
+              name: 'Inlet Name {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.3.3.1.3.1.{#SNMPINDEX}'
               key: 'InletName[{#SNMPVALUE}]'
@@ -572,12 +487,10 @@ zabbix_export:
               trends: '0'
               value_type: CHAR
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
-            -
-              uuid: f8bc7cafae164150aba68db8b3f79e22
-              name: 'Type of Inlet $1'
+            - uuid: f8bc7cafae164150aba68db8b3f79e22
+              name: 'Inlet Type {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.3.3.1.12.1.{#SNMPINDEX}'
               key: 'inletPlugDescriptor[{#SNMPVALUE}]'
@@ -586,12 +499,10 @@ zabbix_export:
               trends: '0'
               value_type: CHAR
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
-            -
-              uuid: 28bdcb0903f94fe6831c66b09cc40985
-              name: 'Current Capability of Inlet $1'
+            - uuid: 28bdcb0903f94fe6831c66b09cc40985
+              name: 'Inlet Current Capability {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.3.3.1.7.1.{#SNMPINDEX}'
               key: 'inletRatedCurrent[{#SNMPVALUE}]'
@@ -600,12 +511,10 @@ zabbix_export:
               trends: '0'
               value_type: CHAR
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
-            -
-              uuid: 1d55f8f82b4f4a249e12c32703906b20
-              name: 'Volatage Capability of Inlet $1'
+            - uuid: 1d55f8f82b4f4a249e12c32703906b20
+              name: 'Inlet Voltage Capability {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.3.3.1.6.1.{#SNMPINDEX}'
               key: 'inletRatedVoltage[{#SNMPVALUE}]'
@@ -614,29 +523,24 @@ zabbix_export:
               trends: '0'
               value_type: CHAR
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
-            -
-              uuid: 38ef3add4cb746bca0d193ffbb003513
-              name: 'Current DecimalDigits of Inlet $1'
+            - uuid: 38ef3add4cb746bca0d193ffbb003513
+              name: 'Inlet Current DecimalDigits {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.3.4.1.7.1.{#SNMPINDEX}.1'
               key: 'inletSensorDecimalDigitsrmsCurrent[{#SNMPVALUE}]'
               delay: '3600'
               value_type: FLOAT
               preprocessing:
-                -
-                  type: JAVASCRIPT
+                - type: JAVASCRIPT
                   parameters:
                     - 'return  (Math.pow(0.1, value))'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
-            -
-              uuid: 4abffda55b124193b7e035fb3afb4cec
-              name: 'RAW Current of Inlet $1'
+            - uuid: 4abffda55b124193b7e035fb3afb4cec
+              name: 'Inlet RAW Current {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.4.1.{#SNMPINDEX}.1'
               key: 'measurementsInletSensorRAWValuermsCurrent[{#SNMPVALUE}]'
@@ -644,12 +548,10 @@ zabbix_export:
               trends: 1825d
               value_type: FLOAT
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
-            -
-              uuid: 29882051e4a14c1ca35723b6dd9ad337
-              name: 'State of Frequency on Inlet $1'
+            - uuid: 29882051e4a14c1ca35723b6dd9ad337
+              name: 'Inlet Frequency State {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.3.1.{#SNMPINDEX}.23'
               key: 'measurementsInletSensorStateFrequency[{#SNMPVALUE}]'
@@ -658,28 +560,23 @@ zabbix_export:
               valuemap:
                 name: 'Raritan PDU State Enumeration'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
               trigger_prototypes:
-                -
-                  uuid: 85674c09f7524cffb4c2f16872f28a29
+                - uuid: 85674c09f7524cffb4c2f16872f28a29
                   expression: 'last(/Raritan PDU/measurementsInletSensorStateFrequency[{#SNMPVALUE}])<>4'
                   name: 'Frequency problem on Inlet {#SNMPVALUE}'
                   priority: AVERAGE
-                -
-                  uuid: 767607fda3fc46fe85470180e1ef6228
+                - uuid: 767607fda3fc46fe85470180e1ef6228
                   expression: 'last(/Raritan PDU/measurementsInletSensorStateFrequency[{#SNMPVALUE}])=6'
                   name: 'Frequency problem too high on Inlet {#SNMPVALUE}'
                   priority: HIGH
-                -
-                  uuid: 0dbc8247e7ee4fa386327ddbe4eb91ba
+                - uuid: 0dbc8247e7ee4fa386327ddbe4eb91ba
                   expression: 'last(/Raritan PDU/measurementsInletSensorStateFrequency[{#SNMPVALUE}])=2'
                   name: 'Frequency problem too low on Inlet {#SNMPVALUE}'
                   priority: HIGH
-            -
-              uuid: 52b877e062e04b8aae25e301b98fe291
-              name: 'State of activeEnergy on Inlet $1'
+            - uuid: 52b877e062e04b8aae25e301b98fe291
+              name: 'Inlet Active Energy State {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.3.1.{#SNMPINDEX}.8'
               key: 'measurementsInletSensorStatermsactiveEnergy[{#SNMPVALUE}]'
@@ -688,18 +585,15 @@ zabbix_export:
               valuemap:
                 name: 'Raritan PDU State Enumeration'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
               trigger_prototypes:
-                -
-                  uuid: 6fdedf020ac948018e2750558795773d
+                - uuid: 6fdedf020ac948018e2750558795773d
                   expression: 'last(/Raritan PDU/measurementsInletSensorStatermsactiveEnergy[{#SNMPVALUE}])<>4'
-                  name: 'activeEnergy problem on Inlet {#SNMPVALUE}'
+                  name: 'Inlet Active Energy State {#SNMPVALUE} Problem {#SNMPVALUE}'
                   priority: AVERAGE
-            -
-              uuid: 8b613929a5d04659898c9095a7149008
-              name: 'State of activePower on Inlet $1'
+            - uuid: 8b613929a5d04659898c9095a7149008
+              name: 'Intel Active Power State {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.3.1.{#SNMPINDEX}.5'
               key: 'measurementsInletSensorStatermsactivePower[{#SNMPVALUE}]'
@@ -708,18 +602,15 @@ zabbix_export:
               valuemap:
                 name: 'Raritan PDU State Enumeration'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
               trigger_prototypes:
-                -
-                  uuid: b9c29db0d4f549c5bc641a8ef9dadc89
+                - uuid: b9c29db0d4f549c5bc641a8ef9dadc89
                   expression: 'last(/Raritan PDU/measurementsInletSensorStatermsactivePower[{#SNMPVALUE}])<>4'
-                  name: 'activePower problem on Inlet {#SNMPVALUE}'
+                  name: 'Inlet Active Power {#SNMPVALUE} Problem {#SNMPVALUE}'
                   priority: AVERAGE
-            -
-              uuid: 99d7194a0ac64b17bea5a296042ee208
-              name: 'State of apparentPower on Inlet $1'
+            - uuid: 99d7194a0ac64b17bea5a296042ee208
+              name: 'Inlet Apparent Power State {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.3.1.{#SNMPINDEX}.6'
               key: 'measurementsInletSensorStatermsapparentPower[{#SNMPVALUE}]'
@@ -728,18 +619,15 @@ zabbix_export:
               valuemap:
                 name: 'Raritan PDU State Enumeration'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
               trigger_prototypes:
-                -
-                  uuid: d935818849384a2dac4f920b17814b97
+                - uuid: d935818849384a2dac4f920b17814b97
                   expression: 'last(/Raritan PDU/measurementsInletSensorStatermsapparentPower[{#SNMPVALUE}])<>4'
-                  name: 'apparentPower problem on Inlet {#SNMPVALUE}'
+                  name: 'Inlet Apparent Power {#SNMPVALUE} Problem {#SNMPVALUE}'
                   priority: AVERAGE
-            -
-              uuid: 614ef2a2b433464aaca87e632e2f51e5
-              name: 'State of Current on Inlet $1'
+            - uuid: 614ef2a2b433464aaca87e632e2f51e5
+              name: 'Inlet Current State {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.3.1.{#SNMPINDEX}.1'
               key: 'measurementsInletSensorStatermsCurrent[{#SNMPVALUE}]'
@@ -748,28 +636,23 @@ zabbix_export:
               valuemap:
                 name: 'Raritan PDU State Enumeration'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
               trigger_prototypes:
-                -
-                  uuid: f1b210ecd8424916a134878d0092a547
-                  expression: 'last(/Raritan PDU/measurementsInletSensorStatermsCurrent[{#SNMPVALUE}])<>4'
-                  name: 'Current problem on Inlet {#SNMPVALUE}'
-                  priority: AVERAGE
-                -
-                  uuid: 015c685c7588453e99c6344712e77843
+                - uuid: 015c685c7588453e99c6344712e77843
                   expression: 'last(/Raritan PDU/measurementsInletSensorStatermsCurrent[{#SNMPVALUE}])=6'
                   name: 'Current problem too high on Inlet {#SNMPVALUE}'
                   priority: HIGH
-                -
-                  uuid: 2e1ead221c2843e9babb6a5bc6b94aef
+                - uuid: 2e1ead221c2843e9babb6a5bc6b94aef
                   expression: 'last(/Raritan PDU/measurementsInletSensorStatermsCurrent[{#SNMPVALUE}])=2'
-                  name: 'Current problem too low on Inlet {#SNMPVALUE}'
+                  name: 'Current problem too low on Inlet {#SNMPINDEX} - {#SNMPVALUE}'
                   priority: HIGH
-            -
-              uuid: 644487059af247c6bfc705275591adbc
-              name: 'State of powerFactor on Inlet $1'
+                - uuid: f1b210ecd8424916a134878d0092a547
+                  expression: 'last(/Raritan PDU/measurementsInletSensorStatermsCurrent[{#SNMPVALUE}])<>4'
+                  name: 'Inlet Current Problem {#SNMPINDEX} - {#SNMPVALUE}'
+                  priority: AVERAGE
+            - uuid: 644487059af247c6bfc705275591adbc
+              name: 'Inlet Power Factor State {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.3.1.{#SNMPINDEX}.7'
               key: 'measurementsInletSensorStatermspowerFactor[{#SNMPVALUE}]'
@@ -778,18 +661,15 @@ zabbix_export:
               valuemap:
                 name: 'Raritan PDU State Enumeration'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
               trigger_prototypes:
-                -
-                  uuid: 5ea60129569c49d5b33ce67a357ae36b
+                - uuid: 5ea60129569c49d5b33ce67a357ae36b
                   expression: 'last(/Raritan PDU/measurementsInletSensorStatermspowerFactor[{#SNMPVALUE}])<>4'
-                  name: 'powerFactor problem on Inlet {#SNMPVALUE}'
+                  name: 'Inlet Power Factor Problem {#SNMPINDEX} - {#SNMPVALUE}'
                   priority: AVERAGE
-            -
-              uuid: ad38012137e94b86a0167df9c6da83b0
-              name: 'State of Voltage on Inlet $1'
+            - uuid: ad38012137e94b86a0167df9c6da83b0
+              name: 'Inlet Voltage State {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.3.1.{#SNMPINDEX}.4'
               key: 'measurementsInletSensorStatermsVoltage[{#SNMPVALUE}]'
@@ -798,28 +678,23 @@ zabbix_export:
               valuemap:
                 name: 'Raritan PDU State Enumeration'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
               trigger_prototypes:
-                -
-                  uuid: 09c9cec9b9fe486891675faea3ba2934
-                  expression: 'last(/Raritan PDU/measurementsInletSensorStatermsVoltage[{#SNMPVALUE}])<>4'
-                  name: 'Voltage problem on Inlet {#SNMPVALUE}'
-                  priority: AVERAGE
-                -
-                  uuid: 2052ed315252498db1dc80d689e4bec4
+                - uuid: 2052ed315252498db1dc80d689e4bec4
                   expression: 'last(/Raritan PDU/measurementsInletSensorStatermsVoltage[{#SNMPVALUE}])=6'
-                  name: 'Voltage problem too high on Inlet {#SNMPVALUE}'
+                  name: 'Inlet Voltage Problem too high {#SNMPINDEX} - {#SNMPVALUE}'
                   priority: HIGH
-                -
-                  uuid: c0bf538c9032415780d52e11cb8ab456
+                - uuid: c0bf538c9032415780d52e11cb8ab456
                   expression: 'last(/Raritan PDU/measurementsInletSensorStatermsVoltage[{#SNMPVALUE}])=2'
-                  name: 'Voltage problem too low on Inlet {#SNMPVALUE}'
+                  name: 'Inlet Voltage Problem too low {#SNMPINDEX} - {#SNMPVALUE}'
                   priority: HIGH
-            -
-              uuid: edd7b7013e2d4c68b627b0a9628698f1
-              name: 'Current of Inlet $1'
+                - uuid: 09c9cec9b9fe486891675faea3ba2934
+                  expression: 'last(/Raritan PDU/measurementsInletSensorStatermsVoltage[{#SNMPVALUE}])<>4'
+                  name: 'Inlet Voltage Problem {#SNMPINDEX} - {#SNMPVALUE}'
+                  priority: AVERAGE
+            - uuid: edd7b7013e2d4c68b627b0a9628698f1
+              name: 'Inlet Current {#SNMPINDEX}'
               type: CALCULATED
               key: 'measurementsInletSensorUsableValuermsCurrent[{#SNMPVALUE}]'
               delay: '60'
@@ -828,12 +703,10 @@ zabbix_export:
               units: A
               params: 'last(//measurementsInletSensorRAWValuermsCurrent[{#SNMPVALUE}])*last(//inletSensorDecimalDigitsrmsCurrent[{#SNMPVALUE}])'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
-            -
-              uuid: e4d79af9dd1840259b2141a77c2ff8f9
-              name: 'Frequency of Inlet $1'
+            - uuid: e4d79af9dd1840259b2141a77c2ff8f9
+              name: 'Inlet Frequency {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.4.1.{#SNMPINDEX}.23'
               key: 'measurementsInletSensorValueFrequency[{#SNMPVALUE}]'
@@ -842,17 +715,14 @@ zabbix_export:
               value_type: FLOAT
               units: Hz
               preprocessing:
-                -
-                  type: MULTIPLIER
+                - type: MULTIPLIER
                   parameters:
                     - '0.1'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
-            -
-              uuid: 1e3ca14ff2ec4162af3c36eaa718cd1b
-              name: 'activeEnergy of Inlet $1'
+            - uuid: 1e3ca14ff2ec4162af3c36eaa718cd1b
+              name: 'Inlet Active Energy {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.4.1.{#SNMPINDEX}.8'
               key: 'measurementsInletSensorValuermsactiveEnergy[{#SNMPVALUE}]'
@@ -861,17 +731,14 @@ zabbix_export:
               value_type: FLOAT
               units: kWh
               preprocessing:
-                -
-                  type: MULTIPLIER
+                - type: MULTIPLIER
                   parameters:
                     - '0.001'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
-            -
-              uuid: daf26864b2ff460b80000482b1892a5a
-              name: 'activePower of Inlet $1'
+            - uuid: daf26864b2ff460b80000482b1892a5a
+              name: 'Inlet Active Power {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.4.1.{#SNMPINDEX}.5'
               key: 'measurementsInletSensorValuermsactivePower[{#SNMPVALUE}]'
@@ -879,12 +746,10 @@ zabbix_export:
               trends: 1825d
               units: W
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
-            -
-              uuid: 1938e1bd1f6d4d33a11c898984065ad4
-              name: 'apparentPower of Inlet $1'
+            - uuid: 1938e1bd1f6d4d33a11c898984065ad4
+              name: 'Inlet Apparent Power {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.4.1.{#SNMPINDEX}.6'
               key: 'measurementsInletSensorValuermsapparentPower[{#SNMPVALUE}]'
@@ -892,12 +757,10 @@ zabbix_export:
               trends: 1825d
               units: VA
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
-            -
-              uuid: 8dfd6d90abcd4eb182158385af77636a
-              name: 'powerFactor of Inlet $1'
+            - uuid: 8dfd6d90abcd4eb182158385af77636a
+              name: 'Inlet Power Factor {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.4.1.{#SNMPINDEX}.7'
               key: 'measurementsInletSensorValuermspowerFactor[{#SNMPVALUE}]'
@@ -905,17 +768,14 @@ zabbix_export:
               trends: 1825d
               value_type: FLOAT
               preprocessing:
-                -
-                  type: MULTIPLIER
+                - type: MULTIPLIER
                   parameters:
                     - '0.01'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
-            -
-              uuid: b08ac56ae26243e6a58a6c3e9a79b9b0
-              name: 'Voltage of Inlet $1'
+            - uuid: b08ac56ae26243e6a58a6c3e9a79b9b0
+              name: 'Inlet Voltage {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.5.2.3.1.4.1.{#SNMPINDEX}.4'
               key: 'measurementsInletSensorValuermsVoltage[{#SNMPVALUE}]'
@@ -923,41 +783,34 @@ zabbix_export:
               trends: 1825d
               units: V
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Inlets
           graph_prototypes:
-            -
-              uuid: 0ee94315a7214d39bf96e575a2c774de
+            - uuid: 0ee94315a7214d39bf96e575a2c774de
               name: 'Inlet {#SNMPVALUE}'
               graph_items:
-                -
-                  color: FF0000
+                - color: FF0000
                   item:
                     host: 'Raritan PDU'
                     key: 'measurementsInletSensorUsableValuermsCurrent[{#SNMPVALUE}]'
-                -
-                  sortorder: '1'
+                - sortorder: '1'
                   color: FF8000
                   yaxisside: RIGHT
                   item:
                     host: 'Raritan PDU'
                     key: 'measurementsInletSensorValueFrequency[{#SNMPVALUE}]'
-                -
-                  sortorder: '2'
+                - sortorder: '2'
                   color: B4B4B4
                   item:
                     host: 'Raritan PDU'
                     key: 'measurementsInletSensorValuermspowerFactor[{#SNMPVALUE}]'
-                -
-                  sortorder: '3'
+                - sortorder: '3'
                   color: 0040FF
                   yaxisside: RIGHT
                   item:
                     host: 'Raritan PDU'
                     key: 'measurementsInletSensorValuermsVoltage[{#SNMPVALUE}]'
-        -
-          uuid: 40501cfba55b497a840ee7d6483661f7
+        - uuid: 40501cfba55b497a840ee7d6483661f7
           name: Outlets
           type: SNMP_AGENT
           snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.4.1.13742.6.3.5.3.1.2.1]'
@@ -965,26 +818,24 @@ zabbix_export:
           delay: '3600'
           filter:
             conditions:
-              -
-                macro: '{#SNMPVALUE}'
+              - macro: '{#SNMPVALUE}'
                 value: '.*'
                 formulaid: A
           lifetime: 7d
           item_prototypes:
-            -
-              uuid: be925868e99944f6a6b270e8af74842e
-              name: 'OnOff Status of Outlet $1'
+            - uuid: be925868e99944f6a6b270e8af74842e
+              name: 'Outlet Switch Status {#SNMPINDEX}'
               type: SNMP_AGENT
-              snmp_oid: '.1.3.6.1.4.1.13742.6.5.4.3.1.4.1.{#SNMPINDEX}.14'
+              snmp_oid: '.1.3.6.1.4.1.13742.6.5.4.3.1.3.1.{#SNMPINDEX}.14'
               key: 'OnOffStatus[{#SNMPVALUE}]'
               delay: '300'
+              valuemap:
+                name: 'Raritan PDU State Enumeration'
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Outlets
-            -
-              uuid: a06c2fd0f9294bbd88e80db9aa0c0295
-              name: 'Current Capability of Outlet $1'
+            - uuid: a06c2fd0f9294bbd88e80db9aa0c0295
+              name: 'Outlet Current Capability {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.5.3.1.7.1.{#SNMPINDEX}'
               key: 'OutletCurrent[{#SNMPVALUE}]'
@@ -993,12 +844,10 @@ zabbix_export:
               trends: '0'
               value_type: CHAR
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Outlets
-            -
-              uuid: 30b85f0bf6a04cf986f3e970da50cc4c
-              name: 'Name of Outlet $1'
+            - uuid: 30b85f0bf6a04cf986f3e970da50cc4c
+              name: 'Outlet Name {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.5.3.1.3.1.{#SNMPINDEX}'
               key: 'OutletName[{#SNMPVALUE}]'
@@ -1006,12 +855,10 @@ zabbix_export:
               trends: '0'
               value_type: CHAR
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Outlets
-            -
-              uuid: 88cbf46db7b24ac6b758af9f41b33ec3
-              name: 'Type of Outlet $1'
+            - uuid: 88cbf46db7b24ac6b758af9f41b33ec3
+              name: 'Outlet Type {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.5.3.1.29.1.{#SNMPINDEX}'
               key: 'outletReceptacleDescriptor[{#SNMPVALUE}]'
@@ -1020,12 +867,10 @@ zabbix_export:
               trends: '0'
               value_type: CHAR
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Outlets
-            -
-              uuid: ec7f7801601c477fbf196144c47b7a8f
-              name: 'Voltage Capability of Outlet $1'
+            - uuid: ec7f7801601c477fbf196144c47b7a8f
+              name: 'Outlet Voltage Capability {#SNMPINDEX}'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.13742.6.3.5.3.1.6.1.{#SNMPINDEX}'
               key: 'OutletVolts[{#SNMPVALUE}]'
@@ -1034,175 +879,369 @@ zabbix_export:
               trends: '0'
               value_type: CHAR
               tags:
-                -
-                  tag: Application
+                - tag: Application
                   value: Outlets
       valuemaps:
-        -
-          uuid: 1fb7799dfa324164b2262f8f56008455
+        - uuid: d98c810d6b9743178168d9dc3f17bacb
+          name: 'Raritan PDU Sensor Type Enumeration'
+          mappings:
+            - value: '1'
+              newvalue: RMS Current
+            - value: '2'
+              newvalue: Peak Current
+            - value: '3'
+              newvalue: Unbalanced Current
+            - value: '4'
+              newvalue: RMS Voltage
+            - value: '5'
+              newvalue: Active Power
+            - value: '6'
+              newvalue: Apparent Power
+            - value: '7'
+              newvalue: Power Factor
+            - value: '8'
+              newvalue: Active Energy
+            - value: '9'
+              newvalue: Apparent Energy
+            - value: '10'
+              newvalue: Temperature
+            - value: '11'
+              newvalue: Humidity
+            - value: '12'
+              newvalue: Air Flow
+            - value: '13'
+              newvalue: Air Pressure
+            - value: '14'
+              newvalue: On Off
+            - value: '15'
+              newvalue: Trip
+            - value: '16'
+              newvalue: Vibration
+            - value: '17'
+              newvalue: Water Detection
+            - value: '18'
+              newvalue: Smoke Detection
+            - value: '19'
+              newvalue: Binary
+            - value: '20'
+              newvalue: Contact
+            - value: '21'
+              newvalue: Fan Speed
+            - value: '22'
+              newvalue: Surge Protector Status
+            - value: '23'
+              newvalue: Frequency
+            - value: '24'
+              newvalue: Phase Angle
+            - value: '25'
+              newvalue: RMS Voltage LN
+            - value: '26'
+              newvalue: Residual Current
+            - value: '27'
+              newvalue: RCM State
+            - value: '28'
+              newvalue: Absolute Humidity
+            - value: '29'
+              newvalue: Reactive Power
+            - value: '30'
+              newvalue: Other
+            - value: '31'
+              newvalue: None
+            - value: '32'
+              newvalue: Power Quality
+            - value: '33'
+              newvalue: Over Load Status
+            - value: '34'
+              newvalue: Over Heat Status
+            - value: '35'
+              newvalue: Displacement Power Factor
+            - value: '36'
+              newvalue: Residual DC Current
+            - value: '37'
+              newvalue: Fan Status
+            - value: '38'
+              newvalue: Inlet Phase Sync Angle
+            - value: '39'
+              newvalue: Inlet Phase Sync
+            - value: '40'
+              newvalue: Operating State
+            - value: '41'
+              newvalue: Active Inlet
+            - value: '42'
+              newvalue: Illuminance
+            - value: '43'
+              newvalue: Door Contact
+            - value: '44'
+              newvalue: Tamper Detection
+            - value: '45'
+              newvalue: Motion Detection
+            - value: '46'
+              newvalue: i1smpsStatus
+            - value: '47'
+              newvalue: i2smpsStatus
+            - value: '48'
+              newvalue: Switch Status
+            - value: '49'
+              newvalue: Door Lock State
+            - value: '50'
+              newvalue: Door Handle Lock
+            - value: '51'
+              newvalue: Crest Factor
+            - value: '52'
+              newvalue: Length
+            - value: '53'
+              newvalue: Distance
+            - value: '54'
+              newvalue: Active Power Demand
+            - value: '55'
+              newvalue: Residual AC Current
+            - value: '56'
+              newvalue: Particle Density
+            - value: '57'
+              newvalue: Voltage Total Harmonic Distortion
+            - value: '58'
+              newvalue: Current Total Harmonic Distortion
+            - value: '59'
+              newvalue: In Rush Current
+            - value: '60'
+              newvalue: Unbalanced Voltage
+            - value: '61'
+              newvalue: Unbalanced Line Line Current
+            - value: '62'
+              newvalue: Unbalanced Line Line Voltage
+            - value: '63'
+              newvalue: Dew Point
+            - value: '64'
+              newvalue: Mass
+            - value: '65'
+              newvalue: Flux
+            - value: '66'
+              newvalue: Luminous Intensity
+            - value: '67'
+              newvalue: Luminous Energy
+            - value: '68'
+              newvalue: Luminous Flux
+            - value: '69'
+              newvalue: Luminous Emittance
+            - value: '70'
+              newvalue: Electrical Resistance
+            - value: '71'
+              newvalue: Electrical Impedance
+            - value: '72'
+              newvalue: Total Harmonic Distortion
+            - value: '73'
+              newvalue: Magnetic Field Strength
+            - value: '74'
+              newvalue: Magnetic Flux Density
+            - value: '75'
+              newvalue: Electric Field Strength
+            - value: '76'
+              newvalue: Selection
+            - value: '77'
+              newvalue: Rotational Speed
+        - uuid: 1fb7799dfa324164b2262f8f56008455
           name: 'Host status'
           mappings:
-            -
-              value: '0'
+            - value: '0'
               newvalue: Up
-            -
-              value: '2'
+            - value: '2'
               newvalue: Unreachable
-        -
-          uuid: 1aa964c2caea4e93ae79ea6e9d91df67
+        - uuid: 1aa964c2caea4e93ae79ea6e9d91df67
           name: 'Raritan PDU State Enumeration'
           mappings:
-            -
-              value: '-1'
+            - value: '-1'
               newvalue: Unavailable
-            -
-              value: '0'
+            - value: '0'
               newvalue: Open
-            -
-              value: '1'
+            - value: '1'
               newvalue: Closed
-            -
-              value: '2'
-              newvalue: BelowLowerCritical
-            -
-              value: '3'
-              newvalue: BelowLowerWarning
-            -
-              value: '4'
+            - value: '2'
+              newvalue: Below Lower Critical
+            - value: '3'
+              newvalue: Below Lower Warning
+            - value: '4'
               newvalue: Normal
-            -
-              value: '5'
-              newvalue: AboveUpperWarning
-            -
-              value: '6'
-              newvalue: AboveUpperCritical
-            -
-              value: '7'
-              newvalue: 'On'
-            -
-              value: '8'
-              newvalue: 'Off'
-            -
-              value: '9'
+            - value: '5'
+              newvalue: Above Upper Warning
+            - value: '6'
+              newvalue: Above Upper Critical
+            - value: '7'
+              newvalue: On
+            - value: '8'
+              newvalue: Off
+            - value: '9'
               newvalue: Detected
-            -
-              value: '10'
-              newvalue: NotDetected
-            -
-              value: '11'
+            - value: '10'
+              newvalue: Not Detected
+            - value: '11'
               newvalue: Alarmed
-            -
-              value: '12'
-              newvalue: OK
-            -
-              value: '14'
+            - value: '12'
+              newvalue: Okay
+            - value: '13'
               newvalue: Fail
-            -
-              value: '15'
-              newvalue: 'Yes'
-            -
-              value: '16'
-              newvalue: 'No'
-            -
-              value: '17'
+            - value: '14'
+              newvalue: Yes
+            - value: '15'
+              newvalue: No
+            - value: '16'
               newvalue: Standby
-            -
-              value: '20'
-              newvalue: InSync
-            -
-              value: '21'
-              newvalue: OutOfSync
-            -
-              value: '26'
+            - value: '17'
+              newvalue: One
+            - value: '18'
+              newvalue: Two
+            - value: '19'
+              newvalue: In Sync
+            - value: '20'
+              newvalue: Out of Sync
+            - value: '21'
+              newvalue: i1OpenFault
+            - value: '22'
+              newvalue: i1ShortFault
+            - value: '23'
+              newvalue: i2OpenFault
+            - value: '24'
+              newvalue: i2ShortFault
+            - value: '25'
               newvalue: Fault
-            -
-              value: '27'
+            - value: '26'
               newvalue: Warning
-            -
-              value: '28'
+            - value: '27'
               newvalue: Critical
-            -
-              value: '29'
-              newvalue: SelfTest
-            -
-              value: '30'
-              newvalue: NonRedundant
-        -
-          uuid: 1e31bd42758f41bb99c6bb72ccf1496b
+            - value: '28'
+              newvalue: Self Test
+            - value: '29'
+              newvalue: Non-redundant
+        - uuid: 1e31bd42758f41bb99c6bb72ccf1496b
           name: 'Raritan PDU Units Enumeration'
           mappings:
-            -
-              value: '-1'
+            - value: '-1'
               newvalue: None
-            -
-              value: '0'
+            - value: '0'
               newvalue: Other
-            -
-              value: '1'
+            - value: '1'
               newvalue: Volt
-            -
-              value: '2'
-              newvalue: Ampere
-            -
-              value: '3'
+            - value: '2'
+              newvalue: Amp
+            - value: '3'
               newvalue: Watt
-            -
-              value: '4'
-              newvalue: VA
-            -
-              value: '5'
-              newvalue: WattHour
-            -
-              value: '6'
-              newvalue: VAHour
-            -
-              value: '7'
-              newvalue: 'Degree C'
-            -
-              value: '8'
+            - value: '4'
+              newvalue: Volt Amp
+            - value: '5'
+              newvalue: Watt Hour
+            - value: '6'
+              newvalue: Volt amp Hour
+            - value: '7'
+              newvalue: Degree C
+            - value: '8'
               newvalue: Hertz
-            -
-              value: '9'
+            - value: '9'
               newvalue: Percent
-            -
-              value: '10'
-              newvalue: Meterpersec
-            -
-              value: '11'
+            - value: '10'
+              newvalue: Meter per Sec
+            - value: '11'
               newvalue: Pascal
-            -
-              value: '12'
-              newvalue: PSI
-            -
-              value: '13'
-              newvalue: G
-            -
-              value: '14'
-              newvalue: 'Degree F'
-            -
-              value: '15'
-              newvalue: Feet
-            -
-              value: '16'
-              newvalue: Inch
-            -
-              value: '17'
-              newvalue: CM
-            -
-              value: '18'
+            - value: '12'
+              newvalue: psi
+            - value: '13'
+              newvalue: g
+            - value: '14'
+              newvalue: Degree F
+            - value: '15'
+              newvalue: feet
+            - value: '16'
+              newvalue: inches
+            - value: '17'
+              newvalue: cm
+            - value: '18'
               newvalue: Meters
-            -
-              value: '19'
-              newvalue: RPM
-            -
-              value: '20'
-              newvalue: Dgrees
-            -
-              value: '21'
-              newvalue: LUX
-            -
-              value: '22'
-              newvalue: Grampercubicmeter
-            -
-              value: '23'
+            - value: '19'
+              newvalue: rpm
+            - value: '20'
+              newvalue: Degrees
+            - value: '21'
+              newvalue: Lux
+            - value: '22'
+              newvalue: Gram per Cubic Meter
+            - value: '23'
               newvalue: var
+            - value: '24'
+              newvalue: Feet per Sec
+            - value: '25'
+              newvalue: Lbs per Cubic Foot
+            - value: '26'
+              newvalue: Micro Gram per Cubic Meter
+            - value: '27'
+              newvalue: Hour
+            - value: '28'
+              newvalue: Minute
+            - value: '29'
+              newvalue: Second
+            - value: '30'
+              newvalue: Coulomb
+            - value: '31'
+              newvalue: Kelvin
+            - value: '32'
+              newvalue: Volt Amp Reactive Hour
+            - value: '33'
+              newvalue: Volt per Ampere
+            - value: '34'
+              newvalue: Volt per Meter
+            - value: '35'
+              newvalue: gram
+            - value: '36'
+              newvalue: Meter per Square Sec
+            - value: '37'
+              newvalue: Liters per Hour
+            - value: '38'
+              newvalue: Nit
+            - value: '39'
+              newvalue: Candela
+            - value: '40'
+              newvalue: Lumen
+            - value: '41'
+              newvalue: Lumen Second
+            - value: '42'
+              newvalue: Cubic Meter
+            - value: '43'
+              newvalue: Radiant
+            - value: '44'
+              newvalue: Steradiant
+            - value: '45'
+              newvalue: Newton
+            - value: '46'
+              newvalue: Joule
+            - value: '47'
+              newvalue: Ohm
+            - value: '48'
+              newvalue: Tesla
+            - value: '49'
+              newvalue: Henry
+            - value: '50'
+              newvalue: Farad
+            - value: '51'
+              newvalue: Mol
+            - value: '52'
+              newvalue: Becquerel
+            - value: '53'
+              newvalue: Gray
+            - value: '54'
+              newvalue: Sievert
+        - uuid: d00fa543d8874f35aad4ea777f339ff3
+          name: 'Raritan PDU OverCurrent Protector Type Enumeration'
+          mappings:
+            - value: '1'
+              newvalue: 1 Pole Breaker
+            - value: '2'
+              newvalue: 2 Pole Breaker
+            - value: '3'
+              newvalue: 3 Pole Breaker
+            - value: '4'
+              newvalue: Fuse
+            - value: '5'
+              newvalue: Fuse Pair
+            - value: '6'
+              newvalue: RCBO 2 Pole
+            - value: '7'
+              newvalue: RCBO 3 Pole
+            - value: '8'
+              newvalue: RCBO 4 Pole


### PR DESCRIPTION
The template was converted over to the new zabbix template system which uses a new variable syntax - `{#VARIABLE NAME}`. The old template used the 4.x convention of `$1` which no longer is supported.

I also took the chance to 

- add further value mappings to support the new sensor types in the new PX4 product PDU line
- concise naming of sensors so they are ordered properly when sorting by name 