### PR TITLE
Add bits/sec network traffic numbers to UBQT UNIFI SNMP V3 HN (and other smaller fixes)

### DIFF
--- a/Network_Devices/Ubiquiti/template_unifi_ap_snmpv3/6.0/README.md
+++ b/Network_Devices/Ubiquiti/template_unifi_ap_snmpv3/6.0/README.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This template retrieve SNMP data from Unifi AP devices. MIBS requiriments: FROGFOOT-RESOURCES-MIB IANAifType-MIB IF-MIB SNMP-FRAMEWORK-MIB SNMPv2-CONF SNMPv2-MIB SNMPv2-SMI SNMPv2-TC UBNT-MIB UBNT-UniFi-MIB Author: Helmut Leonhardt based on Alex Moura
+This template retrieve SNMP data from Unifi AP devices. MIBS requirements: FROGFOOT-RESOURCES-MIB IANAifType-MIB IF-MIB SNMP-FRAMEWORK-MIB SNMPv2-CONF SNMPv2-MIB SNMPv2-SMI SNMPv2-TC UBNT-MIB UBNT-UniFi-MIB Author: Helmut Leonhardt based on Alex Moura
 
 ## Overview
 
@@ -11,7 +11,7 @@ unifi zabbix snmpv3
 based on Alex Mouras work https://share.zabbix.com/network\_devices/ubiquiti/unifi-snmp-2019-v1-1
   
 
-Ubiquity Controller > Settings > Services > SNMP v3 > enable, set username and passwort
+Ubiquity Controller > Settings > Services > SNMP v3 > enable, set username and password
 Zabbix > Macro >
 {$SNMP\_USERNAME} <= username set in controller
 {$SNMP\_AUTHPASS} & {$SNMP\_PRIVPASS} <= password set in controller
@@ -19,6 +19,12 @@ Zabbix > Macro >
 2020 April
 fixed zabbix version
 fixed virtual interface items
+
+2024 September - Fixes by Crowtrobot
+Add network traffic numbers in bits/sec to simplify comparing to other network devices.
+Replaced some description strings that appeared to be in Portuguese with English strings, or removed them completely where they didn't seem useful.
+Fixed 5GHz channel oid, which was wrong on my UAP-AC-InWall and U6-Enterprise.
+Added 6GHz radio channel oid.  
 
 
 ## Author
@@ -43,41 +49,45 @@ There are no template links in this template.
 
 |Name|Description|Type|Key and additional info|
 |----|-----------|----|----|
-|Wifi Virtual Interfaces|<p>-</p>|`SNMP agent`|unifiVapEssId<p>Update: 30s</p>|
+|WiFi Virtual Interfaces|<p>-</p>|`SNMP agent`|unifiVapEssId<p>Update: 30s</p>|
 
 
 ## Items collected
 
 |Name|Description|Type|Key and additional info|
 |----|-----------|----|----|
-|System Description|<p>Informa o modelo do aparelho</p>|`SNMP agent`|sysDescr.0<p>Update: 30m</p>|
-|Contact|<p>Informa o modelo do aparelho</p>|`SNMP agent`|sysContact.0<p>Update: 60m</p>|
-|Location|<p>Informa o modelo do aparelho</p>|`SNMP agent`|sysLocation.0<p>Update: 60m</p>|
-|IP Address|<p>-</p>|`SNMP agent`|unifiApSystemIp.0<p>Update: 10m</p>|
-|LAN Traffic Incoming|<p>-</p>|`SNMP agent`|unifiIfRxBytes.1<p>Update: 1m</p>|
-|Interface Speed (Mbit/s)|<p>-</p>|`SNMP agent`|unifiIfSpeed.1<p>Update: 60m</p>|
+|System Description|<p>Description (seems to usually be the model and firmware version).</p>|`SNMP agent`|sysDescr.0<p>Update: 30m</p>|
+|Contact|<p>The contact string set for this device in the unifi controler.</p>|`SNMP agent`|sysContact.0<p>Update: 60m</p>|
+|Location|<p>The location string set for this device in the unifi controller.</p>|`SNMP agent`|sysLocation.0<p>Update: 60m</p>|
+|IP Address|<p>The device's IP address.</p>|`SNMP agent`|unifiApSystemIp.0<p>Update: 10m</p>|
+|LAN Traffic Incoming (bytes)|<p>LAN incoming traffic in Bytes/sec</p>|`SNMP agent`|unifiIfRxBytes.1<p>Update: 1m</p>|
+|LAN Traffic Incoming (bits)|<p>LAN incoming traffic in bites/sec</p>|`SNMP agent`|unifiIfRxBits.1<p>Update: 1m</p>|
+|Interface Speed (Mbit/s)|<p>LAN port connection speed in Mbits/s (so 1000 is 1Gbps)</p>|`SNMP agent`|unifiIfSpeed.1<p>Update: 60m</p>|
 |CPU AVG Load 15 Min|<p>-</p>|`SNMP agent`|IaLoad.3<p>Update: 1m</p>|
