### PR TITLE
add recovery expression for VM stopped trigger

### DIFF
--- a/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/template_proxmox-ve-rest-api.yaml.yaml
+++ b/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/template_proxmox-ve-rest-api.yaml.yaml
@@ -1860,6 +1860,8 @@ zabbix_export:
               trigger_prototypes:
                 - uuid: ac085aa97edb40dcb08272e859a39e36
                   expression: 'min(/Template Proxmox VE REST API/vm.status[{#VMID}],900)=0 and {$ENABLE_VM_STOP_ALERT:"{#VMID}"}=1'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/Template Proxmox VE REST API/vm.status[{#VMID}])=1'
                   name: 'VM {#VMID} status is stopped'
                   priority: HIGH
                   description: |
@@ -2290,7 +2292,7 @@ zabbix_export:
                   parameters:
                     - '^\["(?:OK|running|stopped|error|unexpected status|CT is locked \(disk\)|timeout waiting on systemd|Failed to run vncproxy\.|unable to read tail \(got 0 byte\)|interrupted by signal)"\]$'
                     - \0
-                  error_handler: CUSTOM_ERROR
+                  error_handler: CUSTOM_VALUE
                   error_handler_params: '10'
                 - type: LTRIM
                   parameters:


### PR DESCRIPTION
Added explicit recovery expression to "VM {#VMID} status is stopped" trigger, although it should not be necessary. Ensures proper alert recovery when VM status returns to running.