### PR TITLE
Add bond interfaces to Synology Community template

### DIFF
--- a/Storage_Devices/Synology/template_synology_diskstation_snmpv3/6.4/README.md
+++ b/Storage_Devices/Synology/template_synology_diskstation_snmpv3/6.4/README.md
@@ -1,0 +1,176 @@
+# Synology DiskStation SNMPv3
+
+## Description
+
+A SNMPv3 template to monitor Synology DSM, based on https://share.zabbix.com/storage-devices/synology/synology-diskstation
+
+SHA authpass and AES privpass are hardcoded
+
+**Updates**
+
+  - 2020 April: fixed https://github.com/kko/unifi-zabbix-snmpv3/issues/4
+  - 2024 April: modified network interface filter to include bond* interfaces next to eth* interfaces
+
+## Overview
+
+**Setup Synology DSM**
+
+Check the official Synology documentation for your version of DSM:  
+<https://kb.synology.com/en-us/DSM/help/DSM/AdminCenter/system_snmp>
+
+Go to SNMP settings (`Control Panel > Terminal & SNMP > SNMP`) and tick (enable)
+  - "Enable SNMP service"
+  - "SNMPv3 service"
+  - "Enable SNMP privacy"
+
+Set the username, protocol and password for authentication; and also set protocol and password for "SNMP privacy".
+Record the values you set here because you have to replicate them later in Zabbix.
+
+
+**Setup Zabbix**
+
+1. Import the YAML template file in Zabbix (```Zabbix > Configuration > Templates > Import ```)
+2. Create your host and under "Templates", link this template to the host. You can find it by typing its name "Synology DiskStation SNMPv3"
+3. Under "Interfaces", add a "SNMP" interface to the host
+4. Fill the required fields with the same data you already set in DSM.
+    - "Context name": can be left empty
+    - "Security name": is the username in DSM
+    - "Security level": is "authPriv"
+    - "Authentication protocol": same as you set in DSM.   
+    - "Authentication passphrase":  Same as you set in DSM under "SNMPv3 service", "Password" field
+    - "Privacy protocol": Same as you set in DSM under "Enable SNMP privacy", "Protocol".
+    - "Privacy passphrase": Same as you set in DSM under "Enable SNMP privacy", "Password" field
+
+**Troubleshooting**
+
+- If you receive authentication errors, try tos set the Authentication / Privacy protocols to MD5+DES and if this works, then try to upgrade the encrypption step-by-step, changing only one attribute at a time. The choices what Zabbix can support and what is supported in a given version of DSM can be different. Find a common ground with the most strongest crypto. DES, SHA1 and MD5 are not considered cryptographically secure anymore.
+- If all looks good, but does not work, try to restart the Zabbix server.
+
+
+## Author
+
+Helmut Leonhardt
+
+## Macros used
+
+| Name              | Description | Default | Type       |
+|-------------------|-------------|---------|------------|
+| {$DISK_UTIL_HIGH} | <p>-</p>    |`90`     | Text macro |
+| {$DISK_UTIL_WARN} | <p>-</p>    |`80`     | Text macro |
+| {$SNMP_AUTHPASS}  | <p>-</p>    |``       | Text macro |
+| {$SNMP_PORT}      | <p>-</p>    |`161`    | Text macro |
+| {$SNMP_PRIVPASS}  | <p>-</p>    |``       | Text macro |
+| {$SNMP_USERNAME}  | <p>-</p>    |``       | Text macro |
+
+
+## Template links
+
+|Name|
+|----|
+|Template Module ICMP Ping|
+
+
+## Discovery rules
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|Synology Disk(s)|<p>For all disk entry.</p>|`SNMP agent`|synoDisk.diskTable.diskEntry<p>Update: 1h</p>|
+|Synology StorageIO|<p>An entry containing a device and its statistics.</p>|`SNMP agent`|storageIO.storageIOTable.storageIOEntry<p>Update: 1h</p>|
+|Network|<p>-</p>|`SNMP agent`|ifMIB.ifMIBObjects.ifXTable.ifXEntry<p>Update: 1h</p>|
+|Synology iSCSI LUN|<p>An entry containing iscsi lun information.</p>|`SNMP agent`|synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry<p>Update: 1h</p>|
+|Synology SpaceIO|<p>An entry containing a device and its statistics.</p>|`SNMP agent`|spaceIO.spaceIOTable.spaceIOEntry<p>Update: 1h</p>|
+|Synology Disk(s) SMART|<p>An entry containing a disk SMART information.</p>|`SNMP agent`|synologyDiskSMART.diskSMARTTable.diskSMARTEntry<p>Update: 1h</p>|
+|Synology RAID Volume(s)|<p>-</p>|`SNMP agent`|synoRaid.raidTable.raidEntry<p>Update: 1h</p>|
+|Disk|<p>-</p>|`SNMP agent`|host.hrStorage.hrStorageTable.hrStorageEntry<p>Update: 1h</p>|
+|Synology Service(s)|<p>An entry containing Service information.</p>|`SNMP agent`|synologyService.serviceTable.serviceEntry<p>Update: 1h</p>|
+
+
+## Items collected
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|Upgrade Available|<p>Checks whether a new version or update of DSM is available</p>|`SNMP agent`|synoSystem.upgradeAvailable<p>Update: 1h</p>|
+|Total Swap Available|<p>The amount of swap space currently unused or available.</p>|`SNMP agent`|ucdavis.memory.memAvailSwap<p>Update: 3m</p>|
+|CPU User|<p>The percentage of CPU time spent processing user-level code.</p>|`SNMP agent`|synoSystem.ssCpuUser<p>Update: 1m</p>|
+|Load Avg 1 min|<p>1 minute load.</p>|`SNMP agent`|synoSystem.laLoadInt.1<p>Update: 1m</p>|
+|Load Avg 15 min|<p>15 minute load.</p>|`SNMP agent`|synoSystem.laLoadInt.3<p>Update: 1m</p>|
+|Total Shared Memory|<p>The total amount of real or virtual memory currently allocated for use as shared memory.</p>|`SNMP agent`|ucdavis.memory.memShared<p>Update: 3m</p>|
+|Total Buffer Memory|<p>The total amount of real or virtual memory currently allocated for use as memory buffers.</p>|`SNMP agent`|ucdavis.memory.memBuffer<p>Update: 3m</p>|
+|System Fan Status|<p>Returns error if system fan fails.</p>|`SNMP agent`|synoSystem.systemFanStatus<p>Update: 1m</p>|
+|Total Free Memory|<p>The total amount of memory free or available for use on this host.</p>|`SNMP agent`|ucdavis.memory.memTotalFree<p>Update: 3m</p>|
+|CPU System|<p>The percentage of CPU time spent processing system-level code, calculated over the last minute.</p>|`SNMP agent`|synoSystem.ssCpuSystem<p>Update: 1m</p>|
+|Total Swap Space|<p>The total amount of swap space configured for this host.</p>|`SNMP agent`|ucdavis.memory.memTotalSwap<p>Update: 3m</p>|
+|Total Cached Memory|<p>The total amount of real or virtual memory currently allocated for use as cached memory.</p>|`SNMP agent`|ucdavis.memory.memCached<p>Update: 3m</p>|
+|Total Physical Available|<p>The amount of real/physical memory currently unused or available.</p>|`SNMP agent`|ucdavis.memory.memAvailReal<p>Update: 3m</p>|
+|Power Status|<p>Returns error if power supplies fail</p>|`SNMP agent`|synoSystem.powerStatus<p>Update: 1m</p>|
+|Serial Number|<p>Model serial number</p>|`SNMP agent`|synoSystem.serialNumber<p>Update: 1h</p>|
+|CPU Idle|<p>The percentage of processor time spent idle, calculated over the last minute.</p>|`SNMP agent`|synoSystem.ssCpuIdle<p>Update: 1m</p>|
+|Version|<p>The version of DSM</p>|`SNMP agent`|synoSystem.version<p>Update: 1h</p>|
+|System Status|<p>System partition status.</p>|`SNMP agent`|synoSystem.systemStatus<p>Update: 1m</p>|
+|Total Physical Memory|<p>The total amount of real/physical memory installed on this host.</p>|`SNMP agent`|ucdavis.memory.memTotalReal<p>Update: 3m</p>|
+|CPU Fan Status|<p>Returns error if CPU fan fails.</p>|`SNMP agent`|synoSystem.cpuFanStatus<p>Update: 1m</p>|
+|Load Avg 5 min|<p>5 minute load.</p>|`SNMP agent`|synoSystem.laLoadInt.2<p>Update: 1m</p>|
+|Model Name|<p>Model name of this NAS.</p>|`SNMP agent`|synoSystem.modelName<p>Update: 1h</p>|
+|System Temperature|<p>Temperature of this NAS.</p>|`SNMP agent`|synoSystem.temperature<p>Update: 3m</p>|
+|{#SNMPVALUE} Model|<p>Synology disk model name: the disk model name will be showed here.</p>|`SNMP agent`|synoDisk.diskTable.diskEntry.diskModel.[{#SNMPINDEX}]<p>Update: 1d</p><p>LLD</p>|
+|{#SNMPVALUE} Status|<p>Synology disk status: each meanings of status represented describe below: [1] Normal: the hard disk functions normally. [2] Initialized: the hard disk has system partition but no data. [3] NotInitialized: the hard disk does not have system in system partition. [4] SystemPartitionFailed: the system partitions on the hard disks are damaged. [5] Crashed: the hard disk has damaged.</p>|`SNMP agent`|synoDisk.diskTable.diskEntry.diskStatus.[{#SNMPINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|{#SNMPVALUE} Bad sectors count|<p>The count of each disk I/O bad sector</p>|`SNMP agent`|synoDisk.diskTable.diskEntry.diskBadSector.[{#SNMPINDEX}]<p>Update: 12h</p><p>LLD</p>|
+|{#SNMPVALUE} Temperature|<p>Synology disk temperature: the temperature of each disk uses Celsius degree.</p>|`SNMP agent`|synoDisk.diskTable.diskEntry.diskTemperature.[{#SNMPINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|{#SNMPVALUE} Type|<p>Synology disk type: the type of disk will be showed here, including SATA, SSD and so on.</p>|`SNMP agent`|synoDisk.diskTable.diskEntry.diskType.[{#SNMPINDEX}]<p>Update: 1d</p><p>LLD</p>|
+|Storage Load on Disk {#SNMPVALUE}|<p>The load of disk (in %).</p>|`SNMP agent`|storageIO.storageIOTable.storageIOEntry.storageIOLA.[{#SNMPINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|{#SNMPVALUE} byte(s) read since boot|<p>The number of bytes read from this device since boot (32-bit VER.).</p>|`SNMP agent`|storageIO.storageIOTable.storageIOEntry.storageIONRead.[{#SNMPINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|{#SNMPVALUE} byte(s) written since boot|<p>The number of bytes written to this device since boot (32-bit VER.).</p>|`SNMP agent`|storageIO.storageIOTable.storageIOEntry.storageIONWritten.[{#SNMPINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|{#SNMPVALUE} read access(es) since boot|<p>The number of read accesses from this device since boot (32-bit VER.).</p>|`SNMP agent`|storageIO.storageIOTable.storageIOEntry.storageIOReads.[{#SNMPINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|{#SNMPVALUE} write access(es) since boot|<p>The number of write accesses from this device since boot (32-bit VER.).</p>|`SNMP agent`|storageIO.storageIOTable.storageIOEntry.storageIOWrites.[{#SNMPINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|Incomming Packets on Interface {#IFNAME}|<p>The total number of octets received on the interface.</p>|`SNMP agent`|ifMIB.ifMIBObjects.ifXTable.ifXEntry.ifHCInOctets.[{#IFNAME}]<p>Update: 3m</p><p>LLD</p>|
+|Outgoing Packets on Interface {#IFNAME}|<p>The total number of octets transmitted out of the interface.</p>|`SNMP agent`|ifMIB.ifMIBObjects.ifXTable.ifXEntry.ifHCOutOctets.[{#IFNAME}]<p>Update: 3m</p><p>LLD</p>|
+|Disk Latency Read on LUN {#LUNNAME} ({#LUNUID})|<p>LUN read disk latency.</p>|`SNMP agent`|synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNDiskLatencyRead[{#LUNINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|Disk Latency Write on LUN {#LUNNAME} ({#LUNUID})|<p>LUN write disk latency.</p>|`SNMP agent`|synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNDiskLatencyWrite[{#LUNINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|IOPS Read on LUN {#LUNNAME} ({#LUNUID})|<p>LUN read iops.</p>|`SNMP agent`|synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNIopsRead[{#LUNINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|IOPS Write on LUN {#LUNNAME} ({#LUNUID})|<p>LUN write iops.</p>|`SNMP agent`|synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNIopsWrite[{#LUNINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|IO Size Read on LUN {#LUNNAME} ({#LUNUID})|<p>LUN average io size when reading.</p>|`SNMP agent`|synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNIoSizeRead[{#LUNINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|IO Size Write on LUN {#LUNNAME} ({#LUNUID})|<p>LUN average io size when writing.</p>|`SNMP agent`|synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNIoSizeWrite[{#LUNINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|Network Latency TX on LUN {#LUNNAME} ({#LUNUID})|<p>LUN network tx latency.</p>|`SNMP agent`|synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNNetworkLatencyTx[{#LUNINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|Throughput Read High on LUN {#LUNNAME} ({#LUNUID})|<p>LUN read throughput over 32 bits part.</p>|`SNMP agent`|synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNThroughputReadHigh[{#LUNINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|Throughput Read Low on LUN {#LUNNAME} ({#LUNUID})|<p>LUN read throughput over 32 bits part.</p>|`SNMP agent`|synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNThroughputReadLow[{#LUNINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|Throughput Write High on LUN {#LUNNAME} ({#LUNUID})|<p>The higher 32 bit of write throughput.</p>|`SNMP agent`|synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNThroughputWriteHigh[{#LUNINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|Throughput Write Low on LUN {#LUNNAME} ({#LUNUID})|<p>The lower 32 bit of write throughput.</p>|`SNMP agent`|synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNThroughputWriteLow[{#LUNINDEX}]<p>Update: 1m</p><p>LLD</p>|
+|Space Load of Disk {#SNMPVALUE}|<p>The load of disk in the volume (%).</p>|`SNMP agent`|spaceIO.spaceIOTable.spaceIOEntry.spaceIOLA.[{#SNMPINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|{#SNMPVALUE} byte(s) read since boot|<p>The number of bytes read from this volume since boot (32-bit ver.).</p>|`SNMP agent`|spaceIO.spaceIOTable.spaceIOEntry.spaceIONRead.[{#SNMPINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|{#SNMPVALUE} read access(es) since boot|<p>The number of read accesses from this volume since boot.</p>|`SNMP agent`|spaceIO.spaceIOTable.spaceIOEntry.spaceIONReads.[{#SNMPINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|{#SNMPVALUE} write accesses since boot|<p>The number of write accesses to this volume since boot (32-bit ver.).</p>|`SNMP agent`|spaceIO.spaceIOTable.spaceIOEntry.spaceIONWrites.[{#SNMPINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|{#SNMPVALUE} byte(s) written since boot|<p>The number of bytes written to this volume since boot (32-bit ver.).</p>|`SNMP agent`|spaceIO.spaceIOTable.spaceIOEntry.spaceIONWritten.[{#SNMPINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|{#ATTRNAME} on {#SNMPVALUE}|<p>-</p>|`SNMP agent`|synologyDiskSMART.diskSMARTTable.diskSMARTEntry.[{#SNMPINDEX}]<p>Update: 1h</p><p>LLD</p>|
+|{#SNMPVALUE} RAID Name|<p>Synology raid name: the name of each raid will be showed here.</p>|`SNMP agent`|synoRaid.raidTable.raidEntry.raidName.[{#SNMPINDEX}]<p>Update: 1d</p><p>LLD</p>|
+|{#SNMPVALUE} RAID Status|<p>Synology Raid status: each meanings of status represented describe below: [1] Normal: the raid functions normally. [11] Degrade: degrade happens when a tolerable failure of disk(s) occurs. [12] Crashed: raid has crashed and just uses for read-only operation. Note: other status will be showed when creating or deleting raids, including below status: [2] Repairing, [3] Migrating, [4] Expanding, [5] Deleting, [6] Creating(6), [7] RaidSyncing, [8] RaidParityChecking, [9] RaidAssembling and [10] Canceling.</p>|`SNMP agent`|synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|Storage Size on {#IFDESCR}|<p>The size of the storage represented by this entry, in units of hrStorageAllocationUnits.</p>|`SNMP agent`|host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageSize[{#IFINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|Storage Used on {#IFDESCR} (%)|<p>% of disk space used.</p>|`Calculated`|host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX},pct]<p>Update: 5m</p><p>LLD</p>|
+|Storage Used on {#IFDESCR}|<p>The amount of the storage represented by this entry.</p>|`SNMP agent`|host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX}]<p>Update: 3m</p><p>LLD</p>|
+|{#SNMPVALUE} Users|<p>Number of users using this service.</p>|`SNMP agent`|synologyService.serviceTable.serviceEntry.serviceUsers.[{#SNMPINDEX}]<p>Update: 1m</p><p>LLD</p>|
+
+
+## Triggers
+
+|Name|Description|Expression|Priority|
+|----|-----------|----------|--------|
+|Disk Space is CRITICAL on {#IFDESCR}|<p>-</p>|<p>**Expression**: last(/Synology DiskStation/host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX},pct])>90</p><p>**Recovery expression**: </p>|high|
+|Disk Space is LOW on {#IFDESCR}|<p>-</p>|<p>**Expression**: last(/Synology DiskStation/host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX},pct])>80</p><p>**Recovery expression**: </p>|warning|
+|{#SNMPVALUE} disk damaged|<p>The disk is damaged</p>|<p>**Expression**: last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskStatus.[{#SNMPINDEX}])=5</p><p>**Recovery expression**: </p>|high|
+|{#SNMPVALUE} partition damaged|<p>Partitions on the disk are damaged</p>|<p>**Expression**: last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskStatus.[{#SNMPINDEX}])=4</p><p>**Recovery expression**: </p>|average|
+|{#SNMPVALUE} disk contains bad sectors|<p>Bad sectors in disk.</p>|<p>**Expression**: last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskBadSector.[{#SNMPINDEX}])=5</p><p>**Recovery expression**: </p>|high|
+|{#SNMPVALUE} temperature|<p>-</p>|<p>**Expression**: avg(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskTemperature.[{#SNMPINDEX}],#4)>60</p><p>**Recovery expression**: </p>|warning|
+|{#SNMPVALUE} was changed|<p>Disk was changed</p>|<p>**Expression**: (last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskModel.[{#SNMPINDEX}],#1)<>last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskModel.[{#SNMPINDEX}],#2))>0</p><p>**Recovery expression**: </p>|information|
+|Disk SMART attribute {#ATTRNAME} state was changed on {#SNMPVALUE}|<p>-</p>|<p>**Expression**: (last(/Synology DiskStation/synologyDiskSMART.diskSMARTTable.diskSMARTEntry.[{#SNMPINDEX}],#1)<>last(/Synology DiskStation/synologyDiskSMART.diskSMARTTable.diskSMARTEntry.[{#SNMPINDEX}],#2))>0</p><p>**Recovery expression**: </p>|high|
+|Raid status on {HOSTNAME}: abnormal|<p>Repairing(2) Migrating(3) Expanding(4) Deleting(5) Creating(6) RaidSyncing(7) RaidParityChecking(8) RaidAssembling(9) Canceling(10)</p>|<p>**Expression**: last(/Synology DiskStation/synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}])>1 and last(/Synology DiskStation/synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}])<11</p><p>**Recovery expression**: </p>|warning|
+|Raid status on {HOSTNAME}: crashed|<p>RAID has crashed and is now read-only.</p>|<p>**Expression**: last(/Synology DiskStation/synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}])=12</p><p>**Recovery expression**: </p>|high|
+|Raid status on {HOSTNAME}: degrade|<p>Degrade is shown when a tolerable failure of disk(s) occurs.</p>|<p>**Expression**: last(/Synology DiskStation/synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}])=11</p><p>**Recovery expression**: </p>|average|
+|{#SNMPVALUE} disk damaged (LLD)|<p>The disk is damaged</p>|<p>**Expression**: last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskStatus.[{#SNMPINDEX}])=5</p><p>**Recovery expression**: </p>|high|
+|{#SNMPVALUE} partition damaged (LLD)|<p>Partitions on the disk are damaged</p>|<p>**Expression**: last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskStatus.[{#SNMPINDEX}])=4</p><p>**Recovery expression**: </p>|average|
+|{#SNMPVALUE} temperature (LLD)|<p>-</p>|<p>**Expression**: avg(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskTemperature.[{#SNMPINDEX}],#4)>60</p><p>**Recovery expression**: </p>|warning|
+|{#SNMPVALUE} was changed (LLD)|<p>Disk was changed</p>|<p>**Expression**: (last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskModel.[{#SNMPINDEX}],#1)<>last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskModel.[{#SNMPINDEX}],#2))>0</p><p>**Recovery expression**: </p>|information|
+|Disk SMART attribute {#ATTRNAME} state was changed on {#SNMPVALUE} (LLD)|<p>-</p>|<p>**Expression**: (last(/Synology DiskStation/synologyDiskSMART.diskSMARTTable.diskSMARTEntry.[{#SNMPINDEX}],#1)<>last(/Synology DiskStation/synologyDiskSMART.diskSMARTTable.diskSMARTEntry.[{#SNMPINDEX}],#2))>0</p><p>**Recovery expression**: </p>|high|
+|Raid status on {HOSTNAME}: abnormal (LLD)|<p>Repairing(2) Migrating(3) Expanding(4) Deleting(5) Creating(6) RaidSyncing(7) RaidParityChecking(8) RaidAssembling(9) Canceling(10)</p>|<p>**Expression**: last(/Synology DiskStation/synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}])>1 and last(/Synology DiskStation/synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}])<11</p><p>**Recovery expression**: </p>|warning|
+|Raid status on {HOSTNAME}: crashed (LLD)|<p>RAID has crashed and is now read-only.</p>|<p>**Expression**: last(/Synology DiskStation/synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}])=12</p><p>**Recovery expression**: </p>|high|
+|Raid status on {HOSTNAME}: degrade (LLD)|<p>Degrade is shown when a tolerable failure of disk(s) occurs.</p>|<p>**Expression**: last(/Synology DiskStation/synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}])=11</p><p>**Recovery expression**: </p>|average|
+|Disk Space is CRITICAL on {#IFDESCR} (LLD)|<p>-</p>|<p>**Expression**: last(/Synology DiskStation/host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX},pct])>90</p><p>**Recovery expression**: </p>|high|
+|Disk Space is LOW on {#IFDESCR} (LLD)|<p>-</p>|<p>**Expression**: last(/Synology DiskStation/host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX},pct])>80</p><p>**Recovery expression**: </p>|warning|

--- a/Storage_Devices/Synology/template_synology_diskstation_snmpv3/6.4/template_synology_diskstation_snmpv3.yaml
+++ b/Storage_Devices/Synology/template_synology_diskstation_snmpv3/6.4/template_synology_diskstation_snmpv3.yaml
@@ -1,0 +1,1545 @@
+zabbix_export:
+  version: '6.4'  
+  template_groups:
+    -
+      uuid: 7df96b18c230490a9a0a9e2307226338
+      name: Templates
+  templates:
+    -
+      uuid: 23c72497b8d646ad90bf7a0740e0c186
+      template: 'Synology DiskStation'
+      name: 'Synology DiskStation SNMPv3'
+      templates:
+        -
+          name: 'ICMP Ping'
+      groups:
+        -
+          name: Templates
+      items:
+        -
+          uuid: 27de465cef1047b69d710a98b94bd718
+          name: 'CPU Fan Status'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.6574.1.4.2.0
+          key: synoSystem.cpuFanStatus
+          description: 'Returns error if CPU fan fails.'
+          valuemap:
+            name: 'SYNOLOGY-SYSTEM-MIB::systemStatus'
+          tags:
+            -
+              tag: Application
+              value: CPU
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Health'
+          triggers:
+            -
+              uuid: c376b59ea8254415963ba94c0b5e7b28
+              expression: 'last(/Synology DiskStation/synoSystem.cpuFanStatus)<>1'
+              name: 'CPU Fan CRITICAL on {HOST.NAME}'
+              priority: HIGH
+        -
+          uuid: 3d058f51486b4d8cb53833f99412ff27
+          name: 'Load Avg 1 min'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.10.1.5.1
+          key: synoSystem.laLoadInt.1
+          value_type: FLOAT
+          description: '1 minute load.'
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '.01'
+          tags:
+            -
+              tag: Application
+              value: CPU
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Health'
+        -
+          uuid: 324f6183055646e5a27f7ff6c390336c
+          name: 'Load Avg 5 min'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.10.1.5.2
+          key: synoSystem.laLoadInt.2
+          value_type: FLOAT
+          description: '5 minute load.'
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '.01'
+          tags:
+            -
+              tag: Application
+              value: CPU
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Health'
+        -
+          uuid: 8f213559058f4de38c347bf65a4c5b0c
+          name: 'Load Avg 15 min'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.10.1.5.3
+          key: synoSystem.laLoadInt.3
+          value_type: FLOAT
+          description: '15 minute load.'
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '.01'
+          tags:
+            -
+              tag: Application
+              value: CPU
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Health'
+        -
+          uuid: c1a9a20071584c8abd9bb7b9993fb2ce
+          name: 'Model Name'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.6574.1.5.1.0
+          key: synoSystem.modelName
+          delay: 1h
+          trends: '0'
+          value_type: TEXT
+          description: 'Model name of this NAS.'
+          inventory_link: MODEL
+          tags:
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Information'
+        -
+          uuid: df13ecf6fccc494ab05eb850100f73ee
+          name: 'Power Status'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.6574.1.3.0
+          key: synoSystem.powerStatus
+          description: 'Returns error if power supplies fail'
+          valuemap:
+            name: 'SYNOLOGY-SYSTEM-MIB::powerStatus'
+          tags:
+            -
+              tag: Application
+              value: 'Synology System'
+          triggers:
+            -
+              uuid: d891556156414868a096b899513d30cf
+              expression: 'last(/Synology DiskStation/synoSystem.powerStatus)<>1'
+              name: 'Power Status FAILED on {HOST.NAME}'
+              priority: HIGH
+        -
+          uuid: 7a9c633f82b742449c04a386320170e8
+          name: 'Serial Number'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.6574.1.5.2.0
+          key: synoSystem.serialNumber
+          delay: 1h
+          trends: '0'
+          value_type: TEXT
+          description: 'Model serial number'
+          inventory_link: SERIALNO_A
+          tags:
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Information'
+        -
+          uuid: 7805576325bb479086dea34e84b06188
+          name: 'CPU Idle'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.11.11.0
+          key: synoSystem.ssCpuIdle
+          units: '%'
+          description: 'The percentage of processor time spent idle, calculated over the last minute.'
+          tags:
+            -
+              tag: Application
+              value: CPU
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Health'
+          triggers:
+            -
+              uuid: 241feffeef524050922fbfb4e6d1cbef
+              expression: 'avg(/Synology DiskStation/synoSystem.ssCpuIdle,5m)<30'
+              name: 'CPU Usage High on {HOST.NAME}'
+              priority: WARNING
+            -
+              uuid: e8f011cb5264499eb17fadb8330bf707
+              expression: 'avg(/Synology DiskStation/synoSystem.ssCpuIdle,5m)<10'
+              name: 'CPU Usage Very High on {HOST.NAME}'
+              priority: HIGH
+        -
+          uuid: 5def2a5e143443189da1b9c14fd4b931
+          name: 'CPU System'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.11.10.0
+          key: synoSystem.ssCpuSystem
+          units: '%'
+          description: 'The percentage of CPU time spent processing system-level code, calculated over the last minute.'
+          tags:
+            -
+              tag: Application
+              value: CPU
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Health'
+        -
+          uuid: bd59c44267a64d7bb0f05c3511caa2d3
+          name: 'CPU User'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.11.9.0
+          key: synoSystem.ssCpuUser
+          units: '%'
+          description: 'The percentage of CPU time spent processing user-level code.'
+          tags:
+            -
+              tag: Application
+              value: CPU
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Health'
+        -
+          uuid: d4f969b0bc70419ebf722997deb9b263
+          name: 'System Fan Status'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.6574.1.4.1.0
+          key: synoSystem.systemFanStatus
+          description: 'Returns error if system fan fails.'
+          valuemap:
+            name: 'SYNOLOGY-SYSTEM-MIB::systemStatus'
+          tags:
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Health'
+          triggers:
+            -
+              uuid: b791be012ac24883971181234450e394
+              expression: 'last(/Synology DiskStation/synoSystem.systemFanStatus)<>1'
+              name: 'System Fan Status CRITCAL on {HOST.NAME}'
+              priority: WARNING
+        -
+          uuid: 22db1a23ffc34c97b9a81fa2e285e4b3
+          name: 'System Status'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.6574.1.1.0
+          key: synoSystem.systemStatus
+          description: 'System partition status.'
+          valuemap:
+            name: 'SYNOLOGY-SYSTEM-MIB::systemStatus'
+          tags:
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Health'
+          triggers:
+            -
+              uuid: ed08172c092d4a9eb6e59ace3e7f435c
+              expression: 'last(/Synology DiskStation/synoSystem.systemStatus)<>1'
+              name: 'System Partition CRITICAL on {HOST.NAME}'
+              priority: DISASTER
+        -
+          uuid: 753f4a238d404d18ab002141a7685f08
+          name: 'System Temperature'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.6574.1.2.0
+          key: synoSystem.temperature
+          delay: 3m
+          units: C
+          description: 'Temperature of this NAS.'
+          tags:
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Health'
+          triggers:
+            -
+              uuid: 0922bdc084f44428bdc4af8fa815692d
+              expression: 'avg(/Synology DiskStation/synoSystem.temperature,#4)>60'
+              name: 'System Temperature CRITICAL on {HOST.NAME}'
+              priority: AVERAGE
+        -
+          uuid: 39b2385d140e48eba87896f85145ff41
+          name: 'Upgrade Available'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.6574.1.5.4.0
+          key: synoSystem.upgradeAvailable
+          delay: 1h
+          description: 'Checks whether a new version or update of DSM is available'
+          valuemap:
+            name: 'SYNOLOGY-SYSTEM-MIB::upgradeAvailable'
+          tags:
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Information'
+          triggers:
+            -
+              uuid: f58c126d166b478581f7cf9d2d90c3db
+              expression: 'last(/Synology DiskStation/synoSystem.upgradeAvailable)=1'
+              name: 'Update available on {HOST.NAME}'
+              priority: INFO
+              manual_close: 'YES'
+        -
+          uuid: 882b071c2c0548deb1802759e8f365d4
+          name: Version
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.6574.1.5.3.0
+          key: synoSystem.version
+          delay: 1h
+          trends: '0'
+          value_type: TEXT
+          description: 'The version of DSM'
+          inventory_link: OS
+          tags:
+            -
+              tag: Application
+              value: 'Synology System'
+            -
+              tag: Application
+              value: 'System Information'
+        -
+          uuid: fbd86813df5045d0a5f588597c8fb76d
+          name: 'Total Physical Available'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.4.6.0
+          key: ucdavis.memory.memAvailReal
+          delay: 3m
+          units: B
+          description: 'The amount of real/physical memory currently unused or available.'
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            -
+              tag: Application
+              value: Memory
+            -
+              tag: Application
+              value: 'System Health'
+        -
+          uuid: a0ab990e1cec4f2e80e1cc4008842b37
+          name: 'Total Swap Available'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.4.4.0
+          key: ucdavis.memory.memAvailSwap
+          delay: 3m
+          units: B
+          description: 'The amount of swap space currently unused or available.'
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            -
+              tag: Application
+              value: Memory
+            -
+              tag: Application
+              value: 'System Health'
+        -
+          uuid: c738f2780fbc4bfb8f73642ee2d6e5a5
+          name: 'Total Buffer Memory'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.4.14.0
+          key: ucdavis.memory.memBuffer
+          delay: 3m
+          units: B
+          description: 'The total amount of real or virtual memory currently allocated for use as memory buffers.'
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            -
+              tag: Application
+              value: Memory
+            -
+              tag: Application
+              value: 'System Health'
+        -
+          uuid: 24846ebae386418dad6b25792fc085d7
+          name: 'Total Cached Memory'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.4.15.0
+          key: ucdavis.memory.memCached
+          delay: 3m
+          units: B
+          description: 'The total amount of real or virtual memory currently allocated for use as cached memory.'
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            -
+              tag: Application
+              value: Memory
+            -
+              tag: Application
+              value: 'System Health'
+        -
+          uuid: 86a11c6d751e4005b6982e9d761a7f62
+          name: 'Total Shared Memory'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.4.13.0
+          key: ucdavis.memory.memShared
+          delay: 3m
+          units: B
+          description: 'The total amount of real or virtual memory currently allocated for use as shared memory.'
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            -
+              tag: Application
+              value: Memory
+            -
+              tag: Application
+              value: 'System Health'
+        -
+          uuid: 3d8c117d377747b9a52a9de6ff49b967
+          name: 'Total Free Memory'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.4.11.0
+          key: ucdavis.memory.memTotalFree
+          delay: 3m
+          units: B
+          description: 'The total amount of memory free or available for use on this host.'
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            -
+              tag: Application
+              value: Memory
+            -
+              tag: Application
+              value: 'System Health'
+        -
+          uuid: 3a73d95e462a49d59a43ad08e2142465
+          name: 'Total Physical Memory'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.4.5.0
+          key: ucdavis.memory.memTotalReal
+          delay: 3m
+          units: B
+          description: 'The total amount of real/physical memory installed on this host.'
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            -
+              tag: Application
+              value: Memory
+            -
+              tag: Application
+              value: 'System Health'
+        -
+          uuid: 6bef6064cc4149f8a6274dbca6a7b805
+          name: 'Total Swap Space'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.2021.4.3.0
+          key: ucdavis.memory.memTotalSwap
+          delay: 3m
+          units: B
+          description: 'The total amount of swap space configured for this host.'
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            -
+              tag: Application
+              value: Memory
+            -
+              tag: Application
+              value: 'System Health'
+      discovery_rules:
+        -
+          uuid: 882c8f12d1394aa593e400311a995dde
+          name: Disk
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#IFINDEX},.1.3.6.1.2.1.25.2.3.1.1,{#IFDESCR},.1.3.6.1.2.1.25.2.3.1.3,{#IFUNIT},.1.3.6.1.2.1.25.2.3.1.4]'
+          key: host.hrStorage.hrStorageTable.hrStorageEntry
+          delay: 1h
+          filter:
+            conditions:
+              -
+                macro: '{#IFDESCR}'
+                value: /volume
+                formulaid: A
+          item_prototypes:
+            -
+              uuid: 88d7335bb5fb4308b97235923d9d1c45
+              name: 'Storage Size on {#IFDESCR}'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.2.1.25.2.3.1.5.{#IFINDEX}'
+              key: 'host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageSize[{#IFINDEX}]'
+              delay: 3m
+              units: B
+              description: 'The size of the storage represented by this entry, in units of hrStorageAllocationUnits.'
+              preprocessing:
+                -
+                  type: MULTIPLIER
+                  parameters:
+                    - '{#IFUNIT}'
+              tags:
+                -
+                  tag: Application
+                  value: Disk
+            -
+              uuid: cf5711db52f4416caa8359b7452efa85
+              name: 'Storage Used on {#IFDESCR} (%)'
+              type: CALCULATED
+              key: 'host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX},pct]'
+              delay: 5m
+              units: '%'
+              params: 'last(//host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX}])/last(//host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageSize[{#IFINDEX}])*100'
+              description: '% of disk space used.'
+              tags:
+                -
+                  tag: Application
+                  value: Disk
+              trigger_prototypes:
+                -
+                  uuid: 410d2c7ae2ef4caa90ba35f5fafdb48d
+                  expression: 'last(/Synology DiskStation/host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX},pct])>{$DISK_UTIL_HIGH}'
+                  name: 'Disk Space is CRITICAL on {#IFDESCR}'
+                  priority: HIGH
+                -
+                  uuid: 8d7ac6e4b5b44809bf0ae587fcdb3e00
+                  expression: 'last(/Synology DiskStation/host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX},pct])>{$DISK_UTIL_WARN}'
+                  name: 'Disk Space is LOW on {#IFDESCR}'
+                  priority: WARNING
+            -
+              uuid: ea5dce5e4e3a4a9aa261491ed89775d5
+              name: 'Storage Used on {#IFDESCR}'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.2.1.25.2.3.1.6.{#IFINDEX}'
+              key: 'host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX}]'
+              delay: 3m
+              units: B
+              description: 'The amount of the storage represented by this entry.'
+              preprocessing:
+                -
+                  type: MULTIPLIER
+                  parameters:
+                    - '{#IFUNIT}'
+              tags:
+                -
+                  tag: Application
+                  value: Disk
+          graph_prototypes:
+            -
+              uuid: 53b3469649574b48a649c3c5e07117e7
+              name: 'Disk: Storage Evolution on {#IFDESCR}'
+              height: '300'
+              graph_items:
+                -
+                  color: '000000'
+                  calc_fnc: ALL
+                  item:
+                    host: 'Synology DiskStation'
+                    key: 'host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageSize[{#IFINDEX}]'
+                -
+                  sortorder: '1'
+                  drawtype: FILLED_REGION
+                  color: 0000EE
+                  item:
+                    host: 'Synology DiskStation'
+                    key: 'host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX}]'
+            -
+              uuid: 324c1a04258c4c8cad7c472f1f15f42b
+              name: 'Disk: Storage Utilization on {#IFDESCR}'
+              width: '600'
+              height: '340'
+              yaxismax: '0'
+              show_work_period: 'NO'
+              show_triggers: 'NO'
+              type: PIE
+              show_3d: 'YES'
+              graph_items:
+                -
+                  color: 5B5B5B
+                  calc_fnc: LAST
+                  type: GRAPH_SUM
+                  item:
+                    host: 'Synology DiskStation'
+                    key: 'host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageSize[{#IFINDEX}]'
+                -
+                  sortorder: '1'
+                  color: AEEE00
+                  calc_fnc: LAST
+                  item:
+                    host: 'Synology DiskStation'
+                    key: 'host.hrStorage.hrStorageTable.hrStorageEntry.hrStorageUsed[{#IFINDEX}]'
+        -
+          uuid: f64d354a85ca46ee94d76effb3a0be46
+          name: Network
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#IFALIAS},1.3.6.1.2.1.31.1.1.1.18,{#IFNAME},1.3.6.1.2.1.31.1.1.1.1]'
+          key: ifMIB.ifMIBObjects.ifXTable.ifXEntry
+          delay: 1h
+          filter:
+            evaltype: OR
+            conditions:
+              -
+                macro: '{#IFNAME}'
+                value: eth
+                formulaid: A
+              -
+                macro: '{#IFNAME}'
+                value: bond
+                formulaid: A
+          item_prototypes:
+            -
+              uuid: 55433155e81a418cb29b9c690a5d0491
+              name: 'Incomming Packets on Interface {#IFNAME}'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.2.1.31.1.1.1.6.{#SNMPINDEX}'
+              key: 'ifMIB.ifMIBObjects.ifXTable.ifXEntry.ifHCInOctets.[{#IFNAME}]'
+              delay: 3m
+              value_type: FLOAT
+              units: bps
+              description: 'The total number of octets received on the interface.'
+              preprocessing:
+                -
+                  type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                -
+                  type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                -
+                  tag: Application
+                  value: Network
+            -
+              uuid: e8de2f0e63ad4d758f22a195a4175b78
+              name: 'Outgoing Packets on Interface {#IFNAME}'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.2.1.31.1.1.1.10.{#SNMPINDEX}'
+              key: 'ifMIB.ifMIBObjects.ifXTable.ifXEntry.ifHCOutOctets.[{#IFNAME}]'
+              delay: 3m
+              value_type: FLOAT
+              units: bps
+              description: 'The total number of octets transmitted out of the interface.'
+              preprocessing:
+                -
+                  type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                -
+                  type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                -
+                  tag: Application
+                  value: Network
+          graph_prototypes:
+            -
+              uuid: 1615a291310546698d405260e5ca1492
+              name: 'Network: Traffic on Interface {#IFNAME}'
+              graph_items:
+                -
+                  drawtype: GRADIENT_LINE
+                  color: 00AA00
+                  item:
+                    host: 'Synology DiskStation'
+                    key: 'ifMIB.ifMIBObjects.ifXTable.ifXEntry.ifHCInOctets.[{#IFNAME}]'
+                -
+                  sortorder: '1'
+                  drawtype: GRADIENT_LINE
+                  color: 3333FF
+                  item:
+                    host: 'Synology DiskStation'
+                    key: 'ifMIB.ifMIBObjects.ifXTable.ifXEntry.ifHCOutOctets.[{#IFNAME}]'
+        -
+          uuid: f9076b7aa85342aabf4db01c8800fda2
+          name: 'Synology SpaceIO'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.4.1.6574.102.1.1.2]'
+          key: spaceIO.spaceIOTable.spaceIOEntry
+          delay: 1h
+          filter:
+            conditions:
+              -
+                macro: '{#SNMPVALUE}'
+                value: sd
+                formulaid: A
+          description: 'An entry containing a device and its statistics.'
+          item_prototypes:
+            -
+              uuid: 4574eadec3dc43af86d756a3286734fb
+              name: 'Space Load of Disk {#SNMPVALUE}'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.102.1.1.7.{#SNMPINDEX}'
+              key: 'spaceIO.spaceIOTable.spaceIOEntry.spaceIOLA.[{#SNMPINDEX}]'
+              delay: 3m
+              units: '%'
+              description: 'The load of disk in the volume (%).'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Spaceio'
+            -
+              uuid: 30f7351c90f54e19b24089e06692afa6
+              name: '{#SNMPVALUE} byte(s) read since boot'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.102.1.1.3.{#SNMPINDEX}'
+              key: 'spaceIO.spaceIOTable.spaceIOEntry.spaceIONRead.[{#SNMPINDEX}]'
+              delay: 3m
+              status: DISABLED
+              units: byte(s)
+              description: 'The number of bytes read from this volume since boot (32-bit ver.).'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Spaceio'
+            -
+              uuid: 6042a97bd1a3411d9e16797f8efc4812
+              name: '{#SNMPVALUE} read access(es) since boot'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.102.1.1.5.{#SNMPINDEX}'
+              key: 'spaceIO.spaceIOTable.spaceIOEntry.spaceIONReads.[{#SNMPINDEX}]'
+              delay: 3m
+              status: DISABLED
+              units: byte(s)
+              description: 'The number of read accesses from this volume since boot.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Spaceio'
+            -
+              uuid: f66c133715d34c8d81a7b0945e258b02
+              name: '{#SNMPVALUE} write accesses since boot'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.102.1.1.6.{#SNMPINDEX}'
+              key: 'spaceIO.spaceIOTable.spaceIOEntry.spaceIONWrites.[{#SNMPINDEX}]'
+              delay: 3m
+              status: DISABLED
+              units: byte(s)
+              description: 'The number of write accesses to this volume since boot (32-bit ver.).'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Spaceio'
+            -
+              uuid: 4cbec0953c7b4e6590c39922a9e3fdb4
+              name: '{#SNMPVALUE} byte(s) written since boot'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.102.1.1.4.{#SNMPINDEX}'
+              key: 'spaceIO.spaceIOTable.spaceIOEntry.spaceIONWritten.[{#SNMPINDEX}]'
+              delay: 3m
+              status: DISABLED
+              units: byte(s)
+              description: 'The number of bytes written to this volume since boot (32-bit ver.).'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Spaceio'
+          graph_prototypes:
+            -
+              uuid: f073336a62714d0496774d7094719448
+              name: 'SpaceIO: Load on Disk {#SNMPVALUE} (in %)'
+              graph_items:
+                -
+                  color: EE00EE
+                  item:
+                    host: 'Synology DiskStation'
+                    key: 'spaceIO.spaceIOTable.spaceIOEntry.spaceIOLA.[{#SNMPINDEX}]'
+        -
+          uuid: 3c6ecf48282a4b9da5f56670ac770ccd
+          name: 'Synology StorageIO'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.4.1.6574.101.1.1.2]'
+          key: storageIO.storageIOTable.storageIOEntry
+          delay: 1h
+          filter:
+            conditions:
+              -
+                macro: '{#SNMPVALUE}'
+                value: sd
+                formulaid: A
+          description: 'An entry containing a device and its statistics.'
+          item_prototypes:
+            -
+              uuid: 098e76bb02be4156806c4889bf0723a9
+              name: 'Storage Load on Disk {#SNMPVALUE}'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.101.1.1.8.{#SNMPINDEX}'
+              key: 'storageIO.storageIOTable.storageIOEntry.storageIOLA.[{#SNMPINDEX}]'
+              delay: 3m
+              units: '%'
+              description: 'The load of disk (in %).'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Storageio'
+            -
+              uuid: 964804a4353d4270a25e1749fc054903
+              name: '{#SNMPVALUE} byte(s) read since boot'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.101.1.1.3.{#SNMPINDEX}'
+              key: 'storageIO.storageIOTable.storageIOEntry.storageIONRead.[{#SNMPINDEX}]'
+              delay: 3m
+              status: DISABLED
+              units: byte(s)
+              description: 'The number of bytes read from this device since boot (32-bit VER.).'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Storageio'
+            -
+              uuid: 442be3a22a7a4cf6b6a86bb2f748c875
+              name: '{#SNMPVALUE} byte(s) written since boot'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.101.1.1.4.{#SNMPINDEX}'
+              key: 'storageIO.storageIOTable.storageIOEntry.storageIONWritten.[{#SNMPINDEX}]'
+              delay: 3m
+              status: DISABLED
+              units: byte(s)
+              description: 'The number of bytes written to this device since boot (32-bit VER.).'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Storageio'
+            -
+              uuid: 360c6db137dd4f5b9a12c5696a07e0dd
+              name: '{#SNMPVALUE} read access(es) since boot'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.101.1.1.5.{#SNMPINDEX}'
+              key: 'storageIO.storageIOTable.storageIOEntry.storageIOReads.[{#SNMPINDEX}]'
+              delay: 3m
+              status: DISABLED
+              units: access(es)
+              description: 'The number of read accesses from this device since boot (32-bit VER.).'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Storageio'
+            -
+              uuid: 38dcfe8124704310b70af781d90598ad
+              name: '{#SNMPVALUE} write access(es) since boot'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.101.1.1.6.{#SNMPINDEX}'
+              key: 'storageIO.storageIOTable.storageIOEntry.storageIOWrites.[{#SNMPINDEX}]'
+              delay: 3m
+              status: DISABLED
+              units: access(es)
+              description: 'The number of write accesses from this device since boot (32-bit VER.).'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Storageio'
+          graph_prototypes:
+            -
+              uuid: 922306759fc045178139ca3f5b6fe89b
+              name: 'StorageIO: Load on Disk {#SNMPVALUE}'
+              show_work_period: 'NO'
+              show_triggers: 'NO'
+              ymin_type_1: ITEM
+              ymin_item_1:
+                host: 'Synology DiskStation'
+                key: 'storageIO.storageIOTable.storageIOEntry.storageIOLA.[{#SNMPINDEX}]'
+              ymax_type_1: ITEM
+              ymax_item_1:
+                host: 'Synology DiskStation'
+                key: 'storageIO.storageIOTable.storageIOEntry.storageIOLA.[{#SNMPINDEX}]'
+              graph_items:
+                -
+                  drawtype: BOLD_LINE
+                  color: 0000EE
+                  calc_fnc: ALL
+                  type: GRAPH_SUM
+                  item:
+                    host: 'Synology DiskStation'
+                    key: 'storageIO.storageIOTable.storageIOEntry.storageIOLA.[{#SNMPINDEX}]'
+        -
+          uuid: 667d018d2ea941e9a29a5856af6a9eb9
+          name: 'Synology Disk(s)'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.4.1.6574.2.1.1.2]'
+          key: synoDisk.diskTable.diskEntry
+          delay: 1h
+          description: 'For all disk entry.'
+          item_prototypes:
+            -
+              uuid: cfb366c37f364af1846c9f0b0d4f344f
+              name: '{#SNMPVALUE} Bad sectors count'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.2.1.1.9.{#SNMPINDEX}'
+              key: 'synoDisk.diskTable.diskEntry.diskBadSector.[{#SNMPINDEX}]'
+              delay: 12h
+              description: 'The count of each disk I/O bad sector'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Disk'
+              trigger_prototypes:
+                -
+                  uuid: 1aaced98ed6a4c37830d48bf309d16cc
+                  expression: 'last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskBadSector.[{#SNMPINDEX}])>0'
+                  name: '{#SNMPVALUE} disk contains bad sectors'
+                  priority: HIGH
+                  description: 'Bad sectors in disk.'
+            -
+              uuid: 8d8dd79307c04518a19a164507fdac5c
+              name: '{#SNMPVALUE} Model'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.2.1.1.3.{#SNMPINDEX}'
+              key: 'synoDisk.diskTable.diskEntry.diskModel.[{#SNMPINDEX}]'
+              delay: 1d
+              trends: '0'
+              value_type: TEXT
+              description: 'Synology disk model name: the disk model name will be showed here.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Disk'
+              trigger_prototypes:
+                -
+                  uuid: 5aa70edd984f42f384148304354056d0
+                  expression: '(last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskModel.[{#SNMPINDEX}],#1)<>last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskModel.[{#SNMPINDEX}],#2))>0'
+                  name: '{#SNMPVALUE} was changed'
+                  priority: INFO
+                  description: 'Disk was changed'
+            -
+              uuid: dc7657205e7e4c3a884d461d2106f779
+              name: '{#SNMPVALUE} Status'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.2.1.1.5.{#SNMPINDEX}'
+              key: 'synoDisk.diskTable.diskEntry.diskStatus.[{#SNMPINDEX}]'
+              description: |
+                Synology disk status: each meanings of status represented describe below:
+                [1] Normal: the hard disk functions normally.
+                [2] Initialized: the hard disk has system partition but no data.
+                [3] NotInitialized: the hard disk does not have system in system partition.	
+                [4] SystemPartitionFailed: the system partitions on the hard disks are damaged.
+                [5] Crashed: the hard disk has damaged.
+              valuemap:
+                name: 'SYNOLOGY-DISK-MIB::diskStatus'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Disk'
+              trigger_prototypes:
+                -
+                  uuid: 42706ae3d0784f7a8647da128a49e062
+                  expression: 'last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskStatus.[{#SNMPINDEX}])=5'
+                  name: '{#SNMPVALUE} disk damaged'
+                  priority: HIGH
+                  description: 'The disk is damaged'
+                -
+                  uuid: cfbfc8ab2f5d49f4b5d0428a596f5e21
+                  expression: 'last(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskStatus.[{#SNMPINDEX}])=4'
+                  name: '{#SNMPVALUE} partition damaged'
+                  priority: AVERAGE
+                  description: 'Partitions on the disk are damaged'
+            -
+              uuid: 2128c339329f43d1bca031e5c70f954e
+              name: '{#SNMPVALUE} Temperature'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.2.1.1.6.{#SNMPINDEX}'
+              key: 'synoDisk.diskTable.diskEntry.diskTemperature.[{#SNMPINDEX}]'
+              units: C
+              description: 'Synology disk temperature: the temperature of each disk uses Celsius degree.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Disk'
+              trigger_prototypes:
+                -
+                  uuid: b43b70d6de3e4ccd9dfc62b580b2de78
+                  expression: 'avg(/Synology DiskStation/synoDisk.diskTable.diskEntry.diskTemperature.[{#SNMPINDEX}],#4)>60'
+                  name: '{#SNMPVALUE} temperature'
+                  priority: WARNING
+            -
+              uuid: a2d9899c31124f9489708038b1d7e543
+              name: '{#SNMPVALUE} Type'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.2.1.1.4.{#SNMPINDEX}'
+              key: 'synoDisk.diskTable.diskEntry.diskType.[{#SNMPINDEX}]'
+              delay: 1d
+              trends: '0'
+              value_type: TEXT
+              description: 'Synology disk type: the type of disk will be showed here, including SATA, SSD and so on.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Disk'
+          graph_prototypes:
+            -
+              uuid: fb46a95187c845c9a6ac93d6e531b9c0
+              name: 'Temperature: Disk {#SNMPVALUE}'
+              graph_items:
+                -
+                  drawtype: FILLED_REGION
+                  color: 2774A4
+                  calc_fnc: ALL
+                  item:
+                    host: 'Synology DiskStation'
+                    key: 'synoDisk.diskTable.diskEntry.diskTemperature.[{#SNMPINDEX}]'
+                -
+                  sortorder: '1'
+                  color: 3333FF
+                  item:
+                    host: 'Synology DiskStation'
+                    key: synoSystem.temperature
+        -
+          uuid: cc008d4c140349ccb7cea3010c9598a7
+          name: 'Synology Disk(s) SMART'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.4.1.6574.5.1.1.2,{#ATTRNAME},.1.3.6.1.4.1.6574.5.1.1.3,{#ATTRID},.1.3.6.1.4.1.6574.5.1.1.4,{#ATTRCURRENT},.1.3.6.1.4.1.6574.5.1.1.5,{#ATTRWORST},.1.3.6.1.4.1.6574.5.1.1.6,{#ATTRTHRESHOLD},.1.3.6.1.4.1.6574.5.1.1.7,{#ATTRRAW},.1.3.6.1.4.1.6574.5.1.1.8,{#ATTRSTATUS},.1.3.6.1.4.1.6574.5.1.1.9]'
+          key: synologyDiskSMART.diskSMARTTable.diskSMARTEntry
+          delay: 1h
+          description: 'An entry containing a disk SMART information.'
+          item_prototypes:
+            -
+              uuid: 46d19451821d41ada5517acea9eff282
+              name: '{#ATTRNAME} on {#SNMPVALUE}'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.5.1.1.9.{#SNMPINDEX}'
+              key: 'synologyDiskSMART.diskSMARTTable.diskSMARTEntry.[{#SNMPINDEX}]'
+              delay: 1h
+              trends: '0'
+              value_type: TEXT
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Disk SMART'
+              trigger_prototypes:
+                -
+                  uuid: d9121ba10d894e2998b88875e7b3697d
+                  expression: '(last(/Synology DiskStation/synologyDiskSMART.diskSMARTTable.diskSMARTEntry.[{#SNMPINDEX}],#1)<>last(/Synology DiskStation/synologyDiskSMART.diskSMARTTable.diskSMARTEntry.[{#SNMPINDEX}],#2))>0'
+                  name: 'Disk SMART attribute {#ATTRNAME} state was changed on {#SNMPVALUE}'
+                  priority: HIGH
+        -
+          uuid: 10bc114adb524dc3a41e1135580d56cc
+          name: 'Synology iSCSI LUN'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#LUNINDEX},.1.3.6.1.4.1.6574.104.1.1.1,{#LUNUID},.1.3.6.1.4.1.6574.104.1.1.2,{#LUNNAME},.1.3.6.1.4.1.6574.104.1.1.3]'
+          key: synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry
+          delay: 1h
+          description: 'An entry containing iscsi lun information.'
+          item_prototypes:
+            -
+              uuid: 634ff65ef9b645f6b7e22d0211b9e3b5
+              name: 'Disk Latency Read on LUN {#LUNNAME} ({#LUNUID})'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.104.1.1.10.{#LUNINDEX}'
+              key: 'synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNDiskLatencyRead[{#LUNINDEX}]'
+              value_type: FLOAT
+              units: ms
+              description: 'LUN read disk latency.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology iSCSI LUN'
+            -
+              uuid: ab4e5b7cd47445ff8f1ed9304051563f
+              name: 'Disk Latency Write on LUN {#LUNNAME} ({#LUNUID})'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.104.1.1.11.{#LUNINDEX}'
+              key: 'synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNDiskLatencyWrite[{#LUNINDEX}]'
+              value_type: FLOAT
+              units: ms
+              description: 'LUN write disk latency.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology iSCSI LUN'
+            -
+              uuid: 4decc07717734d0588fe53949eef7dd9
+              name: 'IOPS Read on LUN {#LUNNAME} ({#LUNUID})'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.104.1.1.8.{#LUNINDEX}'
+              key: 'synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNIopsRead[{#LUNINDEX}]'
+              value_type: FLOAT
+              units: iops
+              description: 'LUN read iops.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology iSCSI LUN'
+            -
+              uuid: 946b749bb38646328555c9fa4199a30d
+              name: 'IOPS Write on LUN {#LUNNAME} ({#LUNUID})'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.104.1.1.9.{#LUNINDEX}'
+              key: 'synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNIopsWrite[{#LUNINDEX}]'
+              value_type: FLOAT
+              units: iops
+              description: 'LUN write iops.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology iSCSI LUN'
+            -
+              uuid: 5dadb1e9c5a84b6daae30b3a13fc8036
+              name: 'IO Size Read on LUN {#LUNNAME} ({#LUNUID})'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.104.1.1.14.{#LUNINDEX}'
+              key: 'synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNIoSizeRead[{#LUNINDEX}]'
+              value_type: FLOAT
+              units: B
+              description: 'LUN average io size when reading.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology iSCSI LUN'
+            -
+              uuid: 055643f0938147ba84fc8230d3891b7e
+              name: 'IO Size Write on LUN {#LUNNAME} ({#LUNUID})'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.104.1.1.15.{#LUNINDEX}'
+              key: 'synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNIoSizeWrite[{#LUNINDEX}]'
+              value_type: FLOAT
+              units: B
+              description: 'LUN average io size when writing.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology iSCSI LUN'
+            -
+              uuid: 45b3bcd46a93411d8398d9922393119f
+              name: 'Network Latency TX on LUN {#LUNNAME} ({#LUNUID})'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.104.1.1.12.{#LUNINDEX}'
+              key: 'synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNNetworkLatencyTx[{#LUNINDEX}]'
+              value_type: FLOAT
+              units: ms
+              description: 'LUN network tx latency.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology iSCSI LUN'
+            -
+              uuid: 5046a5114f3f419096c877ebf4f4e312
+              name: 'Throughput Read High on LUN {#LUNNAME} ({#LUNUID})'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.104.1.1.4.{#LUNINDEX}'
+              key: 'synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNThroughputReadHigh[{#LUNINDEX}]'
+              value_type: FLOAT
+              units: bps
+              description: 'LUN read throughput over 32 bits part.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology iSCSI LUN'
+            -
+              uuid: 554d45f7632341d486878cb715be817e
+              name: 'Throughput Read Low on LUN {#LUNNAME} ({#LUNUID})'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.104.1.1.5.{#LUNINDEX}'
+              key: 'synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNThroughputReadLow[{#LUNINDEX}]'
+              value_type: FLOAT
+              units: bps
+              description: 'LUN read throughput over 32 bits part.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology iSCSI LUN'
+            -
+              uuid: 19abf3cc7cbd4417b6dac751d76e2730
+              name: 'Throughput Write High on LUN {#LUNNAME} ({#LUNUID})'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.104.1.1.6.{#LUNINDEX}'
+              key: 'synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNThroughputWriteHigh[{#LUNINDEX}]'
+              value_type: FLOAT
+              units: bps
+              description: 'The higher 32 bit of write throughput.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology iSCSI LUN'
+            -
+              uuid: a74861d2c7584977a363ccdbd175a709
+              name: 'Throughput Write Low on LUN {#LUNNAME} ({#LUNUID})'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.104.1.1.7.{#LUNINDEX}'
+              key: 'synologyiSCSILUN.iSCSILUNTable.iSCSILUNEntry.iSCSILUNThroughputWriteLow[{#LUNINDEX}]'
+              value_type: FLOAT
+              units: bps
+              description: 'The lower 32 bit of write throughput.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology iSCSI LUN'
+        -
+          uuid: accc2d63ba3d4b5eb380263ac7c796b0
+          name: 'Synology Service(s)'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.4.1.6574.6.1.1.2]'
+          key: synologyService.serviceTable.serviceEntry
+          delay: 1h
+          description: 'An entry containing Service information.'
+          item_prototypes:
+            -
+              uuid: 134a32937dd84c1f9707d98c3ca4590b
+              name: '{#SNMPVALUE} Users'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.6.1.1.3.{#SNMPINDEX}'
+              key: 'synologyService.serviceTable.serviceEntry.serviceUsers.[{#SNMPINDEX}]'
+              units: user(s)
+              description: 'Number of users using this service.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology Services'
+          graph_prototypes:
+            -
+              uuid: 2d68532bbb1745bb8a21e0b967f38f36
+              name: 'Service: {#SNMPVALUE} Users'
+              show_triggers: 'NO'
+              ymin_type_1: ITEM
+              ymin_item_1:
+                host: 'Synology DiskStation'
+                key: 'synologyService.serviceTable.serviceEntry.serviceUsers.[{#SNMPINDEX}]'
+              ymax_type_1: ITEM
+              ymax_item_1:
+                host: 'Synology DiskStation'
+                key: 'synologyService.serviceTable.serviceEntry.serviceUsers.[{#SNMPINDEX}]'
+              graph_items:
+                -
+                  color: 0000EE
+                  calc_fnc: ALL
+                  item:
+                    host: 'Synology DiskStation'
+                    key: 'synologyService.serviceTable.serviceEntry.serviceUsers.[{#SNMPINDEX}]'
+        -
+          uuid: c3711376bd4f44a396888c6d9d715569
+          name: 'Synology RAID Volume(s)'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.4.1.6574.3.1.1.2]'
+          key: synoRaid.raidTable.raidEntry
+          delay: 1h
+          item_prototypes:
+            -
+              uuid: 46b1b67cb8b041e996c6a4e8a6d0efdb
+              name: '{#SNMPVALUE} RAID Name'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.3.1.1.2.{#SNMPINDEX}'
+              key: 'synoRaid.raidTable.raidEntry.raidName.[{#SNMPINDEX}]'
+              delay: 1d
+              trends: '0'
+              value_type: TEXT
+              description: 'Synology raid name: the name of each raid will be showed here.'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology RAID'
+            -
+              uuid: 9578a9400bde447da90cf5ee217c655e
+              name: '{#SNMPVALUE} RAID Status'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.6574.3.1.1.3.{#SNMPINDEX}'
+              key: 'synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}]'
+              delay: 3m
+              description: |
+                Synology Raid status: each meanings of status represented describe below:
+                [1] Normal: the raid functions normally.
+                [11] Degrade: degrade happens when a tolerable failure of disk(s) occurs.
+                [12] Crashed: raid has crashed and just uses for read-only operation.
+                
+                Note: other status will be showed when creating or deleting raids, including below status:
+                [2] Repairing,
+                [3] Migrating,
+                [4] Expanding, 
+                [5] Deleting,
+                [6] Creating(6),
+                [7] RaidSyncing,
+                [8] RaidParityChecking,
+                [9] RaidAssembling and
+                [10] Canceling.
+              valuemap:
+                name: 'SYNOLOGY-RAID-MIB::raidStatus'
+              tags:
+                -
+                  tag: Application
+                  value: 'Synology RAID'
+              trigger_prototypes:
+                -
+                  uuid: 5477ff1d1f2c47dfbfb938169ec9f731
+                  expression: 'last(/Synology DiskStation/synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}])>1 and last(/Synology DiskStation/synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}])<11'
+                  name: 'Raid status on {HOSTNAME}: abnormal'
+                  priority: WARNING
+                  description: |
+                    Repairing(2)
+                    Migrating(3)
+                    Expanding(4)
+                    Deleting(5)
+                    Creating(6)
+                    RaidSyncing(7)
+                    RaidParityChecking(8)
+                    RaidAssembling(9)
+                    Canceling(10)
+                -
+                  uuid: 1192b77fa9c6464fa60e82d774d0f9ba
+                  expression: 'last(/Synology DiskStation/synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}])=12'
+                  name: 'Raid status on {HOSTNAME}: crashed'
+                  priority: HIGH
+                  description: 'RAID has crashed and is now read-only.'
+                -
+                  uuid: 2a9c87888a914fab8a75c0fb70b59dbd
+                  expression: 'last(/Synology DiskStation/synoRaid.raidTable.raidEntry.raidStatus.[{#SNMPINDEX}])=11'
+                  name: 'Raid status on {HOSTNAME}: degrade'
+                  priority: AVERAGE
+                  description: 'Degrade is shown when a tolerable failure of disk(s) occurs.'
+      macros:
+        -
+          macro: '{$DISK_UTIL_HIGH}'
+          value: '90'
+        -
+          macro: '{$DISK_UTIL_WARN}'
+          value: '80'
+        -
+          macro: '{$SNMP_AUTHPASS}'
+        -
+          macro: '{$SNMP_PORT}'
+          value: '161'
+        -
+          macro: '{$SNMP_PRIVPASS}'
+        -
+          macro: '{$SNMP_USERNAME}'
+      valuemaps:
+        -
+          uuid: 3a17c5b68b454649893d7e32f0c55db7
+          name: 'SYNOLOGY-DISK-MIB::diskStatus'
+          mappings:
+            -
+              value: '1'
+              newvalue: Normal
+            -
+              value: '2'
+              newvalue: Initialized
+            -
+              value: '3'
+              newvalue: 'Not Initialized'
+            -
+              value: '4'
+              newvalue: 'System Partition Failed'
+            -
+              value: '5'
+              newvalue: Crashed
+        -
+          uuid: 9257948aeb2b4d9d82816b00d38eb0a3
+          name: 'SYNOLOGY-RAID-MIB::raidStatus'
+          mappings:
+            -
+              value: '1'
+              newvalue: Normal
+            -
+              value: '2'
+              newvalue: Repairing
+            -
+              value: '3'
+              newvalue: Migrating
+            -
+              value: '4'
+              newvalue: Expanding
+            -
+              value: '5'
+              newvalue: Deleting
+            -
+              value: '6'
+              newvalue: Creating
+            -
+              value: '7'
+              newvalue: 'Raid Syncing'
+            -
+              value: '8'
+              newvalue: 'Raid Parity Checking'
+            -
+              value: '9'
+              newvalue: 'Raid Assembling'
+            -
+              value: '10'
+              newvalue: Canceling
+            -
+              value: '11'
+              newvalue: Degraded
+            -
+              value: '12'
+              newvalue: Crashed
+        -
+          uuid: afdf475a79c74b05909e622376f2bfd0
+          name: 'SYNOLOGY-SYSTEM-MIB::powerStatus'
+          mappings:
+            -
+              value: '1'
+              newvalue: Normal
+            -
+              value: '2'
+              newvalue: Failed
+        -
+          uuid: 1ce7265bf0424e3cad1cb8a87012afa0
+          name: 'SYNOLOGY-SYSTEM-MIB::systemStatus'
+          mappings:
+            -
+              value: '1'
+              newvalue: Normal
+            -
+              value: '2'
+              newvalue: Failed
+        -
+          uuid: b8b5468ab72e473d842f63b653d5d431
+          name: 'SYNOLOGY-SYSTEM-MIB::upgradeAvailable'
+          mappings:
+            -
+              value: '1'
+              newvalue: Available
+            -
+              value: '2'
+              newvalue: Unavailable
+            -
+              value: '3'
+              newvalue: Connecting
+            -
+              value: '4'
+              newvalue: Disconnected
+            -
+              value: '5'
+              newvalue: Others
+  graphs:
+    -
+      uuid: 22fe43ffac72474bb67f4010cb2b3c4b
+      name: 'CPU: Idle System User'
+      height: '300'
+      graph_items:
+        -
+          drawtype: BOLD_LINE
+          color: 1A7C11
+          calc_fnc: ALL
+          item:
+            host: 'Synology DiskStation'
+            key: synoSystem.ssCpuIdle
+        -
+          sortorder: '1'
+          color: F63100
+          calc_fnc: ALL
+          item:
+            host: 'Synology DiskStation'
+            key: synoSystem.ssCpuSystem
+        -
+          sortorder: '2'
+          color: 2774A4
+          calc_fnc: ALL
+          item:
+            host: 'Synology DiskStation'
+            key: synoSystem.ssCpuUser
+    -
+      uuid: 68b0ec1cb01c4c5c838e288db0866691
+      name: 'Memory: Physical Memory (Exploded)'
+      width: '600'
+      height: '340'
+      yaxismax: '0'
+      show_work_period: 'NO'
+      show_triggers: 'NO'
+      type: EXPLODED
+      show_3d: 'YES'
+      graph_items:
+        -
+          color: 6C59DC
+          calc_fnc: LAST
+          type: GRAPH_SUM
+          item:
+            host: 'Synology DiskStation'
+            key: ucdavis.memory.memTotalReal
+        -
+          sortorder: '1'
+          color: EEEE00
+          calc_fnc: LAST
+          item:
+            host: 'Synology DiskStation'
+            key: ucdavis.memory.memAvailReal
+    -
+      uuid: 5a869a677b254629825e145277b54173
+      name: 'Memory: Swap Memory (Exploded)'
+      width: '600'
+      height: '340'
+      yaxismax: '0'
+      show_work_period: 'NO'
+      show_triggers: 'NO'
+      type: EXPLODED
+      show_3d: 'YES'
+      graph_items:
+        -
+          color: A54F10
+          calc_fnc: LAST
+          type: GRAPH_SUM
+          item:
+            host: 'Synology DiskStation'
+            key: ucdavis.memory.memTotalSwap
+        -
+          sortorder: '1'
+          color: 2774A4
+          calc_fnc: LAST
+          item:
+            host: 'Synology DiskStation'
+            key: ucdavis.memory.memAvailSwap
+    -
+      uuid: 7047bceded544c67ade37f095a519a05
+      name: 'System: Temperature'
+      graph_items:
+        -
+          drawtype: FILLED_REGION
+          color: 2774A4
+          calc_fnc: ALL
+          item:
+            host: 'Synology DiskStation'
+            key: synoSystem.temperature


### PR DESCRIPTION
changes the community template for Synology "template_synology_diskstation_snmpv3/6.4" to also include bonded interfaces next to normal ethX interfaces in the value retrival