### PR TITLE
Add macro for job running time and trigger

### DIFF
--- a/Unsorted/template_zabbix_semaphore_ansible/7.0/template_zabbix_semaphore_ansible.yaml
+++ b/Unsorted/template_zabbix_semaphore_ansible/7.0/template_zabbix_semaphore_ansible.yaml
@@ -91,11 +91,20 @@ zabbix_export:
                 - tag: Semaphore
                   value: task-status
               trigger_prototypes:
+                - uuid: 0c6cf1cfefea495099fb62b336db9fba
+                  expression: |
+                    min(/Zabbix template semaphore task monitoring/task.status[{#ID}],{$JOB_RUNNING_TIME})=3
+                    and max(/Zabbix template semaphore task monitoring/task.status[{#ID}],{$JOB_RUNNING_TIME})=3
+                    and {$ENABLE_TRIGGER:"{#ID}"}=1
+                  name: 'Task {#NAME} (Task ID {#LAST_TASK_ID}) in failed state for >{$JOB_RUNNING_TIME}'
+                  opdata: 'Status: {ITEM.LASTVALUE}'
+                  priority: AVERAGE
+                  manual_close: 'YES'
                 - uuid: bb8e442fd6a348fe83031d1270f52466
                   expression: 'last(/Zabbix template semaphore task monitoring/task.status[{#ID}])=2 and {$ENABLE_TRIGGER:"{#ID}"}=1'
                   name: 'Task {#NAME} Task-ID {#LAST_TASK_ID} failed'
                   opdata: 'Status: {ITEM.LASTVALUE}'
-                  priority: WARNING
+                  priority: AVERAGE
                   manual_close: 'YES'
           master_item:
             key: semaphore.raw
@@ -119,6 +128,9 @@ zabbix_export:
         - macro: '{$ENABLE_TRIGGER}'
           value: '1'
           description: 'Enables task failure triggers (1 = enabled, 0 = disabled)'
+        - macro: '{$JOB_RUNNING_TIME}'
+          value: 5h
+          description: 'Time period the job must remain in running state before triggering an alert (e.g. 5h)'
         - macro: '{$PROJECT_NUMBER}'
           value: '1'
           description: 'Semaphore project ID (e.g., 1 for Project with ID 1)'


### PR DESCRIPTION
- Added macro {#JOB_RUNNING_TIME} to define time threshold for job running state
- Created trigger to alert when task status remains 'running' (value=3) for the defined duration: min(...,{$JOB_RUNNING_TIME})=3 and max(...,{$JOB_RUNNING_TIME})=3