### PR TITLE
Adding community rootless podman monitoring template with clear instructions.

### DIFF
--- a/Applications/Podman_via_ActiveAgent/7.0/Rootless Podman Monitoring.yaml
+++ b/Applications/Podman_via_ActiveAgent/7.0/Rootless Podman Monitoring.yaml
@@ -12,7 +12,7 @@ zabbix_export:
         - name: Templates/Applications
       items:
         - uuid: c5af8fb4366540c198a6b3ff456c67ea
-          name: '[Item] [AAP] Podman Export (JSON)'
+          name: 'Podman Export (JSON)'
           type: ZABBIX_ACTIVE
           key: podman.ps
           value_type: TEXT
@@ -33,7 +33,7 @@ zabbix_export:
                   return JSON.stringify(obj);
       discovery_rules:
         - uuid: 8c048ac39dba423bab561ad70b901e2a
-          name: '[DISC] [AAP] Containers'
+          name: 'Discover Containers'
           type: DEPENDENT
           key: podman.ps.containers
           delay: '0'

--- a/Applications/Podman_via_ActiveAgent/README.md
+++ b/Applications/Podman_via_ActiveAgent/README.md
@@ -69,7 +69,7 @@ UserParameter=podman.ps,sudo -u $USER podman ps -a --format json
 zabbix  ALL=($USER) NOPASSWD: /usr/bin/podman ps -a --format json
 
 ## Tested with
-(Agent): Zabbix Agent2 v7.0.X
-(Server): Zabbix Server v7.0.X
-(Guest OS): RHEL 9.X
-(Podman): 4.9.4
+(Agent): Zabbix Agent2 v7.0.X <br/>
+(Server): Zabbix Server v7.0.X <br/>
+(Guest OS): RHEL 9.X <br/>
+(Podman): 4.9.4 <br/>

