### PR TITLE
optimised trigger messages

### DIFF
--- a/Applications/Backup/template_Proxmox_Backup_Server/7.4/README.md
+++ b/Applications/Backup/template_Proxmox_Backup_Server/7.4/README.md
@@ -50,6 +50,3 @@ This template was originally developed by nikosch86 and then heavily modified an
 
 
 ---
-
-
-

--- a/Applications/Backup/template_Proxmox_Backup_Server/7.4/template_PBS_by_https.yaml
+++ b/Applications/Backup/template_Proxmox_Backup_Server/7.4/template_PBS_by_https.yaml
@@ -9,7 +9,7 @@ zabbix_export:
       name: 'Proxmox Backup Server by HTTP'
       vendor:
         name: VoltKraft
-        version: 1.3.1
+        version: 1.4.1
       groups:
         - name: Templates/Applications
       items:
@@ -250,6 +250,10 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.data[0].status'
+                - type: REGEX
+                  parameters:
+                    - '^([A-Z]+)'
+                    - \1
               timeout: 10s
               url: 'https://{$PBS.HOST}:{$PBS.PORT}/api2/json/nodes/0/tasks'
               query_fields:
@@ -268,10 +272,30 @@ zabbix_export:
                 - tag: component
                   value: datastore
               trigger_prototypes:
