### PR TITLE
Create template_fortinet_BGP_Peers.yaml

### DIFF
--- a/Network_Devices/Fortigate/template_fortinet_BGP_Peers/6.4/template_fortinet_BGP_Peers.yaml
+++ b/Network_Devices/Fortigate/template_fortinet_BGP_Peers/6.4/template_fortinet_BGP_Peers.yaml
@@ -1,0 +1,102 @@
+zabbix_export:
+  version: '6.4'
+  template_groups:
+    - uuid: 36bff6c29af64692839d077febfc7079
+      name: 'Templates/Network devices'
+  templates:
+    - uuid: 0be07a71289e43f2873247bd254b7b5e
+      template: 'FortiGate BGP by SNMP'
+      name: 'FortiGate BGP by SNMP'
+      description: |
+        The template for monitoring Fortigate BGP PEERS by SNMP.
+        
+        MIBs used
+        BGP4-MIB
+        https://simpleweb.org/ietf/mibs/modules/IETF/txt/BGP4-MIB
+        
+        Zabbix 6.4
+        
+        By DF.
+      groups:
+        - name: 'Templates/Network devices'
+      discovery_rules:
+        - uuid: 3b3a96419fc043f88609ba9fd5ccbc39
+          name: 'BGP Peers Discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#PEERREMOTEID},1.3.6.1.2.1.15.3.1.1,{#PEERSTATE},1.3.6.1.2.1.15.3.1.2,{#PEERADMINSTATUS},1.3.6.1.2.1.15.3.1.3,{#PEERREMOTEAS},1.3.6.1.2.1.15.3.1.9,{#PEERESTABLISHEDTIME},1.3.6.1.2.1.15.3.1.16,{#PEERREMOTEADDR},1.3.6.1.2.1.15.3.1.7]'
+          key: bgp.peers.discovery
+          item_prototypes:
+            - uuid: cde6571ace1844e689e197f90bf86405
+              name: 'BGP Peer {#PEERREMOTEADDR} - AS:{#PEERREMOTEAS} Admin Status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.15.3.1.3.{#SNMPINDEX}'
+              key: 'bgp.peer.adminstatus[peer.adminstatus.{#SNMPINDEX}]'
+              valuemap:
+                name: bgpPeerAdminStatus
+              tags:
+                - tag: BGP
+                  value: 'BGP Peers'
+            - uuid: 469710f61b5e4fc59dc5f6af8169da0b
+              name: 'BGP Peer {#PEERREMOTEADDR} - AS:{#PEERREMOTEAS} RemoteID'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.15.3.1.1.{#SNMPINDEX}'
+              key: 'bgp.peer.remoteid[peer.remoteid.{#SNMPINDEX}]'
+              trends: '0'
+              value_type: TEXT
+              tags:
+                - tag: BGP
+                  value: 'BGP Peers'
+            - uuid: bb1c46e6b73842bc85e8b425706f5660
+              name: 'BGP Peer {#PEERREMOTEADDR} - AS:{#PEERREMOTEAS} State'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.15.3.1.2.{#SNMPINDEX}'
+              key: 'bgp.peer.status[peer.status.{#SNMPINDEX}]'
+              valuemap:
+                name: bgpPeerState
+              tags:
+                - tag: BGP
+                  value: 'BGP Peers'
+            - uuid: 0dbbd360961c407a86720804d6493d1d
+              name: 'BGP Peer {#PEERREMOTEADDR} - AS:{#PEERREMOTEAS} Established Time'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.15.3.1.16.{#SNMPINDEX}'
+              key: 'bgp.peer.time[peer.time.{#SNMPINDEX}]'
+              units: uptime
+              tags:
+                - tag: BGP
+                  value: 'BGP Peers'
+          trigger_prototypes:
+            - uuid: b52477ff98384147a265437c32d8a4bf
+              expression: 'last(/FortiGate BGP by SNMP/bgp.peer.status[peer.status.{#SNMPINDEX}])<>6 and last(/FortiGate BGP by SNMP/bgp.peer.adminstatus[peer.adminstatus.{#SNMPINDEX}])<>1'
+              name: 'BGP Peer {#PEERREMOTEADDR} - AS:{#PEERREMOTEAS} State'
+              priority: HIGH
+      tags:
+        - tag: class
+          value: network
+        - tag: target
+          value: fortigate
+        - tag: target
+          value: fortinet
+      valuemaps:
+        - uuid: 9086d8258481499687ed6ca13f42ede9
+          name: bgpPeerAdminStatus
+          mappings:
+            - value: '1'
+              newvalue: stop
+            - value: '2'
+              newvalue: start
+        - uuid: dbaa62f96c7b46c090e19485c3de12ed
+          name: bgpPeerState
+          mappings:
+            - value: '6'
+              newvalue: established
+            - value: '5'
+              newvalue: openconfirm
+            - value: '4'
+              newvalue: opensent
+            - value: '3'
+              newvalue: active
+            - value: '2'
+              newvalue: connect
+            - value: '1'
+              newvalue: idle


### PR DESCRIPTION
I've created a new template for Fortigate by SNMP for monitoring BGP Peers.

It was made with Zabbix 6.4 and it will discover any BGP peer configured in Fortinet Fortigate firewalls.