--- a/Applications/Podman_via_ActiveAgent/README.md
+++ b/Applications/Podman_via_ActiveAgent/README.md
@@ -1,0 +1,66 @@
+# Rootless Podman Monitoring
+
+## Overview
+
+This template serves as a partial replacement for the docker work-around currently used by some people. This template remains highly scalable, with the template assigned per host you intend to monitor. It uses the Podman CLI to execute the necessary commands. Podman by default runs in a rootless nature making it a challenge to correctly list the running containers on a given host. You cannot natively in the Podman CLI list another users pods, unless you are that user. THis template leverage customer "User Parameters" and sudo permissions to check running pods belonging to other users.
+
+## Author
+
+Michael Redbourne, Bulletproof Solutions
+
+## Macros used
+
+|Name|Description|Default|Type|
+|----|-----------|-------|----|
+|{#CONTAINER_NAME}|Friendly Container Name|N/A|Text macro|
+|{#CONTAINER_ID}|Container GUID/ID|N/A|Text macro|
+
+## Template links
+
+There are no template links in this template.
+
+## Discovery rules
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|Discover Containers|Leverages the item "podman.ps" to capture discovery information using LLDs.|`Dependent Item`|podman.ps.containers|
+
+
+## Items collected
+
+|Name|Description|Type|Key|Dependency|Information|Preprocessing|
+|----|-----------|----|---|----------|-----------|-------------|
+|Podman Export (JSON)|Captures the raw JSON from the command: "podman ps -a --format json"|Zabbix Agent (Active)|podman.ps|N/A|Text|Yes (JS)|
+
+## Item Prototypes
+|Name|Description|Type|Key|Dependency|Information|Preprocessing|
+|----|-----------|----|---|----------|-----------|-------------|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.AutoRemove[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.Created[{#CONTAINER_NAME}]|podman.ps|Integer|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.CreatedAt[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.ExitCode[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.Exited[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.ImageID[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.Mounts[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.Names[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.Networks[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.PID[{#CONTAINER_NAME}]|podman.ps|Integer|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.Pod[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.PodName[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.Restarts[{#CONTAINER_NAME}]|podman.ps|Integer|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.StartedAt[{#CONTAINER_NAME}]|podman.ps|Integer|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.State[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
+|{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.Status[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
+
+## Trigger Prototypes
+|Name|Description|Expression|Priority|
+|----|-----------|----------|--------|
+
+## Special Notes
+Two host-level changes must be made. One will modify the Zabbix Agent configuration to include an additional user parameter. The other is a sudo change to allow zabbix to "change users" to the target user(s). Change the $USER variable to the user running your pods.
+
+## Zabbix Agent Config Change
+UserParameter=podman.ps,sudo -u $USER podman ps -a --format json
+
+## Sudo Change (visudo /etc/sudoers.d/zabbix)
+zabbix  ALL=($USER) NOPASSWD: /usr/bin/podman ps -a --format json

--- a/Applications/Podman_via_ActiveAgent/README.md
+++ b/Applications/Podman_via_ActiveAgent/README.md
@@ -53,8 +53,11 @@ There are no template links in this template.
 |{#CONTAINER_NAME}: |N/A|Dependent Item|podman.ps.containers.Status[{#CONTAINER_NAME}]|podman.ps|Character|Yes (JSON Path)|
 
 ## Trigger Prototypes
-|Name|Description|Expression|Priority|
-|----|-----------|----------|--------|
+|Name|Description|Expression|Priority|Recovery|
+|----|-----------|----------|--------|--------|
+|{#CONTAINER_NAME} Has Recently Restarted|N/A|change(/Template - RHEL 9 - Ansible Automation Platform/podman.ps.containers.StartedAt[{#CONTAINER_NAME}])>0 or change(/Template - RHEL 9 - Ansible Automation Platform/podman.ps.containers.Restarts[{#CONTAINER_NAME}])>0|Warning|Yes
+|{#CONTAINER_NAME} Is Not Running|N/A|last(/Template - RHEL 9 - Ansible Automation Platform/podman.ps.containers.State[{#CONTAINER_NAME}])<>"running"|Average|Yes|
+|{#CONTAINER_NAME} Is Offline|N/A|last(/Template - RHEL 9 - Ansible Automation Platform/podman.ps.containers.exited[{#CONTAINER_NAME}])="true"|High|Yes|
 
 ## Special Notes
 Two host-level changes must be made. One will modify the Zabbix Agent configuration to include an additional user parameter. The other is a sudo change to allow zabbix to "change users" to the target user(s). Change the $USER variable to the user running your pods.
@@ -64,3 +67,9 @@ UserParameter=podman.ps,sudo -u $USER podman ps -a --format json
 
 ## Sudo Change (visudo /etc/sudoers.d/zabbix)
 zabbix  ALL=($USER) NOPASSWD: /usr/bin/podman ps -a --format json
+
+## Tested with
+(Agent): Zabbix Agent2 v7.0.X
+(Server): Zabbix Server v7.0.X
+(Guest OS): RHEL 9.X
+(Podman): 4.9.4

--- a/Applications/Podman_via_ActiveAgent/Rootless Podman Monitoring.yaml
+++ b/Applications/Podman_via_ActiveAgent/Rootless Podman Monitoring.yaml
@@ -1,0 +1,296 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: a571c0d144b14fd4a87a9d9b2aa9fcd6
+      name: Templates/Applications
+  templates:
+    - uuid: 6573fdceab784930a0545452236a03b6
+      template: 'Rootless Podman Monitoring'
+      name: 'Rootless Podman Monitoring'
+      groups:
+        - name: Templates
+        - name: Templates/Applications
+      items:
+        - uuid: c5af8fb4366540c198a6b3ff456c67ea
+          name: '[Item] [AAP] Podman Export (JSON)'
+          type: ZABBIX_ACTIVE
+          key: podman.ps
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var obj = JSON.parse(value);
+                  
+                  for (var i = 0; i < obj.length; i++) {
+                    if (Array.isArray(obj[i].Names) && obj[i].Names.length === 1) {
+                      obj[i].Name = obj[i].Names[0];
+                      delete obj[i].Names;
+                    }
+                  }
+                  
+                  return JSON.stringify(obj);
+      discovery_rules:
+        - uuid: 8c048ac39dba423bab561ad70b901e2a
+          name: '[DISC] [AAP] Containers'
+          type: DEPENDENT
+          key: podman.ps.containers
+          delay: '0'
+          item_prototypes:
+            - uuid: ccce3800bbba49128875b04bd267a1f8
+              name: '{#CONTAINER_NAME}: Auto Remove'
+              type: DEPENDENT
+              key: 'podman.ps.containers.autoremove[{#CONTAINER_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].AutoRemove.first()'
+              master_item:
+                key: podman.ps
+            - uuid: 7a4014b90ca14b51a09a43cace048a1b
+              name: '{#CONTAINER_NAME}: Created At'
+              type: DEPENDENT
+              key: 'podman.ps.containers.createdAt[{#CONTAINER_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].CreatedAt.first()'
+              master_item:
+                key: podman.ps
+            - uuid: d544725373b84424ae3ed4ad5a664149
+              name: '{#CONTAINER_NAME}: Created'
+              type: DEPENDENT
+              key: 'podman.ps.containers.Created[{#CONTAINER_NAME}]'
+              delay: '0'
+              trends: '0'
+              units: unixtime
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].Created.first()'
+              master_item:
+                key: podman.ps
+            - uuid: 3164c84a19ab4c19be26c78c2c9f7a00
+              name: '{#CONTAINER_NAME}: Exit Code'
+              type: DEPENDENT
+              key: 'podman.ps.containers.exitCode[{#CONTAINER_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].ExitCode.first()'
+              master_item:
+                key: podman.ps
+            - uuid: d981c3e21722472d86df474f3c7901dc
+              name: '{#CONTAINER_NAME}: Exited'
+              type: DEPENDENT
+              key: 'podman.ps.containers.exited[{#CONTAINER_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].Exited.first()'
+              master_item:
+                key: podman.ps
+              trigger_prototypes:
+                - uuid: 8b7b94d80d3e41409d9c061336a3110e
+                  expression: 'last(/Rootless Podman Monitoring/podman.ps.containers.exited[{#CONTAINER_NAME}])="true"'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/Rootless Podman Monitoring/podman.ps.containers.exited[{#CONTAINER_NAME}])="false"'
+                  name: '{#CONTAINER_NAME} Is Offline'
+                  priority: HIGH
+                  description: 'Detects when a rootless podman container has entered an "exited" state. This indicates the container is likely offline and may require remediation.'
+            - uuid: 886047517c564d9191a12a32bd9d61b3
+              name: '{#CONTAINER_NAME}: Image ID'
+              type: DEPENDENT
+              key: 'podman.ps.containers.imageId[{#CONTAINER_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].ImageID.first()'
+              master_item:
+                key: podman.ps
+            - uuid: c0d9c537e50c48c8b1c0beba1dbc37b9
+              name: '{#CONTAINER_NAME}: Mounts'
+              type: DEPENDENT
+              key: 'podman.ps.containers.Mounts[{#CONTAINER_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].Mounts.first()'
+              master_item:
+                key: podman.ps
+            - uuid: 181e91fd691a4c25a3222f1e7337f7cf
+              name: '{#CONTAINER_NAME}: Names'
+              type: DEPENDENT
+              key: 'podman.ps.containers.names[{#CONTAINER_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].Names.first()'
+              master_item:
+                key: podman.ps
+            - uuid: 3a4ee9d26fa14c70878e856d678fdfbc
+              name: '{#CONTAINER_NAME}: Networks'
+              type: DEPENDENT
+              key: 'podman.ps.containers.Networks[{#CONTAINER_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].Networks.first()'
+              master_item:
+                key: podman.ps
+            - uuid: 809b88a0e23f412c977954ed22152f91
+              name: '{#CONTAINER_NAME}: PID'
+              type: DEPENDENT
+              key: 'podman.ps.containers.PID[{#CONTAINER_NAME}]'
+              delay: '0'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].Pid.first()'
+              master_item:
+                key: podman.ps
+            - uuid: 63779f16b8ff47109f86f541ea4d5ab5
+              name: '{#CONTAINER_NAME}: Pod Name'
+              type: DEPENDENT
+              key: 'podman.ps.containers.PodName[{#CONTAINER_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].PodName.first()'
+              master_item:
+                key: podman.ps
+            - uuid: 293b0cf48097476081cb6f8b8633b559
+              name: '{#CONTAINER_NAME}: Pod'
+              type: DEPENDENT
+              key: 'podman.ps.containers.Pod[{#CONTAINER_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].Pod.first()'
+              master_item:
+                key: podman.ps
+            - uuid: 2a4098e60f8b4e18b9e22d11582d8042
+              name: '{#CONTAINER_NAME}: Restarts'
+              type: DEPENDENT
+              key: 'podman.ps.containers.Restarts[{#CONTAINER_NAME}]'
+              delay: '0'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].Restarts.first()'
+              master_item:
+                key: podman.ps
+            - uuid: dc4d62f7d5fd40118ba1cd4256a1b7e9
+              name: '{#CONTAINER_NAME}: Started At'
+              type: DEPENDENT
+              key: 'podman.ps.containers.StartedAt[{#CONTAINER_NAME}]'
+              delay: '0'
+              trends: '0'
+              units: unixtime
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].StartedAt.first()'
+              master_item:
+                key: podman.ps
+            - uuid: 11a2d553d42d4546a0b2a534d02d39cc
+              name: '{#CONTAINER_NAME}: State'
+              type: DEPENDENT
+              key: 'podman.ps.containers.State[{#CONTAINER_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].State.first()'
+              master_item:
+                key: podman.ps
+              trigger_prototypes:
+                - uuid: 18c60fcd19d742259051b1167d0d7fae
+                  expression: 'last(/Rootless Podman Monitoring/podman.ps.containers.State[{#CONTAINER_NAME}])<>"running"'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/Rootless Podman Monitoring/podman.ps.containers.State[{#CONTAINER_NAME}])="running"'
+                  name: '{#CONTAINER_NAME} Is Not Running'
+                  priority: AVERAGE
+                  description: 'This rule detects when a given container is not a running state. This may differ from a "exited" state and may indicate anything from an offline container, a container being allocated or de-allocated, to a container being restarted.'
+            - uuid: a1a6e324861641a3ba94e90e4a1ff796
+              name: '{#CONTAINER_NAME}: Status'
+              type: DEPENDENT
+              key: 'podman.ps.containers.Status[{#CONTAINER_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.[?(@.Name == "{#CONTAINER_NAME}")].Status.first()'
+              master_item:
+                key: podman.ps
+          trigger_prototypes:
+            - uuid: 8bdcb545fa9d4ba891cdbcebe241172a
+              expression: 'change(/Rootless Podman Monitoring/podman.ps.containers.StartedAt[{#CONTAINER_NAME}])>0 or change(/Rootless Podman Monitoring/podman.ps.containers.Restarts[{#CONTAINER_NAME}])>0'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'change(/Rootless Podman Monitoring/podman.ps.containers.StartedAt[{#CONTAINER_NAME}])>0 and change(/Rootless Podman Monitoring/podman.ps.containers.Restarts[{#CONTAINER_NAME}])>0'
+              name: '{#CONTAINER_NAME} Has Recently Restarted'
+              priority: WARNING
+              description: 'The rule detects a change in unixtime() value for the "Started At" podman variable or a change in the number retstarts. This indicates the container has likely restarted recently. Any positive change in detected timestamp will fire this alert. The alert will resolve once no change has been detected.'
+              manual_close: 'YES'
+          master_item:
+            key: podman.ps
+          lld_macro_paths:
+            - lld_macro: '{#CONTAINER_ID}'
+              path: $.Id
+            - lld_macro: '{#CONTAINER_NAME}'
+              path: $.Name
+      tags:
+        - tag: Program
+          value: Podman
+        - tag: Program2
+          value: AAP
+      valuemaps:
+        - uuid: bf91182dca60442fa3b477db1992f017
+          name: Image
+          mappings:
+            - type: REGEXP
+              value: 'redis-6:latest'
+              newvalue: Redis
+            - type: REGEXP
+              value: 'receptor-rhel8:latest'
+              newvalue: Receptor
+            - type: REGEXP
+              value: 'controller-rhel8:latest'
+              newvalue: Controller


### PR DESCRIPTION
This template leverages the active agent (passive should work as well) on ZBX version 7.0.X for both the server and agent. Tested environment is RHEL 9.4 and RHEL 9.5, podman 4.9.4.

Minor changes need to be done by the end user to enable limited sudo access to execute the podman command as another user. The template can be duplicated to distinguish users and servers. If you have multiple users on a single server, you will need to add more than one object, then duplicate out the discovery rules, LLDs, and prototypes. Will probably need to add more monitoring points.

Items use the friendly name of a container. However, the IDs (GUID) of the container is captured and can be used in lieu, if desired.