### PR TITLE
Cisco Catalyst 9800 template

### DIFF
--- a/Network_Devices/Cisco/template_cisco_9800/README.md
+++ b/Network_Devices/Cisco/template_cisco_9800/README.md
@@ -1,0 +1,131 @@
+# zabbix-cisco-9800
+Zabbix template for Cisco Catalyst 9800 Series Wireless Controllers
+
+## What it is?
+This is a Zabbix template for [Cisco Catalyst 9800 Series Wireless Controllers](https://www.cisco.com/site/us/en/products/networking/wireless/wireless-lan-controllers/catalyst-9800-series/index.html) using SNMP.
+It covers wireless monitoring like Wireless Client Count, AP Count, Radio utilization, Mobility tunnel status, and High Availability status.
+Please use the "Cisco IOS by SNMP" template or others to get general IOS-XE status like CPU utilization, Memory usage, or interface status.
+
+
+## Requirements
+- Cisco Catalyst 9800 Series Wireless Controller and supported Access Point
+  - [Embedded Wireless Controller for Catalyst Access Point](https://www.cisco.com/c/en/us/products/wireless/embedded-wireless-controller-on-catalyst-access-points/index.html) doesn't work [^1] 
+  - Other controllers, including [Cisco Catalyst 9800-CL Wireless Controller for Cloud](https://www.cisco.com/c/en/us/products/collateral/wireless/catalyst-9800-cl-wireless-controller-cloud/nb-06-cat9800-cl-cloud-wirel-data-sheet-ctp-en.html) may work
+- IOS-XE 17.11 or later software image to get many wireless SNMP OIDs like AIRESPACE-WIRELESS-MIB::bsnDot11EssNumberOfMobileStations
+- SNMP and SNMP trap configuration on Catalyst 9800 WLC
+- Zabbix 6.0 or later (tested on 6.0.29)
+[^1]: Embedded Wireless Controller (EWC) does not support SNMP and does not implement the SNMP MIBs of Cisco Catalyst 9800 Series Wireless Controllers, although EWC might respond to some of the object identifiers (OIDs). [Configuration guide](https://www.cisco.com/c/en/us/td/docs/wireless/controller/ewc/17-6/config-guide/ewc_cg_17_6/new_configuration_model.html)
+
+Here is a sample configuration for SNMP
+```
+snmp-server community [SNMP COMMUNITY] RO
+snmp-server location ["YOUR PHYSICAL ADDRESS"]
+snmp-server enable traps wireless bsnAutoRF
+snmp-server enable traps rf
+snmp-server host [ZABBIX IP ADDRESS] version 2c [SNMP COMMUNITY]
+```
+
+
+## SNMP MIBs used
+| Monitoring Item                      | SNMP MIBs                                                                                        |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| AP Name                              | AIRESPACE-WIRELESS-MIB::bsnAPName                                                                |
+| AP Channel Number (2.4GHz)           | AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber                                                  |
+| AP Channel Number (5GHz)             | AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber<br>CISCO-LWAPP-AP-MIB::cLApExtensionChannels     |
+| AP Channel Bandwidth (5GHz)          | CISCO-LWAPP-AP-MIB::cLAp11ChannelBandwidth                                                       |
+| AP Channel Utilization (2.4GHz/5GHz) | AIRESPACE-WIRELESS-MIB::bsnAPIfLoadChannelUtilization                                            |
+| AP Operation Status                  | AIRESPACE-WIRELESS-MIB::bsnAPOperationStatus                                                     |
+| AP Serial Number                     | AIRESPACE-WIRELESS-MIB::bsnAPSerialNumber                                                        |
+| AP Software Version                  | AIRESPACE-WIRELESS-MIB::bsnAPSoftwareVersion                                                     |
+| AP Tx Power Level (2.4GHz/5GHz)      | AIRESPACE-WIRELESS-MIB::bsnAPIfPhyTxPowerLevel                                                   |
+| Current Number of AP                 | CISCO-LWAPP-AP-MIB::cLApGlobalAPConnectCount.0                                                   |
+| Number of APs Supported              | CISCO-LWAPP-AP-MIB::cLApGlobalMaxApsSupported.0                                                  |
+| HA SSO status                        | CISCO-LWAPP-HA-MIB::cLHaPeerHotStandbyEvent                                                      |
+| Mobility Member Status (Control)     | CISCO-LWAPP-MOBILITY-MIB::cLMobilityGroupMembersOperControlPathStatus                            |
+| Mobility Member Status (Data)        | CISCO-LWAPP-MOBILITY-MIB::cLMobilityGroupMembersOperControlPathStatus                            |
+| Rouge AP Count                       | AIRESPACE-WIRELESS-MIB::bsnRogueAPDot11MacAddress                                                |
+| Rogue Client Count                   | AIRESPACE-WIRELESS-MIB::bsnRogueClientDot11MacAddress                                            |
+| SSID Administrative Status           | AIRESPACE-WIRELESS-MIB::bsnDot11EssAdminStatus                                                   |
+| SSID Number of Clients               | AIRESPACE-WIRELESS-MIB::bsnDot11EssNumberOfMobileStations                                        |
+| AP disassociation                    | AIRESPACE-WIRELESS-MIB::bsnAPDisassociated<br>CISCO-LWAPP-AP-MIB::ciscoLwappApAssociated         |
+| Channel Changed                      | AIRESPACE-WIRELESS-MIB::bsnAPCurrentChannelChanged                                               |
+| DFS Radar Detection                  | AIRESPACE-WIRELESS-MIB::bsnRadarChannelDetected                                                  |
+
+The template uses just OID and Standard MIB. No need to install vendor MIBs. Please refer to the below MIBs to understand each SNMP MIB.
+- AIRESPACE-REF-MIB.my
+- AIRESPACE-WIRELESS-CAPABILITY.my
+- AIRESPACE-WIRELESS-MIB.my
+- CISCO-LWAPP-AP-MIB.my
+- CISCO-LWAPP-DOT11-MIB.my
+- CISCO-LWAPP-RF-MIB.my
+- CISCO-LWAPP-TC-MIB.my
+- CISCO-LWAPP-WLAN-MIB.my
+- CISCO-SMI.my
+- CISCO-TC.my
+- ENTITY-MIB.my
+
+[https://github.com/cisco/cisco-mibs](https://github.com/cisco/cisco-mibs)
+
+
+## Screenshots
+![Screenshot1](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/385067/4dd37fb6-fc9d-7e33-23aa-9928b1c4a85b.png)
+![Screenshot2](https://qiita-image-store.s3.ap-northeast-1.amazonaws.com/0/385067/fdc40126-9b34-8200-5ac5-6ea7dad9ecd6.png)
+
+
+## Tested Environment
+- Cisco IOS Software [Dublin], C9800 Software (C9800_IOSXE-K9), Version 17.12.3, RELEASE SOFTWARE (fc7)
+  - C9800-L-F-K9
+  - C9800-CL-K9
+- Zabbix 6.0.29
+
+> [!IMPORTANT]
+The test is only done in small lab environments. In a large environment, monitor the CPU utilization of the Wireless Controller in case SNMP consumes too many resources.
+
+
+## Dicovery rules
+| Name | Description | Type | Key and additional info |
+| ------- | -------| -------| -------|
+| bsnAPTable | Enumerate Access Point and create prototype for each | SNMP Agent | AIRESPACE-WIRELESS-MIB::bsnAPName <br>Update: 1h|
+| cLMobilityGroupMembersOperEntry | Enumurate Mobility Group Member and createprotoype for each | SNMP Agent | CISCO-LWAPP-MOBILITY-MIB::cLMobilityGroupMembersOperNodeAddress <br>Update: 1h|
+| cLWlanSsid | Enumerate SSID and create prototype for each | SNMP Agent | CISCO-LWAPP-WLAN-MIB::cLWlanSsid <br>Update: 1h |
+
+
+## Items collected
+| Name | Description | Type | Key and additional info |
+| ------- | -------| -------| -------|
+| AP Name                              |-| SNMP Agent | AIRESPACE-WIRELESS-MIB::bsnAPName <br> Update: 1h  |
+| AP Channel Number (2.4GHz)           |-| SNMP Agent | AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber <br> Update: 15min   |
+| AP Channel Number (5GHz)             |Chennel bonding is supported| SNMP Agent |  AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber <br> + CISCO-LWAPP-AP-MIB::cLApExtensionChannels <br> Update: 15min|
+| AP Channel Bandwidth (5GHz)          |-| SNMP Agent | CISCO-LWAPP-AP-MIB::cLAp11ChannelBandwidth    <br> Update: 15min    |
+| AP Channel Utilization (2.4GHz/5GHz) |-| SNMP Agent | AIRESPACE-WIRELESS-MIB::bsnAPIfLoadChannelUtilization  <br> Update: 15min |
+| AP Operation Status                  |-| SNMP Agent | AIRESPACE-WIRELESS-MIB::bsnAPOperationStatus  <br> Update: 15min|
+| AP Serial Number                     |-| SNMP Agent | AIRESPACE-WIRELESS-MIB::bsnAPSerialNumber <br> Update: 24h |
+| AP Software Version                  |-| SNMP Agent | AIRESPACE-WIRELESS-MIB::bsnAPSoftwareVersion  <br> Update 1h |
+| AP Tx Power Level (2.4GHz/5GHz)      |-| SNMP Agent | AIRESPACE-WIRELESS-MIB::bsnAPIfPhyTxPowerLevel <br> Update: 15min|
+| Current Number of AP                 |-| SNMP Agent | CISCO-LWAPP-AP-MIB::cLApGlobalAPConnectCount.0 <br> Update: 1min |
+| Number of APs Supported              |-| SNMP Agent | CISCO-LWAPP-AP-MIB::cLApGlobalMaxApsSupported.0  <br> Update: 15min |
+| HA SSO status                        |-| SNMP Agent | CISCO-LWAPP-HA-MIB::cLHaPeerHotStandbyEvent <br> Update: 15min|
+| Mobility Member Status (Control)     |-| SNMP Agent | CISCO-LWAPP-MOBILITY-MIB::cLMobilityGroupMembersOperControlPathStatus <br> Update: 1min|
+| Mobility Member Status (Data)        |-| SNMP Agent | CISCO-LWAPP-MOBILITY-MIB::cLMobilityGroupMembersOperControlPathStatus  <br> Update: 1min |
+| Rouge AP Count                       |-| SNMP Agent | AIRESPACE-WIRELESS-MIB::bsnRogueAPDot11MacAddress <br> Update: 15min |
+| Rogue Client Count                   |-| SNMP Agent | AIRESPACE-WIRELESS-MIB::bsnRogueClientDot11MacAddress  <br> Update: 15min|
+| SSID Administrative Status           |-| SNMP Agent | AIRESPACE-WIRELESS-MIB::bsnDot11EssAdminStatus <br> Update: 1min |
+| SSID Number of Clients               |-| SNMP Agent | AIRESPACE-WIRELESS-MIB::bsnDot11EssNumberOfMobileStations <br> Update: 1min|
+| AP diassociation                     |-| SNMP Trap | AIRESPACE-WIRELESS-MIB::bsnAPDisassociated <br> CISCO-LWAPP-AP-MIB::ciscoLwappApAssociated 
+| Channel Changed                      |-| SNMP Trap | AIRESPACE-WIRELESS-MIB::bsnAPCurrentChannelChanged |
+| DFS Radar Detection                  |-| SNMP Trap | AIRESPACE-WIRELESS-MIB::bsnRadarChannelDetected  |
+
+
+##  Triggers
+| Name | Description | Expression | Priority |
+| ------- | -------| -------| -------|
+|AP Name: {{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.2\.1\.1\.3\..*\=\s(.*)",\1)} Disjoined|Problem trigger TrapOID<br>AIRESPACE-WIRELESS-MIB::bsnAPDisassociated<br><br>Recovery trigger TrapOID<br>CISCO-LWAPP-AP-MIB::ciscoLwappApAssociated<br><br>Tag "APNAME" from<br>AIRESPACE-WIRELESS-MIB::bsnAPName (problem)<br>CISCO-LWAPP-AP-MIB::cLApName (recovery)|<b>Problem expression</b><br>find(/Cisco Catalyst 9800 by SNMP/snmptrap[SNMPv2-SMI::enterprises.14179.2.6.3.8$\|SNMPv2-SMI::enterprises.9.9.513.0.4$],,"regexp","14179.2.6.3.8")=1<br><br><b>Recovery expression</b><br>find(/Cisco Catalyst 9800 by SNMP/snmptrap[SNMPv2-SMI::enterprises.14179.2.6.3.8$\|SNMPv2-SMI::enterprises.9.9.513.0.4$],,"regexp","9.9.513.0.4")=1| Warning|
+|Channel Updated Trap on {{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.2\.1\.1\.3\..*\=\s(.*)",\1)} Primaly Channel: {{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.6\.2\.23\..*\=\s(.*)",\1)} [^2]|AIRESPACE-WIRELESS-MIB::bsnAPCurrentChannelChanged<br><br>APNAME<br>AIRESPACE-WIRELESS-MIB::bsnAPName<br><br>find(/Cisco Catalyst 9800 by SNMP/snmptrap["SNMPv2-SMI::enterprises.14179.2.6.3.16"],86400)=1|<b>Expression</b><br>find(/Cisco Catalyst 9800 by SNMP/snmptrap["SNMPv2-SMI::enterprises.14179.2.6.3.16"],,"like","SNMPv2-SMI::enterprises.14179.2.6.3.16")=1 |Information|
+|DFS Detected on {{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.2\.1\.1\.3\..*\=\s(.*)",\1)} Channel: {{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.2\.2\.1\.4\..*\=\s(.*)",\1)}|Trigger SNMP OID<br>AIRESPACE-WIRELESS-MIB::bsnRadarChannelDetected<br><br>APNAME<br>AIRESPACE-WIRELESS-MIB::bsnAPName<br><br>CHANNEL<br>AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber<br><br>find(/Cisco Catalyst 9800 by SNMP/snmptrap["SNMPv2-SMI::enterprises.14179.2.6.3.81"],86400)=1| <b>Expression</b><br>find(/Cisco Catalyst 9800 by SNMP/snmptrap["SNMPv2-SMI::enterprises.14179.2.6.3.81"],,"like","SNMPv2-SMI::enterprises.14179.2.6.3.81")=1|Information|
+|HA Peer Hotstandby status changed |Track CISCO-LWAPP-HA-MIB::cLHaPeerHotStandbyEvent| <b>Expression</b><br>change(/Cisco Catalyst 9800 by SNMP/cLHaPeerHotStandbyEvent)<>0 |Warning|
+|Maxmimum AP join limit has reached|Trigger<br>CISCO-LWAPP-AP-MIB::cLApGlobalAPConnectCount.0<br>= CISCO-LWAPP-AP-MIB::cLApGlobalMaxApsSupported.0|<b>Expression</b><br>last(/Cisco Catalyst 9800 by SNMP/cLApGlobalAPConnectCount)=last(/Cisco Catalyst 9800 by SNMP/cLApGlobalMaxApsSupported)|Average|
+|AP Operation Status changed {#APNAME} |This is tracking AIRESPACE-WIRELESS-MIB::bsnAPOperationStatus.<br>It will be useful when SNMP trap is not used.|<b>Problem expression</b><br>last(/Cisco Catalyst 9800 by SNMP/bsnAPOperationStatus[{#APNAME}])=2 and last(/Cisco Catalyst 9800 by SNMP/bsnAPOperationStatus[{#APNAME}],#1)<>last(/Cisco Catalyst 9800 by SNMP/bsnAPOperationStatus[{#APNAME}],#2)<br><br><b>Recovery expression</b><br>find(/Cisco Catalyst 9800 by SNMP/bsnAPOperationStatus[{#APNAME}],3,,"1")=1|Warning|
+|Channel Updated on {#APNAME} |This is tracking AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber. <br>This trigger can catch channel update of both manual channel assignment and auto assignment. |<b>Problem expression</b><br>(nodata(/Cisco Catalyst 9800 by SNMP/bsnAPIfPhyChannelNumber-24ghz-[{#APNAME}],900)=0 <br>or<br>nodata(/Cisco Catalyst 9800 by SNMP/bsnAPIfPhyChannelNumber-cLApExtensionChannels-5ghz-[{#APNAME}],900)=0)<br><br>and<br><br>(change(/Cisco Catalyst 9800 by SNMP/bsnAPIfPhyChannelNumber-24ghz-[{#APNAME}])<>0<br>or<br>change(/Cisco Catalyst 9800 by SNMP/bsnAPIfPhyChannelNumber-cLApExtensionChannels-5ghz-[{#APNAME}])<>0)|Information|
+|Mobility Peer status down [{#MOBILITYPEER}]|Tracking CISCO-LWAPP-MOBILITY-MIB::cLMobilityGroupMembersOperControlPathStatus|<b>Problem expression</b><br>last(/Cisco Catalyst 9800 by SNMP/cLMobilityGroupMembersOperControlPathStatus[{#MOBILITYPEER}])=2<br>and<br>(last(/Cisco Catalyst 9800 by SNMP/cLMobilityGroupMembersOperControlPathStatus[{#MOBILITYPEER}],#1)<>last(/Cisco Catalyst 9800 by SNMP/cLMobilityGroupMembersOperControlPathStatus[{#MOBILITYPEER}],#2))<br><br><b>Recovery expression</b><br>find(/Cisco Catalyst 9800 by SNMP/cLMobilityGroupMembersOperControlPathStatus[{#MOBILITYPEER}],600,,"1")=1|Warning|
+
+[^2]: trigger is disabled as default

--- a/Network_Devices/Cisco/template_cisco_9800/template-cisco-9800.yaml
+++ b/Network_Devices/Cisco/template_cisco_9800/template-cisco-9800.yaml
@@ -1,0 +1,637 @@
+zabbix_export:
+  version: '6.0'
+  date: '2024-05-17T11:31:38Z'
+  groups:
+    - uuid: 7df96b18c230490a9a0a9e2307226333
+      name: Templates
+  templates:
+    - uuid: 1903846af2b84ce987d390c869593a12
+      template: 'Cisco Catalyst 9800 by SNMP'
+      name: 'Cisco Catalyst 9800 by SNMP'
+      description: |
+        Zabbix template for Cisco Catalyst 9800 series wireless controller.
+        Needs IOS-XE 17.11 or later software image to get some of the SNMP MIBs on this template.
+        Tested on IOS-XE 17.12.3 and Zabbix 6.0.29 LTS.
+        
+        This template focuses on wireless-related statuses like AP association, AP channel, or wireless client per SSID.
+        Use the "Cisco IOS by SNMP" template to get general IOS-XE statuses like CPU utilization, memory usage, or interface status.
+        
+        This template uses OID and Standard MIB. No need to install vendor MIBs.
+        AIRESPACE-REF-MIB.my
+        AIRESPACE-WIRELESS-CAPABILITY.my
+        AIRESPACE-WIRELESS-MIB.my
+        CISCO-LWAPP-AP-MIB.my
+        CISCO-LWAPP-DOT11-MIB.my
+        CISCO-LWAPP-RF-MIB.my
+        CISCO-LWAPP-TC-MIB.my
+        CISCO-LWAPP-WLAN-MIB.my
+        CISCO-SMI.my
+        CISCO-TC.my
+        ENTITY-MIB.my
+        Please refer to the below MIBs for what information OID can take.
+        https://github.com/cisco/cisco-mibs
+      groups:
+        - name: Templates
+      items:
+        - uuid: dd2ff6f63c9d40d5b61ee3a6d42cd864
+          name: 'Rogue AP Count'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#ROGUEAP},1.3.6.1.4.1.14179.2.1.7.1.1]'
+          key: bsnRogueAPEntry
+          delay: 15m
+          description: |
+            AIRESPACE-WIRELESS-MIB::bsnRogueAPDot11MacAddress
+            Count # of RogueAP
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var obj = JSON.parse(value);
+                  // Return the number of rows in the array
+                  return obj.length;
+          tags:
+            - tag: component
+              value: network
+        - uuid: 936063a57ef54d5597883906df8486bf
+          name: 'Rogue Client Count'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#ROGUECLIENT},1.3.6.1.4.1.14179.2.1.14.1.1]'
+          key: bsnRogueClientEntry
+          delay: 15m
+          description: |
+            AIRESPACE-WIRELESS-MIB::bsnRogueClientDot11MacAddress
+            Count # of RogueClient
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var obj = JSON.parse(value);
+                  // Return the number of rows in the array
+                  return obj.length;
+          tags:
+            - tag: component
+              value: network
+        - uuid: af4c43cb6b9d4be19345fa58a6ffcb58
+          name: 'Inventory - Current Number of AP'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.9.9.513.1.3.35.0
+          key: cLApGlobalAPConnectCount
+          description: 'CISCO-LWAPP-AP-MIB::cLApGlobalAPConnectCount.0'
+          tags:
+            - tag: Application
+              value: Inventory
+        - uuid: c28ec71ee39045c7aa6214bd4c7a03b3
+          name: 'Inventory - Number of APs Supported'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.9.9.513.1.3.28.0
+          key: cLApGlobalMaxApsSupported
+          delay: 1h
+          description: 'CISCO-LWAPP-AP-MIB::cLApGlobalMaxApsSupported.0'
+          tags:
+            - tag: Application
+              value: Inventory
+        - uuid: c57d7bbeb4ad4eb390c7eaa4bc639f05
+          name: 'HA Peer Hotstandby Status'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.9.9.843.1.3.4.0
+          key: cLHaPeerHotStandbyEvent
+          description: 'CISCO-LWAPP-HA-MIB::cLHaPeerHotStandbyEvent'
+          valuemap:
+            name: 'CISCO-LWAPP-HA-MIB::cLHaPeerHotStandbyEvent'
+          tags:
+            - tag: component
+              value: network
+          triggers:
+            - uuid: ee2b5e036c8d45d298b504b0e09bbe59
+              expression: 'change(/Cisco Catalyst 9800 by SNMP/cLHaPeerHotStandbyEvent)<>0'
+              name: 'HA Peer Hotstandby status changed'
+              priority: WARNING
+              description: 'Track CISCO-LWAPP-HA-MIB::cLHaPeerHotStandbyEvent'
+              manual_close: 'YES'
+        - uuid: 719ce1427daf4b8d8731b4b3bfa6b3cc
+          name: 'SNMP Trap - Channel Changed'
+          type: SNMP_TRAP
+          key: 'snmptrap["SNMPv2-SMI::enterprises.14179.2.6.3.16"]'
+          delay: '0'
+          history: 2w
+          trends: '0'
+          value_type: LOG
+          description: 'AIRESPACE-WIRELESS-MIB::bsnAPCurrentChannelChanged'
+          tags:
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 868fb423dc94467a936e2e1e0c9c3eaf
+              expression: 'find(/Cisco Catalyst 9800 by SNMP/snmptrap["SNMPv2-SMI::enterprises.14179.2.6.3.16"],,"like","SNMPv2-SMI::enterprises.14179.2.6.3.16")=1'
+              recovery_mode: NONE
+              name: 'Channel Updated Trap on {{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.2\.1\.1\.3\..*\=\s(.*)",\1)} Primaly Channel: {{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.6\.2\.23\..*\=\s(.*)",\1)}'
+              status: DISABLED
+              priority: INFO
+              description: |
+                AIRESPACE-WIRELESS-MIB::bsnAPCurrentChannelChanged
+                
+                APNAME
+                AIRESPACE-WIRELESS-MIB::bsnAPName
+                
+                find(/Cisco Catalyst 9800 by SNMP/snmptrap["SNMPv2-SMI::enterprises.14179.2.6.3.16"],86400)=1
+              manual_close: 'YES'
+              tags:
+                - tag: APNAME
+                  value: '{{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.2\.1\.1\.3.*\=\s(.*)",\1)}'
+        - uuid: 786fc58513eb4423879004f71faeb78d
+          name: 'SNMP Trap - RadarChannelDetected'
+          type: SNMP_TRAP
+          key: 'snmptrap["SNMPv2-SMI::enterprises.14179.2.6.3.81"]'
+          delay: '0'
+          trends: '0'
+          value_type: LOG
+          description: 'AIRESPACE-WIRELESS-MIB::bsnRadarChannelDetected'
+          tags:
+            - tag: component
+              value: network
+          triggers:
+            - uuid: c3f611b0ecde4b6da4ca254125f0f08d
+              expression: 'find(/Cisco Catalyst 9800 by SNMP/snmptrap["SNMPv2-SMI::enterprises.14179.2.6.3.81"],,"like","SNMPv2-SMI::enterprises.14179.2.6.3.81")=1'
+              recovery_mode: NONE
+              name: 'DFS Detected on {{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.2\.1\.1\.3\..*\=\s(.*)",\1)} Channel: {{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.2\.2\.1\.4\..*\=\s(.*)",\1)}'
+              priority: INFO
+              description: |
+                Trigger SNMP OID
+                AIRESPACE-WIRELESS-MIB::bsnRadarChannelDetected
+                
+                APNAME
+                AIRESPACE-WIRELESS-MIB::bsnAPName
+                
+                CHANNEL
+                AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber
+                
+                find(/Cisco Catalyst 9800 by SNMP/snmptrap["SNMPv2-SMI::enterprises.14179.2.6.3.81"],86400)=1
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                - tag: APNAME
+                  value: '{{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.2\.1\.1\.3.*\=\s(.*)",\1)}'
+                - tag: CHANNEL
+                  value: '{{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.2\.2\.1\.4\..*\=\s(.*)",\1)}'
+        - uuid: 21ed5acca9f747fcb84084311c964f27
+          name: 'SNMP Trap - AP disassociation'
+          type: SNMP_TRAP
+          key: 'snmptrap[SNMPv2-SMI::enterprises.14179.2.6.3.8$|SNMPv2-SMI::enterprises.9.9.513.0.4$]'
+          delay: '0'
+          history: 2w
+          trends: '0'
+          value_type: LOG
+          description: |
+            AIRESPACE-WIRELESS-MIB::bsnAPDisassociated
+            CISCO-LWAPP-AP-MIB::ciscoLwappApAssociated
+          tags:
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 0eaba496846642cab39f3451fdce776a
+              expression: 'find(/Cisco Catalyst 9800 by SNMP/snmptrap[SNMPv2-SMI::enterprises.14179.2.6.3.8$|SNMPv2-SMI::enterprises.9.9.513.0.4$],,"regexp","14179\.2\.6\.3\.8")=1'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'find(/Cisco Catalyst 9800 by SNMP/snmptrap[SNMPv2-SMI::enterprises.14179.2.6.3.8$|SNMPv2-SMI::enterprises.9.9.513.0.4$],,"regexp","9\.9\.513\.0\.4")=1'
+              correlation_mode: TAG_VALUE
+              correlation_tag: APNAME
+              name: 'AP Name: {{ITEM.VALUE}.regsub("SNMPv2\-SMI\:\:enterprises\.14179\.2\.2\.1\.1\.3\..*\=\s(.*)",\1)} Disjoined'
+              priority: WARNING
+              description: |
+                Problem trigger TrapOID
+                AIRESPACE-WIRELESS-MIB::bsnAPDisassociated
+                
+                Recovery trigger TrapOID
+                CISCO-LWAPP-AP-MIB::ciscoLwappApAssociated
+                
+                Tag "APNAME" from
+                AIRESPACE-WIRELESS-MIB::bsnAPName (problem)
+                CISCO-LWAPP-AP-MIB::cLApName (recovery)
+              type: MULTIPLE
+              manual_close: 'YES'
+              tags:
+                - tag: APNAME
+                  value: '{{ITEM.VALUE}.regsub(".*\.1\.1.*\=\s\"(.*)\"$",\1)}'
+      discovery_rules:
+        - uuid: 25285293f80b4aa6bb473da008620040
+          name: bsnAPTable
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#APNAME},1.3.6.1.4.1.14179.2.2.1.1.3,{#APOPERATIONSTATUS},1.3.6.1.4.1.14179.2.2.1.1.6]'
+          key: bsnAPEntry
+          delay: 1h
+          description: |
+            AP Name
+            AIRESPACE-WIRELESS-MIB::bsnAPName
+            
+            AP Operation Status
+            AIRESPACE-WIRELESS-MIB::bsnAPOperationStatus
+          item_prototypes:
+            - uuid: 419f589f041243d9ac2212cea89b9b4f
+              name: 'ChannelUtilization {#APNAME} 5GHz'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.14179.2.2.13.1.3.{#SNMPINDEX}.1'
+              key: 'bsnAPIfLoadChannelUtilization-5ghz-[{#APNAME}]'
+              delay: 15m
+              units: '%'
+              description: 'AIRESPACE-WIRELESS-MIB::bsnAPIfLoadChannelUtilization for 5GHz'
+              tags:
+                - tag: component
+                  value: 'access point'
+            - uuid: c0a3a8bc2e53441594572d30b7aa1cef
+              name: 'ChannelUtilization {#APNAME} 2.4GHz'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.14179.2.2.13.1.3.{#SNMPINDEX}.0'
+              key: 'bsnAPIfLoadChannelUtilization-24ghz-[{#APNAME}]'
+              delay: 15m
+              units: '%'
+              description: 'AIRESPACE-WIRELESS-MIB::bsnAPIfLoadChannelUtilization for 2.4GHz'
+              tags:
+                - tag: component
+                  value: 'access point'
+            - uuid: fc03582a7aec47d69c4f918fc7abaf65
+              name: 'PrimaryChannelNumber {#APNAME} 5GHz'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.14179.2.2.2.1.4.{#SNMPINDEX}.1'
+              key: 'bsnAPIfPhyChannelNumber-5ghz-[{#APNAME}]'
+              delay: 15m
+              trends: '0'
+              value_type: CHAR
+              description: |
+                AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber for 5GHz
+                It shows only primary channel under channel bonding
+              tags:
+                - tag: component
+                  value: 'access point'
+            - uuid: f9628cb3fbf846489fbba95fe15e7c5d
+              name: 'ChannelNumber {#APNAME} 2.4GHz'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.14179.2.2.2.1.4.{#SNMPINDEX}.0'
+              key: 'bsnAPIfPhyChannelNumber-24ghz-[{#APNAME}]'
+              delay: 15m
+              description: 'AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber for 2.4GHz'
+              tags:
+                - tag: component
+                  value: 'access point'
+            - uuid: a702c6d9cab6469b81c655e347f75418
+              name: 'ChannelNumber {#APNAME} 5GHz'
+              type: CALCULATED
+              key: 'bsnAPIfPhyChannelNumber-cLApExtensionChannels-5ghz-[{#APNAME}]'
+              delay: 15m
+              trends: '0'
+              value_type: CHAR
+              params: 'concat(last(//bsnAPIfPhyChannelNumber-5ghz-[{#APNAME}]),last(//cLApExtensionChannels-5ghz-[{#APNAME}]))'
+              description: |
+                AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber + CISCO-LWAPP-AP-MIB::cLApExtensionChannels
+                Join primary channel number and extension channel number.
+            - uuid: 06ed98af57e04333bc165328278e0e53
+              name: 'TxPowerLevel {#APNAME} 5GHz'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.14179.2.2.2.1.6.{#SNMPINDEX}.1'
+              key: 'bsnAPIfPhyTxPowerLevel-5ghz-[{#APNAME}]'
+              delay: 15m
+              description: 'AIRESPACE-WIRELESS-MIB::bsnAPIfPhyTxPowerLevel for 5GHz'
+              tags:
+                - tag: component
+                  value: 'access point'
+            - uuid: a6a7a066df144f22b246b4740aa90f86
+              name: 'TxPowerLevel {#APNAME} 2.4GHz'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.14179.2.2.2.1.6.{#SNMPINDEX}.0'
+              key: 'bsnAPIfPhyTxPowerLevel-24ghz-[{#APNAME}]'
+              delay: 15m
+              description: 'AIRESPACE-WIRELESS-MIB::bsnAPIfPhyTxPowerLevel for 2.4GHz'
+              tags:
+                - tag: component
+                  value: 'access point'
+            - uuid: ede119d1493c46ddabd4e5728dda1fad
+              name: 'OperationStatus {#APNAME}'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.14179.2.2.1.1.6.{#SNMPINDEX}'
+              key: 'bsnAPOperationStatus[{#APNAME}]'
+              delay: 15m
+              trends: '0'
+              value_type: CHAR
+              description: 'AIRESPACE-WIRELESS-MIB::bsnAPOperationStatus'
+              valuemap:
+                name: 'AIRESPACE-WIRELESS-MIB::bsnAPOperationStatus'
+              tags:
+                - tag: component
+                  value: 'access point'
+              trigger_prototypes:
+                - uuid: b626183cc6f14afb8e8603fa9401c78d
+                  expression: |
+                    last(/Cisco Catalyst 9800 by SNMP/bsnAPOperationStatus[{#APNAME}])=2
+                    and
+                    last(/Cisco Catalyst 9800 by SNMP/bsnAPOperationStatus[{#APNAME}],#1)<>last(/Cisco Catalyst 9800 by SNMP/bsnAPOperationStatus[{#APNAME}],#2)
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'find(/Cisco Catalyst 9800 by SNMP/bsnAPOperationStatus[{#APNAME}],3,,"1")=1'
+                  correlation_mode: TAG_VALUE
+                  correlation_tag: APNAME
+                  name: 'AP Operation Status changed {#APNAME}'
+                  priority: WARNING
+                  description: |
+                    This is tracking AIRESPACE-WIRELESS-MIB::bsnAPOperationStatus.
+                    It will be useful when SNMP trap is not used.
+                    
+                    
+                    change(/Cisco Catalyst 9800 by SNMP/bsnAPOperationStatus[{#APNAME}])<>0
+                  manual_close: 'YES'
+                  tags:
+                    - tag: APNAME
+                      value: '{#APNAME}'
+            - uuid: 14bfeb82c030437499207667eebe548e
+              name: 'APSerialNumber {#APNAME}'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.14179.2.2.1.1.17.{#SNMPINDEX}'
+              key: 'bsnAPSerialNumber-[{#APNAME}]'
+              delay: 24h
+              trends: '0'
+              value_type: CHAR
+              description: 'AIRESPACE-WIRELESS-MIB::bsnAPSerialNumber'
+              tags:
+                - tag: component
+                  value: 'access point'
+            - uuid: 332aab416dff499491b04b6364c005e0
+              name: 'APSoftwareVersion {#APNAME}'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.14179.2.2.1.1.8.{#SNMPINDEX}'
+              key: 'bsnAPSoftwareVersion[{#APNAME}]'
+              delay: 1h
+              trends: '0'
+              value_type: CHAR
+              description: 'AIRESPACE-WIRELESS-MIB::bsnAPSoftwareVersion'
+              tags:
+                - tag: component
+                  value: 'access point'
+            - uuid: 6754ef4caa16401580a4a34ff947ce96
+              name: 'ChannelBandwidth {#APNAME} 5GHz'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.9.9.513.1.2.1.1.23.{#SNMPINDEX}.1'
+              key: 'cLAp11ChannelBandwidth-5ghz-[{#APNAME}]'
+              delay: 15m
+              description: 'CISCO-LWAPP-AP-MIB::cLAp11ChannelBandwidth for 5GHz'
+              valuemap:
+                name: 'CISCO-LWAPP-AP-MIB::cLAp11ChannelBandwidth'
+              tags:
+                - tag: component
+                  value: 'access point'
+            - uuid: ef5e15a5b609485780da69c108a9b6ff
+              name: 'ExtentionChannel {#APNAME} 5GHz'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.9.9.513.1.2.1.1.24.{#SNMPINDEX}.1'
+              key: 'cLApExtensionChannels-5ghz-[{#APNAME}]'
+              delay: 15m
+              trends: '0'
+              value_type: CHAR
+              description: 'CISCO-LWAPP-AP-MIB::cLApExtensionChannels'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      if (value === '') {
+                        return value;
+                      } else {
+                        value = "," + value;
+                        return value;
+                      }
+                      
+              tags:
+                - tag: component
+                  value: 'access point'
+          trigger_prototypes:
+            - uuid: 5e57bb3c238d4e9abbf3f8dd230136fb
+              expression: |
+                (nodata(/Cisco Catalyst 9800 by SNMP/bsnAPIfPhyChannelNumber-24ghz-[{#APNAME}],900)=0
+                or
+                nodata(/Cisco Catalyst 9800 by SNMP/bsnAPIfPhyChannelNumber-cLApExtensionChannels-5ghz-[{#APNAME}],900)=0)
+                
+                
+                
+                and
+                
+                (change(/Cisco Catalyst 9800 by SNMP/bsnAPIfPhyChannelNumber-24ghz-[{#APNAME}])<>0
+                or
+                change(/Cisco Catalyst 9800 by SNMP/bsnAPIfPhyChannelNumber-cLApExtensionChannels-5ghz-[{#APNAME}])<>0)
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: |
+                changecount(/Cisco Catalyst 9800 by SNMP/bsnAPIfPhyChannelNumber-24ghz-[{#APNAME}],3600)=0
+                and
+                changecount(/Cisco Catalyst 9800 by SNMP/bsnAPIfPhyChannelNumber-cLApExtensionChannels-5ghz-[{#APNAME}],3600)=0
+              name: 'Channel Updated on {#APNAME}'
+              priority: INFO
+              description: |
+                This is tracking AIRESPACE-WIRELESS-MIB::bsnAPIfPhyChannelNumber.
+                It will useful when SNMP trap is not used.
+                This trigger can catch channel update of both manual channel assignment and auto assignment.
+              manual_close: 'YES'
+              tags:
+                - tag: APNAME
+                  value: '{#APNAME}'
+        - uuid: 38ff4c1e53b04ce5a3d18a8f1a086b89
+          name: cLMobilityGroupMembersOperEntry
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#MOBILITYPEER},1.3.6.1.4.1.9.9.576.1.9.1.2]'
+          key: cLMobilityGroupMembersOperEntry
+          delay: 1h
+          description: |
+            CISCO-LWAPP-MOBILITY-MIB::cLMobilityGroupMembersOperEntry
+            CISCO-LWAPP-MOBILITY-MIB::cLMobilityGroupMembersOperNodeAddress
+          item_prototypes:
+            - uuid: 8236d6435aba480e8bca7977836d5b3c
+              name: 'MobilityGroupMembersOperControlPathStatus [{#MOBILITYPEER}]'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.9.9.576.1.9.1.5.{#SNMPINDEX}'
+              key: 'cLMobilityGroupMembersOperControlPathStatus[{#MOBILITYPEER}]'
+              description: 'CISCO-LWAPP-MOBILITY-MIB::cLMobilityGroupMembersOperControlPathStatus'
+              valuemap:
+                name: cLMobilityGroupMembersOperPathStatus
+              trigger_prototypes:
+                - uuid: d97a723cdb1546609c462521d0415a7d
+                  expression: |
+                    last(/Cisco Catalyst 9800 by SNMP/cLMobilityGroupMembersOperControlPathStatus[{#MOBILITYPEER}])=2
+                    and
+                    (last(/Cisco Catalyst 9800 by SNMP/cLMobilityGroupMembersOperControlPathStatus[{#MOBILITYPEER}],#1)<>last(/Cisco Catalyst 9800 by SNMP/cLMobilityGroupMembersOperControlPathStatus[{#MOBILITYPEER}],#2))
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'find(/Cisco Catalyst 9800 by SNMP/cLMobilityGroupMembersOperControlPathStatus[{#MOBILITYPEER}],600,,"1")=1'
+                  correlation_mode: TAG_VALUE
+                  correlation_tag: PEER
+                  name: 'Mobility Peer status down [{#MOBILITYPEER}]'
+                  priority: WARNING
+                  description: |
+                    Tracking 
+                    CISCO-LWAPP-MOBILITY-MIB::cLMobilityGroupMembersOperControlPathStatus
+                  manual_close: 'YES'
+                  tags:
+                    - tag: PEER
+                      value: '[{#MOBILITYPEER}]'
+            - uuid: 928e5a3c779f429e9b182567fa44e040
+              name: 'MobilityGroupMembersOperDataPathStatus [{#MOBILITYPEER}]'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.9.9.576.1.9.1.4.{#SNMPINDEX}'
+              key: 'cLMobilityGroupMembersOperDataPathStatus[{#MOBILITYPEER}]'
+              description: 'CISCO-LWAPP-MOBILITY-MIB::cLMobilityGroupMembersOperControlPathStatus'
+              valuemap:
+                name: cLMobilityGroupMembersOperPathStatus
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Parse the JSON string to convert it into a JavaScript object
+                  var obj = JSON.parse(value);
+                  
+                  // Function to convert hexadecimal to decimal and format it as an IPv4 address
+                  function hexToIpv4Address(hexString) {
+                    // Remove spaces and split the hexadecimal string into an array
+                    var hexArray = hexString.trim().split(' ');
+                  
+                    // Convert each hexadecimal value to decimal and format it as an IPv4 address
+                    var decimalArray = [];
+                    for (var i = 0; i < hexArray.length; i++) {
+                      decimalArray.push(parseInt(hexArray[i], 16));
+                    }
+                  
+                    // Convert the array of numbers to an IPv4 address string
+                    var ipAddress = decimalArray.join('.');
+                    return ipAddress;
+                  }
+                  
+                  // Function to convert hexadecimal to an IPv6 address format
+                  function hexToIpv6Address(hexString) {
+                    // Remove spaces and split the hexadecimal string into an array
+                    var hexArray = hexString.trim().split(' ');
+                  
+                    // Convert each hexadecimal value to a 2-digit hexadecimal string and pair them
+                    var pairs = [];
+                    for (var i = 0; i < hexArray.length; i += 2) {
+                      pairs.push(hexArray[i] + hexArray[i + 1]);
+                    }
+                  
+                    // Join the pairs with colons to format as an IPv6 address
+                    var ipv6Address = pairs.join(':');
+                    return ipv6Address;
+                  }
+                  
+                  // Function to determine if the input is IPv4 or IPv6
+                  function isIpv4(hexString) {
+                    // If the array length is 4, it's IPv4; if longer, it's IPv6
+                    var hexArray = hexString.trim().split(' ');
+                    return hexArray.length === 4;
+                  }
+                  
+                  // Convert {#MOBILITYPEER} of each element to the appropriate IP address format
+                  for (var i = 0; i < obj.length; i++) {
+                    if (isIpv4(obj[i]["{#MOBILITYPEER}"])) {
+                      obj[i]["{#MOBILITYPEER}"] = hexToIpv4Address(obj[i]["{#MOBILITYPEER}"]);
+                    } else {
+                      obj[i]["{#MOBILITYPEER}"] = hexToIpv6Address(obj[i]["{#MOBILITYPEER}"]);
+                    }
+                  }
+                  
+                  // Convert the object back to a JSON string and return it
+                  return JSON.stringify(obj);
+                  
+        - uuid: 5847c3ef43a849f0930943331339ecb2
+          name: cLWlanSsid
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},1.3.6.1.4.1.9.9.512.1.1.1.1.4]'
+          key: cLWlanSsid
+          delay: 1h
+          description: 'CISCO-LWAPP-WLAN-MIB::cLWlanSsid'
+          item_prototypes:
+            - uuid: 0995145307004624a54590732c43296d
+              name: 'WLAN - {#SNMPVALUE} Administrative Status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.14179.2.1.1.1.6.{#SNMPINDEX}'
+              key: 'bsnDot11EssAdminStatus-[{#SNMPVALUE}]'
+              trends: '0'
+              value_type: CHAR
+              description: 'AIRESPACE-WIRELESS-MIB::bsnDot11EssAdminStatus'
+              valuemap:
+                name: 'AIRESPACE-WIRELESS-MIB::bsnDot11EssAdminStatus'
+              tags:
+                - tag: component
+                  value: WLAN
+            - uuid: 4fc71ce361cc40cd84f5fc8a24745118
+              name: 'WLAN - {#SNMPVALUE} Number of Clients'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.14179.2.1.1.1.38.{#SNMPINDEX}'
+              key: 'bsnDot11EssNumberOfMobileStations-[{#SNMPVALUE}]'
+              description: 'AIRESPACE-WIRELESS-MIB::bsnDot11EssNumberOfMobileStations'
+              tags:
+                - tag: component
+                  value: WLAN
+          graph_prototypes:
+            - uuid: 2171914368f8429f94afb9927a81e195
+              name: 'WLAN - {#SNMPVALUE} Number of Clients'
+              graph_items:
+                - color: 0080FF
+                  item:
+                    host: 'Cisco Catalyst 9800 by SNMP'
+                    key: 'bsnDot11EssNumberOfMobileStations-[{#SNMPVALUE}]'
+      tags:
+        - tag: class
+          value: network
+        - tag: target
+          value: cisco
+        - tag: target
+          value: cisco-catalyst-9800
+      valuemaps:
+        - uuid: fe4c43a2da0c4068bc37c9d7e6a029fb
+          name: 'AIRESPACE-WIRELESS-MIB::bsnAPOperationStatus'
+          mappings:
+            - value: '1'
+              newvalue: associated
+            - value: '2'
+              newvalue: disassociating
+            - value: '3'
+              newvalue: downloading
+        - uuid: 4af351ff6288425da85693782199c489
+          name: 'AIRESPACE-WIRELESS-MIB::bsnDot11EssAdminStatus'
+          mappings:
+            - value: '0'
+              newvalue: disable
+            - value: '1'
+              newvalue: enable
+        - uuid: 1bcf503cacf2469c87640f3644dcef46
+          name: 'CISCO-LWAPP-AP-MIB::cLAp11ChannelBandwidth'
+          mappings:
+            - value: '1'
+              newvalue: 5MHz
+            - value: '2'
+              newvalue: 10MHz
+            - value: '3'
+              newvalue: 20MHz
+            - value: '4'
+              newvalue: 40MHz
+            - value: '5'
+              newvalue: 80MHz
+            - value: '6'
+              newvalue: 160MHz
+            - value: '7'
+              newvalue: 80MHz+80MHz
+        - uuid: c7ced9cfc6274ebebf457e30d9561cde
+          name: 'CISCO-LWAPP-HA-MIB::cLHaPeerHotStandbyEvent'
+          mappings:
+            - value: '0'
+              newvalue: none
+            - value: '1'
+              newvalue: 'HA Peer Hotstandby'
+        - uuid: c005b50e977241eca3718c37e3089232
+          name: cLMobilityGroupMembersOperPathStatus
+          mappings:
+            - value: '1'
+              newvalue: up
+            - value: '2'
+              newvalue: down
+  triggers:
+    - uuid: 73b1509a8f1d46788cceab95c91b9dff
+      expression: 'last(/Cisco Catalyst 9800 by SNMP/cLApGlobalAPConnectCount)=last(/Cisco Catalyst 9800 by SNMP/cLApGlobalMaxApsSupported)'
+      name: 'Maxmimum AP join limit has reached'
+      priority: AVERAGE
+      description: |
+        Trigger
+        CISCO-LWAPP-AP-MIB::cLApGlobalAPConnectCount.0
+        = CISCO-LWAPP-AP-MIB::cLApGlobalMaxApsSupported.0
+      manual_close: 'YES'
+      tags:
+        - tag: scope
+          value: capacity


### PR DESCRIPTION
### Overview
This pull request adds a template for Cisco Catalyst 9800 series wireless LAN controller

### What it is?
- SNMP based template for Cisco Catalyst 9800 series wireless LAN controller
- It covers wireless monitoring like Wireless Client Count, AP Count, Radio utilization, Mobility tunnel status, and High Availability status. 
- It relies "Cisco IOS by SNMP" template or others to get general IOS-XE status like CPU utilization, Memory usage, or interface status.

### Background
- Current Zabbix templates including user community support either legacy AireOS based Wireless Controller, Meraki or just for IOS-XE like interface stats.
- Current generation Cisco wireless controller is not monitored via Zabbix from wireless point of view, because some of SNMP MIBs changed from AireOS

### Target Zabbix version
- 6.0 and later (tested on 6.0.29)

### Testing
I tested this template on my environment below.
- Cisco IOS Software [Dublin], C9800 Software (C9800_IOSXE-K9), Version 17.12.3, RELEASE SOFTWARE (fc7)
- C9800-L-F-K9
- C9800-CL-K9
- Zabbix 6.0.29


### Note
I updated it to my personal github repository.
If this is merged, it will move to archived. 