+                - uuid: cd4d705fae6842b6a5a762ac5d708702
+                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.datastore.prune.[{#DATASTORE.NAME}])="ERRORS"'
+                  name: 'PBS: Last prune on "{#DATASTORE.NAME}" finished with Errors'
+                  url_name: Webingerface
+                  url: 'https://{$PBS.HOST}:{$PBS.PORT}/#DataStore-{#DATASTORE.NAME}:prunegc'
+                  priority: AVERAGE
+                  tags:
+                    - tag: component
+                      value: datastore
+                - uuid: 38a26228ca12427990af55c308cc6a6b
+                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.datastore.prune.[{#DATASTORE.NAME}])="WARNINGS"'
+                  name: 'PBS: Last prune on "{#DATASTORE.NAME}" finished with Warnings'
+                  url_name: Webingerface
+                  url: 'https://{$PBS.HOST}:{$PBS.PORT}/#DataStore-{#DATASTORE.NAME}:prunegc'
+                  priority: WARNING
+                  tags:
+                    - tag: component
+                      value: datastore
                 - uuid: 18f2c6781ad44518ba9246d55f449362
-                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.datastore.prune.[{#DATASTORE.NAME}])<>"OK"'
-                  name: 'PBS: {#DATASTORE.NAME} Prune not OK'
+                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.datastore.prune.[{#DATASTORE.NAME}])<>"OK" and last(/Proxmox Backup Server by HTTP/pbs.datastore.prune.[{#DATASTORE.NAME}])<>"WARNINGS" and last(/Proxmox Backup Server by HTTP/pbs.datastore.prune.[{#DATASTORE.NAME}])<>"ERRORS"'
+                  name: 'PBS: Last prune on "{#DATASTORE.NAME}" is not OK'
                   opdata: '{ITEM.LASTVALUE1}'
+                  url_name: 'https://{$PBS.HOST}:{$PBS.PORT}/#DataStore-{#DATASTORE.NAME}:pru'
+                  url: Webinterface
                   priority: WARNING
                   tags:
                     - tag: component
@@ -304,6 +328,10 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.data[0].status'
+                - type: REGEX
+                  parameters:
+                    - '^([A-Z]+)'
+                    - \1
               timeout: 10s
               url: 'https://{$PBS.HOST}:{$PBS.PORT}/api2/json/nodes/0/tasks'
               query_fields:
@@ -322,10 +350,30 @@ zabbix_export:
                 - tag: component
                   value: datastore
               trigger_prototypes:
+                - uuid: 3d455497ac034bab8633dc88f6f727c9
+                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.datastore.sync.[{#DATASTORE.NAME}])="ERRORS"'
+                  name: 'PBS: Last Sync on "{#DATASTORE.NAME}" finished with Error'
+                  url_name: Webinterface
+                  url: 'https://{$PBS.HOST}:{$PBS.PORT}/#DataStore-{#DATASTORE.NAME}:syncjobs'
+                  priority: AVERAGE
+                  tags:
+                    - tag: component
+                      value: datastore
+                - uuid: 2c8f45f1b559408bb0eb69252ea70581
+                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.datastore.sync.[{#DATASTORE.NAME}])="WARNINGS"'
+                  name: 'PBS: Last Sync on "{#DATASTORE.NAME}" finished with Warning'
+                  url_name: Webinterface
+                  url: 'https://{$PBS.HOST}:{$PBS.PORT}/#DataStore-{#DATASTORE.NAME}:syncjobs'
+                  priority: WARNING
+                  tags:
+                    - tag: component
+                      value: datastore
                 - uuid: f05aca17c055475cbbec5b5d53056272
-                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.datastore.sync.[{#DATASTORE.NAME}])<>"OK"'
-                  name: 'PBS: {#DATASTORE.NAME} Sync not OK'
+                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.datastore.sync.[{#DATASTORE.NAME}])<>"OK" and last(/Proxmox Backup Server by HTTP/pbs.datastore.sync.[{#DATASTORE.NAME}])<>"WARNINGS" and last(/Proxmox Backup Server by HTTP/pbs.datastore.sync.[{#DATASTORE.NAME}])<>"ERRORS"'
+                  name: 'PBS: Last sync on "{#DATASTORE.NAME}" is not OK'
                   opdata: '{ITEM.LASTVALUE1}'
+                  url_name: Webinterface
+                  url: 'https://{$PBS.HOST}:{$PBS.PORT}/#DataStore-{#DATASTORE.NAME}:syncjobs'
                   priority: WARNING
                   tags:
                     - tag: component
@@ -470,11 +518,19 @@ zabbix_export:
                 - tag: component
                   value: gc
               trigger_prototypes:
-                - uuid: 6999b38f06dc43a7b1bb1b7d9671419b
-                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.gc.last-run-state.[{#DATASTORE.NAME}])<>"OK"'
-                  name: 'PBS: Garbage Collect on {#DATASTORE.NAME} not OK'
+                - uuid: bc642eef0a6e475a8ccfbbce7b50e9e0
+                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.gc.last-run-state.[{#DATASTORE.NAME}])="ERRORS"'
+                  name: 'PBS: Last Garbage Collect on {#DATASTORE.NAME} finished with Error'
                   opdata: 'Last state: {ITEM.LASTVALUE1}'
                   priority: AVERAGE
+                  tags:
+                    - tag: component
+                      value: gc
+                - uuid: 08d8195c4da04924b0eb4d3e696ba7e1
+                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.gc.last-run-state.[{#DATASTORE.NAME}])="WARNINGS"'
+                  name: 'PBS: Last Garbage Collect on {#DATASTORE.NAME} finished with Warning'
+                  opdata: 'Last state: {ITEM.LASTVALUE1}'
+                  priority: WARNING
                   tags:
                     - tag: component
                       value: gc
@@ -637,6 +693,14 @@ zabbix_export:
                 - tag: component
                   value: raw
           trigger_prototypes:
+            - uuid: 6999b38f06dc43a7b1bb1b7d9671419b
+              expression: 'last(/Proxmox Backup Server by HTTP/pbs.gc.last-run-state.[{#DATASTORE.NAME}])<>"OK" and last(/Proxmox Backup Server by HTTP/pbs.gc.[{#DATASTORE.NAME}])<>"ERRORS" and last(/Proxmox Backup Server by HTTP/pbs.gc.[{#DATASTORE.NAME}])<>"WARNINGS"'
+              name: 'PBS: Last Garbage Collect on {#DATASTORE.NAME} is not OK'
+              opdata: 'Last state: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              tags:
+                - tag: component
+                  value: gc
             - uuid: 01c82d1089ed447f95d723e704207064
               expression: 'last(/Proxmox Backup Server by HTTP/pbs.gc.schedule.[{#DATASTORE.NAME}])=0 and last(/Proxmox Backup Server by HTTP/pbs.gc.next-run.[{#DATASTORE.NAME}])=0'
               name: 'PBS: No Garbage Collect schedule configured on {#DATASTORE.NAME}'
@@ -919,16 +983,36 @@ zabbix_export:
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$.body.data[?(@.id=="v-d8039bf5-7305")].["last-run-state"]'
+                    - '$[?(@.id=="{#VERIFY.ID}")].["last-run-state"]'
               master_item:
                 key: pbs.verify
               tags:
                 - tag: component
                   value: backup
               trigger_prototypes:
+                - uuid: 1c013ea66b1147e483907a855bb09a3b
+                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.verify.last-run-state.[{#VERIFY.ID}])="ERRORS"'
+                  name: 'PBS: Last verify Job finished with Error'
+                  url_name: Webinterface
+                  url: 'https://{$PBS.HOST}:{$PBS.PORT}/#DataStore-{#DATASTORE.NAME}:verifyjobs'
+                  priority: AVERAGE
+                  tags:
+                    - tag: component
+                      value: backup
+                - uuid: 9e5d723d9eec4cdbac00e2a9778522f5
+                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.verify.last-run-state.[{#VERIFY.ID}])="WARNINGS"'
+                  name: 'PBS: Last verify Job finished with Warning'
+                  url_name: Webinterface
+                  url: 'https://{$PBS.HOST}:{$PBS.PORT}/#DataStore-{#DATASTORE.NAME}:verifyjobs'
+                  priority: WARNING
+                  tags:
+                    - tag: component
+                      value: backup
                 - uuid: 30cba463b177466796f1df24cb1ff677
-                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.verify.last-run-state.[{#VERIFY.ID}])<>"OK"'
-                  name: 'PBS: Verify Job not OK'
+                  expression: 'last(/Proxmox Backup Server by HTTP/pbs.verify.last-run-state.[{#VERIFY.ID}])<>"OK" and last(/Proxmox Backup Server by HTTP/pbs.verify.last-run-state.[{#VERIFY.ID}])<>"WARNINGS" and last(/Proxmox Backup Server by HTTP/pbs.verify.last-run-state.[{#VERIFY.ID}])<>"ERRORS"'
+                  name: 'PBS: Last verify Job is not OK'
+                  url_name: Webinterface
+                  url: 'https://{$PBS.HOST}:{$PBS.PORT}/#DataStore-{#DATASTORE.NAME}:verifyjobs'
                   priority: AVERAGE
                   tags:
                     - tag: component
@@ -938,8 +1022,10 @@ zabbix_export:
           lld_macro_paths:
             - lld_macro: '{#VERIFY.ID}'
               path: $.id
-            - lld_macro: '{#VERIFY.LAST_RUN_STATE}'
-              path: $.last-run-state
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[*]'
       tags:
         - tag: component
           value: backup


### PR DESCRIPTION
prune, verify, sync and verify jobs now not only show “not OK”, but e.g. Warning or Error