### PR TITLE
Update template_avtech_room_alert_3e.yaml

### DIFF
--- a/SCADA_IoT_Energy_Home_Automation_Industrial_monitoring/template_avtech_room_alert_3e/6.0/template_avtech_room_alert_3e.yaml
+++ b/SCADA_IoT_Energy_Home_Automation_Industrial_monitoring/template_avtech_room_alert_3e/6.0/template_avtech_room_alert_3e.yaml
@@ -37,6 +37,11 @@ zabbix_export:
           value_type: FLOAT
           units: °C
           description: 'Temperature reading from the internal thermometer'
+          preprocessing:
+            -
+              type: MULTIPLIER
+              parameters:
+                - '0.01'
           triggers:
             -
               uuid: aae943b07eb94079a00d09a4fe225e90


### PR DESCRIPTION
the temperature received is formatted like "2406" to mean "24.06°C", so it requires a preprocessing step to multiply the received value by 0.01