### PR TITLE
Update template_pi-hole_api.yaml

### DIFF
--- a/Applications/template_pi-hole_api/6.0/README.md
+++ b/Applications/template_pi-hole_api/6.0/README.md
@@ -93,7 +93,9 @@ Undefined_ID
 
 ## Macros used
 
-There are no macros links in this template.
+|Name|Description|Default|Type|
+|----|-----------|-------|----|
+|{$WEB.PORT}|<p>Web interface port</p>|`80`|Text macro|
 
 ## Template links
 

--- a/Applications/template_pi-hole_api/6.0/template_pi-hole_api.yaml
+++ b/Applications/template_pi-hole_api/6.0/template_pi-hole_api.yaml
@@ -114,7 +114,7 @@ zabbix_export:
           key: json.pihole
           trends: '0'
           value_type: TEXT
-          url: 'http://{HOST.IP}/admin/api.php'
+          url: 'http://{HOST.IP}:{$WEB.PORT}/admin/api.php'
           query_fields:
             -
               name: summaryRaw
@@ -270,7 +270,7 @@ zabbix_export:
           key: json.pihole.querytypes
           trends: '0'
           value_type: TEXT
-          url: 'http://{HOST.IP}/admin/api.php'
+          url: 'http://{HOST.IP}:{$WEB.PORT}/admin/api.php'
           query_fields:
             -
               name: getQueryTypes
@@ -629,6 +629,11 @@ zabbix_export:
             -
               tag: Application
               value: DNS
+      macros:
+        -
+          macro: '{$WEB.PORT}'
+          value: '80'
+      
   graphs:
     -
       uuid: f74d491b474d49bcb9faa24a804be6d9


### PR DESCRIPTION
New macro {$WEB.PORT} if Pi-Hole web interface is running on a custom port. Default value is 80. HTTP agent items have also been updated to use this macro.