### PR TITLE
Add new template for fortinet fortiswitch

### DIFF
--- a/Network_Devices/Fortinet/FortiSwitch/template_fortinet_fortiswitch/7.0/README.md
+++ b/Network_Devices/Fortinet/FortiSwitch/template_fortinet_fortiswitch/7.0/README.md
@@ -1,0 +1,111 @@
+Fortinet FortiSwitch by SNMP
+## Overview
+
+Fortinet FortiSwitch integration for Zabbix 7.0.
+
+May also work with Zabbix 6.4 because it is using the new walk[] master and dependent items logic, but have not tested yet.
+
+Monitors:
+- OS version
+- Serial number
+- ICMP checks
+- System name, location, object ID etc
+- Network interfaces
+- CPU & Memory
+
+## Author
+
+Christos Diamantis - christos.diamantis@outlook.com
+
+## Macros used
+
+|Name|Description|Default|Type|
+|----|-----------|----|----|
+|{$CPU.UTILIZATION.CRIT}|<p>-</p>|`70`|Text macro|
+|{$CPU.UTILIZATION.WARN}|<p>-</p>|`50`|Text macro|
+|{$MEM.UTILIZATION.CRIT}|<p>-</p>|`80`|Text macro|
+|{$MEM.UTILIZATION.WARN}|<p>-</p>|`60`|Text macro|
+|{$NET.IF.IFADMINSTATUS.MATCHES}|<p>-</p>|`^.*`|Text macro|
+|{$NET.IF.IFADMINSTATUS.NOT_MATCHES}|Ignore down(2) administrative status|`^2$`|Text macro|
+|{$NET.IF.IFALIAS.MATCHES}|<p>-</p>|`.*`|Text macro|
+|{$NET.IF.IFALIAS.NOT_MATCHES}|<p>-</p>|`CHANGE_IF_NEEDED`|Text macro|
+|{$NET.IF.IFDESCR.MATCHES}|<p>-</p>|`.*`|Text macro|
+|{$NET.IF.IFDESCR.NOT_MATCHES}|<p>-</p>|`CHANGE_IF_NEEDED`|Text macro|
+|{$NET.IF.IFNAME.MATCHES}|<p>-</p>|`^.*$`|Text macro|
+|{$NET.IF.IFNAME.NOT_MATCHES}|Filter out loopbacks, nulls, docker veth links and docker0 bridge by default|`(^Software Loopback Interface\|^NULL[0-9.]*$\|^[Ll]o[0-9.]*$\|^[Ss]ystem$\|^Nu[0-9.]*$\|^veth[0-9a-z]+$\|docker[0-9]+\|br-[a-z0-9]{12}\|^quarantine.*$\|^onboarding.*$\|^naf.root.*$\|^nac_segment.*$\|^l2t.root.*$\|^_default.*$)`|Text macro|
+|{$NET.IF.IFOPERSTATUS.MATCHES}|<p>-</p>|`^.*$`|Text macro|
+|{$NET.IF.IFOPERSTATUS.NOT_MATCHES}|Ignore notPresent(6)|`^6$`|Text macro|
+|{$NET.IF.IFTYPE.MATCHES}|<p>-</p>|`.*`|Text macro|
+|{$NET.IF.IFTYPE.NOT_MATCHES}|<p>-</p>|`CHANGE_IF_NEEDED`|Text macro|
+|{$SNMP_TIMEOUT}|<p>-</p>|`5m`|Text macro|
+
+## Template links
+
+There are no template links in this template
+
+## Discovery rules
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|Network interfaces discovery|Discovering interfaces from IF-MIB.|SNMP_AGENT|net.if.discovery|
+|EtherLike discovery|Discovering interfaces from IF-MIB and EtherLike-MIB. Interfaces with up(1) Operational Status are discovered.|SNMP_AGENT|net.if.duplex.discovery|
+
+## Items collected
+
+|Name|Description|Type|Key and additonal info|
+|----|-----------|----|----|
+|CPU Usage|<p>LLD</p>|`SNMP_AGENT`|fsw.cpu.usage|
+|Memory total|<p>LLD</p>|`SNMP_AGENT`|fsw.mem.total|
+|Memory used|<p>LLD</p>|`SNMP_AGENT`|fsw.mem.used|
+|Memory utilization|<p>LLD</p>|`CALCULATED`|fsw.mem.utilization|
+|Storage total|<p>LLD</p>|`SNMP_AGENT`|fsw.storage.total|
+|Storage used|<p>LLD</p>|`SNMP_AGENT`|fsw.storage.used|
+|Storage utilization|<p>LLD</p>|`CALCULATED`|fsw.storage.utilization|
+|ICMP ping|<p>LLD</p>|`SIMPLE`|icmpping|
+|ICMP loss|<p>LLD</p>|`SIMPLE`|icmppingloss|
+|ICMP response time|<p>LLD</p>|`SIMPLE`|icmppingsec|
+|SNMP traps (fallback)|Item is used to collect all SNMP traps unmatched by other snmptrap items|`SNMP_TRAP`|snmptrap.fallback|
+|System contact details|MIB: SNMPv2-MIB The textual identification of the contact person for this managed node, together with information on how to contact this person.  If no contact information is known, the value is the zero-length string. |`SNMP_AGENT`|system.contact|
+|System description|MIB: SNMPv2-MIB A textual description of the entity. This value should include the full name and version identification of the system's hardware type, software operating-system, and networking software. |`SNMP_AGENT`|system.descr|
+|Hardware model name|MIB: ENTITY-MIB|`SNMP_AGENT`|system.hw.model|
+|Hardware serial number|MIB: ENTITY-MIB|`SNMP_AGENT`|system.hw.serialnumber|
+|Uptime (hardware)|MIB: HOST-RESOURCES-MIB The amount of time since this host was last initialized. Note that this is different from sysUpTime in the SNMPv2-MIB [RFC1907] because sysUpTime is the uptime of the network management portion of the system. |`SNMP_AGENT`|system.hw.uptime|
+|System location|MIB: SNMPv2-MIB The physical location of this node (e.g., `telephone closet, 3rd floor').  If the location is unknown, the value is the zero-length string. |`SNMP_AGENT`|system.location|
+|System name|MIB: SNMPv2-MIB An administratively-assigned name for this managed node.By convention, this is the node's fully-qualified domain name.  If the name is unknown, the value is the zero-length string. |`SNMP_AGENT`|system.name|
+|Uptime (network)|MIB: SNMPv2-MIB The time (in hundredths of a second) since the network management portion of the system was last re-initialized. |`SNMP_AGENT`|system.net.uptime|
+|System object ID|MIB: SNMPv2-MIB The vendor's authoritative identification of the network management subsystem contained in the entity.  This value is allocated within the SMI enterprises subtree (1.3.6.1.4.1) and provides an easy and unambiguous means for determining`what kind of box' is being managed.  For example, if vendor`Flintstones, Inc.' was assigned the subtree1.3.6.1.4.1.4242, it could assign the identifier 1.3.6.1.4.1.4242.1.1 to its `Fred Router'. |`SNMP_AGENT`|system.objectid|
+|Operating system|<p>LLD</p>|`SNMP_AGENT`|system.sw.os|
+|SNMP agent availability|<p>LLD</p>|`INTERNAL`|zabbix[host,snmp,available]|
+|Interface {#IFNAME}({#IFDESCR}): Inbound packets discarded|MIB: IF-MIB The number of inbound packets which were chosen to be discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol. One possible reason for discarding such a packet could be to free up buffer space. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime. |`SNMP_AGENT`|net.if.in.discards[{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFDESCR}): Inbound packets with errors|MIB: IF-MIB For packet-oriented interfaces, the number of inbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of inbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime. |`SNMP_AGENT`|net.if.in.errors[{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFDESCR}): In utilization|<p>-</p>|`CALCULATED`|net.if.in.util[{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFDESCR}): Bits received|MIB: IF-MIB The total number of octets received on the interface, including framing characters. This object is a 64-bit version of ifInOctets. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime. |`SNMP_AGENT`|net.if.in[{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFDESCR}): Outbound packets discarded|MIB: IF-MIB The number of outbound packets which were chosen to be discarded even though no errors had been detected to prevent their being deliverable to a higher-layer protocol. One possible reason for discarding such a packet could be to free up buffer space. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime. |`SNMP_AGENT`|net.if.out.discards[{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFDESCR}): Outbound packets with errors|MIB: IF-MIB For packet-oriented interfaces, the number of outbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of outbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime. |`SNMP_AGENT`|net.if.out.errors[{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFDESCR}): Out utilization|<p>-</p>|`CALCULATED`|net.if.out.util[{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFDESCR}): Bits sent|MIB: IF-MIB The total number of octets transmitted out of the interface, including framing characters. This object is a 64-bit version of ifOutOctets.Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime. |`SNMP_AGENT`|net.if.out[{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFDESCR}): Speed|MIB: IF-MIB An estimate of the interface's current bandwidth in units of 1,000,000 bits per second. If this object reports a value of `n' then the speed of the interface is somewhere in the range of `n-500,000' to`n+499,999'.  For interfaces which do not vary in bandwidth or for those where no accurate estimation can be made, this object should contain the nominal bandwidth. For a sub-layer which has no concept of bandwidth, this object should be zero. |`SNMP_AGENT`|net.if.speed[{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFDESCR}): Operational status|MIB: IF-MIB The current operational state of the interface. - The testing(3) state indicates that no operational packet scan be passed - If ifAdminStatus is down(2) then ifOperStatus should be down(2) - If ifAdminStatus is changed to up(1) then ifOperStatus should change to up(1) if the interface is ready to transmit and receive network traffic - It should change todormant(5) if the interface is waiting for external actions (such as a serial line waiting for an incoming connection) - It should remain in the down(2) state if and only if there is a fault that prevents it from going to the up(1) state - It should remain in the notPresent(6) state if the interface has missing(typically, hardware) components. |`SNMP_AGENT`|net.if.status[{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFDESCR}): Total utilization|<p>-</p>|`CALCULATED`|net.if.total.util[{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFDESCR}): Interface type|MIB: IF-MIB The type of interface. Additional values for ifType are assigned by the Internet Assigned Numbers Authority (IANA), through updating the syntax of the IANAifType textual convention. |`SNMP_AGENT`|net.if.type[{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFDESCR}): Duplex status|MIB: EtherLike-MIB Object name: dot3StatsDuplexStatus The current mode of operation of the MAC entity.  'unknown' indicates that the current duplex mode could not be determined.  Management control of the duplex mode is accomplished through the MAU MIB.  When an interface does not support autonegotiation, or when autonegotiation is not enabled, the duplex mode is controlled using ifMauDefaultType.  When autonegotiation is supported and enabled, duplex mode is controlled using ifMauAutoNegAdvertisedBits.  In either case, the currently operating duplex mode is reflected both in this object and in ifMauType.  Note that this object provides redundant information with ifMauType.  Normally, redundant objects are discouraged.  However, in this instance, it allows a management application to determine the duplex status of an interface without having to know every possible value of ifMauType.  This was felt to be sufficiently valuable to justify the redundancy. Reference: [IEEE 802.3 Std.], 30.3.1.1.32,aDuplexStatus. |`SNMP_AGENT`|net.if.duplex[{#SNMPINDEX}]<p>LLD</p>|
+
+## Triggers
+
+|Name|Description|Expression|Priority|
+|----|-----------|----|----|
+|High CPU Utilization|<p>-</p>|<p>**Expression**: last(/Fortinet FortiSwitch by SNMP/fsw.cpu.usage)>{$CPU.UTILIZATION.CRIT}</p>|HIGH|
+|High CPU Utilization|<p>-</p>|<p>**Expression**: last(/Fortinet FortiSwitch by SNMP/fsw.cpu.usage)>{$CPU.UTILIZATION.WARN}</p>|WARNING|
+|High Memory Utilization|<p>-</p>|<p>**Expression**: last(/Fortinet FortiSwitch by SNMP/fsw.mem.utilization)>{$MEM.UTILIZATION.CRIT}</p>|HIGH|
+|High Memory Utilization|<p>-</p>|<p>**Expression**: last(/Fortinet FortiSwitch by SNMP/fsw.mem.utilization)>{$MEM.UTILIZATION.WARN}</p>|WARNING|
+|High Storage Utilization|<p>-</p>|<p>**Expression**: last(/Fortinet FortiSwitch by SNMP/fsw.storage.utilization)>=90</p>|HIGH|
+|Unavailable by ICMP ping|Last three attempts returned timeout.  Please check device connectivity.|<p>**Expression**: max(/Fortinet FortiSwitch by SNMP/icmpping,#3)=0</p>|HIGH|
+|High ICMP ping loss|<p>-</p>|<p>**Expression**: min(/Fortinet FortiSwitch by SNMP/icmppingloss,5m)>{$ICMP_LOSS_WARN} and min(/Fortinet FortiSwitch by SNMP/icmppingloss,5m)<100</p>|WARNING|
+|High ICMP ping response time|<p>-</p>|<p>**Expression**: avg(/Fortinet FortiSwitch by SNMP/icmppingsec,5m)>{$ICMP_RESPONSE_TIME_WARN}</p>|WARNING|
+|Device has been replaced|Device serial number has changed. Ack to close|<p>**Expression**: last(/Fortinet FortiSwitch by SNMP/system.hw.serialnumber,#1)<>last(/Fortinet FortiSwitch by SNMP/system.hw.serialnumber,#2) and length(last(/Fortinet FortiSwitch by SNMP/system.hw.serialnumber))>0</p>|INFO|
+|System name has changed|System name has changed. Ack to close.|<p>**Expression**: last(/Fortinet FortiSwitch by SNMP/system.name,#1)<>last(/Fortinet FortiSwitch by SNMP/system.name,#2) and length(last(/Fortinet FortiSwitch by SNMP/system.name))>0</p>|INFO|
+|Operating system description has changed|Operating system description has changed. Possible reasons that system has been updated or replaced. Ack to close.|<p>**Expression**: last(/Fortinet FortiSwitch by SNMP/system.sw.os,#1)<>last(/Fortinet FortiSwitch by SNMP/system.sw.os,#2) and length(last(/Fortinet FortiSwitch by SNMP/system.sw.os))>0</p>|INFO|
+|No SNMP data collection|SNMP is not available for polling. Please check device connectivity and SNMP settings.|<p>**Expression**: max(/Fortinet FortiSwitch by SNMP/zabbix[host,snmp,available],{$SNMP.TIMEOUT})=0</p>|WARNING|
+|Interface {#IFNAME}({#IFDESCR}): Ethernet has changed to lower speed than it was before|This Ethernet connection has transitioned down from its known maximum speed. This might be a sign of autonegotiation issues. Ack to close.|<p>**Expression**: change(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])<0 and last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])>0 and ( last(/Fortinet FortiSwitch by SNMP/net.if.type[{#SNMPINDEX}])=6 or last(/Fortinet FortiSwitch by SNMP/net.if.type[{#SNMPINDEX}])=7 or last(/Fortinet FortiSwitch by SNMP/net.if.type[{#SNMPINDEX}])=11 or last(/Fortinet FortiSwitch by SNMP/net.if.type[{#SNMPINDEX}])=62 or last(/Fortinet FortiSwitch by SNMP/net.if.type[{#SNMPINDEX}])=69 or last(/Fortinet FortiSwitch by SNMP/net.if.type[{#SNMPINDEX}])=117 ) and (last(/Fortinet FortiSwitch by SNMP/net.if.status[{#SNMPINDEX}])<>2) </p><p>**Recovery expression**: (change(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])>0 and last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}],#2)>0) or (last(/Fortinet FortiSwitch by SNMP/net.if.status[{#SNMPINDEX}])=2) </p>|INFO|
+|Interface {#IFNAME}({#IFDESCR}): High inbound bandwidth usage|The network interface utilization is close to its estimated maximum bandwidth.|<p>**Expression**: (avg(/Fortinet FortiSwitch by SNMP/net.if.in[{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])) and last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])>0 </p><p>**Recovery expression**: avg(/Fortinet FortiSwitch by SNMP/net.if.in[{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])</p>|WARNING|
+|Interface {#IFNAME}({#IFDESCR}): High outbound bandwidth usage|The network interface utilization is close to its estimated maximum bandwidth.|<p>**Expression**: (avg(/Fortinet FortiSwitch by SNMP/net.if.out[{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])) and last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])>0 </p><p>**Recovery expression**: avg(/Fortinet FortiSwitch by SNMP/net.if.out[{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])</p>|WARNING|

--- a/Network_Devices/Fortinet/FortiSwitch/template_fortinet_fortiswitch/7.0/fortiswitch_template.yaml
+++ b/Network_Devices/Fortinet/FortiSwitch/template_fortinet_fortiswitch/7.0/fortiswitch_template.yaml
@@ -1,0 +1,1667 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 36bff6c29af64692839d077febfc7079
+      name: 'Templates/Network devices'
+  templates:
+    - uuid: 3f790ffcac9e4ae4b5613b8640e92c77
+      template: 'Fortinet FortiSwitch by SNMP'
+      name: 'Fortinet FortiSwitch by SNMP'
+      description: |
+        Template for monitoring Fortinet FortiSwitch by SNMP
+        
+        Created by Christos Diamantis
+        christos.diamantis@outlook.com
+      vendor:
+        name: ChristosDiamantis
+        version: 7.0-0
+      groups:
+        - name: 'Templates/Network devices'
+      items:
+        - uuid: ebb4bb8c4b30473382737904c1b06160
+          name: 'CPU Usage'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.12356.106.4.1.2.0
+          key: fsw.cpu.usage
+          units: '%'
+          tags:
+            - tag: component
+              value: cpu
+            - tag: component
+              value: health
+          triggers:
+            - uuid: 91542ce1e74347c4be294021660fbe84
+              expression: 'last(/Fortinet FortiSwitch by SNMP/fsw.cpu.usage)>{$CPU.UTILIZATION.CRIT}'
+              name: 'High CPU Utilization'
+              priority: HIGH
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: health
+            - uuid: 9c5a1d11a9fe40baa86be0428f61deb8
+              expression: 'last(/Fortinet FortiSwitch by SNMP/fsw.cpu.usage)>{$CPU.UTILIZATION.WARN}'
+              name: 'High CPU Utilization'
+              priority: WARNING
+              manual_close: 'YES'
+              dependencies:
+                - name: 'High CPU Utilization'
+                  expression: 'last(/Fortinet FortiSwitch by SNMP/fsw.cpu.usage)>{$CPU.UTILIZATION.CRIT}'
+              tags:
+                - tag: scope
+                  value: health
+        - uuid: 693d1b1c71c74d768acd25896bd26b4b
+          name: 'Memory total'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.12356.106.4.1.4.0
+          key: fsw.mem.total
+          units: B
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: memory
+        - uuid: 77a24eaf7aed4b86abba837154abb4fd
+          name: 'Memory used'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.12356.106.4.1.3.0
+          key: fsw.mem.used
+          units: B
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: memory
+        - uuid: 42942af673f84bc799f6c51acfc4c163
+          name: 'Memory utilization'
+          type: CALCULATED
+          key: fsw.mem.utilization
+          value_type: FLOAT
+          units: '%'
+          params: '100*last(//fsw.mem.used)/last(//fsw.mem.total)'
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: memory
+          triggers:
+            - uuid: 27229ffae9b04675866a8cc23b52b36b
+              expression: 'last(/Fortinet FortiSwitch by SNMP/fsw.mem.utilization)>{$MEM.UTILIZATION.CRIT}'
+              name: 'High Memory Utilization'
+              priority: HIGH
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: health
+            - uuid: 9035734b4fa948f28d8c18f70be64ee6
+              expression: 'last(/Fortinet FortiSwitch by SNMP/fsw.mem.utilization)>{$MEM.UTILIZATION.WARN}'
+              name: 'High Memory Utilization'
+              priority: WARNING
+              manual_close: 'YES'
+              dependencies:
+                - name: 'High Memory Utilization'
+                  expression: 'last(/Fortinet FortiSwitch by SNMP/fsw.mem.utilization)>{$MEM.UTILIZATION.CRIT}'
+              tags:
+                - tag: scope
+                  value: health
+        - uuid: 6c1d0defccb1498b81d2a54764aabba5
+          name: 'Storage total'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.12356.106.4.1.6.0
+          key: fsw.storage.total
+          units: B
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '1000000'
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: storage
+        - uuid: 12dcfb94e94940a2b64df92f5db14ac0
+          name: 'Storage used'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.12356.106.4.1.5.0
+          key: fsw.storage.used
+          units: B
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '1000000'
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: storage
+        - uuid: 7ccbd55f882943248010599cb2fcaa84
+          name: 'Storage utilization'
+          type: CALCULATED
+          key: fsw.storage.utilization
+          value_type: FLOAT
+          units: '%'
+          params: '100*last(//fsw.storage.used)/last(//fsw.storage.total)'
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: storage
+          triggers:
+            - uuid: 540e6408aefc46489a26b526506a2e72
+              expression: 'last(/Fortinet FortiSwitch by SNMP/fsw.storage.utilization)>=90'
+              name: 'High Storage Utilization'
+              priority: HIGH
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: health
+        - uuid: d334df8838f349a7852b9c7a8e7ed10c
+          name: 'ICMP ping'
+          type: SIMPLE
+          key: icmpping
+          history: 7d
+          valuemap:
+            name: 'Service state'
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 7ac32d3a81484c059a8381311ae602a1
+              expression: 'max(/Fortinet FortiSwitch by SNMP/icmpping,#3)=0'
+              name: 'Unavailable by ICMP ping'
+              priority: HIGH
+              description: 'Last three attempts returned timeout.  Please check device connectivity.'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: 8ce6a0a0474d4a1b92fcc7cecdeb30d3
+          name: 'ICMP loss'
+          type: SIMPLE
+          key: icmppingloss
+          history: 7d
+          value_type: FLOAT
+          units: '%'
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: network
+          triggers:
+            - uuid: f6a6be317f374713a29b7df3b9279c93
+              expression: 'min(/Fortinet FortiSwitch by SNMP/icmppingloss,5m)>{$ICMP_LOSS_WARN} and min(/Fortinet FortiSwitch by SNMP/icmppingloss,5m)<100'
+              name: 'High ICMP ping loss'
+              opdata: 'Loss: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              dependencies:
+                - name: 'Unavailable by ICMP ping'
+                  expression: 'max(/Fortinet FortiSwitch by SNMP/icmpping,#3)=0'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: performance
+        - uuid: 984f1db345d246ce93c93590abf72d6b
+          name: 'ICMP response time'
+          type: SIMPLE
+          key: icmppingsec
+          history: 7d
+          value_type: FLOAT
+          units: s
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 593d919ed0d84b67a91d98c1c3f1f1f1
+              expression: 'avg(/Fortinet FortiSwitch by SNMP/icmppingsec,5m)>{$ICMP_RESPONSE_TIME_WARN}'
+              name: 'High ICMP ping response time'
+              opdata: 'Value: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              dependencies:
+                - name: 'High ICMP ping loss'
+                  expression: 'min(/Fortinet FortiSwitch by SNMP/icmppingloss,5m)>{$ICMP_LOSS_WARN} and min(/Fortinet FortiSwitch by SNMP/icmppingloss,5m)<100'
+                - name: 'Unavailable by ICMP ping'
+                  expression: 'max(/Fortinet FortiSwitch by SNMP/icmpping,#3)=0'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: performance
+        - uuid: 582156ffa8264d76ae8d991eae5d733b
+          name: 'SNMP traps (fallback)'
+          type: SNMP_TRAP
+          key: snmptrap.fallback
+          history: 7d
+          value_type: LOG
+          description: 'Item is used to collect all SNMP traps unmatched by other snmptrap items'
+          logtimefmt: 'hh:mm:sszyyyy/MM/dd'
+          tags:
+            - tag: component
+              value: system
+        - uuid: b33573958da1450c9a68e53f52b39945
+          name: 'System contact details'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.4.0
+          key: system.contact
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            The textual identification of the contact person for this managed node, together with information on how to contact this person.  If no contact information is known, the value is the zero-length string.
+          inventory_link: CONTACT
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+        - uuid: 88e586cc67d44058bba303064255852e
+          name: 'System description'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.1.0
+          key: system.descr
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            A textual description of the entity. This value should
+            include the full name and version identification of the system's hardware type, software operating-system, and
+            networking software.
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+        - uuid: ea808e227ffa425ab4b9eac7da5d6000
+          name: 'Hardware model name'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.47.1.1.1.1.13.1
+          key: system.hw.model
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          description: 'MIB: ENTITY-MIB'
+          inventory_link: MODEL
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+        - uuid: 1e89bc89590245639dcea458dbb507ac
+          name: 'Hardware serial number'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.47.1.1.1.1.11.1
+          key: system.hw.serialnumber
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          description: 'MIB: ENTITY-MIB'
+          inventory_link: SERIALNO_A
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: b0b665cb936b4d0283e5c4cbe6e0b550
+              expression: 'last(/Fortinet FortiSwitch by SNMP/system.hw.serialnumber,#1)<>last(/Fortinet FortiSwitch by SNMP/system.hw.serialnumber,#2) and length(last(/Fortinet FortiSwitch by SNMP/system.hw.serialnumber))>0'
+              name: 'Device has been replaced'
+              event_name: 'Device has been replaced (new serial number received)'
+              priority: INFO
+              description: 'Device serial number has changed. Ack to close'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 299fa350b6cf4b1493b707bdaae1b40c
+          name: 'Uptime (hardware)'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.25.1.1.0
+          key: system.hw.uptime
+          history: 7d
+          trends: 0d
+          units: uptime
+          description: |
+            MIB: HOST-RESOURCES-MIB
+            The amount of time since this host was last initialized. Note that this is different from sysUpTime in the SNMPv2-MIB [RFC1907] because sysUpTime is the uptime of the network management portion of the system.
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - '-1'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: MULTIPLIER
+              parameters:
+                - '0.01'
+          tags:
+            - tag: component
+              value: system
+        - uuid: a2db792645a843c5ba0438d0c2bcd771
+          name: 'System location'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.6.0
+          key: system.location
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            The physical location of this node (e.g., `telephone closet, 3rd floor').  If the location is unknown, the value is the zero-length string.
+          inventory_link: LOCATION
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          tags:
+            - tag: component
+              value: system
+        - uuid: da2bdb5d4f4e4b15a99f7d9a6cfc5f2c
+          name: 'System name'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.5.0
+          key: system.name
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            An administratively-assigned name for this managed node.By convention, this is the node's fully-qualified domain name.  If the name is unknown, the value is the zero-length string.
+          inventory_link: NAME
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 1dcbbd770e224b61b1f610198a841e41
+              expression: 'last(/Fortinet FortiSwitch by SNMP/system.name,#1)<>last(/Fortinet FortiSwitch by SNMP/system.name,#2) and length(last(/Fortinet FortiSwitch by SNMP/system.name))>0'
+              name: 'System name has changed'
+              event_name: 'System name has changed (new name: {ITEM.VALUE})'
+              priority: INFO
+              description: 'System name has changed. Ack to close.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: ed7c9002db84460fac89effa01c45254
+          name: 'Uptime (network)'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.3.0
+          key: system.net.uptime
+          history: 7d
+          trends: 0d
+          units: uptime
+          description: |
+            MIB: SNMPv2-MIB
+            The time (in hundredths of a second) since the network management portion of the system was last re-initialized.
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.01'
+          tags:
+            - tag: component
+              value: system
+        - uuid: 72f8329f31054f78bb6fc436ffcb33fe
+          name: 'System object ID'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.2.0
+          key: system.objectid
+          history: 7d
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            The vendor's authoritative identification of the network management subsystem contained in the entity.  This value is allocated within the SMI enterprises subtree (1.3.6.1.4.1) and provides an easy and unambiguous means for determining`what kind of box' is being managed.  For example, if vendor`Flintstones, Inc.' was assigned the subtree1.3.6.1.4.1.4242, it could assign the identifier 1.3.6.1.4.1.4242.1.1 to its `Fred Router'.
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          tags:
+            - tag: component
+              value: system
+        - uuid: 0c0baa97c7c348908343616ed58c5fe2
+          name: 'Operating system'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.12356.106.4.1.1.0
+          key: system.sw.os
+          delay: 30m
+          history: 7d
+          value_type: TEXT
+          inventory_link: OS
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: d18c1f065042422d9378e24fd5cba2cc
+              expression: 'last(/Fortinet FortiSwitch by SNMP/system.sw.os,#1)<>last(/Fortinet FortiSwitch by SNMP/system.sw.os,#2) and length(last(/Fortinet FortiSwitch by SNMP/system.sw.os))>0'
+              recovery_mode: NONE
+              name: 'Operating system description has changed'
+              priority: INFO
+              description: 'Operating system description has changed. Possible reasons that system has been updated or replaced. Ack to close.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'System name has changed'
+                  expression: 'last(/Fortinet FortiSwitch by SNMP/system.name,#1)<>last(/Fortinet FortiSwitch by SNMP/system.name,#2) and length(last(/Fortinet FortiSwitch by SNMP/system.name))>0'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 6b8817c305874c4caf64457c0b20e46d
+          name: 'SNMP agent availability'
+          type: INTERNAL
+          key: 'zabbix[host,snmp,available]'
+          history: 7d
+          valuemap:
+            name: zabbix.host.available
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 277af0bf8c7547c991f4b48f1804fdbe
+              expression: 'max(/Fortinet FortiSwitch by SNMP/zabbix[host,snmp,available],{$SNMP.TIMEOUT})=0'
+              name: 'No SNMP data collection'
+              opdata: 'Current state: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'SNMP is not available for polling. Please check device connectivity and SNMP settings.'
+              tags:
+                - tag: scope
+                  value: availability
+      discovery_rules:
+        - uuid: f3754e3b47e54953afcbe431ac53a7bc
+          name: 'Network interfaces discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#IFOPERSTATUS},1.3.6.1.2.1.2.2.1.8,{#IFADMINSTATUS},1.3.6.1.2.1.2.2.1.7,{#IFALIAS},1.3.6.1.2.1.31.1.1.1.18,{#IFNAME},1.3.6.1.2.1.31.1.1.1.1,{#IFDESCR},1.3.6.1.2.1.2.2.1.2,{#IFTYPE},1.3.6.1.2.1.2.2.1.3]'
+          key: net.if.discovery
+          delay: 1h
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#IFADMINSTATUS}'
+                value: '{$NET.IF.IFADMINSTATUS.MATCHES}'
+              - macro: '{#IFADMINSTATUS}'
+                value: '{$NET.IF.IFADMINSTATUS.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFALIAS}'
+                value: '{$NET.IF.IFALIAS.MATCHES}'
+              - macro: '{#IFALIAS}'
+                value: '{$NET.IF.IFALIAS.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFDESCR}'
+                value: '{$NET.IF.IFDESCR.MATCHES}'
+              - macro: '{#IFDESCR}'
+                value: '{$NET.IF.IFDESCR.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFNAME}'
+                value: '{$NET.IF.IFNAME.MATCHES}'
+              - macro: '{#IFNAME}'
+                value: '{$NET.IF.IFNAME.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFOPERSTATUS}'
+                value: '{$NET.IF.IFOPERSTATUS.MATCHES}'
+              - macro: '{#IFOPERSTATUS}'
+                value: '{$NET.IF.IFOPERSTATUS.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFTYPE}'
+                value: '{$NET.IF.IFTYPE.MATCHES}'
+              - macro: '{#IFTYPE}'
+                value: '{$NET.IF.IFTYPE.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+          description: 'Discovering interfaces from IF-MIB.'
+          item_prototypes:
+            - uuid: 1fc50ae106274e7a9b1a2793716afbec
+              name: 'Interface {#IFNAME}({#IFDESCR}): Inbound packets discarded'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.13.{#SNMPINDEX}'
+              key: 'net.if.in.discards[{#SNMPINDEX}]'
+              history: 7d
+              description: |
+                MIB: IF-MIB
+                The number of inbound packets which were chosen to be discarded
+                even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.
+                One possible reason for discarding such a packet could be to free up buffer space.
+                Discontinuities in the value of this counter can occur at re-initialization of the management system,
+                and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: e72546f80d2b465cbafcfcf60ce860eb
+              name: 'Interface {#IFNAME}({#IFDESCR}): Inbound packets with errors'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.14.{#SNMPINDEX}'
+              key: 'net.if.in.errors[{#SNMPINDEX}]'
+              history: 7d
+              description: |
+                MIB: IF-MIB
+                For packet-oriented interfaces, the number of inbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of inbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+              trigger_prototypes:
+                - uuid: 65aec8a4076e41d98ff2c3018a827214
+                  expression: 'min(/Fortinet FortiSwitch by SNMP/net.if.in.errors[{#SNMPINDEX}],5m)>{$IF.ERRORS.WARN:"{#IFNAME}"}'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'max(/Fortinet FortiSwitch by SNMP/net.if.in.errors[{#SNMPINDEX}],5m)<{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8'
+                  name: 'Interface {#IFNAME}({#IFDESCR}): High input error rate'
+                  event_name: 'Interface {#IFNAME}({#IFALIAS}): High input error rate ( > {$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)'
+                  opdata: 'errors in: {ITEM.LASTVALUE1}'
+                  priority: WARNING
+                  description: 'Recovers when below 80% of {$IF.ERRORS.WARN:"{#IFNAME}"} threshold'
+                  dependencies:
+                    - name: 'Interface {#IFNAME}({#IFDESCR}): Link down'
+                      expression: '{$IFCONTROL:"{#IFNAME}"}=1 and (last(/Fortinet FortiSwitch by SNMP/net.if.status[{#SNMPINDEX}])=2)'
+                  tags:
+                    - tag: scope
+                      value: performance
+            - uuid: 0da40fcdbc994c3a98623307f9567af0
+              name: 'Interface {#IFNAME}({#IFDESCR}): In utilization'
+              type: CALCULATED
+              key: 'net.if.in.util[{#SNMPINDEX}]'
+              value_type: FLOAT
+              units: '%'
+              params: '100*(last(//net.if.in[{#SNMPINDEX}])/last(//net.if.speed[{#SNMPINDEX}]))'
+              preprocessing:
+                - type: CHECK_NOT_SUPPORTED
+                  parameters:
+                    - '-1'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: 653b12d1132c4f3dac2c92232f7e6be6
+              name: 'Interface {#IFNAME}({#IFDESCR}): Bits received'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.31.1.1.1.6.{#SNMPINDEX}'
+              key: 'net.if.in[{#SNMPINDEX}]'
+              history: 7d
+              units: bps
+              description: |
+                MIB: IF-MIB
+                The total number of octets received on the interface, including framing characters. This object is a 64-bit version of ifInOctets. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: b5c5c693b8324442925ca40046cf0158
+              name: 'Interface {#IFNAME}({#IFDESCR}): Outbound packets discarded'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.19.{#SNMPINDEX}'
+              key: 'net.if.out.discards[{#SNMPINDEX}]'
+              history: 7d
+              description: |
+                MIB: IF-MIB
+                The number of outbound packets which were chosen to be discarded
+                even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.
+                One possible reason for discarding such a packet could be to free up buffer space.
+                Discontinuities in the value of this counter can occur at re-initialization of the management system,
+                and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: b2920f349a024016a1327e1135eee459
+              name: 'Interface {#IFNAME}({#IFDESCR}): Outbound packets with errors'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.20.{#SNMPINDEX}'
+              key: 'net.if.out.errors[{#SNMPINDEX}]'
+              history: 7d
+              description: |
+                MIB: IF-MIB
+                For packet-oriented interfaces, the number of outbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of outbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+              trigger_prototypes:
+                - uuid: 220847f113f94043bee3f5be5c942ea6
+                  expression: 'min(/Fortinet FortiSwitch by SNMP/net.if.out.errors[{#SNMPINDEX}],5m)>{$IF.ERRORS.WARN:"{#IFNAME}"}'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'max(/Fortinet FortiSwitch by SNMP/net.if.out.errors[{#SNMPINDEX}],5m)<{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8'
+                  name: 'Interface {#IFNAME}({#IFDESCR}): High output error rate'
+                  event_name: 'Interface {#IFNAME}({#IFALIAS}): High output error rate ( > {$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)'
+                  opdata: 'errors out: {ITEM.LASTVALUE2}'
+                  priority: WARNING
+                  description: 'Recovers when below 80% of {$IF.ERRORS.WARN:"{#IFNAME}"} threshold'
+                  dependencies:
+                    - name: 'Interface {#IFNAME}({#IFDESCR}): Link down'
+                      expression: '{$IFCONTROL:"{#IFNAME}"}=1 and (last(/Fortinet FortiSwitch by SNMP/net.if.status[{#SNMPINDEX}])=2)'
+                  tags:
+                    - tag: scope
+                      value: performance
+            - uuid: fee23df5a9064afda984cf79368b159a
+              name: 'Interface {#IFNAME}({#IFDESCR}): Out utilization'
+              type: CALCULATED
+              key: 'net.if.out.util[{#SNMPINDEX}]'
+              value_type: FLOAT
+              units: '%'
+              params: '100*(last(//net.if.out[{#SNMPINDEX}])/last(//net.if.speed[{#SNMPINDEX}]))'
+              preprocessing:
+                - type: CHECK_NOT_SUPPORTED
+                  parameters:
+                    - '-1'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: f8d03e546db44266acb73900cfe90b92
+              name: 'Interface {#IFNAME}({#IFDESCR}): Bits sent'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.31.1.1.1.10.{#SNMPINDEX}'
+              key: 'net.if.out[{#SNMPINDEX}]'
+              history: 7d
+              units: bps
+              description: |
+                MIB: IF-MIB
+                The total number of octets transmitted out of the interface, including framing characters. This object is a 64-bit version of ifOutOctets.Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: 5805aab428084485b007a51a8a87a22c
+              name: 'Interface {#IFNAME}({#IFDESCR}): Speed'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.31.1.1.1.15.{#SNMPINDEX}'
+              key: 'net.if.speed[{#SNMPINDEX}]'
+              history: 7d
+              units: bps
+              description: |
+                MIB: IF-MIB
+                An estimate of the interface's current bandwidth in units of 1,000,000 bits per second. If this object reports a value of `n' then the speed of the interface is somewhere in the range of `n-500,000' to`n+499,999'.  For interfaces which do not vary in bandwidth or for those where no accurate estimation can be made, this object should contain the nominal bandwidth. For a sub-layer which has no concept of bandwidth, this object should be zero.
+              preprocessing:
+                - type: MULTIPLIER
+                  parameters:
+                    - '1000000'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: ff22de0e3b0342929d67d211ba73ab91
+              name: 'Interface {#IFNAME}({#IFDESCR}): Operational status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.8.{#SNMPINDEX}'
+              key: 'net.if.status[{#SNMPINDEX}]'
+              history: 7d
+              description: |
+                MIB: IF-MIB
+                The current operational state of the interface.
+                - The testing(3) state indicates that no operational packet scan be passed
+                - If ifAdminStatus is down(2) then ifOperStatus should be down(2)
+                - If ifAdminStatus is changed to up(1) then ifOperStatus should change to up(1) if the interface is ready to transmit and receive network traffic
+                - It should change todormant(5) if the interface is waiting for external actions (such as a serial line waiting for an incoming connection)
+                - It should remain in the down(2) state if and only if there is a fault that prevents it from going to the up(1) state
+                - It should remain in the notPresent(6) state if the interface has missing(typically, hardware) components.
+              valuemap:
+                name: 'IF-MIB::ifOperStatus'
+              preprocessing:
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+              trigger_prototypes:
+                - uuid: bb2b7f2d9c754aa4815fcef027209872
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and (last(/Fortinet FortiSwitch by SNMP/net.if.status[{#SNMPINDEX}])=2)'
+                  name: 'Interface {#IFNAME}({#IFDESCR}): Link down'
+                  opdata: 'Current state: {ITEM.LASTVALUE1}'
+                  priority: AVERAGE
+                  description: |
+                    This trigger expression works as follows:
+                    1. Can be triggered if operations status is down.
+                    2. {$IFCONTROL:"{#IFNAME}"}=1 - user can redefine Context macro to value - 0. That marks this interface as not important. No new trigger will be fired if this interface is down.
+                  tags:
+                    - tag: scope
+                      value: availability
+            - uuid: fddd145e2b06401ebec51e5fedee8053
+              name: 'Interface {#IFNAME}({#IFDESCR}): Total utilization'
+              type: CALCULATED
+              key: 'net.if.total.util[{#SNMPINDEX}]'
+              value_type: FLOAT
+              units: '%'
+              params: '100*((last(//net.if.in[{#SNMPINDEX}])+last(//net.if.out[{#SNMPINDEX}]))/last(//net.if.speed[{#SNMPINDEX}]))'
+              preprocessing:
+                - type: CHECK_NOT_SUPPORTED
+                  parameters:
+                    - '-1'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: 1ed37ac64a6e46b3a4dd37f26b2c1453
+              name: 'Interface {#IFNAME}({#IFDESCR}): Interface type'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.3.{#SNMPINDEX}'
+              key: 'net.if.type[{#SNMPINDEX}]'
+              history: 7d
+              description: |
+                MIB: IF-MIB
+                The type of interface.
+                Additional values for ifType are assigned by the Internet Assigned Numbers Authority (IANA),
+                through updating the syntax of the IANAifType textual convention.
+              valuemap:
+                name: 'IF-MIB::ifType'
+              preprocessing:
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+          trigger_prototypes:
+            - uuid: bc9b4ae81799458fa566c89f6054296c
+              expression: |
+                change(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])<0 and last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])>0
+                and (
+                last(/Fortinet FortiSwitch by SNMP/net.if.type[{#SNMPINDEX}])=6 or
+                last(/Fortinet FortiSwitch by SNMP/net.if.type[{#SNMPINDEX}])=7 or
+                last(/Fortinet FortiSwitch by SNMP/net.if.type[{#SNMPINDEX}])=11 or
+                last(/Fortinet FortiSwitch by SNMP/net.if.type[{#SNMPINDEX}])=62 or
+                last(/Fortinet FortiSwitch by SNMP/net.if.type[{#SNMPINDEX}])=69 or
+                last(/Fortinet FortiSwitch by SNMP/net.if.type[{#SNMPINDEX}])=117
+                )
+                and
+                (last(/Fortinet FortiSwitch by SNMP/net.if.status[{#SNMPINDEX}])<>2)
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: |
+                (change(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])>0 and last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}],#2)>0) or
+                (last(/Fortinet FortiSwitch by SNMP/net.if.status[{#SNMPINDEX}])=2)
+              name: 'Interface {#IFNAME}({#IFDESCR}): Ethernet has changed to lower speed than it was before'
+              opdata: 'Current reported speed: {ITEM.LASTVALUE1}'
+              priority: INFO
+              description: 'This Ethernet connection has transitioned down from its known maximum speed. This might be a sign of autonegotiation issues. Ack to close.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'Interface {#IFNAME}({#IFDESCR}): Link down'
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and (last(/Fortinet FortiSwitch by SNMP/net.if.status[{#SNMPINDEX}])=2)'
+              tags:
+                - tag: scope
+                  value: notice
+            - uuid: 8de374d894834ee988a64ae5e4fcc09c
+              expression: |
+                (avg(/Fortinet FortiSwitch by SNMP/net.if.in[{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])) and
+                last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])>0
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'avg(/Fortinet FortiSwitch by SNMP/net.if.in[{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])'
+              name: 'Interface {#IFNAME}({#IFDESCR}): High inbound bandwidth usage'
+              event_name: 'Interface {#IFNAME}({#IFALIAS}): High inbound bandwidth usage ( > {$IF.UTIL.MAX:"{#IFNAME}"}% )'
+              opdata: 'In: {ITEM.LASTVALUE1}, speed: {ITEM.LASTVALUE2}'
+              priority: WARNING
+              description: 'The network interface utilization is close to its estimated maximum bandwidth.'
+              dependencies:
+                - name: 'Interface {#IFNAME}({#IFDESCR}): Link down'
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and (last(/Fortinet FortiSwitch by SNMP/net.if.status[{#SNMPINDEX}])=2)'
+              tags:
+                - tag: scope
+                  value: performance
+            - uuid: 79ebb7c7ecfa41c8ba7d9e478c70a5b4
+              expression: |
+                (avg(/Fortinet FortiSwitch by SNMP/net.if.out[{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])) and
+                last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])>0
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'avg(/Fortinet FortiSwitch by SNMP/net.if.out[{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Fortinet FortiSwitch by SNMP/net.if.speed[{#SNMPINDEX}])'
+              name: 'Interface {#IFNAME}({#IFDESCR}): High outbound bandwidth usage'
+              event_name: 'Interface {#IFNAME}({#IFALIAS}): High outbound bandwidth usage ( > {$IF.UTIL.MAX:"{#IFNAME}"}% )'
+              opdata: 'Out: {ITEM.LASTVALUE1}, speed: {ITEM.LASTVALUE2}'
+              priority: WARNING
+              description: 'The network interface utilization is close to its estimated maximum bandwidth.'
+              dependencies:
+                - name: 'Interface {#IFNAME}({#IFDESCR}): Link down'
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and (last(/Fortinet FortiSwitch by SNMP/net.if.status[{#SNMPINDEX}])=2)'
+              tags:
+                - tag: scope
+                  value: performance
+          graph_prototypes:
+            - uuid: ec6d75a895da49f2b00a08956c189316
+              name: 'Interface {#IFNAME}({#IFALIAS}): Network traffic'
+              graph_items:
+                - drawtype: GRADIENT_LINE
+                  color: 1A7C11
+                  item:
+                    host: 'Fortinet FortiSwitch by SNMP'
+                    key: 'net.if.in[{#SNMPINDEX}]'
+                - sortorder: '1'
+                  drawtype: BOLD_LINE
+                  color: 2774A4
+                  item:
+                    host: 'Fortinet FortiSwitch by SNMP'
+                    key: 'net.if.out[{#SNMPINDEX}]'
+                - sortorder: '2'
+                  color: F63100
+                  yaxisside: RIGHT
+                  item:
+                    host: 'Fortinet FortiSwitch by SNMP'
+                    key: 'net.if.out.errors[{#SNMPINDEX}]'
+                - sortorder: '3'
+                  color: A54F10
+                  yaxisside: RIGHT
+                  item:
+                    host: 'Fortinet FortiSwitch by SNMP'
+                    key: 'net.if.in.errors[{#SNMPINDEX}]'
+                - sortorder: '4'
+                  color: FC6EA3
+                  yaxisside: RIGHT
+                  item:
+                    host: 'Fortinet FortiSwitch by SNMP'
+                    key: 'net.if.out.discards[{#SNMPINDEX}]'
+                - sortorder: '5'
+                  color: 6C59DC
+                  yaxisside: RIGHT
+                  item:
+                    host: 'Fortinet FortiSwitch by SNMP'
+                    key: 'net.if.in.discards[{#SNMPINDEX}]'
+        - uuid: 02c1cd7416a245ee8c38e5218afa4aa2
+          name: 'EtherLike discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},1.3.6.1.2.1.10.7.2.1.19,{#IFOPERSTATUS},1.3.6.1.2.1.2.2.1.8,{#IFALIAS},1.3.6.1.2.1.31.1.1.1.18,{#IFNAME},1.3.6.1.2.1.31.1.1.1.1,{#IFDESCR},1.3.6.1.2.1.2.2.1.2]'
+          key: net.if.duplex.discovery
+          delay: 1h
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#IFDESCR}'
+                value: '{$NET.IF.IFDESCR.MATCHES}'
+              - macro: '{#IFDESCR}'
+                value: '{$NET.IF.IFDESCR.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFOPERSTATUS}'
+                value: '1'
+              - macro: '{#SNMPVALUE}'
+                value: (2|3)
+          description: 'Discovering interfaces from IF-MIB and EtherLike-MIB. Interfaces with up(1) Operational Status are discovered.'
+          item_prototypes:
+            - uuid: e0b5159388bb4944a3a9735e9fdb256c
+              name: 'Interface {#IFNAME}({#IFDESCR}): Duplex status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.10.7.2.1.19.{#SNMPINDEX}'
+              key: 'net.if.duplex[{#SNMPINDEX}]'
+              history: 7d
+              description: |
+                MIB: EtherLike-MIB
+                Object name: dot3StatsDuplexStatus
+                The current mode of operation of the MAC
+                entity.  'unknown' indicates that the current
+                duplex mode could not be determined.
+                
+                Management control of the duplex mode is
+                accomplished through the MAU MIB.  When
+                an interface does not support autonegotiation,
+                or when autonegotiation is not enabled, the
+                duplex mode is controlled using
+                ifMauDefaultType.  When autonegotiation is
+                supported and enabled, duplex mode is controlled
+                using ifMauAutoNegAdvertisedBits.  In either
+                case, the currently operating duplex mode is
+                reflected both in this object and in ifMauType.
+                
+                Note that this object provides redundant
+                information with ifMauType.  Normally, redundant
+                objects are discouraged.  However, in this
+                instance, it allows a management application to
+                determine the duplex status of an interface
+                without having to know every possible value of
+                ifMauType.  This was felt to be sufficiently
+                valuable to justify the redundancy.
+                Reference: [IEEE 802.3 Std.], 30.3.1.1.32,aDuplexStatus.
+              valuemap:
+                name: 'EtherLike-MIB::dot3StatsDuplexStatus'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+              trigger_prototypes:
+                - uuid: 77bf424918ce491ab57211d58c097119
+                  expression: 'last(/Fortinet FortiSwitch by SNMP/net.if.duplex[{#SNMPINDEX}])=2'
+                  name: 'Interface {#IFNAME}({#IFALIAS}): In half-duplex mode'
+                  priority: WARNING
+                  description: 'Please check autonegotiation settings and cabling'
+                  tags:
+                    - tag: scope
+                      value: performance
+      tags:
+        - tag: class
+          value: network
+        - tag: target
+          value: fortinet
+        - tag: target
+          value: fortiswitch
+      macros:
+        - macro: '{$CPU.UTILIZATION.CRIT}'
+          value: '70'
+        - macro: '{$CPU.UTILIZATION.WARN}'
+          value: '50'
+        - macro: '{$MEM.UTILIZATION.CRIT}'
+          value: '80'
+        - macro: '{$MEM.UTILIZATION.WARN}'
+          value: '60'
+        - macro: '{$NET.IF.IFADMINSTATUS.MATCHES}'
+          value: '^.*'
+        - macro: '{$NET.IF.IFADMINSTATUS.NOT_MATCHES}'
+          value: ^2$
+          description: 'Ignore down(2) administrative status'
+        - macro: '{$NET.IF.IFALIAS.MATCHES}'
+          value: '.*'
+        - macro: '{$NET.IF.IFALIAS.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+        - macro: '{$NET.IF.IFDESCR.MATCHES}'
+          value: '.*'
+        - macro: '{$NET.IF.IFDESCR.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+        - macro: '{$NET.IF.IFNAME.MATCHES}'
+          value: '^.*$'
+        - macro: '{$NET.IF.IFNAME.NOT_MATCHES}'
+          value: '(^Software Loopback Interface|^NULL[0-9.]*$|^[Ll]o[0-9.]*$|^[Ss]ystem$|^Nu[0-9.]*$|^veth[0-9a-z]+$|docker[0-9]+|br-[a-z0-9]{12}|^quarantine.*$|^onboarding.*$|^naf.root.*$|^nac_segment.*$|^l2t.root.*$|^_default.*$)'
+          description: 'Filter out loopbacks, nulls, docker veth links and docker0 bridge by default'
+        - macro: '{$NET.IF.IFOPERSTATUS.MATCHES}'
+          value: '^.*$'
+        - macro: '{$NET.IF.IFOPERSTATUS.NOT_MATCHES}'
+          value: ^6$
+          description: 'Ignore notPresent(6)'
+        - macro: '{$NET.IF.IFTYPE.MATCHES}'
+          value: '.*'
+        - macro: '{$NET.IF.IFTYPE.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+        - macro: '{$SNMP_TIMEOUT}'
+          value: 5m
+      valuemaps:
+        - uuid: 680a5a9e565f417bb2b4cf8cb3497bec
+          name: 'EtherLike-MIB::dot3StatsDuplexStatus'
+          mappings:
+            - value: '1'
+              newvalue: unknown
+            - value: '2'
+              newvalue: halfDuplex
+            - value: '3'
+              newvalue: fullDuplex
+        - uuid: 3baf2cb138c04a75a44728a86a5f3dee
+          name: 'IF-MIB::ifOperStatus'
+          mappings:
+            - value: '1'
+              newvalue: up
+            - value: '2'
+              newvalue: down
+            - value: '3'
+              newvalue: testing
+            - value: '4'
+              newvalue: unknown
+            - value: '5'
+              newvalue: dormant
+            - value: '6'
+              newvalue: notPresent
+            - value: '7'
+              newvalue: lowerLayerDown
+        - uuid: 496c50ea85e643bdb623a163c3da3d51
+          name: 'IF-MIB::ifType'
+          mappings:
+            - value: '1'
+              newvalue: other
+            - value: '2'
+              newvalue: regular1822
+            - value: '3'
+              newvalue: hdh1822
+            - value: '4'
+              newvalue: ddnX25
+            - value: '5'
+              newvalue: rfc877x25
+            - value: '6'
+              newvalue: ethernetCsmacd
+            - value: '7'
+              newvalue: iso88023Csmacd
+            - value: '8'
+              newvalue: iso88024TokenBus
+            - value: '9'
+              newvalue: iso88025TokenRing
+            - value: '10'
+              newvalue: iso88026Man
+            - value: '11'
+              newvalue: starLan
+            - value: '12'
+              newvalue: proteon10Mbit
+            - value: '13'
+              newvalue: proteon80Mbit
+            - value: '14'
+              newvalue: hyperchannel
+            - value: '15'
+              newvalue: fddi
+            - value: '16'
+              newvalue: lapb
+            - value: '17'
+              newvalue: sdlc
+            - value: '18'
+              newvalue: ds1
+            - value: '19'
+              newvalue: e1
+            - value: '20'
+              newvalue: basicISDN
+            - value: '21'
+              newvalue: primaryISDN
+            - value: '22'
+              newvalue: propPointToPointSerial
+            - value: '23'
+              newvalue: ppp
+            - value: '24'
+              newvalue: softwareLoopback
+            - value: '25'
+              newvalue: eon
+            - value: '26'
+              newvalue: ethernet3Mbit
+            - value: '27'
+              newvalue: nsip
+            - value: '28'
+              newvalue: slip
+            - value: '29'
+              newvalue: ultra
+            - value: '30'
+              newvalue: ds3
+            - value: '31'
+              newvalue: sip
+            - value: '32'
+              newvalue: frameRelay
+            - value: '33'
+              newvalue: rs232
+            - value: '34'
+              newvalue: para
+            - value: '35'
+              newvalue: arcnet
+            - value: '36'
+              newvalue: arcnetPlus
+            - value: '37'
+              newvalue: atm
+            - value: '38'
+              newvalue: miox25
+            - value: '39'
+              newvalue: sonet
+            - value: '40'
+              newvalue: x25ple
+            - value: '41'
+              newvalue: iso88022llc
+            - value: '42'
+              newvalue: localTalk
+            - value: '43'
+              newvalue: smdsDxi
+            - value: '44'
+              newvalue: frameRelayService
+            - value: '45'
+              newvalue: v35
+            - value: '46'
+              newvalue: hssi
+            - value: '47'
+              newvalue: hippi
+            - value: '48'
+              newvalue: modem
+            - value: '49'
+              newvalue: aal5
+            - value: '50'
+              newvalue: sonetPath
+            - value: '51'
+              newvalue: sonetVT
+            - value: '52'
+              newvalue: smdsIcip
+            - value: '53'
+              newvalue: propVirtual
+            - value: '54'
+              newvalue: propMultiplexor
+            - value: '55'
+              newvalue: ieee80212
+            - value: '56'
+              newvalue: fibreChannel
+            - value: '57'
+              newvalue: hippiInterface
+            - value: '58'
+              newvalue: frameRelayInterconnect
+            - value: '59'
+              newvalue: aflane8023
+            - value: '60'
+              newvalue: aflane8025
+            - value: '61'
+              newvalue: cctEmul
+            - value: '62'
+              newvalue: fastEther
+            - value: '63'
+              newvalue: isdn
+            - value: '64'
+              newvalue: v11
+            - value: '65'
+              newvalue: v36
+            - value: '66'
+              newvalue: g703at64k
+            - value: '67'
+              newvalue: g703at2mb
+            - value: '68'
+              newvalue: qllc
+            - value: '69'
+              newvalue: fastEtherFX
+            - value: '70'
+              newvalue: channel
+            - value: '71'
+              newvalue: ieee80211
+            - value: '72'
+              newvalue: ibm370parChan
+            - value: '73'
+              newvalue: escon
+            - value: '74'
+              newvalue: dlsw
+            - value: '75'
+              newvalue: isdns
+            - value: '76'
+              newvalue: isdnu
+            - value: '77'
+              newvalue: lapd
+            - value: '78'
+              newvalue: ipSwitch
+            - value: '79'
+              newvalue: rsrb
+            - value: '80'
+              newvalue: atmLogical
+            - value: '81'
+              newvalue: ds0
+            - value: '82'
+              newvalue: ds0Bundle
+            - value: '83'
+              newvalue: bsc
+            - value: '84'
+              newvalue: async
+            - value: '85'
+              newvalue: cnr
+            - value: '86'
+              newvalue: iso88025Dtr
+            - value: '87'
+              newvalue: eplrs
+            - value: '88'
+              newvalue: arap
+            - value: '89'
+              newvalue: propCnls
+            - value: '90'
+              newvalue: hostPad
+            - value: '91'
+              newvalue: termPad
+            - value: '92'
+              newvalue: frameRelayMPI
+            - value: '93'
+              newvalue: x213
+            - value: '94'
+              newvalue: adsl
+            - value: '95'
+              newvalue: radsl
+            - value: '96'
+              newvalue: sdsl
+            - value: '97'
+              newvalue: vdsl
+            - value: '98'
+              newvalue: iso88025CRFPInt
+            - value: '99'
+              newvalue: myrinet
+            - value: '100'
+              newvalue: voiceEM
+            - value: '101'
+              newvalue: voiceFXO
+            - value: '102'
+              newvalue: voiceFXS
+            - value: '103'
+              newvalue: voiceEncap
+            - value: '104'
+              newvalue: voiceOverIp
+            - value: '105'
+              newvalue: atmDxi
+            - value: '106'
+              newvalue: atmFuni
+            - value: '107'
+              newvalue: atmIma
+            - value: '108'
+              newvalue: pppMultilinkBundle
+            - value: '109'
+              newvalue: ipOverCdlc
+            - value: '110'
+              newvalue: ipOverClaw
+            - value: '111'
+              newvalue: stackToStack
+            - value: '112'
+              newvalue: virtualIpAddress
+            - value: '113'
+              newvalue: mpc
+            - value: '114'
+              newvalue: ipOverAtm
+            - value: '115'
+              newvalue: iso88025Fiber
+            - value: '116'
+              newvalue: tdlc
+            - value: '117'
+              newvalue: gigabitEthernet
+            - value: '118'
+              newvalue: hdlc
+            - value: '119'
+              newvalue: lapf
+            - value: '120'
+              newvalue: v37
+            - value: '121'
+              newvalue: x25mlp
+            - value: '122'
+              newvalue: x25huntGroup
+            - value: '123'
+              newvalue: trasnpHdlc
+            - value: '124'
+              newvalue: interleave
+            - value: '125'
+              newvalue: fast
+            - value: '126'
+              newvalue: ip
+            - value: '127'
+              newvalue: docsCableMaclayer
+            - value: '128'
+              newvalue: docsCableDownstream
+            - value: '129'
+              newvalue: docsCableUpstream
+            - value: '130'
+              newvalue: a12MppSwitch
+            - value: '131'
+              newvalue: tunnel
+            - value: '132'
+              newvalue: coffee
+            - value: '133'
+              newvalue: ces
+            - value: '134'
+              newvalue: atmSubInterface
+            - value: '135'
+              newvalue: l2vlan
+            - value: '136'
+              newvalue: l3ipvlan
+            - value: '137'
+              newvalue: l3ipxvlan
+            - value: '138'
+              newvalue: digitalPowerline
+            - value: '139'
+              newvalue: mediaMailOverIp
+            - value: '140'
+              newvalue: dtm
+            - value: '141'
+              newvalue: dcn
+            - value: '142'
+              newvalue: ipForward
+            - value: '143'
+              newvalue: msdsl
+            - value: '144'
+              newvalue: ieee1394
+            - value: '145'
+              newvalue: if-gsn
+            - value: '146'
+              newvalue: dvbRccMacLayer
+            - value: '147'
+              newvalue: dvbRccDownstream
+            - value: '148'
+              newvalue: dvbRccUpstream
+            - value: '149'
+              newvalue: atmVirtual
+            - value: '150'
+              newvalue: mplsTunnel
+            - value: '151'
+              newvalue: srp
+            - value: '152'
+              newvalue: voiceOverAtm
+            - value: '153'
+              newvalue: voiceOverFrameRelay
+            - value: '154'
+              newvalue: idsl
+            - value: '155'
+              newvalue: compositeLink
+            - value: '156'
+              newvalue: ss7SigLink
+            - value: '157'
+              newvalue: propWirelessP2P
+            - value: '158'
+              newvalue: frForward
+            - value: '159'
+              newvalue: rfc1483
+            - value: '160'
+              newvalue: usb
+            - value: '161'
+              newvalue: ieee8023adLag
+            - value: '162'
+              newvalue: bgppolicyaccounting
+            - value: '163'
+              newvalue: frf16MfrBundle
+            - value: '164'
+              newvalue: h323Gatekeeper
+            - value: '165'
+              newvalue: h323Proxy
+            - value: '166'
+              newvalue: mpls
+            - value: '167'
+              newvalue: mfSigLink
+            - value: '168'
+              newvalue: hdsl2
+            - value: '169'
+              newvalue: shdsl
+            - value: '170'
+              newvalue: ds1FDL
+            - value: '171'
+              newvalue: pos
+            - value: '172'
+              newvalue: dvbAsiIn
+            - value: '173'
+              newvalue: dvbAsiOut
+            - value: '174'
+              newvalue: plc
+            - value: '175'
+              newvalue: nfas
+            - value: '176'
+              newvalue: tr008
+            - value: '177'
+              newvalue: gr303RDT
+            - value: '178'
+              newvalue: gr303IDT
+            - value: '179'
+              newvalue: isup
+            - value: '180'
+              newvalue: propDocsWirelessMaclayer
+            - value: '181'
+              newvalue: propDocsWirelessDownstream
+            - value: '182'
+              newvalue: propDocsWirelessUpstream
+            - value: '183'
+              newvalue: hiperlan2
+            - value: '184'
+              newvalue: propBWAp2Mp
+            - value: '185'
+              newvalue: sonetOverheadChannel
+            - value: '186'
+              newvalue: digitalWrapperOverheadChannel
+            - value: '187'
+              newvalue: aal2
+            - value: '188'
+              newvalue: radioMAC
+            - value: '189'
+              newvalue: atmRadio
+            - value: '190'
+              newvalue: imt
+            - value: '191'
+              newvalue: mvl
+            - value: '192'
+              newvalue: reachDSL
+            - value: '193'
+              newvalue: frDlciEndPt
+            - value: '194'
+              newvalue: atmVciEndPt
+            - value: '195'
+              newvalue: opticalChannel
+            - value: '196'
+              newvalue: opticalTransport
+            - value: '197'
+              newvalue: propAtm
+            - value: '198'
+              newvalue: voiceOverCable
+            - value: '199'
+              newvalue: infiniband
+            - value: '200'
+              newvalue: teLink
+            - value: '201'
+              newvalue: q2931
+            - value: '202'
+              newvalue: virtualTg
+            - value: '203'
+              newvalue: sipTg
+            - value: '204'
+              newvalue: sipSig
+            - value: '205'
+              newvalue: docsCableUpstreamChannel
+            - value: '206'
+              newvalue: econet
+            - value: '207'
+              newvalue: pon155
+            - value: '208'
+              newvalue: pon622
+            - value: '209'
+              newvalue: bridge
+            - value: '210'
+              newvalue: linegroup
+            - value: '211'
+              newvalue: voiceEMFGD
+            - value: '212'
+              newvalue: voiceFGDEANA
+            - value: '213'
+              newvalue: voiceDID
+            - value: '214'
+              newvalue: mpegTransport
+            - value: '215'
+              newvalue: sixToFour
+            - value: '216'
+              newvalue: gtp
+            - value: '217'
+              newvalue: pdnEtherLoop1
+            - value: '218'
+              newvalue: pdnEtherLoop2
+            - value: '219'
+              newvalue: opticalChannelGroup
+            - value: '220'
+              newvalue: homepna
+            - value: '221'
+              newvalue: gfp
+            - value: '222'
+              newvalue: ciscoISLvlan
+            - value: '223'
+              newvalue: actelisMetaLOOP
+            - value: '224'
+              newvalue: fcipLink
+            - value: '225'
+              newvalue: rpr
+            - value: '226'
+              newvalue: qam
+            - value: '227'
+              newvalue: lmp
+            - value: '228'
+              newvalue: cblVectaStar
+            - value: '229'
+              newvalue: docsCableMCmtsDownstream
+            - value: '230'
+              newvalue: adsl2
+            - value: '231'
+              newvalue: macSecControlledIF
+            - value: '232'
+              newvalue: macSecUncontrolledIF
+            - value: '233'
+              newvalue: aviciOpticalEther
+            - value: '234'
+              newvalue: atmbond
+            - value: '235'
+              newvalue: voiceFGDOS
+            - value: '236'
+              newvalue: mocaVersion1
+            - value: '237'
+              newvalue: ieee80216WMAN
+            - value: '238'
+              newvalue: adsl2plus
+            - value: '239'
+              newvalue: dvbRcsMacLayer
+            - value: '240'
+              newvalue: dvbTdm
+            - value: '241'
+              newvalue: dvbRcsTdma
+            - value: '242'
+              newvalue: x86Laps
+            - value: '243'
+              newvalue: wwanPP
+            - value: '244'
+              newvalue: wwanPP2
+            - value: '245'
+              newvalue: voiceEBS
+            - value: '246'
+              newvalue: ifPwType
+            - value: '247'
+              newvalue: ilan
+            - value: '248'
+              newvalue: pip
+            - value: '249'
+              newvalue: aluELP
+            - value: '250'
+              newvalue: gpon
+            - value: '251'
+              newvalue: vdsl2
+            - value: '252'
+              newvalue: capwapDot11Profile
+            - value: '253'
+              newvalue: capwapDot11Bss
+            - value: '254'
+              newvalue: capwapWtpVirtualRadio
+            - value: '255'
+              newvalue: bits
+            - value: '256'
+              newvalue: docsCableUpstreamRfPort
+            - value: '257'
+              newvalue: cableDownstreamRfPort
+            - value: '258'
+              newvalue: vmwareVirtualNic
+            - value: '259'
+              newvalue: ieee802154
+            - value: '260'
+              newvalue: otnOdu
+            - value: '261'
+              newvalue: otnOtu
+            - value: '262'
+              newvalue: ifVfiType
+            - value: '263'
+              newvalue: g9981
+            - value: '264'
+              newvalue: g9982
+            - value: '265'
+              newvalue: g9983
+            - value: '266'
+              newvalue: aluEpon
+            - value: '267'
+              newvalue: aluEponOnu
+            - value: '268'
+              newvalue: aluEponPhysicalUni
+            - value: '269'
+              newvalue: aluEponLogicalLink
+            - value: '270'
+              newvalue: aluGponOnu
+            - value: '271'
+              newvalue: aluGponPhysicalUni
+            - value: '272'
+              newvalue: vmwareNicTeam
+            - value: '277'
+              newvalue: docsOfdmDownstream
+            - value: '278'
+              newvalue: docsOfdmaUpstream
+            - value: '279'
+              newvalue: gfast
+            - value: '280'
+              newvalue: sdci
+            - value: '281'
+              newvalue: xboxWireless
+            - value: '282'
+              newvalue: fastdsl
+            - value: '283'
+              newvalue: docsCableScte55d1FwdOob
+            - value: '284'
+              newvalue: docsCableScte55d1RetOob
+            - value: '285'
+              newvalue: docsCableScte55d2DsOob
+            - value: '286'
+              newvalue: docsCableScte55d2UsOob
+            - value: '287'
+              newvalue: docsCableNdf
+            - value: '288'
+              newvalue: docsCableNdr
+            - value: '289'
+              newvalue: ptm
+            - value: '290'
+              newvalue: ghn
+        - uuid: 9445a0740ab841649da395df21b385ff
+          name: 'Service state'
+          mappings:
+            - value: '0'
+              newvalue: Down
+            - value: '1'
+              newvalue: Up
+        - uuid: 5fac7127da624a208d35fa480bd1e440
+          name: zabbix.host.available
+          mappings:
+            - value: '0'
+              newvalue: 'not available'
+            - value: '1'
+              newvalue: available
+            - value: '2'
+              newvalue: unknown
+  triggers:
+    - uuid: 355e67ee67ee4e1085d11e499bc83396
+      expression: '(last(/Fortinet FortiSwitch by SNMP/system.hw.uptime)>0 and last(/Fortinet FortiSwitch by SNMP/system.hw.uptime)<10m) or (last(/Fortinet FortiSwitch by SNMP/system.hw.uptime)=0 and last(/Fortinet FortiSwitch by SNMP/system.net.uptime)<10m)'
+      name: 'Host has been restarted'
+      event_name: '{HOST.NAME} has been restarted (uptime < 10m)'
+      priority: WARNING
+      description: 'Uptime is less than 10 minutes.'
+      manual_close: 'YES'
+      tags:
+        - tag: scope
+          value: notice


### PR DESCRIPTION
New template for monitoring Fortinet FortiSwitches and discovering all interfaces.
Working using SNMP bulk walk requests as in Zabbix 6.4 and Zabbix 7.0