### PR TITLE
Add SNMP template for Ruckus APs to zabbix 6.0

### DIFF
--- a/Network_Devices/Ruckus/template_snmp_ruckus_ap/6.0/template_snmp_ruckus_aps.yaml
+++ b/Network_Devices/Ruckus/template_snmp_ruckus_ap/6.0/template_snmp_ruckus_aps.yaml
@@ -1,0 +1,587 @@
+zabbix_export:
+  version: '6.0'
+  date: '2025-05-16T18:00:53Z'
+  groups:
+    - uuid: 6e72578a1cb74baca65b3231f3fc468b
+      name: Ruckus
+  templates:
+    - uuid: 8479b449a4224cc89f56f57cff5de05f
+      template: SNMP_Ruckus_APs
+      name: SNMP_Ruckus_APs
+      description: |
+        ## Overview
+        
+        SNMP_Ruckus_APS
+        =====================
+        
+        SNMP monitoring directly from the Ruckus AP
+        
+        Tested with R350 APs on Zabbix 6.0.39
+        Once utilizes the vendor's SNMP MIB, in theory should work with other Ruckus APs models
+        
+        ##Author
+        
+        Mario Jorge Limeira dos Santos
+      groups:
+        - name: Ruckus
+      items:
+        - uuid: 60ccb148f95e489a904490caa005e90c
+          name: 'ICMP Ping'
+          type: SIMPLE
+          key: icmpping
+          history: 1w
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 59013ec46a5b4a9386520610af813f5a
+              expression: 'max(/SNMP_Ruckus_APs/icmpping,#3)=0'
+              name: 'Unavailable by ICMP ping'
+              priority: HIGH
+              description: 'Last three attempts returned timeout.  Please check device connectivity.'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: da6f442de14f403dae23305f824f21e7
+          name: 'CPU utilization'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.25053.1.1.11.1.1.1.1.0
+          key: 'ruckusSystemCPUUtil[{#SNMPVALUE}]'
+          history: 7d
+          units: '%'
+          description: 'CPU Utilization'
+          tags:
+            - tag: component
+              value: cpu
+          triggers:
+            - uuid: a3c464e9dac64eed9b9c09678ccfac5b
+              expression: 'min(/SNMP_Ruckus_APs/ruckusSystemCPUUtil[{#SNMPVALUE}],5m)>{$CPU.UTIL.CRIT}'
+              name: 'High CPU utilization'
+              event_name: 'High CPU utilization (over {$CPU.UTIL.CRIT}% for 5m)'
+              priority: WARNING
+              description: 'CPU utilization is too high. The system might be slow to respond.'
+              tags:
+                - tag: scope
+                  value: performance
+        - uuid: 6aeeb41b943f4d63b697dc752af3609d
+          name: 'Memory Utilization'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.25053.1.1.11.1.1.1.2.0
+          key: 'ruckusSystemMemoryUtil[{#SNMPVALUE}]'
+          history: 7d
+          units: '%'
+          description: 'Memory Utilization'
+          tags:
+            - tag: component
+              value: memory
+          triggers:
+            - uuid: 1b384cea327c41c88a1732b20a302d48
+              expression: 'min(/SNMP_Ruckus_APs/ruckusSystemMemoryUtil[{#SNMPVALUE}],5m)>{$MEMORY.UTIL.MAX}'
+              name: 'High memory utilization'
+              event_name: 'High memory utilization (>{$MEMORY.UTIL.MAX}% for 5m)'
+              priority: AVERAGE
+              description: 'The system is running out of free memory.'
+              tags:
+                - tag: scope
+                  value: capacity
+                - tag: scope
+                  value: performance
+        - uuid: 9f198f0b3600420abc3285a24cb54aa8
+          name: 'SNMP agent availability'
+          type: INTERNAL
+          key: 'zabbix[host,snmp,available]'
+          history: 7d
+          description: |
+            Availability of SNMP checks on the host. The value of this item corresponds to availability icons in the host list.
+            Possible value:
+            0 - not available
+            1 - available
+            2 - unknown
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 78c980037df04b2fa74eaf91390908f4
+              expression: 'max(/SNMP_Ruckus_APs/zabbix[host,snmp,available],{$SNMP.TIMEOUT})=0'
+              name: 'No SNMP data collection'
+              priority: WARNING
+              description: 'SNMP is not available for polling. Please check device connectivity and SNMP settings.'
+              tags:
+                - tag: scope
+                  value: availability
+      discovery_rules:
+        - uuid: ef3b55503c4b43f286db2d2916a74c0f
+          name: Ruckus_AP
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.4.1.25053.1.1.4.1.1.1.11]'
+          key: 'AP-[{#SNMPVALUE}]'
+          delay: 2m
+          lifetime: 7d
+          description: 'Discover AP and retrieve MAC address'
+          item_prototypes:
+            - uuid: 5fddf40aeace4dbbb003909cedda76cb
+              name: Location
+              type: SNMP_AGENT
+              snmp_oid: 1.3.6.1.4.1.25053.1.1.4.1.1.1.10.0
+              key: 'ruckusDeviceLocation[{#SNMPVALUE}]'
+              delay: '360'
+              trends: '0'
+              value_type: TEXT
+              description: 'retrieves device location'
+              tags:
+                - tag: Application
+                  value: AP->Location
+            - uuid: 27dec1e6bc7f4f14a63b1d9a43e60cfe
+              name: Name
+              type: SNMP_AGENT
+              snmp_oid: 1.3.6.1.4.1.25053.1.1.4.1.1.1.1.0
+              key: 'ruckusDeviceName[{#SNMPVALUE}]'
+              delay: '360'
+              trends: '0'
+              value_type: TEXT
+              description: 'retrieves device name'
+              tags:
+                - tag: Application
+                  value: AP->Name
+              trigger_prototypes:
+                - uuid: 797f309a008746738cc3db21db113709
+                  expression: 'last(/SNMP_Ruckus_APs/ruckusDeviceName[{#SNMPVALUE}],#1)<>last(/SNMP_Ruckus_APs/ruckusDeviceName[{#SNMPVALUE}],#2) and length(last(/SNMP_Ruckus_APs/ruckusDeviceName[{#SNMPVALUE}]))>0'
+                  name: '{#SNMPVALUE}: Name has changed'
+                  event_name: 'AP name has changed (new name: {ITEM.VALUE})'
+                  priority: INFO
+                  description: 'AP name has changed. Ack to close.'
+                  tags:
+                    - tag: scope
+                      value: notice
+                    - tag: scope
+                      value: security
+            - uuid: 1833fbca25034005a3d5d685864321ab
+              name: 'IP Address'
+              type: SNMP_AGENT
+              snmp_oid: 1.3.6.1.4.1.25053.1.1.4.1.1.4.1.1.2.39
+              key: 'ruckusDeviceWanIPAddr[{#SNMPVALUE}]'
+              delay: '120'
+              trends: '0'
+              value_type: TEXT
+              description: 'retrieves device IP address'
+              tags:
+                - tag: Application
+                  value: AP->IPAddress
+            - uuid: 8bd96572e33a48d891aa131b05746f42
+              name: NetMask
+              type: SNMP_AGENT
+              snmp_oid: 1.3.6.1.4.1.25053.1.1.4.1.1.4.1.1.4.39
+              key: 'ruckusDeviceWanNetMask[{#SNMPVALUE}]'
+              delay: '360'
+              trends: '0'
+              value_type: TEXT
+              description: 'Retrieves device Wan Network Mask'
+              tags:
+                - tag: Application
+                  value: AP->Netmask
+            - uuid: ce65ea5ad71f4fbdae57317a504bb43e
+              name: Model
+              type: SNMP_AGENT
+              snmp_oid: 1.3.6.1.4.1.25053.1.1.2.1.1.1.1.0
+              key: 'ruckusHwInfoModelNumber[{#SNMPVALUE}]'
+              delay: '360'
+              trends: '0'
+              value_type: TEXT
+              description: 'Retrieves device model'
+              tags:
+                - tag: Application
+                  value: AP->Model
+            - uuid: 08cac2e15c48411bb99f6d120762931b
+              name: 'Serial Number'
+              type: SNMP_AGENT
+              snmp_oid: 1.3.6.1.4.1.25053.1.1.2.1.1.1.2.0
+              key: 'ruckusHwInfoSerialNumber[{#SNMPVALUE}]'
+              delay: '360'
+              trends: '0'
+              value_type: TEXT
+              description: 'Retrieves device serial number'
+              tags:
+                - tag: Application
+                  value: AP->Serial
+            - uuid: 007cf81bdb7f43519dee44a01e6e94cb
+              name: 'Authenticated Clients (Total)'
+              type: CALCULATED
+              key: ruckusRadioStatsNumAuthSta
+              history: 30d
+              trends: 180d
+              units: users
+              params: 'last(//ruckusRadioStatsNumAuthSta24Ghz[{#SNMPVALUE}])+last(//ruckusRadioStatsNumAuthSta5Ghz[{#SNMPVALUE}])'
+              description: 'Authenticated Users (Total)'
+              tags:
+                - tag: Application
+                  value: 'Authenticated Users (Total)'
+                - tag: Application
+                  value: SSID
+                - tag: component
+                  value: network
+            - uuid: e3247072800d43ef9a9aa222419ec097
+              name: 'Authenticated Clients - 5Ghz'
+              type: SNMP_AGENT
+              snmp_oid: 1.3.6.1.4.1.25053.1.1.12.1.1.1.3.1.3.2
+              key: 'ruckusRadioStatsNumAuthSta5Ghz[{#SNMPVALUE}]'
+              history: 30d
+              trends: 180d
+              units: users
+              description: 'Authenticated Users on 5Ghz'
+              tags:
+                - tag: Application
+                  value: 'Authenticated Users on 5Ghz'
+                - tag: Application
+                  value: SSID
+                - tag: component
+                  value: network
+            - uuid: 19ac785d12754bb38b323743be7d0297
+              name: 'Authenticated Clients 2.4Ghz'
+              type: SNMP_AGENT
+              snmp_oid: 1.3.6.1.4.1.25053.1.1.12.1.1.1.3.1.3.1
+              key: 'ruckusRadioStatsNumAuthSta24Ghz[{#SNMPVALUE}]'
+              history: 30d
+              trends: 180d
+              units: users
+              description: 'Authenticated Users on 2.4Ghz'
+              tags:
+                - tag: Application
+                  value: 'Authenticated Users on 2.4Ghz'
+                - tag: Application
+                  value: SSID
+                - tag: component
+                  value: network
+            - uuid: 91e6b6b3908b4c80b284c3b7bef2050f
+              name: 'RX bytes (Total)'
+              type: CALCULATED
+              key: ruckusRadioStatsRxBytes
+              history: 30d
+              trends: 60d
+              units: b
+              params: 'last(//ruckusRadioStatsRxBytes24Ghz[{#SNMPVALUE}])+last(//ruckusRadioStatsRxBytes5Ghz[{#SNMPVALUE}])'
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: Application
+                  value: 'RX bytes (Total)'
+                - tag: Application
+                  value: Traffic
+                - tag: component
+                  value: network
+            - uuid: 693615595004418da523901c3fda6a88
+              name: 'RX bytes on 5Ghz'
+              type: SNMP_AGENT
+              snmp_oid: .1.3.6.1.4.1.25053.1.1.12.1.1.1.3.1.16.2
+              key: 'ruckusRadioStatsRxBytes5Ghz[{#SNMPVALUE}]'
+              history: 30d
+              trends: 60d
+              units: b
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: Application
+                  value: Traffic
+                - tag: component
+                  value: network
+            - uuid: 6b6fc0bfec034b199659933e804d3094
+              name: 'RX bytes on 2.4Ghz'
+              type: SNMP_AGENT
+              snmp_oid: .1.3.6.1.4.1.25053.1.1.12.1.1.1.3.1.16.1
+              key: 'ruckusRadioStatsRxBytes24Ghz[{#SNMPVALUE}]'
+              history: 30d
+              trends: 60d
+              units: b
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: Application
+                  value: Traffic
+                - tag: component
+                  value: network
+            - uuid: 4f66f561b614449bb50bad9ccfc0d637
+              name: 'TX bytes (Total)'
+              type: CALCULATED
+              key: ruckusRadioStatsTxBytes
+              history: 30d
+              trends: 60d
+              units: b
+              params: 'last(//ruckusRadioStatsTxBytes24Ghz[{#SNMPVALUE}])+last(//ruckusRadioStatsTxBytes5Ghz[{#SNMPVALUE}])'
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: Application
+                  value: Traffic
+                - tag: Application
+                  value: 'TX bytes (Total)'
+                - tag: component
+                  value: network
+            - uuid: 0e2b7cfb7676420e8be742da7dd41fa7
+              name: 'TX bytes on 5Ghz'
+              type: SNMP_AGENT
+              snmp_oid: .1.3.6.1.4.1.25053.1.1.12.1.1.1.3.1.22.2
+              key: 'ruckusRadioStatsTxBytes5Ghz[{#SNMPVALUE}]'
+              history: 30d
+              trends: 60d
+              units: b
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: Application
+                  value: Traffic
+                - tag: component
+                  value: network
+            - uuid: b10871b4251a4dff9fbf818c91f1dd1e
+              name: 'TX bytes on 2.4Ghz'
+              type: SNMP_AGENT
+              snmp_oid: .1.3.6.1.4.1.25053.1.1.12.1.1.1.3.1.22.1
+              key: 'ruckusRadioStatsTxBytes24Ghz[{#SNMPVALUE}]'
+              history: 30d
+              trends: 60d
+              units: b
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: Application
+                  value: Traffic
+                - tag: component
+                  value: network
+            - uuid: e03a373785e9402aa2ef7bf51b94cf18
+              name: 'WLAN Interface Status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.25053.1.1.6.1.1.1.1.1.12.{#SNMPINDEX}'
+              key: 'ruckusWLANAdminStatus[{#SNMPVALUE}]'
+              delay: '120'
+              trends: '0'
+              value_type: CHAR
+              description: 'Administrative status of the WLAN interface. Enumeration: ''down'': 2, ''up'': 1.'
+              tags:
+                - tag: Application
+                  value: AP->Status
+              trigger_prototypes:
+                - uuid: 88352bdcf8f448dd8d81c0a6fb4eb4c0
+                  expression: 'last(/SNMP_Ruckus_APs/ruckusWLANAdminStatus[{#SNMPVALUE}])=2'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/SNMP_Ruckus_APs/ruckusWLANAdminStatus[{#SNMPVALUE}])=1'
+                  name: '{#SNMPVALUE} - WLAN interface status was DOWN'
+                  event_name: '{#SNMPVALUE} - WLAN interface status was DOWN'
+                  priority: AVERAGE
+                  tags:
+                    - tag: scope
+                      value: availability
+            - uuid: cda55b6242604e81919bc917f05a0beb
+              name: Uptime
+              type: SNMP_AGENT
+              snmp_oid: .1.3.6.1.2.1.1.3.0
+              key: 'sysUpTime[{#SNMPVALUE}]'
+              delay: '120'
+              units: uptime
+              preprocessing:
+                - type: CHECK_NOT_SUPPORTED
+                  parameters:
+                    - ''
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.01'
+              tags:
+                - tag: Application
+                  value: AP->Uptime
+              trigger_prototypes:
+                - uuid: efe529a8250d4895b1aa773a8bc996a1
+                  expression: 'last(/SNMP_Ruckus_APs/sysUpTime[{#SNMPVALUE}])=0'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/SNMP_Ruckus_APs/sysUpTime[{#SNMPVALUE}])>0'
+                  name: '{#SNMPVALUE} is Down'
+                  event_name: '{#SNMPVALUE} is Down'
+                  priority: HIGH
+                  tags:
+                    - tag: scope
+                      value: availability
+          graph_prototypes:
+            - uuid: ff303c5cc67f40eeb623532cbc2816e0
+              name: 'Authenticated Clients (Total)'
+              ymin_type_1: ITEM
+              ymin_item_1:
+                host: SNMP_Ruckus_APs
+                key: ruckusRadioStatsNumAuthSta
+              graph_items:
+                - color: 1A7C11
+                  calc_fnc: ALL
+                  item:
+                    host: SNMP_Ruckus_APs
+                    key: ruckusRadioStatsNumAuthSta
+            - uuid: 685af9c92c344dffbbf3602c662b59c7
+              name: 'RX bytes (Total)'
+              ymin_type_1: ITEM
+              ymin_item_1:
+                host: SNMP_Ruckus_APs
+                key: ruckusRadioStatsRxBytes
+              graph_items:
+                - drawtype: GRADIENT_LINE
+                  color: 1A7C11
+                  calc_fnc: ALL
+                  item:
+                    host: SNMP_Ruckus_APs
+                    key: ruckusRadioStatsRxBytes
+            - uuid: 489c69b1676147678abe64c755f8a3b1
+              name: 'TX bytes (Total)'
+              ymin_type_1: ITEM
+              ymin_item_1:
+                host: SNMP_Ruckus_APs
+                key: ruckusRadioStatsTxBytes
+              graph_items:
+                - drawtype: GRADIENT_LINE
+                  color: 1A7C11
+                  calc_fnc: ALL
+                  item:
+                    host: SNMP_Ruckus_APs
+                    key: ruckusRadioStatsTxBytes
+        - uuid: 4d29494850544e73a452eefcfbe68483
+          name: SSIDs
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.4.1.25053.1.1.6.1.1.1.1.1.1]'
+          key: 'ssid-[{#SNMPVALUE}]'
+          delay: 2m
+          lifetime: 7d
+          description: 'Discover SSIDs from AP'
+          item_prototypes:
+            - uuid: 2283a04d2f2d40d09ed8d78ce1552601
+              name: 'SSID: {#SNMPVALUE}'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.25053.1.1.6.1.1.1.1.1.1.{#SNMPINDEX}'
+              key: 'ruckusWLANSSID[{#SNMPVALUE}]'
+              delay: 2m
+              history: 30d
+              trends: '0'
+              value_type: CHAR
+              tags:
+                - tag: Application
+                  value: SSID
+            - uuid: acffd7cee40047c88b9a960411c683c1
+              name: '{#SNMPVALUE} - Rx Bytes'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.25053.1.1.6.1.1.1.4.1.24.{#SNMPINDEX}'
+              key: 'ruckusWLANStatsRxBytes[{#SNMPVALUE}]'
+              delay: 2m
+              history: 30d
+              trends: 60d
+              units: b
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: Application
+                  value: Traffic
+            - uuid: e1ba120f413747fa9d1b2a723412c81c
+              name: '{#SNMPVALUE} - Tx Bytes'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.4.1.25053.1.1.6.1.1.1.4.1.39.{#SNMPINDEX}'
+              key: 'ruckusWLANStatsTxBytes[{#SNMPVALUE}]'
+              delay: 2m
+              history: 30d
+              trends: 60d
+              units: b
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: Application
+                  value: Traffic
+          graph_prototypes:
+            - uuid: 89c83d230ec943f3a2d7c4ab3d08ea95
+              name: '{#SNMPVALUE} Data transmission'
+              ymin_type_1: FIXED
+              graph_items:
+                - drawtype: GRADIENT_LINE
+                  color: 1A7C11
+                  calc_fnc: MAX
+                  item:
+                    host: SNMP_Ruckus_APs
+                    key: 'ruckusWLANStatsRxBytes[{#SNMPVALUE}]'
+                - sortorder: '1'
+                  drawtype: GRADIENT_LINE
+                  color: '274482'
+                  calc_fnc: MAX
+                  item:
+                    host: SNMP_Ruckus_APs
+                    key: 'ruckusWLANStatsTxBytes[{#SNMPVALUE}]'
+      tags:
+        - tag: class
+          value: network
+        - tag: class
+          value: wireless
+        - tag: target
+          value: ap
+        - tag: target
+          value: ruckus
+      macros:
+        - macro: '{$CPU.UTIL.CRIT}'
+          value: '90'
+        - macro: '{$MEMORY.UTIL.MAX}'
+          value: '90'
+        - macro: '{$SNMP.TIMEOUT}'
+          value: 5m
+  graphs:
+    - uuid: d9e896ae2c604a7b83e69bd24f338bcc
+      name: 'CPU Utilization'
+      ymin_type_1: FIXED
+      ymax_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 1A7C11
+          item:
+            host: SNMP_Ruckus_APs
+            key: 'ruckusSystemCPUUtil[{#SNMPVALUE}]'
+    - uuid: d576261038874c99a85fcce81a4ad4b0
+      name: 'Memory Utilization'
+      ymin_type_1: FIXED
+      ymax_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 1A7C11
+          item:
+            host: SNMP_Ruckus_APs
+            key: 'ruckusSystemMemoryUtil[{#SNMPVALUE}]'


### PR DESCRIPTION
Create template_snmp_ruckus_aps.yaml and directory structure
This template aims to help to monitoring Ruckus APs on an individually basis using SNMP.