### PR TITLE
Add new Zabbix template for Toshiba multifunctional printers

### DIFF
--- a/Printers/Toshiba/template_toshiba_multifunctional_generic/7.0/README.md
+++ b/Printers/Toshiba/template_toshiba_multifunctional_generic/7.0/README.md
@@ -1,0 +1,54 @@
+# Printer Toshiba multifunctional generic
+
+## Description
+
+**SNMP Template for Toshiba printers**
+**Author:** Myrenic
+
+## Macros used
+
+There are no macros used in this template.
+
+## Template links
+
+There are no template links in this template.
+
+## Discovery rules
+
+| Name                        | Description                              | Key                       | Type       | Interval |
+| --------------------------- | ---------------------------------------- | ------------------------- | ---------- | -------- |
+| Consumables Level Discovery | Discovery of toner levels for all colors | ConsumablesLevelDiscovery | SNMP agent | 1h       |
+
+### Item Prototypes
+
+| Name                             | Key                                | SNMP OID                                | Type       | Value Type | Units |
+| -------------------------------- | ---------------------------------- | --------------------------------------- | ---------- | ---------- | ----- |
+| Consumables Level - {#SNMPVALUE} | prtConsumablesLevel\[{#SNMPINDEX}] | .1.3.6.1.2.1.43.11.1.1.9.1.{#SNMPINDEX} | SNMP agent | Float      | %     |
+
+### Trigger Prototypes
+
+| Name                               | Expression                                          | Severity |
+| ---------------------------------- | --------------------------------------------------- | -------- |
+| {#SNMPVALUE}: consumable is empty  | last(/Printer Toshiba multifunctional generic/prtConsumablesLevel[{#SNMPINDEX}])=0   | High  |
+| {#SNMPVALUE}: consumable is nearly empty | last(/Printer Toshiba multifunctional generic/prtConsumablesLevel[{#SNMPINDEX}])<3 and last(/Printer Toshiba multifunctional generic/prtConsumablesLevel[{#SNMPINDEX}])>-3         | Information     |
+
+## Items collected
+
+| Name                    | Description                                              | Type       | Key                         | Interval |
+| ----------------------- | -------------------------------------------------------- | ---------- | --------------------------- | -------- |
+| Device Manufacturer     | Textual identification of the device manufacturer        | SNMP agent | deviceManufacturer          | 1d       |
+| Device Model            |                                                          | SNMP agent | deviceModel                 | 1d       |
+| Printer Status          |                                                          | SNMP agent | prtConsoleDisplayBufferText | default  |
+| Printer Display Message |                                                          | SNMP agent | prtDisplayMessageText       | default  |
+| Page Counter            |                                                          | SNMP agent | prtMarkerLifeCount          | 30m      |
+| Device Contact          | Contact person for this managed node                     | SNMP agent | sysContact                  | 1d       |
+| Device Location         | Physical location of this node                           | SNMP agent | sysLocation                 | 1d       |
+| Device Name             | Administratively-assigned name for this node             | SNMP agent | sysName                     | 1d       |
+| Device Uptime           | Time since the system's network management was restarted | SNMP agent | sysUpTime                   | default  |
+
+## Triggers
+
+| Name                               | Expression                                          | Severity |
+| ---------------------------------- | --------------------------------------------------- | -------- |
+| Black toner empty                  | last(/Printer Toshiba multifunctional generic/prtBlackTonerLevel)=0   | Average  |
+| Printer restarted                  | change(/Printer Toshiba multifunctional generic/sysUpTime)<10         | Info     |

--- a/Printers/Toshiba/template_toshiba_multifunctional_generic/7.0/template_toshiba_multifunctional_generic.yaml
+++ b/Printers/Toshiba/template_toshiba_multifunctional_generic/7.0/template_toshiba_multifunctional_generic.yaml
@@ -1,5 +1,5 @@
 zabbix_export:
-  version: '7.4'
+  version: '7.0'
   template_groups:
     - uuid: 9840f59a62a84ee3843fe5d597a177f7
       name: Printers

--- a/Printers/Toshiba/template_toshiba_multifunctional_generic/7.0/template_toshiba_multifunctional_generic.yaml
+++ b/Printers/Toshiba/template_toshiba_multifunctional_generic/7.0/template_toshiba_multifunctional_generic.yaml
@@ -1,0 +1,189 @@
+zabbix_export:
+  version: '7.4'
+  template_groups:
+    - uuid: 9840f59a62a84ee3843fe5d597a177f7
+      name: Printers
+  templates:
+    - uuid: a6531a2804b24fbaacfb92a7a469646f
+      template: 'Printer Toshiba multifunctional generic'
+      name: 'Printer Toshiba multifunctional generic'
+      description: |
+        ## SNMP Template for Toshiba multifunctional generic printers
+        
+        ## Author:
+        Myrenic
+      groups:
+        - name: Printers
+      items:
+        - uuid: 20e6100e7f744e72b4e9df3b630a6706
+          name: 'Device Manufacturer'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.43.8.2.1.14.1.1
+          key: deviceManufacturer
+          delay: 1d
+          history: 30d
+          value_type: CHAR
+          description: 'Textual identification of the device manufacturer.'
+          inventory_link: VENDOR
+          tags:
+            - tag: Application
+              value: General
+        - uuid: 217f97dc954245f789df52dc2b995b1e
+          name: 'Device Model'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.25.3.2.1.3.1
+          key: deviceModel
+          delay: 1d
+          history: 30d
+          value_type: CHAR
+          inventory_link: MODEL
+          tags:
+            - tag: Application
+              value: General
+        - uuid: 64b6b1a84b0344e59eaa8f443118706a
+          name: 'Printer Status'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.25.3.5.1.1.1
+          key: prtConsoleDisplayBufferText
+          history: 30d
+          value_type: CHAR
+          preprocessing:
+            - type: STR_REPLACE
+              parameters:
+                - '1'
+                - other
+            - type: STR_REPLACE
+              parameters:
+                - '2'
+                - unknown
+            - type: STR_REPLACE
+              parameters:
+                - '3'
+                - idle
+            - type: STR_REPLACE
+              parameters:
+                - '4'
+                - printing
+            - type: STR_REPLACE
+              parameters:
+                - '5'
+                - warmup
+          tags:
+            - tag: Application
+              value: Printer
+        - uuid: 448c324ac01045c8b73412e7dee4880e
+          name: 'Printer Display Message'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.43.16.5.1.2.1.1
+          key: prtDisplayMessageText
+          history: 30d
+          value_type: CHAR
+          preprocessing:
+            - type: DISCARD_UNCHANGED
+          tags:
+            - tag: Application
+              value: Printer
+        - uuid: 9d77707a03c640e4924cda53dc361af2
+          name: 'Page Counter'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.43.10.2.1.4.1.1
+          key: prtMarkerLifeCount
+          delay: 30m
+          history: 90d
+          value_type: LOG
+          tags:
+            - tag: Application
+              value: Printer
+        - uuid: f89ca52cb8e1426ead016a3242d546ed
+          name: 'Device Contact'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.1.4.0
+          key: sysContact
+          delay: 1d
+          history: 30d
+          value_type: CHAR
+          description: 'Contact person for this managed node.'
+          inventory_link: CONTACT
+          tags:
+            - tag: Application
+              value: General
+        - uuid: c8a98ca6918b4f58a0bbeccaaf81491c
+          name: 'Device Location'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.1.6.0
+          key: sysLocation
+          delay: 1d
+          history: 30d
+          value_type: CHAR
+          description: 'Physical location of this node.'
+          inventory_link: LOCATION
+          tags:
+            - tag: Application
+              value: General
+        - uuid: 94044a5beac14710b172fc9dacad9963
+          name: 'Device Name'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.43.5.1.1.16.1
+          key: sysName
+          delay: 1d
+          history: 30d
+          value_type: CHAR
+          description: 'Administratively-assigned name for this managed node.'
+          inventory_link: NAME
+          tags:
+            - tag: Application
+              value: General
+        - uuid: b8d81a898fd841a09da93197e415e9e7
+          name: 'Device Uptime'
+          type: SNMP_AGENT
+          snmp_oid: 'SNMPv2-MIB::sysUpTime.0'
+          key: sysUpTime
+          history: 90d
+          units: uptime
+          description: 'Time since the network management portion of the system was last re-initialized.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.01'
+          tags:
+            - tag: Application
+              value: General
+          triggers:
+            - uuid: 54b8910236b24c65ab629483044f5805
+              expression: 'change(/Printer Toshiba multifunctional generic/sysUpTime)<10'
+              name: 'Printer {HOST.NAME} restarted'
+              priority: INFO
+      discovery_rules:
+        - uuid: bff76bdae92d4df59a03c460b45122f7
+          name: 'Consumables Level Discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},.1.3.6.1.2.1.43.11.1.1.6.1]'
+          key: ConsumablesLevelDiscovery
+          delay: 1h
+          description: 'Discovery of toner levels for different colors'
+          item_prototypes:
+            - uuid: ffd493a283ac4cfcbc37401026b9b26c
+              name: 'Consumables Level - {#SNMPVALUE}'
+              type: SNMP_AGENT
+              snmp_oid: '.1.3.6.1.2.1.43.11.1.1.9.1.{#SNMPINDEX}'
+              key: 'prtConsumablesLevel[{#SNMPINDEX}]'
+              value_type: FLOAT
+              trends: '0'
+              units: '%'
+              trigger_prototypes:
+                - uuid: a518f179ba5e42d6acef989c3fb4a306
+                  expression: 'last(/Printer Toshiba multifunctional generic/prtConsumablesLevel[{#SNMPINDEX}])=0'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/Printer Toshiba multifunctional generic/prtConsumablesLevel[{#SNMPINDEX}])<>0'
+                  name: '{#SNMPVALUE}: consumable is empty'
+                  event_name: '{#SNMPVALUE}: consumable is empty (value = 0)'
+                  opdata: 'Current value : {ITEM.LASTVALUE}'
+                  priority: HIGH
+                - uuid: 3dcc51711c8349289ef154a5fa8f27c8
+                  expression: 'last(/Printer Toshiba multifunctional generic/prtConsumablesLevel[{#SNMPINDEX}])<3 and last(/Printer Toshiba multifunctional generic/prtConsumablesLevel[{#SNMPINDEX}])>-3'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/Printer Toshiba multifunctional generic/prtConsumablesLevel[{#SNMPINDEX}])>3 or last(/Printer Toshiba multifunctional generic/prtConsumablesLevel[{#SNMPINDEX}])<-3'
+                  name: '{#SNMPVALUE}: consumable is nearly empty'
+                  event_name: '{#SNMPVALUE}: consumable is nearly empty (value = 0)'
+                  opdata: 'Current value : {ITEM.LASTVALUE}'
+                  priority: WARNING


### PR DESCRIPTION
**Description**

This pull request introduces a new SNMP monitoring template for Toshiba multifunctional printers, designed for integration with Zabbix 7.4 and later.

**Features**

**Capabilities**

* Device information: Manufacturer, Model, Contact, Location, Name, and Uptime.
* Printer status monitoring with detailed status codes (idle, printing, warmup, etc.).
* Display messages directly from the printer console.
* Page counter tracking for usage statistics.
* Consumables level discovery for toner monitoring across multiple colors.

**Triggers**

* Trigger for detecting printer restarts based on uptime changes.
* High and warning priority triggers for consumables running empty or nearly empty.

 **Monitoring**

* SNMP agent type items with appropriate delays and history retention for efficient polling.
* Preprocessing rules to translate status codes into readable text.
* Discovery rules to dynamically track consumables and generate related items and triggers.

**Details**

* SNMP OIDs aligned with standard printer MIBs for Toshiba multifunctional devices.
* Delay settings optimized for low impact polling: daily for static info, 30 minutes for counters, hourly for discovery.
* Template grouped under "Printers" for better organization in Zabbix frontend.
* Designed and authored by Myrenic.

**Files Added**

* `template_printer_toshiba_multifunctional_generic.yaml` - the full Zabbix template export file.
* `README.md` - documentation