### PR TITLE
Add docker container to run ookla speedtest

### DIFF
--- a/Applications/Template_App_Speedtest_Wan/7.0/Dockerfile
+++ b/Applications/Template_App_Speedtest_Wan/7.0/Dockerfile
@@ -1,0 +1,14 @@
+FROM docker.io/library/alpine:latest AS build
+RUN wget -O speedtest.tgz \
+	  "https://install.speedtest.net/app/cli/ookla-speedtest-1.2.0-linux-x86_64.tgz" \
+	  && tar zxvf speedtest.tgz \
+	  && chmod +x speedtest && chown root:root speedtest
+
+FROM docker.io/library/alpine:latest
+COPY --from=build /speedtest /bin/
+COPY record_speedtest_docker.sh /bin/record_speedtest.sh
+RUN apk add --no-cache zabbix-utils
+RUN adduser -S speedtest
+USER speedtest
+
+ENTRYPOINT ["/bin/record_speedtest.sh"]

--- a/Applications/Template_App_Speedtest_Wan/7.0/README.md
+++ b/Applications/Template_App_Speedtest_Wan/7.0/README.md
@@ -21,6 +21,13 @@ Todd Blake
 
     `0 */6 * * * /usr/local/bin/record_speedtest.sh # feed speedtest info into zabbix every 6 hours`
 
+# Docker:
+Alternatively to collect the speedtest data, a docker container can be run:
+
+```bash
+$ docker run --rm -e ZABBIX_SERVER="123.123.123.123" -e SPEEDTEST_HOST="my-speedtest-host" -e SPEEDTESTPARAMS="--accept-license" siegy22/speedtest-cli-zabbix
+```
+
 # Example Dashboard
 ![Example Dashboard](dashboard.png?raw=true "Example Dashboard")
 

--- a/Applications/Template_App_Speedtest_Wan/7.0/record_speedtest_docker.sh
+++ b/Applications/Template_App_Speedtest_Wan/7.0/record_speedtest_docker.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+test -z "$ZABBIX_SERVER" && echo "ZABBIX_SERVER enviornment variable is required." && exit
+test -z "$SPEEDTEST_HOST" && echo "SPEEDTEST_HOST enviornment variable is required." && exit
+
+OUTFILE=$(mktemp)
+NOW=$(date +%s)
+
+speedtest $SPEEDTESTPARAMS -f json --accept-license > $OUTFILE
+
+F="$(cat $OUTFILE)"
+
+# do we have PSKID and PSKFILE?
+if [ -f "$PSKFILE" -a -n "$PSKID" ];then
+	zabbix_sender --tls-connect psk --tls-psk-identity "$PSKID" --tls-psk-file "$PSKFILE" -z "$ZABBIX_SERVER" -s "$SPEEDTEST_HOST" -k "custom.speedtest[runtime]" -o "$NOW" > /dev/null 2>&1
+	zabbix_sender --tls-connect psk --tls-psk-identity "$PSKID" --tls-psk-file "$PSKFILE" -z "$ZABBIX_SERVER" -s "$SPEEDTEST_HOST" -k "custom.speedtest[json]" -o "$F" > /dev/null 2>&1
+else
+	zabbix_sender -z "$ZABBIX_SERVER" -s "$SPEEDTEST_HOST" -k "custom.speedtest[runtime]" -o "$NOW"
+	zabbix_sender -z "$ZABBIX_SERVER" -s "$SPEEDTEST_HOST" -k "custom.speedtest[json]" -o "$F"
+fi


### PR DESCRIPTION
Also create a separate script that makes more sense in a container environment. The current one's error handling is not the best, because it is meant to run as a cronjob it should not output anything. In a container environment that does not really matter.

See the README adjustment for more details.