### PR TITLE
[FIX-PATRONI-TEMPLATE-2025081300] Repair the triggers

### DIFF
--- a/Databases/template_patroni/7.4/template_patroni.xml
+++ b/Databases/template_patroni/7.4/template_patroni.xml
@@ -128,7 +128,7 @@ return leader_num * (syncstandby_num + 1);</parameter>
               <uuid>198a0f506622428fb5d635cf2a1e4a0c</uuid>
               <expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)=0</expression>
               <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-              <recovery_expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)&gt;=2</recovery_expression>
+              <recovery_expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)&gt;0</recovery_expression>
               <name>Patroni Cluster Status: CRITICAL (without any leader node)</name>
               <priority>HIGH</priority>
               <description>0 leader nodes.</description>
@@ -227,9 +227,9 @@ return leader_num * (syncstandby_num + 1);</parameter>
           <triggers>
             <trigger>
               <uuid>3f97e094422144f0be89399c98bea51b</uuid>
-              <expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)=1</expression>
+              <expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.pause_mode)=1</expression>
               <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-              <recovery_expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)=0</recovery_expression>
+              <recovery_expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.pause_mode)=0</recovery_expression>
               <name>Patroni cluster is PAUSED</name>
               <priority>WARNING</priority>
             </trigger>
@@ -363,9 +363,9 @@ return 0; // consistency</parameter>
           <triggers>
             <trigger>
               <uuid>8181bb54b6ba4986b8949db8c8d06f30</uuid>
-              <expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)=1</expression>
+              <expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.timeline_consistency)=1</expression>
               <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-              <recovery_expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)=0</recovery_expression>
+              <recovery_expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.timeline_consistency)=0</recovery_expression>
               <name>Patroni cluster: Some nodes have different timelines</name>
               <priority>WARNING</priority>
             </trigger>

--- a/Databases/template_patroni/7.4/template_patroni.xml
+++ b/Databases/template_patroni/7.4/template_patroni.xml
@@ -128,7 +128,7 @@ return leader_num * (syncstandby_num + 1);</parameter>
               <uuid>198a0f506622428fb5d635cf2a1e4a0c</uuid>
               <expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)=0</expression>
               <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-              <recovery_expression>{last()}&gt;=2</recovery_expression>
+              <recovery_expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)&gt;=2</recovery_expression>
               <name>Patroni Cluster Status: CRITICAL (without any leader node)</name>
               <priority>HIGH</priority>
               <description>0 leader nodes.</description>
@@ -137,7 +137,7 @@ return leader_num * (syncstandby_num + 1);</parameter>
               <uuid>9661d5b1b1434840a3bdf14ef170a113</uuid>
               <expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)=1</expression>
               <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-              <recovery_expression>{last()}&gt;=2</recovery_expression>
+              <recovery_expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)&gt;=2</recovery_expression>
               <name>Patroni Cluster Status: WARNING (without any sync_standby node)</name>
               <priority>WARNING</priority>
               <description>1 leader and 0 sync_standby nodes.</description>
@@ -229,7 +229,7 @@ return leader_num * (syncstandby_num + 1);</parameter>
               <uuid>3f97e094422144f0be89399c98bea51b</uuid>
               <expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)=1</expression>
               <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-              <recovery_expression>{last()}=0</recovery_expression>
+              <recovery_expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)=0</recovery_expression>
               <name>Patroni cluster is PAUSED</name>
               <priority>WARNING</priority>
             </trigger>
@@ -290,7 +290,7 @@ if has any response then record 1.</description>
               <uuid>ceb3a3ea15584e448dc177e0fbb36229</uuid>
               <expression>nodata(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.responsiveness,{$PATRONI.API.STATUS_NO_RESPONSE_THRESHOLD})=1</expression>
               <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-              <recovery_expression>{nodata({$PATRONI.API.STATUS_NO_RESPONSE_THRESHOLD})}=0</recovery_expression>
+              <recovery_expression>nodata(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.responsiveness,{$PATRONI.API.STATUS_NO_RESPONSE_THRESHOLD})=0</recovery_expression>
               <name>Patroni cluster: NO RESPONSE in {$PATRONI.API.STATUS_NO_RESPONSE_THRESHOLD}</name>
               <priority>HIGH</priority>
             </trigger>
@@ -365,7 +365,7 @@ return 0; // consistency</parameter>
               <uuid>8181bb54b6ba4986b8949db8c8d06f30</uuid>
               <expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)=1</expression>
               <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
-              <recovery_expression>{last()}=0</recovery_expression>
+              <recovery_expression>last(/Template App Patroni Cluster monitoring by HTTP/patroni.endpoint.cluster.status.health_code)=0</recovery_expression>
               <name>Patroni cluster: Some nodes have different timelines</name>
               <priority>WARNING</priority>
             </trigger>


### PR DESCRIPTION
The Patroni template when imported into Zabbix 7.4.1 did not create any triggers. This PR fixes the creation of triggers.

Thanks to Oleg Kostikov from "Zabbix Junior Questions" for the guidance.