### PR TITLE
Update RavenDB template - adjust type and units

### DIFF
--- a/Databases/RavenDB/template_ravendb_server/6.0/template_ravendb_server.yaml
+++ b/Databases/RavenDB/template_ravendb_server/6.0/template_ravendb_server.yaml
@@ -46,11 +46,6 @@ zabbix_export:
       snmp_oid: 1.3.6.1.4.1.45751.1.1.3.2.1
       key: cluster.term
       delay: 10s
-      units: s
-      preprocessing:
-      - type: MULTIPLIER
-        parameters:
-        - '0.001'
       tags:
       - tag: RavenDB
         value: Cluster
@@ -588,6 +583,7 @@ zabbix_export:
       snmp_oid: 1.3.6.1.4.1.45751.1.1.1.7.4
       key: server.requests.avgDuration
       delay: 5s
+      value_type: FLOAT
       units: s
       preprocessing:
       - type: MULTIPLIER


### PR DESCRIPTION
Updated type for average request duration and removed unit `s` and preprocessing from cluster terms.