### PR TITLE
Create Nobreak_RagTech_Template.yaml

### DIFF
--- a/Power_(UPS)/RagTech/7.2/Nobreak_RagTech_Template.yaml
+++ b/Power_(UPS)/RagTech/7.2/Nobreak_RagTech_Template.yaml
@@ -1,0 +1,255 @@
+zabbix_export:
+  version: '7.2'
+  template_groups:
+    - uuid: 46e7cca15db942b2ad8c9d9c1823ac53
+      name: Templates/Power
+  templates:
+    - uuid: 4bbb5fd140344b7caaa7fb26d0507589
+      template: 'Nobreak RagTech'
+      name: 'Nobreak RagTech'
+      description: |
+        Template para monitorar Nobreak RagTech com base em JSON.
+        
+        Desenvolvido por Manoel Douglas Rufino Filho.
+        
+        Obs.: Lembre-se de instalar e configurar corretamente o serviço supeviser da RagTech para ter acesso aos dados.
+      groups:
+        - name: Templates/Power
+      items:
+        - uuid: c8db1cd8db0249e0998f1ea448c3a784
+          name: 'Status de Conexão (connected)'
+          type: DEPENDENT
+          key: device.connected
+          history: 1w
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.status.connected
+          master_item:
+            key: 'web.page.get[device_status]'
+          triggers:
+            - uuid: a2106c1020d24aa289031639eeded534
+              expression: 'last(/Nobreak RagTech/device.connected)=0'
+              name: 'Dispositivo Desconectado (connected = 0)'
+              event_name: 'Dispositivo está desconectado.'
+              priority: HIGH
+        - uuid: c5d7c257da9b48a2bb4749137d24c655
+          name: Family
+          type: DEPENDENT
+          key: device.family
+          history: 1w
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.family
+          master_item:
+            key: 'web.page.get[device_status]'
+        - uuid: 69c1aefaf97945ecb4cbfa0108f397bb
+          name: ID
+          type: DEPENDENT
+          key: device.id
+          history: 1w
+          value_type: TEXT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.id
+          master_item:
+            key: 'web.page.get[device_status]'
+        - uuid: acd00d19fa754b12a4feb11d2a6e3c37
+          name: 'ID PC'
+          type: DEPENDENT
+          key: device.idPc
+          history: 1w
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.idPc
+          master_item:
+            key: 'web.page.get[device_status]'
+        - uuid: adaa38b61eea48c58c1afee82f09e602
+          name: 'Last Update'
+          type: DEPENDENT
+          key: device.last
+          history: 1w
+          value_type: TEXT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.last
+          master_item:
+            key: 'web.page.get[device_status]'
+        - uuid: 787d0871c0684c56b3afa791a46ba218
+          name: Model
+          type: DEPENDENT
+          key: device.model
+          history: 1w
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.model
+          master_item:
+            key: 'web.page.get[device_status]'
+        - uuid: 48efe57275b34db9b1826c0e1a41c86f
+          name: Name
+          type: DEPENDENT
+          key: device.name
+          history: 1w
+          value_type: TEXT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.name
+          master_item:
+            key: 'web.page.get[device_status]'
+        - uuid: d86755954bc94cb8b57685600c188d21
+          name: 'USB Port Name'
+          type: DEPENDENT
+          key: device.port.name
+          history: 1w
+          value_type: TEXT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.port.name
+          master_item:
+            key: 'web.page.get[device_status]'
+        - uuid: 91ae8f34aebe47a5ae206bad53233fba
+          name: Protocol
+          type: DEPENDENT
+          key: device.protocol
+          history: 1w
+          value_type: TEXT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.protocol
+          master_item:
+            key: 'web.page.get[device_status]'
+        - uuid: 525a8b8486d547938d6f68393cbdb858
+          name: 'Temperatura (temperature)'
+          type: DEPENDENT
+          key: device.temperature
+          history: 1w
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.vars.temperature
+          master_item:
+            key: 'web.page.get[device_status]'
+          triggers:
+            - uuid: bc2594426cf64fe987b717cab1055a48
+              expression: 'last(/Nobreak RagTech/device.temperature)>60'
+              name: 'Temperatura Alta (temperature > 60°C)'
+              event_name: 'Temperatura do dispositivo está acima de 60°C.'
+              priority: WARNING
+        - uuid: a840e1931fa449f69adf0bef10f6d7ca
+          name: 'User Name'
+          type: DEPENDENT
+          key: device.userName
+          history: 1w
+          value_type: TEXT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.userName
+          master_item:
+            key: 'web.page.get[device_status]'
+        - uuid: f5ee1f085ad342e19d2dff6c29c192f1
+          name: 'User Product'
+          type: DEPENDENT
+          key: device.userProd
+          history: 1w
+          value_type: TEXT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.userProd
+          master_item:
+            key: 'web.page.get[device_status]'
+        - uuid: 765809af381e4840ac8f396cabea99ca
+          name: 'Tensão da Bateria (vBattery)'
+          type: DEPENDENT
+          key: device.vBattery
+          history: 1w
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.vars.vBattery
+          master_item:
+            key: 'web.page.get[device_status]'
+          triggers:
+            - uuid: 26f2478f5655498fbcedc46c6f1eb5f1
+              expression: 'last(/Nobreak RagTech/device.vBattery)<24'
+              name: 'Tensão da Bateria Baixa (vBattery < 24V)'
+              event_name: 'Tensão da bateria está abaixo de 24V.'
+              priority: AVERAGE
+        - uuid: 38467b71a2404729aa0548e9f532747d
+          name: Version
+          type: DEPENDENT
+          key: device.version
+          history: 1w
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.version
+          master_item:
+            key: 'web.page.get[device_status]'
+        - uuid: ae16ab94d3c340f5892c359c0f97483b
+          name: 'Tensão de Entrada (vInput)'
+          type: DEPENDENT
+          key: device.vInput
+          history: 1w
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.vars.vInput
+          master_item:
+            key: 'web.page.get[device_status]'
+          triggers:
+            - uuid: 1161550633204f46bc44fba35870fed2
+              expression: 'last(/Nobreak RagTech/device.vInput)<210 or last(/Nobreak RagTech/device.vInput)>230'
+              name: 'Tensão de Entrada Fora do Esperado (vInput < 210V ou > 230V)'
+              event_name: 'Tensão de entrada está fora da faixa esperada (210V-230V).'
+              priority: WARNING
+        - uuid: 61ce5c288d6142fb9268db2c8fc51b55
+          name: 'Tensão de Saída (vOutput)'
+          type: DEPENDENT
+          key: device.vOutput
+          history: 1w
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.device.vars.vOutput
+          master_item:
+            key: 'web.page.get[device_status]'
+          triggers:
+            - uuid: 139fe43b88104347b5fc5f9f0338d494
+              expression: 'last(/Nobreak RagTech/device.vOutput)<210 or last(/Nobreak RagTech/device.vOutput)>230'
+              name: 'Tensão de Saída Fora do Esperado (vOutput < 210V ou > 230V)'
+              event_name: 'Tensão de saída está fora da faixa esperada (210V-230V).'
+              priority: WARNING
+        - uuid: a3acfc89a9f34a28b8eed7928919485f
+          name: 'Device JSON Data'
+          type: HTTP_AGENT
+          key: 'web.page.get[device_status]'
+          history: 1w
+          value_type: TEXT
+          timeout: 15s
+          url: 'http://{HOST.CONN}:4470/mon/1.1/device/FFFFFFFF07'
+      tags:
+        - tag: class
+          value: hardware
+        - tag: target
+          value: nobreak
+        - tag: target
+          value: ragtech


### PR DESCRIPTION
EN: Template for monitoring RagTech UPS based on JSON.
BR: Template para monitorar Nobreak RagTech com base em JSON.

Note: Remember to install and correctly configure the RagTech supervisor service to access the data.
Obs.: Lembre-se de instalar e configurar corretamente o serviço supeviser da RagTech para ter acesso aos dados.
