### PR TITLE
Fix temperature sensor discovery in PAN-OS >=10.1.6

### DIFF
--- a/Network_Devices/Palo_Alto/template_palo_alto_with_64-bit_counters_(snmpv2)/6.0/template_palo_alto_with_64-bit_counters_(snmpv2).yaml
+++ b/Network_Devices/Palo_Alto/template_palo_alto_with_64-bit_counters_(snmpv2)/6.0/template_palo_alto_with_64-bit_counters_(snmpv2).yaml
@@ -235,7 +235,7 @@ zabbix_export:
             conditions:
               -
                 macro: '{#PHY}'
-                value: '.*(Temperature).*'
+                value: '.*(temperature).*'
                 formulaid: A
           item_prototypes:
             -


### PR DESCRIPTION
Fix #130
Example discovery item data on PAN-OS 11.2:
`[{"{#SNMPINDEX}":"1","{#PHY}":"PA-1410"},{"{#SNMPINDEX}":"2","{#PHY}":"CPU Die temperature sensor"},{"{#SNMPINDEX}":"3","{#PHY}":"U9 temperature sensor"},{"{#SNMPINDEX}":"4","{#PHY}":"U66 temperature sensor"},{"{#SNMPINDEX}":"5","{#PHY}":"Power Supply #1"},{"{#SNMPINDEX}":"6","{#PHY}":"Power Supply #2"},{"{#SNMPINDEX}":"7","{#PHY}":"Fan #1 RPM"},{"{#SNMPINDEX}":"8","{#PHY}":"Fan #2 RPM"},{"{#SNMPINDEX}":"9","{#PHY}":"Fan #3 RPM"},{"{#SNMPINDEX}":"10","{#PHY}":"Fan #4 RPM"},{"{#SNMPINDEX}":"11","{#PHY}":"Fan #5 RPM"}]`