### PR TITLE
add and update resource usage triggers for Proxmox template

### DIFF
--- a/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/template_proxmox-ve-rest-api.yaml
+++ b/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/template_proxmox-ve-rest-api.yaml
@@ -170,6 +170,12 @@ zabbix_export:
           tags:
             - tag: PVE
               value: CPU
+          triggers:
+            - uuid: 9551ed5e07264f4a90f57a8b8f2c8530
+              expression: 'min(/Template Proxmox VE REST API/pve.cpu.utilization,300)=90'
+              name: 'High CPU usage on {HOST.NAME} (>90%)'
+              opdata: 'CPU utilization: {ITEM.LASTVALUE1}'
+              priority: AVERAGE
         - uuid: 8d7c1e46d5444b06ad419ffab9415d44
           name: 'PVE CPU info'
           type: DEPENDENT
@@ -1860,6 +1866,8 @@ zabbix_export:
               trigger_prototypes:
                 - uuid: ac085aa97edb40dcb08272e859a39e36
                   expression: 'min(/Template Proxmox VE REST API/vm.status[{#VMID}],900)=0 and {$ENABLE_VM_STOP_ALERT:"{#VMID}"}=1'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/Template Proxmox VE REST API/vm.status[{#VMID}])=1'
                   name: 'VM {#VMID} status is stopped'
                   priority: HIGH
                   description: |
@@ -2034,15 +2042,6 @@ zabbix_export:
                 - tag: PVE
                   value: Storage
               trigger_prototypes:
-                - uuid: 2b032af2b5d54593a4f5910d6ae3f912
-                  expression: 'min(/Template Proxmox VE REST API/storage.avail[{#STORAGE_NAME}],900)<32212254720 and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
-                  name: 'Storage [{#STORAGE_NAME}] low available space'
-                  event_name: 'Current available space: {ITEM.LASTVALUE}'
-                  priority: AVERAGE
-                  description: |
-                    Use the following host macros to control the “Storage low available space” trigger for each storage:
-                    {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1 enables the “Storage low available space” trigger
-                    {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=0 disables (suppresses) the “Storage low available space” trigger
                 - uuid: cf31e839babb4b8a90b395ad3df47023
                   expression: 'min(/Template Proxmox VE REST API/storage.avail[{#STORAGE_NAME}],900)=0 and {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=1'
                   name: 'Storage [{#STORAGE_NAME}] not available'
@@ -2161,6 +2160,34 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Storage
+          trigger_prototypes:
+            - uuid: 2b032af2b5d54593a4f5910d6ae3f912
+              expression: |
+                ((last(/Template Proxmox VE REST API/storage.size[{#STORAGE_NAME}]) - last(/Template Proxmox VE REST API/storage.avail[{#STORAGE_NAME}])) 
+                 / last(/Template Proxmox VE REST API/storage.size[{#STORAGE_NAME}]) * 100) >= 90 and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1
+              name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} > 90%)'
+              opdata: 'Total: {ITEM.LASTVALUE1}, Available: {ITEM.LASTVALUE2}'
+              priority: AVERAGE
+              description: |
+                Use the following host macros to control the “Storage low available space” trigger for each storage:
+                {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1 enables the “Storage low available space” trigger
+                {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=0 disables (suppresses) the “Storage low available space” trigger
+              dependencies:
+                - name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} > 95%)'
+                  expression: |
+                    ((last(/Template Proxmox VE REST API/storage.size[{#STORAGE_NAME}]) - last(/Template Proxmox VE REST API/storage.avail[{#STORAGE_NAME}])) 
+                     / last(/Template Proxmox VE REST API/storage.size[{#STORAGE_NAME}]) * 100) >= 95 and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1
+            - uuid: 3827182fb0fe498d8e4c09401168d998
+              expression: |
+                ((last(/Template Proxmox VE REST API/storage.size[{#STORAGE_NAME}]) - last(/Template Proxmox VE REST API/storage.avail[{#STORAGE_NAME}])) 
+                 / last(/Template Proxmox VE REST API/storage.size[{#STORAGE_NAME}]) * 100) >= 95 and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1
+              name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} > 95%)'
+              opdata: 'Total: {ITEM.LASTVALUE1}, Available: {ITEM.LASTVALUE2}'
+              priority: HIGH
+              description: |
+                Use the following host macros to control the “Storage low available space” trigger for each storage:
+                {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1 enables the “Storage low available space” trigger
+                {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=0 disables (suppresses) the “Storage low available space” trigger
           graph_prototypes:
             - uuid: e49e5464b78446aabd4313abefda14c1
               name: 'Storage active state {#STORAGE_NAME}'
@@ -2290,7 +2317,7 @@ zabbix_export:
                   parameters:
                     - '^\["(?:OK|running|stopped|error|unexpected status|CT is locked \(disk\)|timeout waiting on systemd|Failed to run vncproxy\.|unable to read tail \(got 0 byte\)|interrupted by signal)"\]$'
                     - \0
-                  error_handler: CUSTOM_ERROR
+                  error_handler: CUSTOM_VALUE
                   error_handler_params: '10'
                 - type: LTRIM
                   parameters:
@@ -3111,6 +3138,24 @@ zabbix_export:
       name: 'High CPU average'
       opdata: 'Current cpu average: {ITEM.LASTVALUE1}'
       priority: AVERAGE
+    - uuid: d7b8381cedda4cd0bcb28053cd731ddf
+      expression: '(last(/Template Proxmox VE REST API/pve.memory.used) / last(/Template Proxmox VE REST API/pve.memory.total)) * 100 > 90'
+      name: 'High memory usage on {HOST.NAME} (>90%)'
+      opdata: 'Memory used: {ITEM.LASTVALUE1}'
+      priority: AVERAGE
+    - uuid: 6ec8009a0c62481d85fb57b7eb83e6f2
+      expression: '((last(/Template Proxmox VE REST API/pve.rootfs.used) / last(/Template Proxmox VE REST API/pve.rootfs.size)) * 100) > 90'
+      name: 'High root filesystem usage on {HOST.NAME} (>90%)'
+      opdata: 'Disk usage: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
+      priority: AVERAGE
+      dependencies:
+        - name: 'High root filesystem usage on {HOST.NAME} (>95%)'
+          expression: '((last(/Template Proxmox VE REST API/pve.rootfs.used) / last(/Template Proxmox VE REST API/pve.rootfs.size)) * 100) > 95'
+    - uuid: d621a5f2dbce40c5a96d7f5573ede065
+      expression: '((last(/Template Proxmox VE REST API/pve.rootfs.used) / last(/Template Proxmox VE REST API/pve.rootfs.size)) * 100) > 95'
+      name: 'High root filesystem usage on {HOST.NAME} (>95%)'
+      opdata: 'Disk usage: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
+      priority: HIGH
   graphs:
     - uuid: bbdef5c2775146b4ad30ac91ad877624
       name: 'Load average'


### PR DESCRIPTION
- Added high memory usage trigger (>90%) using pve.memory.used / pve.memory.total
- Added high CPU usage trigger (>90% over 5 minutes) using pve.cpu.utilization
- Added high root disk usage trigger (>90%) using pve.rootfs.used / pve.rootfs.size
- Added critical root disk usage trigger (>95%) for early warning escalation
- Added high storage usage trigger (≥90%) using storage.size - storage.avail
  * Trigger name: "High storage usage on {HOST.NAME} ({#STORAGE_NAME} ≥ 90%)"
  * Updated expression to fire at exactly and above 90%
  * Added Operational data to show total and available space