### PR TITLE
Tweaks and fixes for ZFS On Linux for Zabbix 7.0

### DIFF
--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/README.md
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/README.md
@@ -1,0 +1,142 @@
+# ZFS on Linux
+
+## Installation
+
+To use the Zabbix ZFS on Linux template, you must first install a correctly configured userparams file on any machines running the zabbix agent and using ZFS.
+
+### Choosing the correct userparams file
+
+There should be two different user parameters files in the same directory as this README, `userparams_zol_without_sudo.conf` and `userparams_zol_with_sudo.conf`. One uses `sudo` to run and thus you must give Zabbix the correct rights and the other doesn't use `sudo`.
+
+On recent ZFS on Linux versions (version 0.7.0+), you don't need sudo to run `zpool list` or `zfs list` so you need to copy `userparams_zol_without_sudo.conf` into `/etc/zabbix/zabbix_agentd.d` or `/etc/zabbix/zabbix_agent2.d` if using zabbix-agent2.
+
+For older ZFS on Linux versions (eg version 0.6.x), you will need to add some sudo rights with the file `userparams_zol_with_sudo.conf`. On some distributions, ZoL already includes a suitable file with all the necessary rights at `/etc/sudoers.d/zfs` but its contents are commented out, you just need to remove the comments and any user will be able to list zfs datasets and pools. An example config might look like so:
+
+```
+## Allow read-only ZoL commands to be called through sudo
+## without a password. Remove the first '#' column to enable.
+##
+## CAUTION: Any syntax error introduced here will break sudo.
+##
+## Cmnd alias specification
+Cmnd_Alias C_ZFS = \
+  /sbin/zfs "", /sbin/zfs help *, \
+  /sbin/zfs get, /sbin/zfs get *, \
+  /sbin/zfs list, /sbin/zfs list *, \
+  /sbin/zpool "", /sbin/zpool help *, \
+  /sbin/zpool iostat, /sbin/zpool iostat *, \
+  /sbin/zpool list, /sbin/zpool list *, \
+  /sbin/zpool status, /sbin/zpool status *, \
+  /sbin/zpool upgrade, /sbin/zpool upgrade -v
+
+## allow any user to use basic read-only ZFS commands
+ALL ALL = (root) NOPASSWD: C_ZFS
+```
+
+If you don't know where your userparameters directory is, this is usually `/etc/zabbix/zabbix_agentd.d`. If in doubt, just look at your `zabbix_agentd.conf` file for the line begining by `Include=`.
+
+### Editing the userparams file
+
+The path used for the `zfs` and `zpool` binaries is different under almost every Linux distro, the paths aren't even the same for Debian and Ubuntu, as one notable example. For this reason you should run `which zfs` and `which zpool` on each ZFS machine you want to monitor with Zabbix to find out the correct paths to use to run these two binaries, then you need to edit the userparams file so that every instance of `zfs` and `zpool` is called using the correct path, if your distro's path doesn't match the path used in example userparams files.
+
+## Macros used
+
+|Name|Description|Default|Type|
+|----|-----------|-------|----|
+|{$ZFS_ARC_META_ALERT}|<p>-</p>|`90`|Text macro|
+|{$ZFS_AVERAGE_ALERT}|<p>-</p>|`90`|Text macro|
+|{$ZFS_DISASTER_ALERT}|<p>-</p>|`99`|Text macro|
+|{$ZFS_HIGH_ALERT}|<p>-</p>|`95`|Text macro|
+|{$ZPOOL_AVERAGE_ALERT}|<p>-</p>|`85`|Text macro|
+|{$ZPOOL_DISASTER_ALERT}|<p>-</p>|`99`|Text macro|
+|{$ZPOOL_HIGH_ALERT}|<p>-</p>|`90`|Text macro|
+|{$ZFS_FSNAME_MATCHES}|<p>Determine datasets to discover</p>|`/`|Text macro|
+|{$ZFS_FSNAME_NOTMATCHES}|<p>Determine datasets to ignore</p>|`([a-z-0-9]{64}$\|[a-z-0-9]{64}-init$)`|Text macro|
+
+
+## Template links
+
+There are no template links in this template.
+
+## Discovery rules
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|Zfs Dataset discovery|<p>Discover ZFS dataset. Dataset names must contain a "/" else it's a zpool.</p>|`Zabbix agent (active)`|zfs.fileset.discovery<p>Update: 30m</p>|
+|Zfs Pool discovery|<p>-</p>|`Zabbix agent (active)`|zfs.pool.discovery<p>Update: 1h</p>|
+|Zfs vdev discovery|<p>-</p>|`Zabbix agent (active)`|zfs.vdev.discovery<p>Update: 1h</p>|
+
+
+## Items collected
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|ZFS on Linux version|<p>-</p>|`Zabbix agent (active)`|vfs.file.contents[/sys/module/zfs/version]<p>Update: 1h</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[metadata_size]<p>Update: 1m</p>|
+|ZFS parameter $1|<p>-</p>|`Zabbix agent (active)`|zfs.get.param[zfs_arc_dnode_limit_percent]<p>Update: 1h</p>|
+|ZFS ARC current size|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[size]<p>Update: 1m</p>|
+|ZFS ARC total read|<p>-</p>|`Calculated`|zfs.arcstats_total_read<p>Update: 1m</p>|
+|ZFS ARC Cache Hit Ratio|<p>-</p>|`Calculated`|zfs.arcstats_hit_ratio<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[mru_size]<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[mru_hits]<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[misses]<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[mfu_size]<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[dbuf_size]<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[data_size]<p>Update: 1m</p>|
+|ZFS ARC minimum size|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[c_min]<p>Update: 1m</p>|
+|ZFS ARC max size|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[c_max]<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[bonus_size]<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>arc_meta_used = hdr_size + metadata_size + dbuf_size + dnode_size + bonus_size</p>|`Zabbix agent (active)`|zfs.arcstats[arc_meta_used]<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[arc_meta_limit]<p>Update: 1m</p>|
+|ZFS parameter $1|<p>-</p>|`Zabbix agent (active)`|zfs.get.param[zfs_arc_meta_limit_percent]<p>Update: 1h</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[mfu_hits]<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[hits]<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[arc_dnode_limit]<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[hdr_size]<p>Update: 1m</p>|
+|ZFS ARC stat "$1"|<p>-</p>|`Zabbix agent (active)`|zfs.arcstats[dnode_size]<p>Update: 1m</p>|
+|Zfs dataset $1 compressratio|<p>-</p>|`Zabbix agent (active)`|zfs.get.compressratio[{#FILESETNAME}]<p>Update: 30m</p><p>LLD</p>|
+|Zfs dataset $1 $2|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#FILESETNAME},available]<p>Update: 5m</p><p>LLD</p>|
+|Zfs dataset $1 $2|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#FILESETNAME},referenced]<p>Update: 5m</p><p>LLD</p>|
+|Zfs dataset $1 $2|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#FILESETNAME},usedbychildren]<p>Update: 5m</p><p>LLD</p>|
+|Zfs dataset $1 $2|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#FILESETNAME},usedbydataset]<p>Update: 1h</p><p>LLD</p>|
+|Zfs dataset $1 $2|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#FILESETNAME},usedbysnapshots]<p>Update: 5m</p><p>LLD</p>|
+|Zfs dataset $1 $2|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#FILESETNAME},used]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME}: Get iostats|<p>-</p>|`Zabbix agent (active)`|zfs.zpool.iostat[{#POOLNAME}]<p>Update: 1m</p><p>LLD</p>|
+|Zpool {#POOLNAME} available|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#POOLNAME},available]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} used|<p>-</p>|`Zabbix agent (active)`|zfs.get.fsinfo[{#POOLNAME},used]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} Health|<p>-</p>|`Zabbix agent (active)`|zfs.zpool.health[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} scrub status|<p>Detect if the pool is currently scrubbing itself. This is not a bad thing itself, but it slows down the entire pool and should be terminated when on production server during business hours if it causes a noticeable slowdown.</p>|`Zabbix agent (active)`|zfs.zpool.scrub[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} read throughput|<p>-</p>|`Dependent item`|zfs.zpool.iostat.nread[{#POOLNAME}]<p>Update: 0</p><p>LLD</p>|
+|Zpool {#POOLNAME} write throughput|<p>-</p>|`Dependent item`|zfs.zpool.iostat.nwritten[{#POOLNAME}]<p>Update: 0</p><p>LLD</p>|
+|Zpool {#POOLNAME} IOPS: reads|<p>-</p>|`Dependent item`|zfs.zpool.iostat.reads[{#POOLNAME}]<p>Update: 0</p><p>LLD</p>|
+|Zpool {#POOLNAME} IOPS: writes|<p>-</p>|`Dependent item`|zfs.zpool.iostat.writes[{#POOLNAME}]<p>Update: 0</p><p>LLD</p>|
+|vdev {#VDEV}: CHECKSUM error counter|<p>This device has experienced an unrecoverable error. Determine if the device needs to be replaced. If yes, use 'zpool replace' to replace the device. If not, clear the error with 'zpool clear'.</p>|`Zabbix agent (active)`|zfs.vdev.error_counter.cksum[{#VDEV}]<p>Update: 5m</p><p>LLD</p>|
+|vdev {#VDEV}: READ error counter|<p>This device has experienced an unrecoverable error. Determine if the device needs to be replaced. If yes, use 'zpool replace' to replace the device. If not, clear the error with 'zpool clear'.</p>|`Zabbix agent (active)`|zfs.vdev.error_counter.read[{#VDEV}]<p>Update: 5m</p><p>LLD</p>|
+|vdev {#VDEV}: WRITE error counter|<p>This device has experienced an unrecoverable error. Determine if the device needs to be replaced. If yes, use 'zpool replace' to replace the device. If not, clear the error with 'zpool clear'.</p>|`Zabbix agent (active)`|zfs.vdev.error_counter.write[{#VDEV}]<p>Update: 5m</p><p>LLD</p>|
+|vdev {#VDEV}: total number of errors|<p>This device has experienced an unrecoverable error. Determine if the device needs to be replaced. If yes, use 'zpool replace' to replace the device. If not, clear the error with 'zpool clear'.</p>|`Calculated`|zfs.vdev.error_total[{#VDEV}]<p>Update: 5m</p><p>LLD</p>|
+
+
+## Triggers
+
+|Name|Description|Expression|Priority|
+|----|-----------|----------|--------|
+|More than {$ZFS_AVERAGE_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > (90/100)</p><p>**Recovery expression**: </p>|average|
+|More than {$ZFS_DISASTER_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > (99/100)</p><p>**Recovery expression**: </p>|disaster|
+|More than {$ZFS_HIGH_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > (95/100)</p><p>**Recovery expression**: </p>|high|
+|More than {$ZPOOL_AVERAGE_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > (85/100)</p><p>**Recovery expression**: </p>|average|
+|More than {$ZPOOL_DISASTER_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > (99/100)</p><p>**Recovery expression**: </p>|disaster|
+|More than {$ZPOOL_HIGH_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > (90/100)</p><p>**Recovery expression**: </p>|high|
+|Zpool {#POOLNAME} is scrubbing for more than 12h on {HOST.NAME}|<p>-</p>|<p>**Expression**: max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],12h)=0</p><p>**Recovery expression**: </p>|average|
+|Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME}|<p>-</p>|<p>**Expression**: max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],24h)=0</p><p>**Recovery expression**: </p>|high|
+|Zpool {#POOLNAME} is {ITEM.VALUE} on {HOST.NAME}|<p>-</p>|<p>**Expression**: find(/ZFS on Linux/zfs.zpool.health[{#POOLNAME}],,"like","ONLINE")=0</p><p>**Recovery expression**: </p>|high|
+|vdev {#VDEV} has encountered {ITEM.VALUE} errors on {HOST.NAME}|<p>This device has experienced an unrecoverable error. Determine if the device needs to be replaced. If yes, use 'zpool replace' to replace the device. If not, clear the error with 'zpool clear'. You may also run a zpool scrub to check if some other undetected errors are present on this vdev.</p>|<p>**Expression**: last(/ZFS on Linux/zfs.vdev.error_total[{#VDEV}])>0</p><p>**Recovery expression**: </p>|high|
+|More than {$ZFS_AVERAGE_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > (90/100)</p><p>**Recovery expression**: </p>|average|
+|More than {$ZFS_DISASTER_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > (99/100)</p><p>**Recovery expression**: </p>|disaster|
+|More than {$ZFS_HIGH_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > (95/100)</p><p>**Recovery expression**: </p>|high|
+|More than {$ZPOOL_AVERAGE_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > (85/100)</p><p>**Recovery expression**: </p>|average|
+|More than {$ZPOOL_DISASTER_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > (99/100)</p><p>**Recovery expression**: </p>|disaster|
+|More than {$ZPOOL_HIGH_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > (90/100)</p><p>**Recovery expression**: </p>|high|
+|Zpool {#POOLNAME} is scrubbing for more than 12h on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],12h)=0</p><p>**Recovery expression**: </p>|average|
+|Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],24h)=0</p><p>**Recovery expression**: </p>|high|
+|Zpool {#POOLNAME} is {ITEM.VALUE} on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: find(/ZFS on Linux/zfs.zpool.health[{#POOLNAME}],,"like","ONLINE")=0</p><p>**Recovery expression**: </p>|high|
+|vdev {#VDEV} has encountered {ITEM.VALUE} errors on {HOST.NAME} (LLD)|<p>This device has experienced an unrecoverable error. Determine if the device needs to be replaced. If yes, use 'zpool replace' to replace the device. If not, clear the error with 'zpool clear'. You may also run a zpool scrub to check if some other undetected errors are present on this vdev.</p>|<p>**Expression**: last(/ZFS on Linux/zfs.vdev.error_total[{#VDEV}])>0</p><p>**Recovery expression**: </p>|high|

--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/template_zfs_on_linux.yaml
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/template_zfs_on_linux.yaml
@@ -1,0 +1,1250 @@
+zabbix_export:
+  version: '6.0'
+  date: '2022-11-16T18:44:30Z'
+  groups:
+    -
+      uuid: 57b7ae836ca64446ba2c296389c009b7
+      name: Templates/Modules
+  templates:
+    -
+      uuid: 47d3c2ff933947368d4bee4b1184d69b
+      template: 'ZFS on Linux'
+      name: 'ZFS on Linux'
+      groups:
+        -
+          name: Templates
+      items:
+        -
+          uuid: 4ecabdcb2104460f83c2ad5f18fd98f9
+          name: 'ZFS on Linux version'
+          key: 'vfs.file.contents[/sys/module/zfs/version]'
+          delay: 1h
+          history: 30d
+          trends: '0'
+          value_type: TEXT
+          tags:
+            -
+              tag: Application
+              value: ZFS
+          triggers:
+            -
+              uuid: 879881de9f8b4b97b5270df192d86850
+              expression: '(last(/ZFS on Linux/vfs.file.contents[/sys/module/zfs/version],#1)<>last(/ZFS on Linux/vfs.file.contents[/sys/module/zfs/version],#2))>0'
+              name: 'Version of ZoL is now {ITEM.VALUE} on {HOST.NAME}'
+              priority: INFO
+        -
+          uuid: 6b5fc935fe194d30badea64eaf3f317f
+          name: 'ZFS ARC stat "arc_dnode_limit"'
+          key: 'zfs.arcstats[arc_dnode_limit]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: 0b7d673688e3429d92aa349762729f83
+          name: 'ZFS ARC stat "arc_meta_limit"'
+          key: 'zfs.arcstats[arc_meta_limit]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: b0b5004458494182bf874545f8eb4e41
+          name: 'ZFS ARC stat "arc_meta_used"'
+          key: 'zfs.arcstats[arc_meta_used]'
+          history: 30d
+          units: B
+          description: 'arc_meta_used = hdr_size + metadata_size + dbuf_size + dnode_size + bonus_size'
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: 795ab079ba13461c872ee1d5c0295704
+          name: 'ZFS ARC stat "bonus_size"'
+          key: 'zfs.arcstats[bonus_size]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: 34a1fb79b2b64ce08ec5b377211372d7
+          name: 'ZFS ARC max size'
+          key: 'zfs.arcstats[c_max]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: d60b8e4f7a3d4bea972e7fe04c3bb5ca
+          name: 'ZFS ARC minimum size'
+          key: 'zfs.arcstats[c_min]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: 5e12dd98f1644f5a87cc5ded5d2e55d8
+          name: 'ZFS ARC stat "data_size"'
+          key: 'zfs.arcstats[data_size]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: 522a0f33c90047bab4f55b7214f51dea
+          name: 'ZFS ARC stat "dbuf_size"'
+          key: 'zfs.arcstats[dbuf_size]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: a3d10ebb57984a829f780a229fc9617c
+          name: 'ZFS ARC stat "dnode_size"'
+          key: 'zfs.arcstats[dnode_size]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: 184eef57aa034cf8acaf6a8f0e02395b
+          name: 'ZFS ARC stat "hdr_size"'
+          key: 'zfs.arcstats[hdr_size]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: cb7bcc02dfc14329a361e194145871c0
+          name: 'ZFS ARC stat "hits"'
+          key: 'zfs.arcstats[hits]'
+          history: 30d
+          preprocessing:
+            -
+              type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: 8df273b6e0904c9ab140f8f13f6ca973
+          name: 'ZFS ARC stat "metadata_size"'
+          key: 'zfs.arcstats[metadata_size]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: dcd96743ed984018bff5d16105693606
+          name: 'ZFS ARC stat "mfu_hits"'
+          key: 'zfs.arcstats[mfu_hits]'
+          history: 30d
+          preprocessing:
+            -
+              type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: 1015ebe8ef6f4626ae7967bf6358f1b3
+          name: 'ZFS ARC stat "mfu_size"'
+          key: 'zfs.arcstats[mfu_size]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: 1298a265a6784e63a166b768e1faf67e
+          name: 'ZFS ARC stat "misses"'
+          key: 'zfs.arcstats[misses]'
+          history: 30d
+          preprocessing:
+            -
+              type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: c85d0e9e1b464748a20148e2f2507609
+          name: 'ZFS ARC stat "mru_hits"'
+          key: 'zfs.arcstats[mru_hits]'
+          history: 30d
+          preprocessing:
+            -
+              type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: 50954c7b43d745d09990011df4d7448c
+          name: 'ZFS ARC stat "mru_size"'
+          key: 'zfs.arcstats[mru_size]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: cd225da5a02346a58dbe0c9808a628eb
+          name: 'ZFS ARC current size'
+          key: 'zfs.arcstats[size]'
+          history: 30d
+          units: B
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: 8c8129f814fe47ae9c71e636599acd90
+          name: 'ZFS ARC Cache Hit Ratio'
+          type: CALCULATED
+          key: zfs.arcstats_hit_ratio
+          history: 30d
+          value_type: FLOAT
+          units: '%'
+          params: '100*(last(//zfs.arcstats[hits])/(last(//zfs.arcstats[hits])+count(//zfs.arcstats[hits],#1,,"0")+last(//zfs.arcstats[misses])))'
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: e644390a9c9743f2844dbc9ef8806a8f
+          name: 'ZFS ARC total read'
+          type: CALCULATED
+          key: zfs.arcstats_total_read
+          history: 30d
+          units: B
+          params: 'last(//zfs.arcstats[hits])+last(//zfs.arcstats[misses])'
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: ebfb742fb123451c9632d12bde0957c4
+          name: 'ZFS parameter zfs_arc_dnode_limit_percent'
+          key: 'zfs.get.param[zfs_arc_dnode_limit_percent]'
+          delay: 1h
+          history: 30d
+          units: '%'
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+        -
+          uuid: 18d8b817852848929f4e0b421cb21532
+          name: 'ZFS parameter zfs_arc_meta_limit_percent'
+          key: 'zfs.get.param[zfs_arc_meta_limit_percent]'
+          delay: 1h
+          history: 30d
+          units: '%'
+          tags:
+            -
+              tag: Application
+              value: ZFS
+            -
+              tag: Application
+              value: 'ZFS ARC'
+      discovery_rules:
+        -
+          uuid: a82a1b7067904fecb06bcf5b88457192
+          name: 'Zfs Dataset discovery'
+          key: zfs.fileset.discovery
+          delay: 30m
+          filter:
+            evaltype: AND
+            conditions:
+              -
+                macro: '{#FILESETNAME}'
+                value: '{$ZFS_FSNAME_MATCHES}'
+                formulaid: A
+              -
+                macro: '{#FILESETNAME}'
+                value: '{$ZFS_FSNAME_NOTMATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: B
+          lifetime: 2d
+          description: 'Discover ZFS dataset. Dataset names must contain a "/" else it''s a zpool.'
+          item_prototypes:
+            -
+              uuid: 4d7c96bd10b44754b2c8790b90c12046
+              name: 'Zfs dataset {#FILESETNAME} compressratio'
+              key: 'zfs.get.compressratio[{#FILESETNAME}]'
+              delay: 30m
+              history: 30d
+              value_type: FLOAT
+              units: '%'
+              preprocessing:
+                -
+                  type: MULTIPLIER
+                  parameters:
+                    - '100'
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS dataset'
+            -
+              uuid: e9df401ae71e45c8a3fdbbd146cdd57b
+              name: 'Zfs dataset {#FILESETNAME} available'
+              key: 'zfs.get.fsinfo[{#FILESETNAME},available]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS dataset'
+            -
+              uuid: ed63bb6942364281bcea80c54b6f8fcc
+              name: 'Zfs dataset {#FILESETNAME} referenced'
+              key: 'zfs.get.fsinfo[{#FILESETNAME},referenced]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS dataset'
+            -
+              uuid: 7ef4530ddf464defb2a64ce674a82c8c
+              name: 'Zfs dataset {#FILESETNAME} usedbychildren'
+              key: 'zfs.get.fsinfo[{#FILESETNAME},usedbychildren]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS dataset'
+            -
+              uuid: 3c7f982147be49629c78aa67a1d8d56e
+              name: 'Zfs dataset {#FILESETNAME} usedbydataset'
+              key: 'zfs.get.fsinfo[{#FILESETNAME},usedbydataset]'
+              delay: 1h
+              history: 30d
+              units: B
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS dataset'
+            -
+              uuid: cc0e02c58b28443eb78eeacc81095966
+              name: 'Zfs dataset {#FILESETNAME} usedbysnapshots'
+              key: 'zfs.get.fsinfo[{#FILESETNAME},usedbysnapshots]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS dataset'
+            -
+              uuid: a54feffafdb34ba08f1474ab4710088d
+              name: 'Zfs dataset {#FILESETNAME} used'
+              key: 'zfs.get.fsinfo[{#FILESETNAME},used]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS dataset'
+          trigger_prototypes:
+            -
+              uuid: cc0b0756d2fe42779b62adf63e38681d
+              expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > ({$ZFS_AVERAGE_ALERT}/100)'
+              name: 'More than {$ZFS_AVERAGE_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}'
+              priority: AVERAGE
+              dependencies:
+                -
+                  name: 'More than {$ZFS_HIGH_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}'
+                  expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > ({$ZFS_HIGH_ALERT}/100)'
+            -
+              uuid: 8bfb157ac42845c0b340e28ae510833c
+              expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > ({$ZFS_DISASTER_ALERT}/100)'
+              name: 'More than {$ZFS_DISASTER_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}'
+              priority: DISASTER
+            -
+              uuid: 9b592a2cba084bec9ceb4f82367e758b
+              expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > ({$ZFS_HIGH_ALERT}/100)'
+              name: 'More than {$ZFS_HIGH_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}'
+              priority: HIGH
+              dependencies:
+                -
+                  name: 'More than {$ZFS_DISASTER_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}'
+                  expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > ({$ZFS_DISASTER_ALERT}/100)'
+          graph_prototypes:
+            -
+              uuid: 5213684719404718b8956d6faf0e6b71
+              name: 'ZFS dataset {#FILESETNAME} usage'
+              type: STACKED
+              ymin_type_1: FIXED
+              graph_items:
+                -
+                  sortorder: '1'
+                  color: 3333FF
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.fsinfo[{#FILESETNAME},usedbydataset]'
+                -
+                  sortorder: '2'
+                  color: FF33FF
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.fsinfo[{#FILESETNAME},usedbysnapshots]'
+                -
+                  sortorder: '3'
+                  color: FF3333
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.fsinfo[{#FILESETNAME},usedbychildren]'
+                -
+                  sortorder: '4'
+                  color: 33FF33
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.fsinfo[{#FILESETNAME},available]'
+        -
+          uuid: 08039e570bd7417294d043f4f7bf960f
+          name: 'Zfs Pool discovery'
+          key: zfs.pool.discovery
+          delay: 1h
+          lifetime: 3d
+          item_prototypes:
+            -
+              uuid: 9f889e9529934fdfbf47a29de32468f0
+              name: 'Zpool {#POOLNAME} available'
+              key: 'zfs.get.fsinfo[{#POOLNAME},available]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS zpool'
+            -
+              uuid: 1993c04b00bc428bbdf43c909967afd2
+              name: 'Zpool {#POOLNAME} used'
+              key: 'zfs.get.fsinfo[{#POOLNAME},used]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS zpool'
+            -
+              uuid: 472e21c79759476984cbf4ce9f12580a
+              name: 'Zpool {#POOLNAME} Health'
+              key: 'zfs.zpool.health[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              trends: '0'
+              value_type: TEXT
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS zpool'
+              trigger_prototypes:
+                -
+                  uuid: 4855fe0ed61b444daad73aa6090b46af
+                  expression: 'find(/ZFS on Linux/zfs.zpool.health[{#POOLNAME}],,"like","ONLINE")=0'
+                  name: 'Zpool {#POOLNAME} is {ITEM.VALUE} on {HOST.NAME}'
+                  priority: HIGH
+            -
+              uuid: 3207e6ffd0fa40c4a1d6e607e4e12375
+              name: 'Zpool {#POOLNAME} read throughput'
+              type: DEPENDENT
+              key: 'zfs.zpool.iostat.nread[{#POOLNAME}]'
+              delay: '0'
+              history: 30d
+              value_type: FLOAT
+              units: Bps
+              preprocessing:
+                -
+                  type: JAVASCRIPT
+                  parameters:
+                    - |
+                      'use strict';
+                      var text = value;
+                      const myArray = text.split("	");
+                      return myArray[5]; 
+              master_item:
+                key: 'zfs.zpool.iostat[{#POOLNAME}]'
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS zpool'
+            -
+              uuid: 78b418605f9b45b29bbd33b93a6b2e82
+              name: 'Zpool {#POOLNAME} write throughput'
+              type: DEPENDENT
+              key: 'zfs.zpool.iostat.nwritten[{#POOLNAME}]'
+              delay: '0'
+              history: 30d
+              value_type: FLOAT
+              units: Bps
+              preprocessing:
+                -
+                  type: JAVASCRIPT
+                  parameters:
+                    - |
+                      'use strict';
+                      var text = value;
+                      const myArray = text.split("	");
+                      return myArray[6]; 
+              master_item:
+                key: 'zfs.zpool.iostat[{#POOLNAME}]'
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS zpool'
+            -
+              uuid: 6b35bf06bf4542318a7999ac4d7952f7
+              name: 'Zpool {#POOLNAME} IOPS: reads'
+              type: DEPENDENT
+              key: 'zfs.zpool.iostat.reads[{#POOLNAME}]'
+              delay: '0'
+              history: 30d
+              value_type: FLOAT
+              units: iops
+              preprocessing:
+                -
+                  type: JAVASCRIPT
+                  parameters:
+                    - |
+                      'use strict';
+                      var text = value;
+                      const myArray = text.split("	");
+                      return myArray[3]; 
+              master_item:
+                key: 'zfs.zpool.iostat[{#POOLNAME}]'
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS zpool'
+            -
+              uuid: b99d5ab922324536bc2e013ac1fca306
+              name: 'Zpool {#POOLNAME} IOPS: writes'
+              type: DEPENDENT
+              key: 'zfs.zpool.iostat.writes[{#POOLNAME}]'
+              delay: '0'
+              history: 30d
+              value_type: FLOAT
+              units: iops
+              preprocessing:
+                -
+                  type: JAVASCRIPT
+                  parameters:
+                    - |
+                      'use strict';
+                      var text = value;
+                      const myArray = text.split("	");
+                      return myArray[4]; 
+              master_item:
+                key: 'zfs.zpool.iostat[{#POOLNAME}]'
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS zpool'
+            -
+              uuid: 7142e6f1eceb4dc29e3a03d494230564
+              name: 'Zpool {#POOLNAME}: Get iostats'
+              key: 'zfs.zpool.iostat[{#POOLNAME}]'
+              history: '0'
+              trends: '0'
+              value_type: TEXT
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS zpool'
+            -
+              uuid: 867075d6eb1743069be868007472192b
+              name: 'Zpool {#POOLNAME} scrub status'
+              key: 'zfs.zpool.scrub[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              description: |
+                Detect if the pool is currently scrubbing itself.
+                
+                This is not a bad thing itself, but it slows down the entire pool and should be terminated when on production server during business hours if it causes a noticeable slowdown.
+              valuemap:
+                name: 'ZFS zpool scrub status'
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS zpool'
+              trigger_prototypes:
+                -
+                  uuid: 792be07c555c4ae6a9819d69d332357b
+                  expression: 'max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],12h)=0'
+                  name: 'Zpool {#POOLNAME} is scrubbing for more than 12h on {HOST.NAME}'
+                  priority: AVERAGE
+                  dependencies:
+                    -
+                      name: 'Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME}'
+                      expression: 'max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],24h)=0'
+                -
+                  uuid: 04cac9633f164227b1f9b2fe26923609
+                  expression: 'max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],24h)=0'
+                  name: 'Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME}'
+                  priority: HIGH
+          trigger_prototypes:
+            -
+              uuid: 82fce07b30114c7e8645689317e2c1b4
+              expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > ({$ZPOOL_AVERAGE_ALERT}/100)'
+              name: 'More than {$ZPOOL_AVERAGE_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}'
+              priority: AVERAGE
+              dependencies:
+                -
+                  name: 'More than {$ZPOOL_HIGH_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}'
+                  expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > ({$ZPOOL_HIGH_ALERT}/100)'
+            -
+              uuid: ab56a2a8eb3d4b4294707e2a8aa94e22
+              expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > ({$ZPOOL_DISASTER_ALERT}/100)'
+              name: 'More than {$ZPOOL_DISASTER_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}'
+              priority: DISASTER
+            -
+              uuid: c9c22e6617af4ad09970d2988c4a7fe7
+              expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > ({$ZPOOL_HIGH_ALERT}/100)'
+              name: 'More than {$ZPOOL_HIGH_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}'
+              priority: HIGH
+              dependencies:
+                -
+                  name: 'More than {$ZPOOL_DISASTER_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}'
+                  expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > ({$ZPOOL_DISASTER_ALERT}/100)'
+          graph_prototypes:
+            -
+              uuid: 926abae3e18144f0899711fdfd16e808
+              name: 'ZFS zpool {#POOLNAME} IOPS'
+              ymin_type_1: FIXED
+              graph_items:
+                -
+                  sortorder: '1'
+                  color: 5C6BC0
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.zpool.iostat.reads[{#POOLNAME}]'
+                -
+                  sortorder: '2'
+                  color: EF5350
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.zpool.iostat.writes[{#POOLNAME}]'
+            -
+              uuid: 63ae2d7acd4d4d15b4c5e7a5a90a063a
+              name: 'ZFS zpool {#POOLNAME} space usage'
+              type: STACKED
+              graph_items:
+                -
+                  sortorder: '1'
+                  color: 00EE00
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.fsinfo[{#POOLNAME},available]'
+                -
+                  sortorder: '2'
+                  color: EE0000
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.fsinfo[{#POOLNAME},used]'
+            -
+              uuid: aa35d164bacd45c5983fd2856781da88
+              name: 'ZFS zpool {#POOLNAME} throughput'
+              ymin_type_1: FIXED
+              graph_items:
+                -
+                  sortorder: '1'
+                  color: 5C6BC0
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.zpool.iostat.nread[{#POOLNAME}]'
+                -
+                  sortorder: '2'
+                  drawtype: BOLD_LINE
+                  color: EF5350
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.zpool.iostat.nwritten[{#POOLNAME}]'
+        -
+          uuid: 6c96e092f08f4b98af9a377782180689
+          name: 'Zfs vdev discovery'
+          key: zfs.vdev.discovery
+          delay: 1h
+          lifetime: 3d
+          item_prototypes:
+            -
+              uuid: 9f63161726774a28905c87aac92cf1e9
+              name: 'vdev {#VDEV}: CHECKSUM error counter'
+              key: 'zfs.vdev.error_counter.cksum[{#VDEV}]'
+              delay: 5m
+              history: 30d
+              description: |
+                This device has experienced an unrecoverable error. Determine if the device needs to be replaced.
+                
+                If yes, use 'zpool replace' to replace the device.
+                
+                If not, clear the error with 'zpool clear'.
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS vdev'
+            -
+              uuid: 48a02eb060fd4b73bdde08a2795c4717
+              name: 'vdev {#VDEV}: READ error counter'
+              key: 'zfs.vdev.error_counter.read[{#VDEV}]'
+              delay: 5m
+              history: 30d
+              description: |
+                This device has experienced an unrecoverable error. Determine if the device needs to be replaced.
+                
+                If yes, use 'zpool replace' to replace the device.
+                
+                If not, clear the error with 'zpool clear'.
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS vdev'
+            -
+              uuid: 15953ba38fde4b8c8681955a27d9204a
+              name: 'vdev {#VDEV}: WRITE error counter'
+              key: 'zfs.vdev.error_counter.write[{#VDEV}]'
+              delay: 5m
+              history: 30d
+              description: |
+                This device has experienced an unrecoverable error. Determine if the device needs to be replaced.
+                
+                If yes, use 'zpool replace' to replace the device.
+                
+                If not, clear the error with 'zpool clear'.
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS vdev'
+            -
+              uuid: 3e64a59d2a154a89a3bc43483942302d
+              name: 'vdev {#VDEV}: total number of errors'
+              type: CALCULATED
+              key: 'zfs.vdev.error_total[{#VDEV}]'
+              delay: 5m
+              history: 30d
+              params: 'last(//zfs.vdev.error_counter.cksum[{#VDEV}])+last(//zfs.vdev.error_counter.read[{#VDEV}])+last(//zfs.vdev.error_counter.write[{#VDEV}])'
+              description: |
+                This device has experienced an unrecoverable error. Determine if the device needs to be replaced.
+                
+                If yes, use 'zpool replace' to replace the device.
+                
+                If not, clear the error with 'zpool clear'.
+              tags:
+                -
+                  tag: Application
+                  value: ZFS
+                -
+                  tag: Application
+                  value: 'ZFS vdev'
+              trigger_prototypes:
+                -
+                  uuid: 44f7667c275d4a04891bc4f1d00e668b
+                  expression: 'last(/ZFS on Linux/zfs.vdev.error_total[{#VDEV}])>0'
+                  name: 'vdev {#VDEV} has encountered {ITEM.VALUE} errors on {HOST.NAME}'
+                  priority: HIGH
+                  description: |
+                    This device has experienced an unrecoverable error. Determine if the device needs to be replaced.
+                    
+                    If yes, use 'zpool replace' to replace the device.
+                    
+                    If not, clear the error with 'zpool clear'.
+                    
+                    You may also run a zpool scrub to check if some other undetected errors are present on this vdev.
+          graph_prototypes:
+            -
+              uuid: ab78dba991ba4311a04740fc69b30381
+              name: 'ZFS vdev {#VDEV} errors'
+              ymin_type_1: FIXED
+              graph_items:
+                -
+                  color: CC00CC
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.vdev.error_counter.cksum[{#VDEV}]'
+                -
+                  sortorder: '1'
+                  color: F63100
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.vdev.error_counter.read[{#VDEV}]'
+                -
+                  sortorder: '2'
+                  color: BBBB00
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.vdev.error_counter.write[{#VDEV}]'
+      macros:
+        -
+          macro: '{$ZFS_ARC_META_ALERT}'
+          value: '90'
+        -
+          macro: '{$ZFS_AVERAGE_ALERT}'
+          value: '90'
+        -
+          macro: '{$ZFS_DISASTER_ALERT}'
+          value: '99'
+        -
+          macro: '{$ZFS_FSNAME_MATCHES}'
+          value: /
+          description: 'Use this to determine the datasets to autodiscover defaults to all datasets with a ''/'' in the name'
+        -
+          macro: '{$ZFS_FSNAME_NOTMATCHES}'
+          value: '([a-z-0-9]{64}$|[a-z-0-9]{64}-init$)'
+          description: 'Use this to determine the datasets to not autodiscover. Ignore docker created datasets by default'
+        -
+          macro: '{$ZFS_HIGH_ALERT}'
+          value: '95'
+        -
+          macro: '{$ZPOOL_AVERAGE_ALERT}'
+          value: '85'
+        -
+          macro: '{$ZPOOL_DISASTER_ALERT}'
+          value: '99'
+        -
+          macro: '{$ZPOOL_HIGH_ALERT}'
+          value: '90'
+      dashboards:
+        -
+          uuid: 180e8c0dc05946e4b8552e3a01df347f
+          name: 'ZFS ARC'
+          pages:
+            -
+              widgets:
+                -
+                  type: GRAPH_CLASSIC
+                  width: '24'
+                  height: '5'
+                  fields:
+                    -
+                      type: INTEGER
+                      name: source_type
+                      value: '0'
+                    -
+                      type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS ARC memory usage'
+                -
+                  type: GRAPH_CLASSIC
+                  'y': '5'
+                  width: '24'
+                  height: '5'
+                  fields:
+                    -
+                      type: INTEGER
+                      name: source_type
+                      value: '0'
+                    -
+                      type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS ARC Cache Hit Ratio'
+                -
+                  type: GRAPH_CLASSIC
+                  'y': '10'
+                  width: '24'
+                  height: '5'
+                  fields:
+                    -
+                      type: INTEGER
+                      name: source_type
+                      value: '0'
+                    -
+                      type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS ARC breakdown'
+                -
+                  type: GRAPH_CLASSIC
+                  'y': '15'
+                  width: '24'
+                  height: '5'
+                  fields:
+                    -
+                      type: INTEGER
+                      name: source_type
+                      value: '0'
+                    -
+                      type: GRAPH
+                      name: graphid
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS ARC arc_meta_used breakdown'
+        -
+          uuid: 442dda5c36c04fc78c3a73eacf26bc7f
+          name: 'ZFS zpools'
+          pages:
+            -
+              widgets:
+                -
+                  type: GRAPH_PROTOTYPE
+                  width: '8'
+                  height: '5'
+                  fields:
+                    -
+                      type: INTEGER
+                      name: source_type
+                      value: '2'
+                    -
+                      type: INTEGER
+                      name: columns
+                      value: '1'
+                    -
+                      type: INTEGER
+                      name: rows
+                      value: '1'
+                    -
+                      type: GRAPH_PROTOTYPE
+                      name: graphid
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS zpool {#POOLNAME} IOPS'
+                -
+                  type: GRAPH_PROTOTYPE
+                  x: '8'
+                  width: '8'
+                  height: '5'
+                  fields:
+                    -
+                      type: INTEGER
+                      name: source_type
+                      value: '2'
+                    -
+                      type: INTEGER
+                      name: columns
+                      value: '1'
+                    -
+                      type: INTEGER
+                      name: rows
+                      value: '1'
+                    -
+                      type: GRAPH_PROTOTYPE
+                      name: graphid
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS zpool {#POOLNAME} throughput'
+                -
+                  type: GRAPH_PROTOTYPE
+                  x: '16'
+                  width: '8'
+                  height: '5'
+                  fields:
+                    -
+                      type: INTEGER
+                      name: source_type
+                      value: '2'
+                    -
+                      type: INTEGER
+                      name: columns
+                      value: '1'
+                    -
+                      type: INTEGER
+                      name: rows
+                      value: '1'
+                    -
+                      type: GRAPH_PROTOTYPE
+                      name: graphid
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS zpool {#POOLNAME} space usage'
+      valuemaps:
+        -
+          uuid: d1d7b0898d06481dbcec8b02d915fb1c
+          name: 'ZFS zpool scrub status'
+          mappings:
+            -
+              value: '0'
+              newvalue: 'Scrub in progress'
+            -
+              value: '1'
+              newvalue: 'No scrub in progress'
+  triggers:
+    -
+      uuid: 1daac44b853b4b6da767c9c3af96b774
+      expression: 'last(/ZFS on Linux/zfs.arcstats[dnode_size])>(last(/ZFS on Linux/zfs.arcstats[arc_dnode_limit])*0.9)'
+      name: 'ZFS ARC dnode size > 90% dnode max size on {HOST.NAME}'
+      priority: HIGH
+    -
+      uuid: 69c18b7ceb3d4da2bda0e05f9a12453f
+      expression: 'last(/ZFS on Linux/zfs.arcstats[arc_meta_used])>(last(/ZFS on Linux/zfs.arcstats[arc_meta_limit])*0.01*{$ZFS_ARC_META_ALERT})'
+      name: 'ZFS ARC meta size > {$ZFS_ARC_META_ALERT}% meta max size on {HOST.NAME}'
+      priority: HIGH
+  graphs:
+    -
+      uuid: 1510111dc5414e6d80a5230ce6a81f1d
+      name: 'ZFS ARC arc_meta_used breakdown'
+      type: STACKED
+      ymin_type_1: FIXED
+      graph_items:
+        -
+          color: 3333FF
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[metadata_size]'
+        -
+          sortorder: '1'
+          color: 00EE00
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[dnode_size]'
+        -
+          sortorder: '2'
+          color: EE0000
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[hdr_size]'
+        -
+          sortorder: '3'
+          color: EEEE00
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[dbuf_size]'
+        -
+          sortorder: '4'
+          color: EE00EE
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[bonus_size]'
+    -
+      uuid: 203eeeaadc9444ccbbc31cf043e836cb
+      name: 'ZFS ARC breakdown'
+      type: STACKED
+      ymin_type_1: FIXED
+      graph_items:
+        -
+          color: 3333FF
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[data_size]'
+        -
+          sortorder: '1'
+          color: 00AA00
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[metadata_size]'
+        -
+          sortorder: '2'
+          color: EE0000
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[dnode_size]'
+        -
+          sortorder: '3'
+          color: CCCC00
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[hdr_size]'
+        -
+          sortorder: '4'
+          color: A54F10
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[dbuf_size]'
+        -
+          sortorder: '5'
+          color: '888888'
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[bonus_size]'
+    -
+      uuid: 4c493303be4a45a7a96d3ef7246843c0
+      name: 'ZFS ARC Cache Hit Ratio'
+      ymin_type_1: FIXED
+      ymax_type_1: FIXED
+      graph_items:
+        -
+          color: 00CC00
+          item:
+            host: 'ZFS on Linux'
+            key: zfs.arcstats_hit_ratio
+    -
+      uuid: b2fce9515a7d4218a5e9015f212c2a60
+      name: 'ZFS ARC memory usage'
+      ymin_type_1: FIXED
+      ymax_type_1: ITEM
+      ymax_item_1:
+        host: 'ZFS on Linux'
+        key: 'zfs.arcstats[c_max]'
+      graph_items:
+        -
+          drawtype: GRADIENT_LINE
+          color: 0000EE
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[size]'
+        -
+          sortorder: '1'
+          drawtype: BOLD_LINE
+          color: DD0000
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[c_max]'
+        -
+          sortorder: '2'
+          color: 00BB00
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[c_min]'

--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/template_zfs_on_linux_active.yaml
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/template_zfs_on_linux_active.yaml
@@ -1,0 +1,1270 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 7df96b18c230490a9a0a9e2307226338
+      name: Templates
+  templates:
+    - uuid: 47d3c2ff933947368d4bee4b1184d69b
+      template: 'ZFS on Linux'
+      name: 'ZFS on Linux'
+      groups:
+        - name: Templates
+      items:
+        - uuid: 4ecabdcb2104460f83c2ad5f18fd98f9
+          name: 'ZFS on Linux version'
+          key: 'vfs.file.contents[/sys/module/zfs/version]'
+          delay: 1h
+          history: 30d
+          value_type: TEXT
+          trends: '0'
+          tags:
+            - tag: Application
+              value: ZFS
+          triggers:
+            - uuid: 879881de9f8b4b97b5270df192d86850
+              expression: '(last(/ZFS on Linux/vfs.file.contents[/sys/module/zfs/version],#1)<>last(/ZFS on Linux/vfs.file.contents[/sys/module/zfs/version],#2))>0'
+              name: 'Version of ZoL is now {ITEM.VALUE} on {HOST.NAME}'
+              priority: INFO
+        - uuid: 6b5fc935fe194d30badea64eaf3f317f
+          name: 'ZFS ARC stat "arc_dnode_limit"'
+          key: 'zfs.arcstats[arc_dnode_limit]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: 0b7d673688e3429d92aa349762729f83
+          name: 'ZFS ARC stat "arc_meta_limit"'
+          key: 'zfs.arcstats[arc_meta_limit]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: b0b5004458494182bf874545f8eb4e41
+          name: 'ZFS ARC stat "arc_meta_used"'
+          key: 'zfs.arcstats[arc_meta_used]'
+          history: 30d
+          units: B
+          description: 'arc_meta_used = hdr_size + metadata_size + dbuf_size + dnode_size + bonus_size'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: 795ab079ba13461c872ee1d5c0295704
+          name: 'ZFS ARC stat "bonus_size"'
+          key: 'zfs.arcstats[bonus_size]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: 34a1fb79b2b64ce08ec5b377211372d7
+          name: 'ZFS ARC max size'
+          key: 'zfs.arcstats[c_max]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: d60b8e4f7a3d4bea972e7fe04c3bb5ca
+          name: 'ZFS ARC minimum size'
+          key: 'zfs.arcstats[c_min]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: 5e12dd98f1644f5a87cc5ded5d2e55d8
+          name: 'ZFS ARC stat "data_size"'
+          key: 'zfs.arcstats[data_size]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: 522a0f33c90047bab4f55b7214f51dea
+          name: 'ZFS ARC stat "dbuf_size"'
+          key: 'zfs.arcstats[dbuf_size]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: a3d10ebb57984a829f780a229fc9617c
+          name: 'ZFS ARC stat "dnode_size"'
+          key: 'zfs.arcstats[dnode_size]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: 184eef57aa034cf8acaf6a8f0e02395b
+          name: 'ZFS ARC stat "hdr_size"'
+          key: 'zfs.arcstats[hdr_size]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: cb7bcc02dfc14329a361e194145871c0
+          name: 'ZFS ARC stat "hits"'
+          key: 'zfs.arcstats[hits]'
+          history: 30d
+          preprocessing:
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: f0ea20eb77e647a18d5960b915fdb8dd
+          name: 'ZFS ARC L2 stat "hits"'
+          key: 'zfs.arcstats[l2_hits]'
+          history: 30d
+          preprocessing:
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC L2'
+        - uuid: 2c6da502ea084cc8b11cab8d3c85752a
+          name: 'ZFS ARC L2 stat "misses"'
+          key: 'zfs.arcstats[l2_misses]'
+          history: 30d
+          preprocessing:
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC L2'
+        - uuid: 79c13311cea242448705d1d926683689
+          name: 'ZFS ARC L2 current size'
+          key: 'zfs.arcstats[l2_size]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC L2'
+        - uuid: 8df273b6e0904c9ab140f8f13f6ca973
+          name: 'ZFS ARC stat "metadata_size"'
+          key: 'zfs.arcstats[metadata_size]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: dcd96743ed984018bff5d16105693606
+          name: 'ZFS ARC stat "mfu_hits"'
+          key: 'zfs.arcstats[mfu_hits]'
+          history: 30d
+          preprocessing:
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: 1015ebe8ef6f4626ae7967bf6358f1b3
+          name: 'ZFS ARC stat "mfu_size"'
+          key: 'zfs.arcstats[mfu_size]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: 1298a265a6784e63a166b768e1faf67e
+          name: 'ZFS ARC stat "misses"'
+          key: 'zfs.arcstats[misses]'
+          history: 30d
+          preprocessing:
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: c85d0e9e1b464748a20148e2f2507609
+          name: 'ZFS ARC stat "mru_hits"'
+          key: 'zfs.arcstats[mru_hits]'
+          history: 30d
+          preprocessing:
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: 50954c7b43d745d09990011df4d7448c
+          name: 'ZFS ARC stat "mru_size"'
+          key: 'zfs.arcstats[mru_size]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: cd225da5a02346a58dbe0c9808a628eb
+          name: 'ZFS ARC current size'
+          key: 'zfs.arcstats[size]'
+          history: 30d
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: 8c8129f814fe47ae9c71e636599acd90
+          name: 'ZFS ARC Cache Hit Ratio'
+          type: CALCULATED
+          key: zfs.arcstats_hit_ratio
+          history: 30d
+          value_type: FLOAT
+          units: '%'
+          params: '100*(last(//zfs.arcstats[hits])/(last(//zfs.arcstats[hits])+count(//zfs.arcstats[hits],#1,,"0")+last(//zfs.arcstats[misses])))'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: 577a20e7636b4bc3b9892620e1668c74
+          name: 'ZFS ARC L2 Cache Hit Ratio'
+          type: CALCULATED
+          key: zfs.arcstats_l2_hit_ratio
+          history: 30d
+          value_type: FLOAT
+          units: '%'
+          params: '100*(last(//zfs.arcstats[l2_hits])/(last(//zfs.arcstats[l2_hits])+count(//zfs.arcstats[l2_hits],#1,,"0")+last(//zfs.arcstats[l2_misses])))'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC L2'
+        - uuid: b8e60d729e0e4de998520e92c87b7a16
+          name: 'ZFS ARC L2 total read'
+          type: CALCULATED
+          key: zfs.arcstats_l2_total_read
+          history: 30d
+          units: B
+          params: 'last(//zfs.arcstats[l2_hits])+last(//zfs.arcstats[l2_misses])'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC L2'
+        - uuid: e644390a9c9743f2844dbc9ef8806a8f
+          name: 'ZFS ARC total read'
+          type: CALCULATED
+          key: zfs.arcstats_total_read
+          history: 30d
+          units: B
+          params: 'last(//zfs.arcstats[hits])+last(//zfs.arcstats[misses])'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: ebfb742fb123451c9632d12bde0957c4
+          name: 'ZFS parameter zfs_arc_dnode_limit_percent'
+          key: 'zfs.get.param[zfs_arc_dnode_limit_percent]'
+          delay: 1h
+          history: 30d
+          units: '%'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: 18d8b817852848929f4e0b421cb21532
+          name: 'ZFS parameter zfs_arc_meta_limit_percent'
+          key: 'zfs.get.param[zfs_arc_meta_limit_percent]'
+          delay: 1h
+          history: 30d
+          units: '%'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ARC'
+        - uuid: d8a44fb843a340c39c91c7f6d8614d84
+          name: 'ZIL commit count'
+          key: 'zfs.zil[zil_commit_count]'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+        - uuid: ca52b9d1d9004e668fb85b59b28774c2
+          name: 'ZIL commit writer count'
+          key: 'zfs.zil[zil_commit_writer_count]'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+        - uuid: b753bdd8fddd4ee494179c2c6edee978
+          name: 'ZIL intent transaction size'
+          key: 'zfs.zil[zil_itx_copied_bytes]'
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+        - uuid: d9c2c89db10341a68e2bc23f55ae05aa
+          name: 'ZIL intent trasaction copied count'
+          key: 'zfs.zil[zil_itx_copied_count]'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+        - uuid: 834a2a0e8b9a4683bdf7f4332f3eccaf
+          name: 'ZIL intent transactions count'
+          key: 'zfs.zil[zil_itx_count]'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+        - uuid: 32c93c96dc1c4f00839e4052ed8fe412
+          name: 'ZIL intent transaction indirect size'
+          key: 'zfs.zil[zil_itx_indirect_bytes]'
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+        - uuid: f06bf8cfe22f45b888aaad1b337a5724
+          name: 'ZIL intent transaction indirect count'
+          key: 'zfs.zil[zil_itx_indirect_count]'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+        - uuid: 7301fd88b3b448ba896b195b7bc90a39
+          name: 'ZIL intent transaction metaslab normal size'
+          key: 'zfs.zil[zil_itx_metaslab_normal_bytes]'
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+        - uuid: e31babb9c33e4751b2b7b777465af13a
+          name: 'ZIL intent transaction metaslab normal count'
+          key: 'zfs.zil[zil_itx_metaslab_normal_count]'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+        - uuid: 53c307889d9242cc84062b7d428400ce
+          name: 'ZIL intent transaction metaslab slog size'
+          key: 'zfs.zil[zil_itx_metaslab_slog_bytes]'
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+        - uuid: a10ccdcc1b3043ea81ed6d95b58fb765
+          name: 'ZIL intent transaction metaslab slog count'
+          key: 'zfs.zil[zil_itx_metaslab_slog_count]'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+        - uuid: 4c9aac99a3c84d69a564981866f555d5
+          name: 'ZIL intent transaction need copy size'
+          key: 'zfs.zil[zil_itx_needcopy_bytes]'
+          units: B
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+        - uuid: 8136a993f86d4b1aa9b629c203fd25e8
+          name: 'ZIL intentent transaction need copy count'
+          key: 'zfs.zil[zil_itx_needcopy_count]'
+          tags:
+            - tag: Application
+              value: ZFS
+            - tag: Application
+              value: 'ZFS ZIL'
+      discovery_rules:
+        - uuid: a82a1b7067904fecb06bcf5b88457192
+          name: 'Zfs Dataset discovery'
+          key: zfs.fileset.discovery
+          delay: 30m
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#FILESETNAME}'
+                value: '{$ZFS_FSNAME_MATCHES}'
+                formulaid: A
+              - macro: '{#FILESETNAME}'
+                value: '{$ZFS_FSNAME_NOTMATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: B
+          lifetime: 2d
+          enabled_lifetime_type: DISABLE_NEVER
+          description: 'Discover ZFS dataset. Dataset names must contain a "/" else it''s a zpool.'
+          item_prototypes:
+            - uuid: 4d7c96bd10b44754b2c8790b90c12046
+              name: 'Zfs dataset {#FILESETNAME} compressratio'
+              key: 'zfs.get.compressratio[{#FILESETNAME}]'
+              delay: 30m
+              history: 30d
+              value_type: FLOAT
+              units: '%'
+              preprocessing:
+                - type: MULTIPLIER
+                  parameters:
+                    - '100'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS dataset'
+            - uuid: e9df401ae71e45c8a3fdbbd146cdd57b
+              name: 'Zfs dataset {#FILESETNAME} available'
+              key: 'zfs.get.fsinfo[{#FILESETNAME},available]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS dataset'
+            - uuid: ed63bb6942364281bcea80c54b6f8fcc
+              name: 'Zfs dataset {#FILESETNAME} referenced'
+              key: 'zfs.get.fsinfo[{#FILESETNAME},referenced]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS dataset'
+            - uuid: 7ef4530ddf464defb2a64ce674a82c8c
+              name: 'Zfs dataset {#FILESETNAME} usedbychildren'
+              key: 'zfs.get.fsinfo[{#FILESETNAME},usedbychildren]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS dataset'
+            - uuid: 3c7f982147be49629c78aa67a1d8d56e
+              name: 'Zfs dataset {#FILESETNAME} usedbydataset'
+              key: 'zfs.get.fsinfo[{#FILESETNAME},usedbydataset]'
+              delay: 1h
+              history: 30d
+              units: B
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS dataset'
+            - uuid: cc0e02c58b28443eb78eeacc81095966
+              name: 'Zfs dataset {#FILESETNAME} usedbysnapshots'
+              key: 'zfs.get.fsinfo[{#FILESETNAME},usedbysnapshots]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS dataset'
+            - uuid: a54feffafdb34ba08f1474ab4710088d
+              name: 'Zfs dataset {#FILESETNAME} used'
+              key: 'zfs.get.fsinfo[{#FILESETNAME},used]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS dataset'
+          trigger_prototypes:
+            - uuid: cc0b0756d2fe42779b62adf63e38681d
+              expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > ({$ZFS_AVERAGE_ALERT}/100)'
+              name: 'More than {$ZFS_AVERAGE_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}'
+              priority: AVERAGE
+              dependencies:
+                - name: 'More than {$ZFS_HIGH_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}'
+                  expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > ({$ZFS_HIGH_ALERT}/100)'
+            - uuid: 8bfb157ac42845c0b340e28ae510833c
+              expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > ({$ZFS_DISASTER_ALERT}/100)'
+              name: 'More than {$ZFS_DISASTER_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}'
+              priority: DISASTER
+            - uuid: 9b592a2cba084bec9ceb4f82367e758b
+              expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > ({$ZFS_HIGH_ALERT}/100)'
+              name: 'More than {$ZFS_HIGH_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}'
+              priority: HIGH
+              dependencies:
+                - name: 'More than {$ZFS_DISASTER_ALERT}% used on dataset {#FILESETNAME} on {HOST.NAME}'
+                  expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#FILESETNAME},used]) ) ) > ({$ZFS_DISASTER_ALERT}/100)'
+          graph_prototypes:
+            - uuid: 5213684719404718b8956d6faf0e6b71
+              name: 'ZFS dataset {#FILESETNAME} usage'
+              yaxismax: '0'
+              show_work_period: 'NO'
+              show_triggers: 'NO'
+              type: PIE
+              graph_items:
+                - sortorder: '1'
+                  color: 3333FF
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.fsinfo[{#FILESETNAME},usedbydataset]'
+                - sortorder: '2'
+                  color: FF33FF
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.fsinfo[{#FILESETNAME},usedbysnapshots]'
+                - sortorder: '3'
+                  color: FF3333
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.fsinfo[{#FILESETNAME},usedbychildren]'
+                - sortorder: '4'
+                  color: 33FF33
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.fsinfo[{#FILESETNAME},available]'
+                - sortorder: '5'
+                  color: '795548'
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.compressratio[{#FILESETNAME}]'
+        - uuid: 08039e570bd7417294d043f4f7bf960f
+          name: 'Zfs Pool discovery'
+          key: zfs.pool.discovery
+          delay: 1h
+          lifetime: 3d
+          enabled_lifetime_type: DISABLE_NEVER
+          item_prototypes:
+            - uuid: 9f889e9529934fdfbf47a29de32468f0
+              name: 'Zpool {#POOLNAME} available'
+              key: 'zfs.get.fsinfo[{#POOLNAME},available]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 1993c04b00bc428bbdf43c909967afd2
+              name: 'Zpool {#POOLNAME} used'
+              key: 'zfs.get.fsinfo[{#POOLNAME},used]'
+              delay: 5m
+              history: 30d
+              units: B
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 472e21c79759476984cbf4ce9f12580a
+              name: 'Zpool {#POOLNAME} Health'
+              key: 'zfs.zpool.health[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              value_type: TEXT
+              trends: '0'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS zpool'
+              trigger_prototypes:
+                - uuid: 4855fe0ed61b444daad73aa6090b46af
+                  expression: 'find(/ZFS on Linux/zfs.zpool.health[{#POOLNAME}],,"like","ONLINE")=0'
+                  name: 'Zpool {#POOLNAME} is {ITEM.VALUE} on {HOST.NAME}'
+                  priority: HIGH
+            - uuid: 3207e6ffd0fa40c4a1d6e607e4e12375
+              name: 'Zpool {#POOLNAME} read throughput'
+              key: 'zfs.zpool.iostat.nread[{#POOLNAME}]'
+              history: 30d
+              value_type: FLOAT
+              units: Bps
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 78b418605f9b45b29bbd33b93a6b2e82
+              name: 'Zpool {#POOLNAME} write throughput'
+              key: 'zfs.zpool.iostat.nwritten[{#POOLNAME}]'
+              history: 30d
+              value_type: FLOAT
+              units: Bps
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 6b35bf06bf4542318a7999ac4d7952f7
+              name: 'Zpool {#POOLNAME} IOPS: reads'
+              key: 'zfs.zpool.iostat.reads[{#POOLNAME}]'
+              history: 30d
+              value_type: FLOAT
+              units: iops
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: b99d5ab922324536bc2e013ac1fca306
+              name: 'Zpool {#POOLNAME} IOPS: writes'
+              key: 'zfs.zpool.iostat.writes[{#POOLNAME}]'
+              history: 30d
+              value_type: FLOAT
+              units: iops
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 867075d6eb1743069be868007472192b
+              name: 'Zpool {#POOLNAME} scrub status'
+              key: 'zfs.zpool.scrub[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              description: |
+                Detect if the pool is currently scrubbing itself.
+                
+                This is not a bad thing itself, but it slows down the entire pool and should be terminated when on production server during business hours if it causes a noticeable slowdown.
+              valuemap:
+                name: 'ZFS zpool scrub status'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS zpool'
+              trigger_prototypes:
+                - uuid: 792be07c555c4ae6a9819d69d332357b
+                  expression: 'max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],12h)=0'
+                  name: 'Zpool {#POOLNAME} is scrubbing for more than 12h on {HOST.NAME}'
+                  priority: AVERAGE
+                  dependencies:
+                    - name: 'Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME}'
+                      expression: 'max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],24h)=0'
+                - uuid: 04cac9633f164227b1f9b2fe26923609
+                  expression: 'max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],24h)=0'
+                  name: 'Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME}'
+                  priority: HIGH
+          trigger_prototypes:
+            - uuid: 82fce07b30114c7e8645689317e2c1b4
+              expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > ({$ZPOOL_AVERAGE_ALERT}/100)'
+              name: 'More than {$ZPOOL_AVERAGE_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}'
+              priority: AVERAGE
+              dependencies:
+                - name: 'More than {$ZPOOL_HIGH_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}'
+                  expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > ({$ZPOOL_HIGH_ALERT}/100)'
+            - uuid: ab56a2a8eb3d4b4294707e2a8aa94e22
+              expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > ({$ZPOOL_DISASTER_ALERT}/100)'
+              name: 'More than {$ZPOOL_DISASTER_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}'
+              priority: DISASTER
+            - uuid: c9c22e6617af4ad09970d2988c4a7fe7
+              expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > ({$ZPOOL_HIGH_ALERT}/100)'
+              name: 'More than {$ZPOOL_HIGH_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}'
+              priority: HIGH
+              dependencies:
+                - name: 'More than {$ZPOOL_DISASTER_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME}'
+                  expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > ({$ZPOOL_DISASTER_ALERT}/100)'
+          graph_prototypes:
+            - uuid: 926abae3e18144f0899711fdfd16e808
+              name: 'ZFS zpool {#POOLNAME} IOPS'
+              ymin_type_1: FIXED
+              graph_items:
+                - sortorder: '1'
+                  color: 5C6BC0
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.zpool.iostat.reads[{#POOLNAME}]'
+                - sortorder: '2'
+                  color: EF5350
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.zpool.iostat.writes[{#POOLNAME}]'
+            - uuid: 63ae2d7acd4d4d15b4c5e7a5a90a063a
+              name: 'ZFS zpool {#POOLNAME} space usage'
+              yaxismax: '0'
+              show_work_period: 'NO'
+              show_triggers: 'NO'
+              type: PIE
+              graph_items:
+                - sortorder: '1'
+                  color: 00EE00
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.fsinfo[{#POOLNAME},available]'
+                - sortorder: '2'
+                  color: EE0000
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.get.fsinfo[{#POOLNAME},used]'
+            - uuid: aa35d164bacd45c5983fd2856781da88
+              name: 'ZFS zpool {#POOLNAME} throughput'
+              ymin_type_1: FIXED
+              graph_items:
+                - sortorder: '1'
+                  color: 5C6BC0
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.zpool.iostat.nread[{#POOLNAME}]'
+                - sortorder: '2'
+                  drawtype: BOLD_LINE
+                  color: EF5350
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.zpool.iostat.nwritten[{#POOLNAME}]'
+        - uuid: 6c96e092f08f4b98af9a377782180689
+          name: 'Zfs vdev discovery'
+          key: zfs.vdev.discovery
+          delay: 1h
+          lifetime: 3d
+          enabled_lifetime_type: DISABLE_NEVER
+          item_prototypes:
+            - uuid: 9f63161726774a28905c87aac92cf1e9
+              name: 'vdev {#VDEV}: CHECKSUM error counter'
+              key: 'zfs.vdev.error_counter.cksum[{#VDEV}]'
+              delay: 5m
+              history: 30d
+              description: |
+                This device has experienced an unrecoverable error. Determine if the device needs to be replaced.
+                
+                If yes, use 'zpool replace' to replace the device.
+                
+                If not, clear the error with 'zpool clear'.
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS vdev'
+            - uuid: 48a02eb060fd4b73bdde08a2795c4717
+              name: 'vdev {#VDEV}: READ error counter'
+              key: 'zfs.vdev.error_counter.read[{#VDEV}]'
+              delay: 5m
+              history: 30d
+              description: |
+                This device has experienced an unrecoverable error. Determine if the device needs to be replaced.
+                
+                If yes, use 'zpool replace' to replace the device.
+                
+                If not, clear the error with 'zpool clear'.
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS vdev'
+            - uuid: 15953ba38fde4b8c8681955a27d9204a
+              name: 'vdev {#VDEV}: WRITE error counter'
+              key: 'zfs.vdev.error_counter.write[{#VDEV}]'
+              delay: 5m
+              history: 30d
+              description: |
+                This device has experienced an unrecoverable error. Determine if the device needs to be replaced.
+                
+                If yes, use 'zpool replace' to replace the device.
+                
+                If not, clear the error with 'zpool clear'.
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS vdev'
+            - uuid: 3e64a59d2a154a89a3bc43483942302d
+              name: 'vdev {#VDEV}: total number of errors'
+              type: CALCULATED
+              key: 'zfs.vdev.error_total[{#VDEV}]'
+              delay: 5m
+              history: 30d
+              params: 'last(//zfs.vdev.error_counter.cksum[{#VDEV}])+last(//zfs.vdev.error_counter.read[{#VDEV}])+last(//zfs.vdev.error_counter.write[{#VDEV}])'
+              description: |
+                This device has experienced an unrecoverable error. Determine if the device needs to be replaced.
+                
+                If yes, use 'zpool replace' to replace the device.
+                
+                If not, clear the error with 'zpool clear'.
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS vdev'
+              trigger_prototypes:
+                - uuid: 44f7667c275d4a04891bc4f1d00e668b
+                  expression: 'last(/ZFS on Linux/zfs.vdev.error_total[{#VDEV}])>0'
+                  name: 'vdev {#VDEV} has encountered {ITEM.VALUE} errors on {HOST.NAME}'
+                  priority: HIGH
+                  description: |
+                    This device has experienced an unrecoverable error. Determine if the device needs to be replaced.
+                    
+                    If yes, use 'zpool replace' to replace the device.
+                    
+                    If not, clear the error with 'zpool clear'.
+                    
+                    You may also run a zpool scrub to check if some other undetected errors are present on this vdev.
+          graph_prototypes:
+            - uuid: ab78dba991ba4311a04740fc69b30381
+              name: 'ZFS vdev {#VDEV} errors'
+              ymin_type_1: FIXED
+              graph_items:
+                - color: CC00CC
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.vdev.error_counter.cksum[{#VDEV}]'
+                - sortorder: '1'
+                  color: F63100
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.vdev.error_counter.read[{#VDEV}]'
+                - sortorder: '2'
+                  color: BBBB00
+                  item:
+                    host: 'ZFS on Linux'
+                    key: 'zfs.vdev.error_counter.write[{#VDEV}]'
+      macros:
+        - macro: '{$ZFS_ARC_META_ALERT}'
+          value: '90'
+        - macro: '{$ZFS_AVERAGE_ALERT}'
+          value: '90'
+        - macro: '{$ZFS_DISASTER_ALERT}'
+          value: '99'
+        - macro: '{$ZFS_FSNAME_MATCHES}'
+          value: /
+          description: 'Use this to determine the datasets to autodiscover defaults to all datasets with a ''/'' in the name'
+        - macro: '{$ZFS_FSNAME_NOTMATCHES}'
+          value: '([a-z-0-9]{64}$|[a-z-0-9]{64}-init$)'
+          description: 'Use this to determine the datasets to not autodiscover. Ignore docker created datasets by default'
+        - macro: '{$ZFS_HIGH_ALERT}'
+          value: '95'
+        - macro: '{$ZPOOL_AVERAGE_ALERT}'
+          value: '85'
+        - macro: '{$ZPOOL_DISASTER_ALERT}'
+          value: '99'
+        - macro: '{$ZPOOL_HIGH_ALERT}'
+          value: '90'
+      dashboards:
+        - uuid: 180e8c0dc05946e4b8552e3a01df347f
+          name: 'ZFS ARC'
+          pages:
+            - widgets:
+                - type: graph
+                  width: '72'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid.0
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS ARC memory usage'
+                    - type: STRING
+                      name: reference
+                      value: AAAAA
+                - type: graph
+                  'y': '5'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid.0
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS ARC Cache Hit Ratio'
+                    - type: STRING
+                      name: reference
+                      value: AAAAB
+                - type: graph
+                  'y': '10'
+                  width: '72'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid.0
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS ARC breakdown'
+                    - type: STRING
+                      name: reference
+                      value: AAAAC
+                - type: graph
+                  'y': '15'
+                  width: '72'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid.0
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS ARC arc_meta_used breakdown'
+                    - type: STRING
+                      name: reference
+                      value: AAAAD
+                - type: graph
+                  name: ZIL
+                  'y': '20'
+                  width: '72'
+                  height: '7'
+                  fields:
+                    - type: GRAPH
+                      name: graphid.0
+                      value:
+                        host: 'ZFS on Linux'
+                        name: ZIL
+                    - type: STRING
+                      name: reference
+                      value: NIYUO
+                - type: graph
+                  name: 'ZFS ARC L2 Cache Hit Ration'
+                  x: '36'
+                  'y': '5'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: GRAPH
+                      name: graphid.0
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS ARC L2 Cache Hit Ratio'
+                    - type: STRING
+                      name: reference
+                      value: WGNUB
+        - uuid: a03da29917fb4a05bdbdaa0e9401f364
+          name: 'ZFS datasets'
+          pages:
+            - widgets:
+                - type: graphprototype
+                  name: 'Zfs dataset {#FILESETNAME}'
+                  width: '72'
+                  height: '5'
+                  fields:
+                    - type: INTEGER
+                      name: columns
+                      value: '3'
+                    - type: GRAPH_PROTOTYPE
+                      name: graphid.0
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS dataset {#FILESETNAME} usage'
+                    - type: STRING
+                      name: reference
+                      value: RCXZT
+        - uuid: 442dda5c36c04fc78c3a73eacf26bc7f
+          name: 'ZFS zpools'
+          pages:
+            - widgets:
+                - type: graphprototype
+                  width: '24'
+                  height: '5'
+                  fields:
+                    - type: INTEGER
+                      name: columns
+                      value: '1'
+                    - type: GRAPH_PROTOTYPE
+                      name: graphid
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS zpool {#POOLNAME} IOPS'
+                    - type: STRING
+                      name: reference
+                      value: AAAAA
+                    - type: INTEGER
+                      name: rows
+                      value: '1'
+                    - type: INTEGER
+                      name: source_type
+                      value: '2'
+                - type: graphprototype
+                  x: '24'
+                  width: '24'
+                  height: '5'
+                  fields:
+                    - type: INTEGER
+                      name: columns
+                      value: '1'
+                    - type: GRAPH_PROTOTYPE
+                      name: graphid
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS zpool {#POOLNAME} throughput'
+                    - type: STRING
+                      name: reference
+                      value: AAAAB
+                    - type: INTEGER
+                      name: rows
+                      value: '1'
+                    - type: INTEGER
+                      name: source_type
+                      value: '2'
+                - type: graphprototype
+                  x: '48'
+                  width: '24'
+                  height: '5'
+                  fields:
+                    - type: INTEGER
+                      name: columns
+                      value: '1'
+                    - type: GRAPH_PROTOTYPE
+                      name: graphid
+                      value:
+                        host: 'ZFS on Linux'
+                        name: 'ZFS zpool {#POOLNAME} space usage'
+                    - type: STRING
+                      name: reference
+                      value: AAAAC
+                    - type: INTEGER
+                      name: rows
+                      value: '1'
+                    - type: INTEGER
+                      name: source_type
+                      value: '2'
+      valuemaps:
+        - uuid: d1d7b0898d06481dbcec8b02d915fb1c
+          name: 'ZFS zpool scrub status'
+          mappings:
+            - value: '0'
+              newvalue: 'Scrub in progress'
+            - value: '1'
+              newvalue: 'No scrub in progress'
+  triggers:
+    - uuid: 1daac44b853b4b6da767c9c3af96b774
+      expression: 'last(/ZFS on Linux/zfs.arcstats[dnode_size])>(last(/ZFS on Linux/zfs.arcstats[arc_dnode_limit])*0.9)'
+      name: 'ZFS ARC dnode size > 90% dnode max size on {HOST.NAME}'
+      priority: HIGH
+    - uuid: 69c18b7ceb3d4da2bda0e05f9a12453f
+      expression: 'last(/ZFS on Linux/zfs.arcstats[arc_meta_used])>(last(/ZFS on Linux/zfs.arcstats[arc_meta_limit])*0.01*{$ZFS_ARC_META_ALERT})'
+      name: 'ZFS ARC meta size > {$ZFS_ARC_META_ALERT}% meta max size on {HOST.NAME}'
+      priority: HIGH
+  graphs:
+    - uuid: 1510111dc5414e6d80a5230ce6a81f1d
+      name: 'ZFS ARC arc_meta_used breakdown'
+      type: STACKED
+      ymin_type_1: FIXED
+      graph_items:
+        - color: 3333FF
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[metadata_size]'
+        - sortorder: '1'
+          color: 00EE00
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[dnode_size]'
+        - sortorder: '2'
+          color: EE0000
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[hdr_size]'
+        - sortorder: '3'
+          color: EEEE00
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[dbuf_size]'
+        - sortorder: '4'
+          color: EE00EE
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[bonus_size]'
+    - uuid: 203eeeaadc9444ccbbc31cf043e836cb
+      name: 'ZFS ARC breakdown'
+      type: STACKED
+      ymin_type_1: FIXED
+      graph_items:
+        - color: 3333FF
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[data_size]'
+        - sortorder: '1'
+          color: 00AA00
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[metadata_size]'
+        - sortorder: '2'
+          color: EE0000
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[dnode_size]'
+        - sortorder: '3'
+          color: CCCC00
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[hdr_size]'
+        - sortorder: '4'
+          color: A54F10
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[dbuf_size]'
+        - sortorder: '5'
+          color: '888888'
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[bonus_size]'
+    - uuid: 4c493303be4a45a7a96d3ef7246843c0
+      name: 'ZFS ARC Cache Hit Ratio'
+      ymin_type_1: FIXED
+      ymax_type_1: FIXED
+      graph_items:
+        - color: 00CC00
+          item:
+            host: 'ZFS on Linux'
+            key: zfs.arcstats_hit_ratio
+    - uuid: d18b6efd7cce4a02a1dea48a447070f8
+      name: 'ZFS ARC L2 Cache Hit Ratio'
+      ymin_type_1: FIXED
+      ymax_type_1: FIXED
+      graph_items:
+        - color: 00CC00
+          item:
+            host: 'ZFS on Linux'
+            key: zfs.arcstats_l2_hit_ratio
+    - uuid: b2fce9515a7d4218a5e9015f212c2a60
+      name: 'ZFS ARC memory usage'
+      ymin_type_1: FIXED
+      ymax_type_1: ITEM
+      ymax_item_1:
+        host: 'ZFS on Linux'
+        key: 'zfs.arcstats[c_max]'
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 0000EE
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[size]'
+        - sortorder: '1'
+          drawtype: BOLD_LINE
+          color: DD0000
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[c_max]'
+        - sortorder: '2'
+          color: 00BB00
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.arcstats[c_min]'
+    - uuid: 1be11abfd35a4e2ca59c233546a694cf
+      name: ZIL
+      type: STACKED
+      graph_items:
+        - color: 1A7C11
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_commit_count]'
+        - sortorder: '1'
+          color: '274482'
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_commit_writer_count]'
+        - sortorder: '2'
+          color: F63100
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_itx_needcopy_count]'
+        - sortorder: '3'
+          color: 2774A4
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_itx_indirect_count]'
+        - sortorder: '4'
+          color: A54F10
+          yaxisside: RIGHT
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_itx_indirect_bytes]'
+        - sortorder: '5'
+          color: FC6EA3
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_itx_metaslab_normal_count]'
+        - sortorder: '6'
+          color: 6C59DC
+          yaxisside: RIGHT
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_itx_metaslab_normal_bytes]'
+        - sortorder: '7'
+          color: AC8C14
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_itx_metaslab_slog_count]'
+        - sortorder: '8'
+          color: 611F27
+          yaxisside: RIGHT
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_itx_metaslab_slog_bytes]'
+        - sortorder: '9'
+          color: F230E0
+          yaxisside: RIGHT
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_itx_needcopy_bytes]'
+        - sortorder: '10'
+          color: 5CCD18
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_itx_count]'
+        - sortorder: '11'
+          color: BB2A02
+          yaxisside: RIGHT
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_itx_copied_bytes]'
+        - sortorder: '12'
+          color: 5A2B57
+          item:
+            host: 'ZFS on Linux'
+            key: 'zfs.zil[zil_itx_copied_count]'

--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/userparams_zol_with_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/userparams_zol_with_sudo.conf
@@ -1,0 +1,44 @@
+# ZFS discovery and configuration
+# original template from pbergbolt (source = https://www.zabbix.com/forum/showthread.php?t=43347), modified by Slash <slash@aceslash.net>
+
+
+# pool discovery
+UserParameter=zfs.pool.discovery,/usr/bin/sudo /sbin/zpool list -H -o name | sed -e '$ ! s/\(.*\)/{"{#POOLNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#POOLNAME}":"\1"}]}/' | sed -e '1  s/\(.*\)/{ \"data\":[\1/'
+# dataset discovery, called "fileset" in the zabbix template for legacy reasons
+UserParameter=zfs.fileset.discovery,/usr/bin/sudo /sbin/zfs list -H -o name | sed -e '$ ! s/\(.*\)/{"{#FILESETNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#FILESETNAME}":"\1"}]}/' | sed -e '1  s/\(.*\)/{ \"data\":[\1/'
+# vdev discovery
+UserParameter=zfs.vdev.discovery,/usr/bin/sudo /sbin/zpool list -Hv | grep '^[[:blank:]]' | egrep -v 'mirror|raidz' | awk '{print $1}' | sed -e '$ ! s/\(.*\)/{"{#VDEV}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#VDEV}":"\1"}]}/' | sed -e '1  s/\(.*\)/{ \"data\":[\1/'
+
+# pool health
+UserParameter=zfs.zpool.health[*],/usr/bin/sudo /sbin/zpool list -H -o health $1
+
+# get any fs option
+UserParameter=zfs.get.fsinfo[*],/usr/bin/sudo /sbin/zfs get -o value -Hp $2 $1
+
+# compressratio need special treatment because of the "x" at the end of the number
+UserParameter=zfs.get.compressratio[*],/usr/bin/sudo /sbin/zfs get -o value -Hp compressratio $1 | sed "s/x//"
+
+# memory used by ZFS: sum of the SPL slab allocator's statistics
+# "There are a few things not included in that, like the page cache used by mmap(). But you can expect it to be relatively accurate."
+UserParameter=zfs.memory.used,echo $(( `cat /proc/spl/kmem/slab | tail -n +3 | awk '{ print $3 }' | tr "\n" "+" | sed "s/$/0/"` ))
+
+# get any global zfs parameters
+UserParameter=zfs.get.param[*],cat /sys/module/zfs/parameters/$1
+
+# ARC stats from /proc/spl/kstat/zfs/arcstats
+UserParameter=zfs.arcstats[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/arcstats
+
+# detect if a scrub is in progress, 0 = in progress, 1 = not in progress
+UserParameter=zfs.zpool.scrub[*],/usr/bin/sudo /sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
+
+# vdev state
+UserParameter=zfs.vdev.state[*],/usr/bin/sudo /sbin/zpool status | grep -m 1 "$1" | awk '{ print $$2 }'
+# vdev READ error counter
+UserParameter=zfs.vdev.error_counter.read[*],/usr/bin/sudo /sbin/zpool status | grep -m 1 "$1" | awk '{ print $$3 }' | numfmt --from=si
+# vdev WRITE error counter
+UserParameter=zfs.vdev.error_counter.write[*],/usr/bin/sudo /sbin/zpool status | grep -m 1 "$1" | awk '{ print $$4 }' | numfmt --from=si
+# vdev CHECKSUM error counter
+UserParameter=zfs.vdev.error_counter.cksum[*],/usr/bin/sudo /sbin/zpool status | grep -m 1 "$1" | awk '{ print $$5 }' | numfmt --from=si
+
+# Get zpool iostats 
+UserParameter=zfs.zpool.iostat[*],/usr/bin/sudo /sbin/zpool iostat $1 -H -p 1 2 | tail -n 1

--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/userparams_zol_without_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/userparams_zol_without_sudo.conf
@@ -1,0 +1,56 @@
+# ZFS discovery and configuration
+# original template from pbergbolt (source = https://www.zabbix.com/forum/showthread.php?t=43347), modified by Slash <slash@aceslash.net>
+
+
+# pool discovery
+UserParameter=zfs.pool.discovery,/sbin/zpool list -H -o name | sed -e '$ ! s/\(.*\)/{"{#POOLNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#POOLNAME}":"\1"}]}/' | sed -e '1  s/\(.*\)/{ \"data\":[\1/'
+# dataset discovery, called "fileset" in the zabbix template for legacy reasons
+UserParameter=zfs.fileset.discovery,/sbin/zfs list -H -o name | sed -e '$ ! s/\(.*\)/{"{#FILESETNAME}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#FILESETNAME}":"\1"}]}/' | sed -e '1  s/\(.*\)/{ \"data\":[\1/'
+# vdev discovery
+UserParameter=zfs.vdev.discovery,/sbin/zpool list -Hv | grep '^[[:blank:]]' | egrep -v 'mirror|raidz' | awk '{print $1}' | sed -e '$ ! s/\(.*\)/{"{#VDEV}":"\1"},/' | sed -e '$  s/\(.*\)/{"{#VDEV}":"\1"}]}/' | sed -e '1  s/\(.*\)/{ \"data\":[\1/'
+
+# pool health
+UserParameter=zfs.zpool.health[*],/sbin/zpool list -H -o health $1
+
+# get any fs option
+UserParameter=zfs.get.fsinfo[*],/sbin/zfs get -o value -Hp $2 $1
+
+# compressratio need special treatment because of the "x" at the end of the number
+UserParameter=zfs.get.compressratio[*],/sbin/zfs get -o value -Hp compressratio $1 | sed "s/x//"
+
+# memory used by ZFS: sum of the SPL slab allocator's statistics
+# "There are a few things not included in that, like the page cache used by mmap(). But you can expect it to be relatively accurate."
+UserParameter=zfs.memory.used,echo $(( `cat /proc/spl/kmem/slab | tail -n +3 | awk '{ print $3 }' | tr "\n" "+" | sed "s/$/0/"` ))
+
+# get any global zfs parameters
+UserParameter=zfs.get.param[*],cat /sys/module/zfs/parameters/$1
+
+# ARC stats from /proc/spl/kstat/zfs/arcstats
+UserParameter=zfs.arcstats[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/arcstats
+
+# ZIL stats from /proc/spl/kstat/zfs/zil
+UserParameter=zfs.zil[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/zil
+
+# detect if a scrub is in progress, 0 = in progress, 1 = not in progress
+UserParameter=zfs.zpool.scrub[*],/sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
+
+# vdev state
+UserParameter=zfs.vdev.state[*],/sbin/zpool status | grep "$1" | awk '{ print $$2 }'
+# vdev READ error counter
+UserParameter=zfs.vdev.error_counter.read[*],/sbin/zpool status | grep "$1" | awk '{ print $$3 }' | numfmt --from=si
+# vdev WRITE error counter
+UserParameter=zfs.vdev.error_counter.write[*],/sbin/zpool status | grep "$1" | awk '{ print $$4 }' | numfmt --from=si
+# vdev CHECKSUM error counter
+UserParameter=zfs.vdev.error_counter.cksum[*],/sbin/zpool status | grep "$1" | awk '{ print $$5 }' | numfmt --from=si
+
+# pool read
+UserParameter=zfs.zpool.iostat.reads[*],/sbin/zpool iostat -Hp $1 | awk '{print $$4}'
+
+# pool write
+UserParameter=zfs.zpool.iostat.writes[*],/sbin/zpool iostat -Hp $1 | awk '{print $$5}'
+
+# pool read throughput
+UserParameter=zfs.zpool.iostat.nread[*],/sbin/zpool iostat -H $1 | awk '{print $$6}' | numfmt --from=si
+
+# pool write throughput
+UserParameter=zfs.zpool.iostat.nwritten[*],/sbin/zpool iostat -H $1 | awk '{print $$7}' | numfmt --from=si


### PR DESCRIPTION
- Make the template an active check
- Add metrics for L2 cache
- Add metrics for ZIL SLOG (could be better anyway)
- Make space usage for zpool and datasets a pie instead of a graph
- Datasets space usage also show compressratio
- Fix read/write IOPS

Tested with an agent2, under debian, with version 2.11 of ZFS On Linux