-|Channel 5G (N/AC)|<p>Informa o modelo do aparelho</p>|`SNMP agent`|unifiVapChannel.5<p>Update: 1m</p>|
+|Channel 5G (N/AC)|<p>WiFi channel on the 5GHz radio</p>|`SNMP agent`|unifiVapChannel.5<p>Update: 1m</p>|
 |Firmware version|<p>-</p>|`SNMP agent`|unifiApSystemVersion.0<p>Update: 60m</p>|
-|Channel 2G (N/G)|<p>Informa o modelo do aparelho</p>|`SNMP agent`|unifiVapChannel.1<p>Update: 1m</p>|
+|Channel 2G (N/G)|<p>WiFi channel on the 2.4GHz radio</p>|`SNMP agent`|unifiVapChannel.1<p>Update: 1m</p>|
 |AP Hostname|<p>-</p>|`SNMP agent`|unifiSysName.0<p>Update: 60m</p>|
 |CPU Usage|<p>-</p>|`SNMP agent`|cpuLoad.0<p>Update: 30s</p>|
 |MAC Address|<p>-</p>|`SNMP agent`|unifiIfMac.1<p>Update: 30m</p>|
 |System Time|<p>-</p>|`SNMP agent`|hrSystemDate.0<p>Update: 30s</p>|
 |Uptime|<p>-</p>|`SNMP agent`|sysUpTime.0<p>Update: 5m</p>|
-|Model|<p>Informa o modelo do aparelho</p>|`SNMP agent`|unifiApSystemModel.0<p>Update: 60m</p>|
+|Model|<p>AP model name</p>|`SNMP agent`|unifiApSystemModel.0<p>Update: 60m</p>|
 |CPU AVG Load 5 Min|<p>-</p>|`SNMP agent`|IaLoad.2<p>Update: 1m</p>|
 |LAN Traffic Outgoing Errors|<p>-</p>|`SNMP agent`|unifiIfTxError.1<p>Update: 1m</p>|
-|LAN Traffic Outgoing|<p>-</p>|`SNMP agent`|unifiIfTxBytes.1<p>Update: 1m</p>|
-|Channel utilization 2G (BGN)|<p>Informa o modelo do aparelho</p>|`SNMP agent`|unifiRadioCuTotal.1<p>Update: 30s</p>|
+|LAN Traffic Outgoing (bytes)|<p>LAN incoming traffic in bytes/sec</p>|`SNMP agent`|unifiIfTxBytes.1<p>Update: 1m</p>|
+|LAN Traffic Outgoing (bits)|<p>LAN incoming traffic in bits/sec</p>|`SNMP agent`|unifiIfTxBits.1<p>Update: 1m</p>|
+|Channel utilization 2G (BGN)|<p>-</p>|`SNMP agent`|unifiRadioCuTotal.1<p>Update: 30s</p>|
 |CPU AVG Load 1 Min|<p>-</p>|`SNMP agent`|IaLoad.1<p>Update: 1m</p>|
