### PR TITLE
Add scrub and resliver stats to ZFS on Linux templates

### DIFF
--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/README.md
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/README.md
@@ -4,6 +4,8 @@
 
 To use the Zabbix ZFS on Linux template, you must first install a correctly configured userparams file on any machines running the zabbix agent and using ZFS.
 
+Additionally, for monitoring of scrub and resilver stats you must install the ZED integration script.
+
 ### Choosing the correct userparams file
 
 There should be two different user parameters files in the same directory as this README, `userparams_zol_without_sudo.conf` and `userparams_zol_with_sudo.conf`. One uses `sudo` to run and thus you must give Zabbix the correct rights and the other doesn't use `sudo`.
@@ -39,6 +41,41 @@ If you don't know where your userparameters directory is, this is usually `/etc/
 
 The path used for the `zfs` and `zpool` binaries is different under almost every Linux distro, the paths aren't even the same for Debian and Ubuntu, as one notable example. For this reason you should run `which zfs` and `which zpool` on each ZFS machine you want to monitor with Zabbix to find out the correct paths to use to run these two binaries, then you need to edit the userparams file so that every instance of `zfs` and `zpool` is called using the correct path, if your distro's path doesn't match the path used in example userparams files.
 
+### Installing the ZED integration script
+
+By default ZFS does not provide a reliable way to get the stats from the most recent scrub or resilver, nor does it record these details. The details of most recent scrub _or_ resilver will be available in the output of `zfs status`, but only until the next scan starts.
+
+As a workaround for this a script has been written to extract stats and timestamps from zfs and record them as custom properties on the root dataset for each pool. This script is a zedlet that will be run by the [ZFS Event Daemon (ZED)](https://openzfs.github.io/openzfs-docs/man/master/8/zed.8.html) whenever a scrub or resilver completes.
+
+To install the script:
+
+1. Work out the "installed zedlets" directory for your platform, for example:
+   ``` bash
+   ZEDLETDIR=$(find /etc/zfs/zed.d/ -type l | head -1 | xargs readlink -f | awk 'BEGIN{OFS=FS="/"};NF--' | sort -u)
+   ```
+1. Copy `scan_finish-zabbix.sh` from this directory to the "installed zedlets" directory and make it executable and owned by root
+1. Link `scan_finish-zabbix.sh` to the "enabled zedlets" directory (always `/etc/zfs/zed.d/`) as `scrub_finish-zabbix.sh` and `resilver_finish-zabbix.sh`
+   ``` bash
+   ln -s ${ZEDLETDIR}/scan_finish-zabbix.sh /etc/zfs/zed.d/scrub_finish-zabbix.sh
+   ln -s ${ZEDLETDIR}/scan_finish-zabbix.sh /etc/zfs/zed.d/resilver_finish-zabbix.sh
+   ```
+1. Restart the ZED daemon to ensure it detects the new scripts
+   ``` bash
+   # On distros using systemd
+   systemctl restart zed
+   ```
+1. Run `set-zfs-scan-defaults.sh` from this directory to set all dataset properties used to the default values
+1. Optionally, run `scan_finish-zabbix.sh` once to set the data for the most recent scan/resilver
+   ``` bash
+   # When running manually need to provide values for variables (usually these are set by zed)
+   export ZPOOL=$(which zpool)
+   export ZFS=$(which zfs)
+   for ZEVENT_POOL in $(zpool status | grep 'pool:' | cut -d':' -f 2); do
+      export ZEVENT_POOL
+      bash /etc/zfs/zed.d/resilver_finish-zabbix.sh || echo failed for ${ZEVENT_POOL}
+   done
+   ```
+
 ## Macros used
 
 |Name|Description|Default|Type|
@@ -52,7 +89,7 @@ The path used for the `zfs` and `zpool` binaries is different under almost every
 |{$ZPOOL_HIGH_ALERT}|<p>-</p>|`90`|Text macro|
 |{$ZFS_FSNAME_MATCHES}|<p>Determine datasets to discover</p>|`/`|Text macro|
 |{$ZFS_FSNAME_NOTMATCHES}|<p>Determine datasets to ignore</p>|`([a-z-0-9]{64}$\|[a-z-0-9]{64}-init$)`|Text macro|
-
+|{$ZPOOL_MAX_SCRUB_INTERVAL}|<p>Allowed time between scrubs (in days)</p>|`40`|Text macro|
 
 ## Template links
 
@@ -110,7 +147,16 @@ There are no template links in this template.
 |Zpool {#POOLNAME} available|<p>-</p>|`Zabbix agent`|zfs.get.fsinfo[{#POOLNAME},available]<p>Update: 5m</p><p>LLD</p>|
 |Zpool {#POOLNAME} used|<p>-</p>|`Zabbix agent`|zfs.get.fsinfo[{#POOLNAME},used]<p>Update: 5m</p><p>LLD</p>|
 |Zpool {#POOLNAME} Health|<p>-</p>|`Zabbix agent`|zfs.zpool.health[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
-|Zpool {#POOLNAME} scrub status|<p>Detect if the pool is currently scrubbing itself. This is not a bad thing itself, but it slows down the entire pool and should be terminated when on production server during business hours if it causes a noticeable slowdown.</p>|`Zabbix agent`|zfs.zpool.scrub[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} scrub status|<p>Detect if the pool is currently scrubbing itself. This is not a bad thing itself, but it slows down the entire pool and should be terminated when on production server during business hours if it causes a noticeable slowdown.</p>|`Zabbix agent`|zfs.zpool.scrub.status[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} scrub timestamp|<p>-</p>|`Zabbix agent`|zfs.zpool.scrub.timestamp[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} scrub repaired|<p>-</p>|`Zabbix agent`|zfs.zpool.scrub.repaired[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} scrub length|<p>-</p>|`Zabbix agent`|zfs.zpool.scrub.length[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} scrub errors|<p>-</p>|`Zabbix agent`|zfs.zpool.scrub.errors[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} resilver status|<p>Detect if the pool is currently resilvering. An unexpected resilver is likely indicative of a problem, so in such an event it is advisable to check the pool.</p>|`Zabbix agent`|zfs.zpool.resilver.status[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} resilver timestamp|<p>-</p>|`Zabbix agent`|zfs.zpool.resilver.timestamp[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} resilver repaired|<p>-</p>|`Zabbix agent`|zfs.zpool.resilver.repaired[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} resilver length|<p>-</p>|`Zabbix agent`|zfs.zpool.resilver.length[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
+|Zpool {#POOLNAME} resilver errors|<p>-</p>|`Zabbix agent`|zfs.zpool.resilver.errors[{#POOLNAME}]<p>Update: 5m</p><p>LLD</p>|
 |Zpool {#POOLNAME} read throughput|<p>-</p>|`Dependent item`|zfs.zpool.iostat.nread[{#POOLNAME}]<p>Update: 0</p><p>LLD</p>|
 |Zpool {#POOLNAME} write throughput|<p>-</p>|`Dependent item`|zfs.zpool.iostat.nwritten[{#POOLNAME}]<p>Update: 0</p><p>LLD</p>|
 |Zpool {#POOLNAME} IOPS: reads|<p>-</p>|`Dependent item`|zfs.zpool.iostat.reads[{#POOLNAME}]<p>Update: 0</p><p>LLD</p>|
@@ -154,7 +200,10 @@ There are no template links in this template.
 |More than {$ZPOOL_AVERAGE_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > (85/100)</p><p>**Recovery expression**: </p>|average|
 |More than {$ZPOOL_DISASTER_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > (99/100)</p><p>**Recovery expression**: </p>|disaster|
 |More than {$ZPOOL_HIGH_ALERT}% used on zpool {#POOLNAME} on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > (90/100)</p><p>**Recovery expression**: </p>|high|
-|Zpool {#POOLNAME} is scrubbing for more than 12h on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],12h)=0</p><p>**Recovery expression**: </p>|average|
-|Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],24h)=0</p><p>**Recovery expression**: </p>|high|
+|Zpool {#POOLNAME} is scrubbing for more than 12h on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: max(/ZFS on Linux/zfs.zpool.scrub.status[{#POOLNAME}],12h)=0</p><p>**Recovery expression**: </p>|average|
+|Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: max(/ZFS on Linux/zfs.zpool.scrub.status[{#POOLNAME}],24h)=0</p><p>**Recovery expression**: </p>|high|
+|Zpool {#POOLNAME} no scrub for over {$ZPOOL_MAX_SCRUB_INTERVAL} days on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: now() - last(/ZFS on Linux/zfs.zpool.scrub.timestamp[{#POOLNAME}],#1) > {$ZPOOL_MAX_SCRUB_INTERVAL} * 1d</p><p>**Recovery expression**: </p>|warning|
+|Zpool {#POOLNAME} is resilvering on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: last(/ZFS on Linux/zfs.zpool.resilver.status[{#POOLNAME}])=0</p><p>**Recovery expression**: </p>|warning|
+|Zpool {#POOLNAME} has recently resilvered on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: change(/ZFS on Linux/zfs.zpool.resilver.timestamp[{#POOLNAME}])<>0</p><p>**Recovery expression**: </p>|warning|
 |Zpool {#POOLNAME} is {ITEM.VALUE} on {HOST.NAME} (LLD)|<p>-</p>|<p>**Expression**: find(/ZFS on Linux/zfs.zpool.health[{#POOLNAME}],,"like","ONLINE")=0</p><p>**Recovery expression**: </p>|high|
 |vdev {#VDEV} has encountered {ITEM.VALUE} errors on {HOST.NAME} (LLD)|<p>This device has experienced an unrecoverable error. Determine if the device needs to be replaced. If yes, use 'zpool replace' to replace the device. If not, clear the error with 'zpool clear'. You may also run a zpool scrub to check if some other undetected errors are present on this vdev.</p>|<p>**Expression**: last(/ZFS on Linux/zfs.vdev.error_total[{#VDEV}])>0</p><p>**Recovery expression**: </p>|high|

--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/files/scan_finish-zabbix.sh
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/files/scan_finish-zabbix.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/bash
+#
+# Collect statistics from recently completed scrub on a ZFS pool and record them
+# as custom properties
+#
+# To install, copy this script to `/usr/lib/zfs-linux/zed.d/` and create links:
+# - /etc/zfs/zed.d/scrub_finish-zabbix.sh
+# - /etc/zfs/zed.d/resilver_finish-zabbix.sh
+# Then restart zed so it picks up the new scripts.
+
+status=$(${ZPOOL} status ${ZEVENT_POOL} | egrep 'scrub repaired|resilvered')
+
+if echo "${status}" | grep 'scrub' >/dev/null; then
+    # Most recent scan was a scrub
+    type='scrub'
+
+    # Example:
+    # scan: scrub repaired 0B in 00:07:05 with 0 errors on Sun Jun  8 00:31:06 2025
+    repaired=$(awk '{print $4}' <<<${status})
+    length=$(awk '{print $6}' <<<${status})
+    errors=$(awk '{print $8}' <<<${status})
+    timestamp=$(awk '{print substr($0, index($0, $11))}' <<<${status})
+elif echo "${status}" | grep 'resilver' >/dev/null; then
+    type='resilver'
+
+    # Example:
+    # scan: resilvered 4.01M in 00:00:00 with 0 errors on Tue Jun 10 22:55:22 2025
+    repaired=$(awk '{print $3}' <<<${status})
+    length=$(awk '{print $5}' <<<${status})
+    errors=$(awk '{print $7}' <<<${status})
+    timestamp=$(awk '{print substr($0, index($0, $10))}' <<<${status})
+else
+    # Unknown most recent scan type, or no recent scan
+    exit 1
+fi
+
+# Data repaired by most recent scan in bytes
+repaired=$(numfmt --from=auto <<<${repaired%B})
+${ZFS} set "zabbix:last-${type}-repaired=${repaired}"   "${ZEVENT_POOL}"
+
+# Length of most recent scan in seconds
+IFS=: read h m s <<<"${length}"
+length=$(( 10#${s} + (10#${m} * 60) + (10#${h} * 3600) ))
+${ZFS} set "zabbix:last-${type}-length=${length}"       "${ZEVENT_POOL}"
+
+# Errors detected by most recent scan
+${ZFS} set "zabbix:last-${type}-errors=${errors}"       "${ZEVENT_POOL}"
+
+# Unix timestamp of most recent scan
+timestamp=$(date -d "${timestamp}" +'%s')
+${ZFS} set "zabbix:last-${type}-timestamp=${timestamp}" "${ZEVENT_POOL}"

--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/files/set-zfs-scan-defaults.sh
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/files/set-zfs-scan-defaults.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+#
+# Run this script once to set default scrub/resilver statistics parameters
+# Will only set a parameter on the pool if it's not already set
+
+
+# Set a custom ZFS property if the property is not already set
+# Parameters:
+#   pool:      Name of the pool to set the parameter for
+#   parameter: Name of the parameter to set (`zabbix:...`)
+function zfs-set-if-empty () {
+    pool="${1}"
+    parameter="${2}"
+
+    # Unset custom parameters return '-' as the default value
+    if [ $(zfs get -Ho value "${parameter}" "${pool}") == '-' ]; then
+        zfs set "${parameter}=0" "${pool}"
+    fi
+}
+
+for pool in $(zpool list -H -o name); do
+    zfs-set-if-empty "${pool}" "zabbix:last-scrub-repaired"
+    zfs-set-if-empty "${pool}" "zabbix:last-scrub-length"
+    zfs-set-if-empty "${pool}" "zabbix:last-scrub-errors"
+    zfs-set-if-empty "${pool}" "zabbix:last-scrub-timestamp"
+
+    zfs-set-if-empty "${pool}" "zabbix:last-resilver-repaired"
+    zfs-set-if-empty "${pool}" "zabbix:last-resilver-length"
+    zfs-set-if-empty "${pool}" "zabbix:last-resilver-errors"
+    zfs-set-if-empty "${pool}" "zabbix:last-resilver-timestamp"
+done

--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/files/userparams_zol_with_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/files/userparams_zol_with_sudo.conf
@@ -32,7 +32,26 @@ UserParameter=zfs.arcstats[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/arcs
 UserParameter=zfs.zil[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/zil
 
 # detect if a scrub is in progress, 0 = in progress, 1 = not in progress
-UserParameter=zfs.zpool.scrub[*],/usr/bin/sudo /sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
+UserParameter=zfs.zpool.scrub.status[*],/usr/bin/sudo /sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
+# Completion timestamp of last completed scrub
+UserParameter=zfs.zpool.scrub.timestamp[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-scrub-timestamp $1
+# Bytes repaired by last completed scrub
+UserParameter=zfs.zpool.scrub.repaired[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-scrub-repaired $1
+# Length of last completed scrub
+UserParameter=zfs.zpool.scrub.length[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-scrub-length $1
+# Errors detected by last completed scrub
+UserParameter=zfs.zpool.scrub.errors[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-scrub-errors $1
+
+# detect if a resilver is in progress, 0 = in progress, 1 = not in progress
+UserParameter=zfs.zpool.resilver.status[*],/usr/bin/sudo /sbin/zpool status $1 | grep "resilver in progress" > /dev/null ; echo $?
+# Completion timestamp of last completed resilver
+UserParameter=zfs.zpool.resilver.timestamp[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-resilver-timestamp $1
+# Bytes repaired by last completed resilver
+UserParameter=zfs.zpool.resilver.repaired[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-resilver-repaired $1
+# Length of last completed resilver
+UserParameter=zfs.zpool.resilver.length[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-resilver-length $1
+# Errors detected by last completed resilver
+UserParameter=zfs.zpool.resilver.errors[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-resilver-errors $1
 
 # vdev state
 UserParameter=zfs.vdev.state[*],/usr/bin/sudo /sbin/zpool status | grep 1 "$1" | awk '{ print $$2 }'

--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/files/userparams_zol_without_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/files/userparams_zol_without_sudo.conf
@@ -32,7 +32,26 @@ UserParameter=zfs.arcstats[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/arcs
 UserParameter=zfs.zil[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/zil
 
 # detect if a scrub is in progress, 0 = in progress, 1 = not in progress
-UserParameter=zfs.zpool.scrub[*],/sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
+UserParameter=zfs.zpool.scrub.status[*],/sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
+# Completion timestamp of last completed scrub
+UserParameter=zfs.zpool.scrub.timestamp[*],/sbin/zfs get -Ho value zabbix:last-scrub-timestamp $1
+# Bytes repaired by last completed scrub
+UserParameter=zfs.zpool.scrub.repaired[*],/sbin/zfs get -Ho value zabbix:last-scrub-repaired $1
+# Length of last completed scrub
+UserParameter=zfs.zpool.scrub.length[*],/sbin/zfs get -Ho value zabbix:last-scrub-length $1
+# Errors detected by last completed scrub
+UserParameter=zfs.zpool.scrub.errors[*],/sbin/zfs get -Ho value zabbix:last-scrub-errors $1
+
+# detect if a resilver is in progress, 0 = in progress, 1 = not in progress
+UserParameter=zfs.zpool.resilver.status[*],/sbin/zpool status $1 | grep "resilver in progress" > /dev/null ; echo $?
+# Completion timestamp of last completed resilver
+UserParameter=zfs.zpool.resilver.timestamp[*],/sbin/zfs get -Ho value zabbix:last-resilver-timestamp $1
+# Bytes repaired by last completed resilver
+UserParameter=zfs.zpool.resilver.repaired[*],/sbin/zfs get -Ho value zabbix:last-resilver-repaired $1
+# Length of last completed resilver
+UserParameter=zfs.zpool.resilver.length[*],/sbin/zfs get -Ho value zabbix:last-resilver-length $1
+# Errors detected by last completed resilver
+UserParameter=zfs.zpool.resilver.errors[*],/sbin/zfs get -Ho value zabbix:last-resilver-errors $1
 
 # vdev state
 UserParameter=zfs.vdev.state[*],/sbin/zpool status | grep "$1" | awk '{ print $$2 }'

--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/template_zfs_on_linux.yaml
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/template_zfs_on_linux.yaml
@@ -678,9 +678,135 @@ zabbix_export:
                   value: ZFS
                 - tag: Application
                   value: 'ZFS zpool'
+            - uuid: 7ee2142fe370462abf86a495e8491fdb
+              name: 'Zpool {#POOLNAME}: Last resilver errors'
+              key: 'zfs.zpool.resilver.errors[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              description: 'Errors repaired by last resilver'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS resilver'
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 1b8247a471cc495b8452e10d8e0d7e8e
+              name: 'Zpool {#POOLNAME}: Last resilver length'
+              key: 'zfs.zpool.resilver.length[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              units: seconds
+              description: 'Time taken by last resilver'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS resilver'
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 08d2ce7444eb4506ae279be92a6df062
+              name: 'Zpool {#POOLNAME}: Last resilver repaired bytes'
+              key: 'zfs.zpool.resilver.repaired[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              units: bytes
+              description: 'Number of bytes repaired by last resilver'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS resilver'
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 34449511d2844c5aa7588c09606fb021
+              name: 'Zpool {#POOLNAME} resilver status'
+              key: 'zfs.zpool.resilver.status[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              description: |
+                Detect if the pool is currently resilvering itself.
+                
+                An unexpected resilver is likely indicative of a problem, so in such an event it is advisable to check the pool.
+              valuemap:
+                name: 'ZFS zpool resilver status'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS resilver'
+                - tag: Application
+                  value: 'ZFS zpool'
+              trigger_prototypes:
+                - uuid: f49d405f67934247a52d4c64ed31df8e
+                  expression: 'last(/ZFS on Linux/zfs.zpool.resilver.status[{#POOLNAME}])=0'
+                  name: 'Zpool {#POOLNAME} is resilvering on {HOST.NAME}'
+                  priority: WARNING
+            - uuid: 14d091cede2740bdbcbe873dd91283a5
+              name: 'Zpool {#POOLNAME}: Last resilver timestamp'
+              key: 'zfs.zpool.resilver.timestamp[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              units: unixtime
+              description: 'Unix timestamp of last resilver completion time'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS resilver'
+                - tag: Application
+                  value: 'ZFS zpool'
+              trigger_prototypes:
+                - uuid: 6da97bf5f5b74d509f9a15a085d6dbb6
+                  expression: 'change(/ZFS on Linux/zfs.zpool.resilver.timestamp[{#POOLNAME}])<>0'
+                  recovery_mode: NONE
+                  name: 'Zpool {#POOLNAME} has recently resilvered on {HOST.NAME}'
+                  priority: WARNING
+                  manual_close: 'YES'
+            - uuid: 7b9042d912fd4cf1ae377f8b3ee56def
+              name: 'Zpool {#POOLNAME}: Last scrub errors'
+              key: 'zfs.zpool.scrub.errors[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              description: 'Errors repaired by last scrub'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS scrub'
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: bb85f43f94d744e0addb569ec406643b
+              name: 'Zpool {#POOLNAME}: Last scrub length'
+              key: 'zfs.zpool.scrub.length[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              units: seconds
+              description: 'Time taken by last scrub'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS scrub'
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 651e2794ca7646ff8aa27f7ea7c13886
+              name: 'Zpool {#POOLNAME}: Last scrub repaired bytes'
+              key: 'zfs.zpool.scrub.repaired[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              units: bytes
+              description: 'Number of bytes repaired by last scrub'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS scrub'
+                - tag: Application
+                  value: 'ZFS zpool'
             - uuid: 867075d6eb1743069be868007472192b
               name: 'Zpool {#POOLNAME} scrub status'
-              key: 'zfs.zpool.scrub[{#POOLNAME}]'
+              key: 'zfs.zpool.scrub.status[{#POOLNAME}]'
               delay: 5m
               history: 30d
               description: |
@@ -693,19 +819,40 @@ zabbix_export:
                 - tag: Application
                   value: ZFS
                 - tag: Application
+                  value: 'ZFS scrub'
+                - tag: Application
                   value: 'ZFS zpool'
               trigger_prototypes:
                 - uuid: 792be07c555c4ae6a9819d69d332357b
-                  expression: 'max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],12h)=0'
+                  expression: 'max(/ZFS on Linux/zfs.zpool.scrub.status[{#POOLNAME}],12h)=0'
                   name: 'Zpool {#POOLNAME} is scrubbing for more than 12h on {HOST.NAME}'
                   priority: AVERAGE
                   dependencies:
                     - name: 'Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME}'
-                      expression: 'max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],24h)=0'
+                      expression: 'max(/ZFS on Linux/zfs.zpool.scrub.status[{#POOLNAME}],24h)=0'
                 - uuid: 04cac9633f164227b1f9b2fe26923609
-                  expression: 'max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],24h)=0'
+                  expression: 'max(/ZFS on Linux/zfs.zpool.scrub.status[{#POOLNAME}],24h)=0'
                   name: 'Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME}'
                   priority: HIGH
+            - uuid: 60eadfaa5aae4e7d8ba3b143875012ab
+              name: 'Zpool {#POOLNAME}: Last scrub timestamp'
+              key: 'zfs.zpool.scrub.timestamp[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              units: unixtime
+              description: 'Unix timestamp of last scrub completion time'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS scrub'
+                - tag: Application
+                  value: 'ZFS zpool'
+              trigger_prototypes:
+                - uuid: a6f1c40c7fc14f049d9447dcd2d2e365
+                  expression: 'now() - last(/ZFS on Linux/zfs.zpool.scrub.timestamp[{#POOLNAME}],#1) > {$ZPOOL_MAX_SCRUB_INTERVAL} * 1d'
+                  name: 'Zpool {#POOLNAME} no scrub for over {$ZPOOL_MAX_SCRUB_INTERVAL} days on {HOST.NAME}'
+                  priority: WARNING
           trigger_prototypes:
             - uuid: 82fce07b30114c7e8645689317e2c1b4
               expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > ({$ZPOOL_AVERAGE_ALERT}/100)'
@@ -898,6 +1045,9 @@ zabbix_export:
           value: '99'
         - macro: '{$ZPOOL_HIGH_ALERT}'
           value: '90'
+        - macro: '{$ZPOOL_MAX_SCRUB_INTERVAL}'
+          value: '40'
+          description: 'Maximum number of days between scrubs'
       dashboards:
         - uuid: 180e8c0dc05946e4b8552e3a01df347f
           name: 'ZFS ARC'
@@ -1073,6 +1223,13 @@ zabbix_export:
                       name: source_type
                       value: '2'
       valuemaps:
+        - uuid: a624c773a53b428d94a033d838287508
+          name: 'ZFS zpool resilver status'
+          mappings:
+            - value: '0'
+              newvalue: 'Resilver in progress'
+            - value: '1'
+              newvalue: 'No resilver in progress'
         - uuid: d1d7b0898d06481dbcec8b02d915fb1c
           name: 'ZFS zpool scrub status'
           mappings:

--- a/Operating_Systems/Linux/template_zfs_on_linux_active/7.0/files/scan_finish-zabbix.sh
+++ b/Operating_Systems/Linux/template_zfs_on_linux_active/7.0/files/scan_finish-zabbix.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/bash
+#
+# Collect statistics from recently completed scrub on a ZFS pool and record them
+# as custom properties
+#
+# To install, copy this script to `/usr/lib/zfs-linux/zed.d/` and create links:
+# - /etc/zfs/zed.d/scrub_finish-zabbix.sh
+# - /etc/zfs/zed.d/resilver_finish-zabbix.sh
+# Then restart zed so it picks up the new scripts.
+
+status=$(${ZPOOL} status ${ZEVENT_POOL} | egrep 'scrub repaired|resilvered')
+
+if echo "${status}" | grep 'scrub' >/dev/null; then
+    # Most recent scan was a scrub
+    type='scrub'
+
+    # Example:
+    # scan: scrub repaired 0B in 00:07:05 with 0 errors on Sun Jun  8 00:31:06 2025
+    repaired=$(awk '{print $4}' <<<${status})
+    length=$(awk '{print $6}' <<<${status})
+    errors=$(awk '{print $8}' <<<${status})
+    timestamp=$(awk '{print substr($0, index($0, $11))}' <<<${status})
+elif echo "${status}" | grep 'resilver' >/dev/null; then
+    type='resilver'
+
+    # Example:
+    # scan: resilvered 4.01M in 00:00:00 with 0 errors on Tue Jun 10 22:55:22 2025
+    repaired=$(awk '{print $3}' <<<${status})
+    length=$(awk '{print $5}' <<<${status})
+    errors=$(awk '{print $7}' <<<${status})
+    timestamp=$(awk '{print substr($0, index($0, $10))}' <<<${status})
+else
+    # Unknown most recent scan type, or no recent scan
+    exit 1
+fi
+
+# Data repaired by most recent scan in bytes
+repaired=$(numfmt --from=auto <<<${repaired%B})
+${ZFS} set "zabbix:last-${type}-repaired=${repaired}"   "${ZEVENT_POOL}"
+
+# Length of most recent scan in seconds
+IFS=: read h m s <<<"${length}"
+length=$(( 10#${s} + (10#${m} * 60) + (10#${h} * 3600) ))
+${ZFS} set "zabbix:last-${type}-length=${length}"       "${ZEVENT_POOL}"
+
+# Errors detected by most recent scan
+${ZFS} set "zabbix:last-${type}-errors=${errors}"       "${ZEVENT_POOL}"
+
+# Unix timestamp of most recent scan
+timestamp=$(date -d "${timestamp}" +'%s')
+${ZFS} set "zabbix:last-${type}-timestamp=${timestamp}" "${ZEVENT_POOL}"

--- a/Operating_Systems/Linux/template_zfs_on_linux_active/7.0/files/set-zfs-scan-defaults.sh
+++ b/Operating_Systems/Linux/template_zfs_on_linux_active/7.0/files/set-zfs-scan-defaults.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+#
+# Run this script once to set default scrub/resilver statistics parameters
+# Will only set a parameter on the pool if it's not already set
+
+
+# Set a custom ZFS property if the property is not already set
+# Parameters:
+#   pool:      Name of the pool to set the parameter for
+#   parameter: Name of the parameter to set (`zabbix:...`)
+function zfs-set-if-empty () {
+    pool="${1}"
+    parameter="${2}"
+
+    # Unset custom parameters return '-' as the default value
+    if [ $(zfs get -Ho value "${parameter}" "${pool}") == '-' ]; then
+        zfs set "${parameter}=0" "${pool}"
+    fi
+}
+
+for pool in $(zpool list -H -o name); do
+    zfs-set-if-empty "${pool}" "zabbix:last-scrub-repaired"
+    zfs-set-if-empty "${pool}" "zabbix:last-scrub-length"
+    zfs-set-if-empty "${pool}" "zabbix:last-scrub-errors"
+    zfs-set-if-empty "${pool}" "zabbix:last-scrub-timestamp"
+
+    zfs-set-if-empty "${pool}" "zabbix:last-resilver-repaired"
+    zfs-set-if-empty "${pool}" "zabbix:last-resilver-length"
+    zfs-set-if-empty "${pool}" "zabbix:last-resilver-errors"
+    zfs-set-if-empty "${pool}" "zabbix:last-resilver-timestamp"
+done

--- a/Operating_Systems/Linux/template_zfs_on_linux_active/7.0/files/userparams_zol_with_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux_active/7.0/files/userparams_zol_with_sudo.conf
@@ -32,7 +32,26 @@ UserParameter=zfs.arcstats[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/arcs
 UserParameter=zfs.zil[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/zil
 
 # detect if a scrub is in progress, 0 = in progress, 1 = not in progress
-UserParameter=zfs.zpool.scrub[*],/usr/bin/sudo /sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
+UserParameter=zfs.zpool.scrub.status[*],/usr/bin/sudo /sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
+# Completion timestamp of last completed scrub
+UserParameter=zfs.zpool.scrub.timestamp[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-scrub-timestamp $1
+# Bytes repaired by last completed scrub
+UserParameter=zfs.zpool.scrub.repaired[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-scrub-repaired $1
+# Length of last completed scrub
+UserParameter=zfs.zpool.scrub.length[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-scrub-length $1
+# Errors detected by last completed scrub
+UserParameter=zfs.zpool.scrub.errors[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-scrub-errors $1
+
+# detect if a resilver is in progress, 0 = in progress, 1 = not in progress
+UserParameter=zfs.zpool.resilver.status[*],/usr/bin/sudo /sbin/zpool status $1 | grep "resilver in progress" > /dev/null ; echo $?
+# Completion timestamp of last completed resilver
+UserParameter=zfs.zpool.resilver.timestamp[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-resilver-timestamp $1
+# Bytes repaired by last completed resilver
+UserParameter=zfs.zpool.resilver.repaired[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-resilver-repaired $1
+# Length of last completed resilver
+UserParameter=zfs.zpool.resilver.length[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-resilver-length $1
+# Errors detected by last completed resilver
+UserParameter=zfs.zpool.resilver.errors[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-resilver-errors $1
 
 # vdev state
 UserParameter=zfs.vdev.state[*],/usr/bin/sudo /sbin/zpool status | grep 1 "$1" | awk '{ print $$2 }'

--- a/Operating_Systems/Linux/template_zfs_on_linux_active/7.0/files/userparams_zol_without_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux_active/7.0/files/userparams_zol_without_sudo.conf
@@ -32,7 +32,26 @@ UserParameter=zfs.arcstats[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/arcs
 UserParameter=zfs.zil[*],awk '/^$1/ {printf $$3;}' /proc/spl/kstat/zfs/zil
 
 # detect if a scrub is in progress, 0 = in progress, 1 = not in progress
-UserParameter=zfs.zpool.scrub[*],/sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
+UserParameter=zfs.zpool.scrub.status[*],/sbin/zpool status $1 | grep "scrub in progress" > /dev/null ; echo $?
+# Completion timestamp of last completed scrub
+UserParameter=zfs.zpool.scrub.timestamp[*],/sbin/zfs get -Ho value zabbix:last-scrub-timestamp $1
+# Bytes repaired by last completed scrub
+UserParameter=zfs.zpool.scrub.repaired[*],/sbin/zfs get -Ho value zabbix:last-scrub-repaired $1
+# Length of last completed scrub
+UserParameter=zfs.zpool.scrub.length[*],/sbin/zfs get -Ho value zabbix:last-scrub-length $1
+# Errors detected by last completed scrub
+UserParameter=zfs.zpool.scrub.errors[*],/sbin/zfs get -Ho value zabbix:last-scrub-errors $1
+
+# detect if a resilver is in progress, 0 = in progress, 1 = not in progress
+UserParameter=zfs.zpool.resilver.status[*],/sbin/zpool status $1 | grep "resilver in progress" > /dev/null ; echo $?
+# Completion timestamp of last completed resilver
+UserParameter=zfs.zpool.resilver.timestamp[*],/sbin/zfs get -Ho value zabbix:last-resilver-timestamp $1
+# Bytes repaired by last completed resilver
+UserParameter=zfs.zpool.resilver.repaired[*],/sbin/zfs get -Ho value zabbix:last-resilver-repaired $1
+# Length of last completed resilver
+UserParameter=zfs.zpool.resilver.length[*],/sbin/zfs get -Ho value zabbix:last-resilver-length $1
+# Errors detected by last completed resilver
+UserParameter=zfs.zpool.resilver.errors[*],/sbin/zfs get -Ho value zabbix:last-resilver-errors $1
 
 # vdev state
 UserParameter=zfs.vdev.state[*],/sbin/zpool status | grep "$1" | awk '{ print $$2 }'

--- a/Operating_Systems/Linux/template_zfs_on_linux_active/7.0/template_zfs_on_linux_active.yaml
+++ b/Operating_Systems/Linux/template_zfs_on_linux_active/7.0/template_zfs_on_linux_active.yaml
@@ -727,9 +727,143 @@ zabbix_export:
                   value: ZFS
                 - tag: Application
                   value: 'ZFS zpool'
+            - uuid: 7ee2142fe370462abf86a495e8491fdb
+              name: 'Zpool {#POOLNAME}: Last resilver errors'
+              type: ZABBIX_ACTIVE
+              key: 'zfs.zpool.resilver.errors[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              description: 'Errors repaired by last resilver'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS resilver'
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 1b8247a471cc495b8452e10d8e0d7e8e
+              name: 'Zpool {#POOLNAME}: Last resilver length'
+              type: ZABBIX_ACTIVE
+              key: 'zfs.zpool.resilver.length[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              units: seconds
+              description: 'Time taken by last resilver'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS resilver'
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 08d2ce7444eb4506ae279be92a6df062
+              name: 'Zpool {#POOLNAME}: Last resilver repaired bytes'
+              type: ZABBIX_ACTIVE
+              key: 'zfs.zpool.resilver.repaired[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              units: bytes
+              description: 'Number of bytes repaired by last resilver'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS resilver'
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 34449511d2844c5aa7588c09606fb021
+              name: 'Zpool {#POOLNAME} resilver status'
+              type: ZABBIX_ACTIVE
+              key: 'zfs.zpool.resilver.status[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              description: |
+                Detect if the pool is currently resilvering itself.
+                
+                An unexpected resilver is likely indicative of a problem, so in such an event it is advisable to check the pool.
+              valuemap:
+                name: 'ZFS zpool resilver status'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS resilver'
+                - tag: Application
+                  value: 'ZFS zpool'
+              trigger_prototypes:
+                - uuid: f49d405f67934247a52d4c64ed31df8e
+                  expression: 'last(/ZFS on Linux/zfs.zpool.resilver.status[{#POOLNAME}])=0'
+                  name: 'Zpool {#POOLNAME} is resilvering on {HOST.NAME}'
+                  priority: WARNING
+            - uuid: 14d091cede2740bdbcbe873dd91283a5
+              name: 'Zpool {#POOLNAME}: Last resilver timestamp'
+              type: ZABBIX_ACTIVE
+              key: 'zfs.zpool.resilver.timestamp[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              units: unixtime
+              description: 'Unix timestamp of last resilver completion time'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS resilver'
+                - tag: Application
+                  value: 'ZFS zpool'
+              trigger_prototypes:
+                - uuid: 6da97bf5f5b74d509f9a15a085d6dbb6
+                  expression: 'change(/ZFS on Linux/zfs.zpool.resilver.timestamp[{#POOLNAME}])<>0'
+                  recovery_mode: NONE
+                  name: 'Zpool {#POOLNAME} has recently resilvered on {HOST.NAME}'
+                  priority: WARNING
+                  manual_close: 'YES'
+            - uuid: 7b9042d912fd4cf1ae377f8b3ee56def
+              name: 'Zpool {#POOLNAME}: Last scrub errors'
+              type: ZABBIX_ACTIVE
+              key: 'zfs.zpool.scrub.errors[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              description: 'Errors repaired by last scrub'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS scrub'
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: bb85f43f94d744e0addb569ec406643b
+              name: 'Zpool {#POOLNAME}: Last scrub length'
+              type: ZABBIX_ACTIVE
+              key: 'zfs.zpool.scrub.length[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              units: seconds
+              description: 'Time taken by last scrub'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS scrub'
+                - tag: Application
+                  value: 'ZFS zpool'
+            - uuid: 651e2794ca7646ff8aa27f7ea7c13886
+              name: 'Zpool {#POOLNAME}: Last scrub repaired bytes'
+              type: ZABBIX_ACTIVE
+              key: 'zfs.zpool.scrub.repaired[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              units: bytes
+              description: 'Number of bytes repaired by last scrub'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS scrub'
+                - tag: Application
+                  value: 'ZFS zpool'
             - uuid: 867075d6eb1743069be868007472192b
               name: 'Zpool {#POOLNAME} scrub status'
-              key: 'zfs.zpool.scrub[{#POOLNAME}]'
+              key: 'zfs.zpool.scrub.status[{#POOLNAME}]'
               type: ZABBIX_ACTIVE
               delay: 5m
               history: 30d
@@ -743,19 +877,41 @@ zabbix_export:
                 - tag: Application
                   value: ZFS
                 - tag: Application
+                  value: 'ZFS scrub'
+                - tag: Application
                   value: 'ZFS zpool'
               trigger_prototypes:
                 - uuid: 792be07c555c4ae6a9819d69d332357b
-                  expression: 'max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],12h)=0'
+                  expression: 'max(/ZFS on Linux/zfs.zpool.scrub.status[{#POOLNAME}],12h)=0'
                   name: 'Zpool {#POOLNAME} is scrubbing for more than 12h on {HOST.NAME}'
                   priority: AVERAGE
                   dependencies:
                     - name: 'Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME}'
-                      expression: 'max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],24h)=0'
+                      expression: 'max(/ZFS on Linux/zfs.zpool.scrub.status[{#POOLNAME}],24h)=0'
                 - uuid: 04cac9633f164227b1f9b2fe26923609
-                  expression: 'max(/ZFS on Linux/zfs.zpool.scrub[{#POOLNAME}],24h)=0'
+                  expression: 'max(/ZFS on Linux/zfs.zpool.scrub.status[{#POOLNAME}],24h)=0'
                   name: 'Zpool {#POOLNAME} is scrubbing for more than 24h on {HOST.NAME}'
                   priority: HIGH
+            - uuid: 60eadfaa5aae4e7d8ba3b143875012ab
+              name: 'Zpool {#POOLNAME}: Last scrub timestamp'
+              type: ZABBIX_ACTIVE
+              key: 'zfs.zpool.scrub.timestamp[{#POOLNAME}]'
+              delay: 5m
+              history: 30d
+              units: unixtime
+              description: 'Unix timestamp of last scrub completion time'
+              tags:
+                - tag: Application
+                  value: ZFS
+                - tag: Application
+                  value: 'ZFS scrub'
+                - tag: Application
+                  value: 'ZFS zpool'
+              trigger_prototypes:
+                - uuid: a6f1c40c7fc14f049d9447dcd2d2e365
+                  expression: 'now() - last(/ZFS on Linux/zfs.zpool.scrub.timestamp[{#POOLNAME}],#1) > {$ZPOOL_MAX_SCRUB_INTERVAL} * 1d'
+                  name: 'Zpool {#POOLNAME} no scrub for over {$ZPOOL_MAX_SCRUB_INTERVAL} days on {HOST.NAME}'
+                  priority: WARNING
           trigger_prototypes:
             - uuid: 82fce07b30114c7e8645689317e2c1b4
               expression: '( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) / ( last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},available]) + last(/ZFS on Linux/zfs.get.fsinfo[{#POOLNAME},used]) ) ) > ({$ZPOOL_AVERAGE_ALERT}/100)'
@@ -952,6 +1108,9 @@ zabbix_export:
           value: '99'
         - macro: '{$ZPOOL_HIGH_ALERT}'
           value: '90'
+        - macro: '{$ZPOOL_MAX_SCRUB_INTERVAL}'
+          value: '40'
+          description: 'Maximum number of days between scrubs'
       dashboards:
         - uuid: 180e8c0dc05946e4b8552e3a01df347f
           name: 'ZFS ARC'
@@ -1127,6 +1286,13 @@ zabbix_export:
                       name: source_type
                       value: '2'
       valuemaps:
+        - uuid: a624c773a53b428d94a033d838287508
+          name: 'ZFS zpool resilver status'
+          mappings:
+            - value: '0'
+              newvalue: 'Resilver in progress'
+            - value: '1'
+              newvalue: 'No resilver in progress'
         - uuid: d1d7b0898d06481dbcec8b02d915fb1c
           name: 'ZFS zpool scrub status'
           mappings:


### PR DESCRIPTION
Updates the ZFS on Linux template with:

* A Zabbix item for resilver status (in progress / not in progress)
* Zabbix items for pool scrub/resilver statistics
   * These stats are extracted using ZED zedlets due to not being exposed reliably
* Triggers for scan-related issues:
   * No recent scrub
   * Active resilver
   * Recent resilver