### PR TITLE
Add template for monitoring file or repository changes on GitHub

### DIFF
--- a/Web_scenarios/template_GitHub_commit/7.4/README.md
+++ b/Web_scenarios/template_GitHub_commit/7.4/README.md
@@ -1,0 +1,51 @@
+# GitHub File or Repository Change Monitor (Zabbix Template)
+
+This Zabbix template monitors changes to a specific file, directory, or entire repository hosted on GitHub.
+It uses the GitHub REST API and Zabbix's native HTTP agent to track the latest commit SHA.
+If a change is detected (new commit), a trigger is fired so the user can be notified via Zabbix actions.
+
+## Features
+
+- No external scripts required (uses HTTP agent only)
+- Detects updates in:
+  - A specific file
+  - A specific folder
+  - The entire repository
+- Works with any public GitHub repository
+- Fully parameterized via macros
+- Trigger on new commit (SHA) detection
+
+## Macros
+
+| Name                      | Description                                                                                         | Default   |
+|---------------------------|-----------------------------------------------------------------------------------------------------|-----------|
+| `{$GITHUB_REPO}`          | GitHub repository in the format `owner/repo` (e.g., `zabbix/zabbix`)                                | `zabbix/community-templates`          |
+| `{$GITHUB_FILE}`          | Relative path to file or folder (e.g., `templates/`, `myfile.yaml`). Leave empty for full repo.     | *(empty)* |
+| `{$GITHUB_BRANCH}`        | Name of the Git branch to monitor (e.g., `main`, `master`)                                          | `main`    |
+| `{$GITHUB_UPDATE_INTERVAL}` | How often (in seconds) the GitHub API should be queried                                            | `1h`    |
+
+
+## Item Details
+
+
+| Item Key            | Name                     | Type       | Update Interval (s)         | Preprocessing                                    |
+| ------------------- | ------------------------ | ---------- | --------------------------- | ------------------------------------------------ |
+| `github.commit.sha` | GitHub latest commit SHA | HTTP Agent | `{$GITHUB_UPDATE_INTERVAL}` | JSONPath: `$.body[0].sha` |
+
+## Trigger
+
+| Name                         | Expression                                   | Severity | Description                                        |
+| ---------------------------- | -------------------------------------------- | -------- | -------------------------------------------------- |
+| New Commit | change(/GitHub commit by HTTP/github.commit.sha)=1 | Info     | Fires when a new commit is detected on the target. |
+
+
+## Requirements
+
+- Zabbix 5.4+ recommended (for JSONPath preprocessing)
+- Internet access from the Zabbix server to `api.github.com`
+
+## Example Use Cases
+
+- Monitor upstream changes to Zabbix templates
+- Get notified when someone updates a script or config in GitHub
+- Watch critical files in your own repositories

--- a/Web_scenarios/template_GitHub_commit/7.4/template_GitHub_commit_by_HTTP.yaml
+++ b/Web_scenarios/template_GitHub_commit/7.4/template_GitHub_commit_by_HTTP.yaml
@@ -1,0 +1,55 @@
+zabbix_export:
+  version: '7.4'
+  template_groups:
+    - uuid: 7df96b18c230490a9a0a9e2307226338
+      name: Templates
+  templates:
+    - uuid: fbade5210ff14096b7023da9b5741894
+      template: 'GitHub commit by HTTP'
+      name: 'GitHub commit by HTTP'
+      description: |
+        This template allows Zabbix to monitor changes in specific files or entire repositories on GitHub.
+        By leveraging the GitHub REST API and Zabbix's native HTTP agent, it checks for new commits to a defined file, directory, or the full repository.
+        If a change is detected (e.g., updated Zabbix template, script, config), a trigger is fired, enabling notification via Zabbix actions.
+      vendor:
+        name: VoltKraft
+        version: '1.0'
+      groups:
+        - name: Templates
+      items:
+        - uuid: b5a9f1181366499293b61e37058e0a16
+          name: 'Commit SHA'
+          type: HTTP_AGENT
+          key: github.commit.sha
+          delay: '{$GITHUB_UPDATE_INTERVAL}'
+          value_type: TEXT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.body[0].sha'
+          timeout: 10s
+          url: 'https://api.github.com/repos/{$GITHUB_REPO}/commits?path={$GITHUB_FILE}&sha={$GITHUB_BRANCH}'
+          status_codes: ''
+          headers:
+            - name: User-Agent
+              value: Zabbix-Agent
+          output_format: JSON
+          triggers:
+            - uuid: b08770832f3241ef900d12edc8d240df
+              expression: 'change(/GitHub commit by HTTP/github.commit.sha)=1'
+              recovery_mode: NONE
+              name: 'New Commit'
+              priority: INFO
+              manual_close: 'YES'
+      macros:
+        - macro: '{$GITHUB_BRANCH}'
+          value: main
+          description: 'Git branch name to monitor (e.g., main or master). Used to determine the commit history of the specified file or repository.'
+        - macro: '{$GITHUB_FILE}'
+          description: 'Relative path to the file or directory inside the repository (e.g., templates/template.yaml or templates/). Leave empty to monitor the entire repository for any changes, including all files and folders across all directories.'
+        - macro: '{$GITHUB_REPO}'
+          value: zabbix/community-templates
+          description: 'GitHub repository in the format owner/repository (e.g., zabbix/zabbix). This defines the repository to monitor for file changes.'
+        - macro: '{$GITHUB_UPDATE_INTERVAL}'
+          value: 1h
+          description: 'Update interval for checking the file''s latest commit. Adjust to control how often GitHub is queried'


### PR DESCRIPTION
This template monitors changes to a specific file, directory, or the entire repository on GitHub by checking the latest commit SHA via the GitHub REST API.
It triggers an alert whenever a new commit is detected.

Let me know if you need adjustments or additional metadata. I'm happy to improve the submission.