-|Channel utilization 5G (AC)|<p>Informa o modelo do aparelho</p>|`SNMP agent`|unifiRadioCuTotal.2<p>Update: 30s</p>|
+|Channel utilization 5G (AC)|<p>-</p>|`SNMP agent`|unifiRadioCuTotal.2<p>Update: 30s</p>|
 |LAN Traffic Incoming Errors|<p>-</p>|`SNMP agent`|unifiIfRxError.1<p>Update: 1m</p>|
 |WIFI Channel $2 on $1|<p>-</p>|`SNMP agent`|unifiVapChannel[{#UNIFIVAPESSID},{#UNIVAPRADIO}]<p>Update: 1m</p><p>LLD</p>|
 |Users $2 on $1|<p>-</p>|`SNMP agent`|unifiVapNumStations[{#UNIFIVAPESSID},{#UNIVAPRADIO}]<p>Update: 30s</p><p>LLD</p>|
-|Traffic Incoming $2 on $1|<p>-</p>|`SNMP agent`|unifiVapRxBytes[{#UNIFIVAPESSID},{#UNIVAPRADIO}]<p>Update: 30s</p><p>LLD</p>|
+|Traffic Incoming $2 on $1 (bytes)|<p>Network traffic incoming on specific WiFi network in Bytes/sec</p>|`SNMP agent`|unifiVapRxBytes[{#UNIFIVAPESSID},{#UNIVAPRADIO}]<p>Update: 30s</p><p>LLD</p>|
+|Traffic Incoming $2 on $1|<p>Network traffic incoming on specific WiFi network in Bits/sec</p>|`SNMP agent`|unifiVapRxBits[{#UNIFIVAPESSID},{#UNIVAPRADIO}]<p>Update: 30s</p><p>LLD</p>|
 |Traffic Incoming Errors per Second $2 on $1|<p>-</p>|`SNMP agent`|unifiVapRxErrors[{#UNIFIVAPESSID},{#UNIVAPRADIO}]<p>Update: 60s</p><p>LLD</p>|
-|Traffic Outgoing $2 on $1|<p>-</p>|`SNMP agent`|unifiVapTxBytes[{#UNIFIVAPESSID},{#UNIVAPRADIO}]<p>Update: 30s</p><p>LLD</p>|
+|Traffic Outgoing $2 on $1 (bytes)|<p>Network traffic outgoing on specific WiFi network in Bytes/sec</p>|`SNMP agent`|unifiVapTxBytes[{#UNIFIVAPESSID},{#UNIVAPRADIO}]<p>Update: 30s</p><p>LLD</p>|
+|Traffic Outgoing $2 on $1 (bits)|<p>Network traffic outgoing on specific WiFi network in bits/sec</p>|`SNMP agent`|unifiVapTxBits[{#UNIFIVAPESSID},{#UNIVAPRADIO}]<p>Update: 30s</p><p>LLD</p>|
 |Traffic Outgoing Errors per Second $2 on $1|<p>-</p>|`SNMP agent`|unifiVapTxErrors[{#UNIFIVAPESSID},{#UNIVAPRADIO}]<p>Update: 60s</p><p>LLD</p>|
 
 

--- a/Network_Devices/Ubiquiti/template_unifi_ap_snmpv3/6.0/template_unifi_ap_snmpv3.yaml
+++ b/Network_Devices/Ubiquiti/template_unifi_ap_snmpv3/6.0/template_unifi_ap_snmpv3.yaml
@@ -13,7 +13,7 @@ zabbix_export:
       description: |
         ## Description
         
-        This template retrieve SNMP data from Unifi AP devices. MIBS requiriments: FROGFOOT-RESOURCES-MIB IANAifType-MIB IF-MIB SNMP-FRAMEWORK-MIB SNMPv2-CONF SNMPv2-MIB SNMPv2-SMI SNMPv2-TC UBNT-MIB UBNT-UniFi-MIB Author: Helmut Leonhardt based on Alex Moura
+        This template uses SNMP data from Unifi AP devices. MIBS requirements: FROGFOOT-RESOURCES-MIB IANAifType-MIB IF-MIB SNMP-FRAMEWORK-MIB SNMPv2-CONF SNMPv2-MIB SNMPv2-SMI SNMPv2-TC UBNT-MIB UBNT-UniFi-MIB Author: Helmut Leonhardt based on Alex Moura
         
         ## Overview
         
@@ -22,7 +22,7 @@ zabbix_export:
         based on Alex Mouras work https://share.zabbix.com/network\_devices/ubiquiti/unifi-snmp-2019-v1-1
           
         
-        Ubiquity Controller > Settings > Services > SNMP v3 > enable, set username and passwort
+        Ubiquity Controller > Settings > Services > SNMP v3 > enable, set username and password
         Zabbix > Macro >
         {$SNMP\_USERNAME} <= username set in controller
         {$SNMP\_AUTHPASS} & {$SNMP\_PRIVPASS} <= password set in controller
@@ -30,6 +30,12 @@ zabbix_export:
         2020 April
         fixed zabbix version
         fixed virtual interface items
+
+        2024 September - Fixes by Crowtrobot
+        Added network traffic numbers in bits/sec to simplify comparing to other network devices.
+        Replaced some description strings that appeared to be in Portuguese with English strings, or removed them completely where they didn't seem useful.
+        Fixed 5GHz channel oid, which was wrong on my UAP-AC-InWall and U6-Enterprise.
+        Added 6GHz radio channel oid.  
         
         
         ## Author
@@ -130,7 +136,7 @@ zabbix_export:
           history: 1w
           trends: '0'
           value_type: TEXT
-          description: 'Informa o modelo do aparelho'
+          description: 'The contact as set in the unifi controller'
           inventory_link: CONTACT
           request_method: POST
           tags:
@@ -147,7 +153,6 @@ zabbix_export:
           history: 1w
           trends: '0'
           value_type: TEXT
-          description: 'Informa o modelo do aparelho'
           inventory_link: HARDWARE_FULL
           request_method: POST
           tags:
@@ -164,7 +169,7 @@ zabbix_export:
           history: 1w
           trends: '0'
           value_type: TEXT
-          description: 'Informa o modelo do aparelho'
+          description: 'The location as set in the unifi controller'
           inventory_link: LOCATION
           request_method: POST
           tags:
@@ -216,7 +221,6 @@ zabbix_export:
           history: 1w
           trends: '0'
           value_type: TEXT
-          description: 'Informa o modelo do aparelho'
           inventory_link: HARDWARE
           request_method: POST
           tags:
@@ -257,17 +261,41 @@ zabbix_export:
               value: 'AP Interface'
         -
           uuid: 437bc4b769714ca18736e44ff4006ad5
-          name: 'LAN Traffic Incoming'
+          name: 'LAN Traffic Incoming (bytes)'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.41112.1.6.2.1.1.6.1
           key: unifiIfRxBytes.1
           history: 1w
           units: Bps
+          delay: 30s
           preprocessing:
             -
               type: CHANGE_PER_SECOND
               parameters:
                 - ''
+          request_method: POST
+          tags:
+            -
+              tag: Application
+              value: 'AP Interface'
+        -
+          uuid: e3d460e8cc414bf7953fbe7d6469f911
+          name: 'LAN Traffic Incoming (bits)'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.41112.1.6.2.1.1.6.1
+          key: unifiIfRxBits.1
+          history: 1w
+          units: bps
+          delay: 30s
+          preprocessing:
+            -
+              type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+            -
+              type: MULTIPLIER
+              parameters:
+                - '8'
           request_method: POST
           tags:
             -
@@ -301,17 +329,41 @@ zabbix_export:
               value: 'AP Interface'
         -
           uuid: 6f3a82d77567425c991229282940e066
-          name: 'LAN Traffic Outgoing'
+          name: 'LAN Traffic Outgoing (bytes)'
           type: SNMP_AGENT
           snmp_oid: .1.3.6.1.4.1.41112.1.6.2.1.1.12.1
           key: unifiIfTxBytes.1
           history: 1w
           units: Bps
+          delay: 30s
           preprocessing:
             -
               type: CHANGE_PER_SECOND
               parameters:
                 - ''
+          request_method: POST
+          tags:
+            -
+              tag: Application
+              value: 'AP Interface'
+        -
+          uuid: 35d24e07791340e4872258b4ce8ba9a4
+          name: 'LAN Traffic Outgoing (bits)'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.41112.1.6.2.1.1.12.1
+          key: unifiIfTxBits.1
+          history: 1w
+          units: bps
+          delay: 30s
+          preprocessing:
+            -
+              type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+            -
+              type: MULTIPLIER
+              parameters:
+                - '8'
           request_method: POST
           tags:
             -
@@ -339,7 +391,6 @@ zabbix_export:
           delay: 30s
           history: 1w
           units: '%'
-          description: 'Informa o modelo do aparelho'
           request_method: POST
           tags:
             -
@@ -365,7 +416,6 @@ zabbix_export:
           delay: 30s
           history: 1w
           units: '%'
-          description: 'Informa o modelo do aparelho'
           request_method: POST
           tags:
             -
@@ -381,6 +431,31 @@ zabbix_export:
               uuid: 3c5a400dfd7248489a24d2ed160accb2
               expression: 'avg(/UBQT UNIFI SNMP V3 HN/unifiRadioCuTotal.2,300s)=90'
               name: 'Channel utilization 5G on {HOST.NAME} very high'
+              priority: AVERAGE
+        -
+          uuid: d230ffd170ec4aad84dd118e17561313
+          name: 'Channel utilization 6G (AC)'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.41112.1.6.1.1.1.6.3
+          key: unifiRadioCuTotal.3
+          delay: 30s
+          history: 1w
+          units: '%'
+          request_method: POST
+          tags:
+            -
+              tag: Application
+              value: 'Virtual Interfaces'
+          triggers:
+            -
+              uuid: 823cbc7e98a44e12b22dc1460f856cfd
+              expression: 'avg(/UBQT UNIFI SNMP V3 HN/unifiRadioCuTotal.3,300s)=80'
+              name: 'Channel utilization 6G on {HOST.NAME} high'
+              priority: WARNING
+            -
+              uuid: 5bdabdf4995a43cc9e57ed227644518f
+              expression: 'avg(/UBQT UNIFI SNMP V3 HN/unifiRadioCuTotal.3,300s)=90'
+              name: 'Channel utilization 6G on {HOST.NAME} very high'
               priority: AVERAGE
         -
           uuid: 105096cba14349f7a059a5dafe3382c6
@@ -405,8 +480,7 @@ zabbix_export:
           snmp_oid: .1.3.6.1.4.1.41112.1.6.1.2.1.4.1
           key: unifiVapChannel.1
           history: 1w
-          status: DISABLED
-          description: 'Informa o modelo do aparelho'
+          description: 'WiFi channel on the 2.4GHz radio'
           request_method: POST
           tags:
             -
@@ -416,11 +490,23 @@ zabbix_export:
           uuid: 4ad270fb856e480480019a1677753d79
           name: 'Channel 5G (N/AC)'
           type: SNMP_AGENT
-          snmp_oid: .1.3.6.1.4.1.41112.1.6.1.2.1.4.5
+          snmp_oid: .1.3.6.1.4.1.41112.1.6.1.2.1.4.3
           key: unifiVapChannel.5
           history: 1w
-          status: DISABLED
-          description: 'Informa o modelo do aparelho'
+          description: 'WiFi channel on the 5GHz radio'
+          request_method: POST
+          tags:
+            -
+              tag: Application
+              value: System
+        -
+          uuid: 2cda09b96c404672a3502fd1439e78a2
+          name: 'Channel 6G (N/AC)'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.4.1.41112.1.6.1.2.1.4.5
+          key: unifiVapChannel.6
+          history: 1w
+          description: 'WiFi channel on the 6GHz radio'
           request_method: POST
           tags:
             -
@@ -461,7 +547,7 @@ zabbix_export:
                   value: 'Virtual Interfaces'
             -
               uuid: f40514a52c8a4c86bfb88d129700b246
-              name: 'Traffic Incoming {#UNIFIVAPESSID} on {#UNIVAPRADIO}'
+              name: 'Traffic Incoming {#UNIFIVAPESSID} on {#UNIVAPRADIO} (bytes)'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.41112.1.6.1.2.1.10.{#SNMPINDEX}'
               key: 'unifiVapRxBytes[{#UNIFIVAPESSID},{#UNIVAPRADIO}]'
@@ -472,6 +558,28 @@ zabbix_export:
                   type: CHANGE_PER_SECOND
                   parameters:
                     - ''
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'Virtual Interfaces'
+            -
+              uuid: dc28fdea598a4ef5be0dec52b769c3d7
+              name: 'Traffic Incoming {#UNIFIVAPESSID} on {#UNIVAPRADIO} (bits)'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.41112.1.6.1.2.1.10.{#SNMPINDEX}'
+              key: 'unifiVapRxBits[{#UNIFIVAPESSID},{#UNIVAPRADIO}]'
+              delay: 30s
+              units: bps
+              preprocessing:
+                -
+                  type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                -
+                  type: MULTIPLIER
+                  parameters:
+                    - '8'
               request_method: POST
               tags:
                 -
@@ -497,7 +605,7 @@ zabbix_export:
                   value: 'Virtual Interfaces'
             -
               uuid: 58ec96db72484ae2a7e596dcd644c1d5
-              name: 'Traffic Outgoing {#UNIFIVAPESSID} on {#UNIVAPRADIO}'
+              name: 'Traffic Outgoing {#UNIFIVAPESSID} on {#UNIVAPRADIO} (bytes)'
               type: SNMP_AGENT
               snmp_oid: '.1.3.6.1.4.1.41112.1.6.1.2.1.16.{#SNMPINDEX}'
               key: 'unifiVapTxBytes[{#UNIFIVAPESSID},{#UNIVAPRADIO}]'
@@ -508,6 +616,28 @@ zabbix_export:
                   type: CHANGE_PER_SECOND
                   parameters:
                     - ''
+              request_method: POST
+              tags:
+                -
+                  tag: Application
+                  value: 'Virtual Interfaces'
+            -
+              uuid: 13a7e5e2075147cdbfe9f1a3a60be264
+              name: 'Traffic Outgoing {#UNIFIVAPESSID} on {#UNIVAPRADIO} (bits)'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.41112.1.6.1.2.1.16.{#SNMPINDEX}'
+              key: 'unifiVapTxBits[{#UNIFIVAPESSID},{#UNIVAPRADIO}]'
+              delay: 30s
+              units: bps
+              preprocessing:
+                -
+                  type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                -
+                  type: MULTIPLIER
+                  parameters:
+                    - '8'
               request_method: POST
               tags:
                 -


### PR DESCRIPTION
First off, apologies if I've done any of this wrong.  Still learning.  

It took me an embarrassingly long time to figure out that network traffic numbers from my ubiquiti access points was wrong on my dashboard because it was all in Bytes/sec (or KB/s, MB/s etc) instead of being in bits/s like all my other network gear reports in.  I assume someone set it up for bytes instead of bits because that's what they wanted, so I added bits/s and left the bytes/s there.  

I also found a few other small things that to fix while I was there:

- Add network traffic numbers in bits/sec to simplify comparing to other network devices.
- Replaced some description strings that appeared to be in Portuguese with English strings, or removed them completely where they didn't seem useful.
- Fixed 5GHz channel oid, was wrong on my UAP-AC-InWall and U6-Enterprise.
- Added 6GHz radio channel oid.

