### PR TITLE
WAN and LAN speedtest updated templates for zabbix 7.4

### DIFF
--- a/Network_Appliances/template_speedtest_lan_monitoring/7.0/Readme.md
+++ b/Network_Appliances/template_speedtest_lan_monitoring/7.0/Readme.md
@@ -1,0 +1,44 @@
+
+# App Speedtest LAN
+
+## Overview
+
+Monitoring the LAN speedtest by iperf on different server
+
+
+It need the script here https://git.cdp.li/polcape/zabbix/tree/master/zabbix-speedtest-lan
+
+
+
+## Macros used
+
+There are no macros links in this template.
+
+## Template links
+
+There are no template links in this template.
+
+## Discovery rules
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|Discovery LAN Server|<p>-</p>|`Zabbix agent`|speedtest-lan.discovery<p>Update: 500s</p>|
+
+
+## Items collected
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|Speedtest {#IPERFNAME} - Download|<p>-</p>|`Zabbix agent`|speedtest-lan.download.server[{#IPERFID}]<p>Update: 600s</p><p>LLD</p>|
+|Speedtest {#IPERFNAME} - Ping|<p>-</p>|`Zabbix agent`|speedtest-lan.ping.server[{#IPERFID}]<p>Update: 600s</p><p>LLD</p>|
+|Speedtest {#IPERFNAME} - Upload|<p>-</p>|`Zabbix agent`|speedtest-lan.upload.server[{#IPERFID}]<p>Update: 600s</p><p>LLD</p>|
+
+
+## Triggers
+
+|Name|Description|Expression|Priority|
+|----|-----------|----------|--------|
+|{HOST.HOST} Download {#IPERFNAME} speed < {#IPERF_TR_DL}Mb/s|<p>-</p>|<p>**Expression**: avg(/App Speedtest LAN/speedtest-lan.download.server[{#IPERFID}],#3)<{#IPERF_TR_DL}</p><p>**Recovery expression**: </p>|warning|
+|{HOST.HOST} Upload {#IPERFNAME} speed < {#IPERF_TR_UL}Mb/s|<p>-</p>|<p>**Expression**: avg(/App Speedtest LAN/speedtest-lan.upload.server[{#IPERFID}],#3)<{#IPERF_TR_UL}</p><p>**Recovery expression**: </p>|warning|
+|{HOST.HOST} Download {#IPERFNAME} speed < {#IPERF_TR_DL}Mb/s (LLD)|<p>-</p>|<p>**Expression**: avg(/App Speedtest LAN/speedtest-lan.download.server[{#IPERFID}],#3)<{#IPERF_TR_DL}</p><p>**Recovery expression**: </p>|warning|
+|{HOST.HOST} Upload {#IPERFNAME} speed < {#IPERF_TR_UL}Mb/s (LLD)|<p>-</p>|<p>**Expression**: avg(/App Speedtest LAN/speedtest-lan.upload.server[{#IPERFID}],#3)<{#IPERF_TR_UL}</p><p>**Recovery expression**: </p>|warning|

--- a/Network_Appliances/template_speedtest_lan_monitoring/7.0/template_speedtest_lan_monitoring.yaml
+++ b/Network_Appliances/template_speedtest_lan_monitoring/7.0/template_speedtest_lan_monitoring.yaml
@@ -1,0 +1,105 @@
+zabbix_export:
+  version: '7.4'
+  template_groups:
+  - uuid: 5b10efdfab754cb3b0a690ee2f49c858
+    name: Template importati
+  templates:
+  - uuid: b9798525a001482e8a7a3a5d032dad22
+    template: App Speedtest LAN
+    name: App Speedtest LAN
+    description: '## Overview
+
+
+      Monitoring the LAN speedtest by iperf on different server
+
+
+
+      It need the script here https://git.cdp.li/polcape/zabbix/tree/master/zabbix-speedtest-lan
+
+      '
+    groups:
+    - name: Template importati
+    discovery_rules:
+    - uuid: 0ee0fa1393614a5f8cc69c65df06c5a8
+      name: Discovery LAN Server
+      key: speedtest-lan.discovery
+      delay: 500s
+      lifetime: 1d
+      item_prototypes:
+      - uuid: c7e305c60f834d4bbee90fe40fc9996e
+        name: Speedtest {#IPERFNAME} - Download
+        key: speedtest-lan.download.server[{#IPERFID}]
+        delay: 600s
+        value_type: FLOAT
+        units: Mbit/s
+        tags:
+        - tag: Application
+          value: LAN SpeedTest
+        trigger_prototypes:
+        - uuid: 8971e323660d47a8adecbaa454d0dca8
+          expression: avg(/App Speedtest LAN/speedtest-lan.download.server[{#IPERFID}],#3)<{#IPERF_TR_DL}
+          name: '{HOST.HOST} Download {#IPERFNAME} speed < {#IPERF_TR_DL}Mb/s'
+          priority: WARNING
+        type: ZABBIX_PASSIVE
+      - uuid: 76633e2217044b66b0e1dc61cd7bb51e
+        name: Speedtest {#IPERFNAME} - Ping
+        key: speedtest-lan.ping.server[{#IPERFID}]
+        delay: 600s
+        value_type: FLOAT
+        units: ms
+        tags:
+        - tag: Application
+          value: LAN SpeedTest
+        type: ZABBIX_PASSIVE
+      - uuid: 9bf79b739c1d4b3b9f264b09b1b5c76f
+        name: Speedtest {#IPERFNAME} - Upload
+        key: speedtest-lan.upload.server[{#IPERFID}]
+        delay: 600s
+        value_type: FLOAT
+        units: Mbit/s
+        tags:
+        - tag: Application
+          value: LAN SpeedTest
+        trigger_prototypes:
+        - uuid: 3bac5873a9754194b741df15bc26b920
+          expression: avg(/App Speedtest LAN/speedtest-lan.upload.server[{#IPERFID}],#3)<{#IPERF_TR_UL}
+          name: '{HOST.HOST} Upload {#IPERFNAME} speed < {#IPERF_TR_UL}Mb/s'
+          priority: WARNING
+        type: ZABBIX_PASSIVE
+      graph_prototypes:
+      - uuid: ad463b009f5843dd9cc189582b0cc904
+        name: Speedtest & ping {#IPERFNAME}
+        ymin_type_1: FIXED
+        graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 1A7C11
+          item:
+            host: App Speedtest LAN
+            key: speedtest-lan.download.server[{#IPERFID}]
+        - sortorder: '1'
+          drawtype: GRADIENT_LINE
+          color: 2774A4
+          item:
+            host: App Speedtest LAN
+            key: speedtest-lan.upload.server[{#IPERFID}]
+        - sortorder: '2'
+          color: F63100
+          item:
+            host: App Speedtest LAN
+            key: speedtest-lan.ping.server[{#IPERFID}]
+      - uuid: 64135840c9af4662a5b2afa28a754fea
+        name: Speedtest {#IPERFNAME}
+        ymin_type_1: FIXED
+        graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 1A7C11
+          item:
+            host: App Speedtest LAN
+            key: speedtest-lan.download.server[{#IPERFID}]
+        - sortorder: '1'
+          drawtype: GRADIENT_LINE
+          color: 2774A4
+          item:
+            host: App Speedtest LAN
+            key: speedtest-lan.upload.server[{#IPERFID}]
+      type: ZABBIX_PASSIVE

--- a/Network_Appliances/template_speedtest_wan_isp_monitoring/7.0/README.md
+++ b/Network_Appliances/template_speedtest_wan_isp_monitoring/7.0/README.md
@@ -1,0 +1,46 @@
+# App Speedtest WAN
+
+## Overview
+
+Monitoring the speedtest by different ISP server on different part of world
+
+
+It need the script here https://git.cdp.li/polcape/zabbix/tree/master/zabbix-speedtest
+
+
+
+## Macros used
+
+There are no macros links in this template.
+
+## Template links
+
+There are no template links in this template.
+
+## Discovery rules
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|Discovery ISP Server|<p>-</p>|`Zabbix agent`|speedtest.discovery<p>Update: 500s</p>|
+
+
+## Items collected
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|Speedtest Best server - Download|<p>-</p>|`Zabbix agent`|speedtest.download<p>Update: 1200s</p>|
+|Speedtest Best server - Upload|<p>-</p>|`Zabbix agent`|speedtest.upload<p>Update: 1200s</p>|
+|Speedtest Best server - Ping|<p>-</p>|`Zabbix agent`|speedtest.ping<p>Update: 1200s</p>|
+|Speedtest {#SERVERNAME} - Download|<p>-</p>|`Zabbix agent`|speedtest.download.server[{#SERVERID}]<p>Update: 1200s</p><p>LLD</p>|
+|Speedtest {#SERVERNAME} - Ping|<p>-</p>|`Zabbix agent`|speedtest.ping.server[{#SERVERID}]<p>Update: 1200s</p><p>LLD</p>|
+|Speedtest {#SERVERNAME} - Upload|<p>-</p>|`Zabbix agent`|speedtest.upload.server[{#SERVERID}]<p>Update: 1200s</p><p>LLD</p>|
+
+
+## Triggers
+
+|Name|Description|Expression|Priority|
+|----|-----------|----------|--------|
+|{HOST.HOST} Download {#SERVERNAME} speed < {#SERVER_TR_DL}Mb/s|<p>-</p>|<p>**Expression**: avg(/App Speedtest WAN/speedtest.download.server[{#SERVERID}],#3)<{#SERVER_TR_DL}</p><p>**Recovery expression**: </p>|warning|
+|{HOST.HOST} Upload {#SERVERNAME} speed < {#SERVER_TR_UL}Mb/s|<p>-</p>|<p>**Expression**: avg(/App Speedtest WAN/speedtest.upload.server[{#SERVERID}],#3)<{#SERVER_TR_UL}</p><p>**Recovery expression**: </p>|warning|
+|{HOST.HOST} Download {#SERVERNAME} speed < {#SERVER_TR_DL}Mb/s (LLD)|<p>-</p>|<p>**Expression**: avg(/App Speedtest WAN/speedtest.download.server[{#SERVERID}],#3)<{#SERVER_TR_DL}</p><p>**Recovery expression**: </p>|warning|
+|{HOST.HOST} Upload {#SERVERNAME} speed < {#SERVER_TR_UL}Mb/s (LLD)|<p>-</p>|<p>**Expression**: avg(/App Speedtest WAN/speedtest.upload.server[{#SERVERID}],#3)<{#SERVER_TR_UL}</p><p>**Recovery expression**: </p>|warning|

--- a/Network_Appliances/template_speedtest_wan_isp_monitoring/7.0/template_speedtest_wan_isp_monitoring.yaml
+++ b/Network_Appliances/template_speedtest_wan_isp_monitoring/7.0/template_speedtest_wan_isp_monitoring.yaml
@@ -1,0 +1,163 @@
+zabbix_export:
+  version: '7.4'
+  template_groups:
+  - uuid: 5b10efdfab754cb3b0a690ee2f49c858
+    name: Template importati
+  templates:
+  - uuid: 7f0b00ac482643d1af772cf96ec8e59e
+    template: App Speedtest WAN
+    name: App Speedtest WAN
+    description: '## Overview
+
+
+      Monitoring the speedtest by different ISP server on different part of world
+
+
+
+      It need the script here https://git.cdp.li/polcape/zabbix/tree/master/zabbix-speedtest
+
+      '
+    groups:
+    - name: Template importati
+    items:
+    - uuid: ab2856576882428d9a4e11726da45284
+      name: Speedtest Best server - Download
+      key: speedtest.download
+      delay: 1200s
+      value_type: FLOAT
+      units: Mbit/s
+      tags:
+      - tag: Application
+        value: ISP SpeedTest
+      triggers:
+      - uuid: 50973001fc084a2186f8b3efed732d20
+        expression: avg(/App Speedtest WAN/speedtest.download,#3)<6
+        name: '{HOST.HOST} Download best server speed < 6Mb/s'
+        priority: WARNING
+      type: ZABBIX_PASSIVE
+    - uuid: ec03a9a94ea24d1989825acab791cd42
+      name: Speedtest Best server - Ping
+      key: speedtest.ping
+      delay: 1200s
+      value_type: FLOAT
+      units: ms
+      tags:
+      - tag: Application
+        value: ISP SpeedTest
+      type: ZABBIX_PASSIVE
+    - uuid: 343221d07d41449aba530a9a5e216808
+      name: Speedtest Best server - Upload
+      key: speedtest.upload
+      delay: 1200s
+      value_type: FLOAT
+      units: Mbit/s
+      tags:
+      - tag: Application
+        value: ISP SpeedTest
+      triggers:
+      - uuid: a12d3eee33a142899d5f1228326cdc51
+        expression: avg(/App Speedtest WAN/speedtest.upload,#3)<0.20
+        name: '{HOST.HOST} Upload best server speed < 0.2Mb/s'
+        priority: WARNING
+      type: ZABBIX_PASSIVE
+    discovery_rules:
+    - uuid: f1f9641b93454e64ba383faec405e524
+      name: Discovery ISP Server
+      key: speedtest.discovery
+      delay: 500s
+      lifetime: 1d
+      item_prototypes:
+      - uuid: 25d2180fb5ac45a7895b8c58ac17d40a
+        name: Speedtest {#SERVERNAME} - Download
+        key: speedtest.download.server[{#SERVERID}]
+        delay: 1200s
+        value_type: FLOAT
+        units: Mbit/s
+        tags:
+        - tag: Application
+          value: ISP SpeedTest
+        trigger_prototypes:
+        - uuid: fb51b464276946298bc31837173f9ad0
+          expression: avg(/App Speedtest WAN/speedtest.download.server[{#SERVERID}],#3)<{#SERVER_TR_DL}
+          name: '{HOST.HOST} Download {#SERVERNAME} speed < {#SERVER_TR_DL}Mb/s'
+          priority: WARNING
+      - uuid: bd8ade3b16454e4d811fe90887ff70d3
+        name: Speedtest {#SERVERNAME} - Ping
+        key: speedtest.ping.server[{#SERVERID}]
+        delay: 1200s
+        value_type: FLOAT
+        units: ms
+        tags:
+        - tag: Application
+          value: ISP SpeedTest
+      - uuid: d179e96179e6426a86a063f789634ea5
+        name: Speedtest {#SERVERNAME} - Upload
+        key: speedtest.upload.server[{#SERVERID}]
+        delay: 1200s
+        value_type: FLOAT
+        units: Mbit/s
+        tags:
+        - tag: Application
+          value: ISP SpeedTest
+        trigger_prototypes:
+        - uuid: 1d7eeac489b4419880797529fc1e4609
+          expression: avg(/App Speedtest WAN/speedtest.upload.server[{#SERVERID}],#3)<{#SERVER_TR_UL}
+          name: '{HOST.HOST} Upload {#SERVERNAME} speed < {#SERVER_TR_UL}Mb/s'
+          priority: WARNING
+      graph_prototypes:
+      - uuid: 8b9993f066064f9d9e65c338158a1bf9
+        name: Speedtest & ping {#SERVERNAME}
+        ymin_type_1: FIXED
+        graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 1A7C11
+          item:
+            host: App Speedtest WAN
+            key: speedtest.download.server[{#SERVERID}]
+        - sortorder: '1'
+          drawtype: GRADIENT_LINE
+          color: 2774A4
+          item:
+            host: App Speedtest WAN
+            key: speedtest.upload.server[{#SERVERID}]
+        - sortorder: '2'
+          color: F63100
+          item:
+            host: App Speedtest WAN
+            key: speedtest.ping.server[{#SERVERID}]
+      - uuid: 6524ba3cca3b414ca73b8ac4988cd062
+        name: Speedtest {#SERVERNAME}
+        ymin_type_1: FIXED
+        graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 1A7C11
+          item:
+            host: App Speedtest WAN
+            key: speedtest.download.server[{#SERVERID}]
+        - sortorder: '1'
+          drawtype: GRADIENT_LINE
+          color: 2774A4
+          item:
+            host: App Speedtest WAN
+            key: speedtest.upload.server[{#SERVERID}]
+  graphs:
+  - uuid: ece0aae2d51643d6a35c802ad169ec3f
+    name: Speedtest Best server - Bandwith
+    ymin_type_1: FIXED
+    graph_items:
+    - drawtype: GRADIENT_LINE
+      color: 1A7C11
+      item:
+        host: App Speedtest WAN
+        key: speedtest.download
+    - sortorder: '1'
+      drawtype: GRADIENT_LINE
+      color: 2774A4
+      item:
+        host: App Speedtest WAN
+        key: speedtest.upload
+    - sortorder: '2'
+      color: F63100
+      item:
+        host: App Speedtest WAN
+        key: speedtest.ping


### PR DESCRIPTION
Updated zabbix speedtest templates to work for zabbix 7.0 and newer (tested on 7.4).