### PR TITLE
Added macro for $SNMP.TIMEOUT in template_Cisco_WiFi_WLC_62.yaml

### DIFF
--- a/Network_Devices/Cisco/template_cisco_WLC/6.0/template_Cisco_WiFi_WLC_62.yaml
+++ b/Network_Devices/Cisco/template_cisco_WLC/6.0/template_Cisco_WiFi_WLC_62.yaml
@@ -849,6 +849,9 @@ zabbix_export:
                   item:
                     host: template_Cisco_WiFi_WLC_62
                     key: 'ifOutOctets[{#SNMPVALUE}]'
+      macros:
+        - macro: '{$SNMP.TIMEOUT}'
+          value: 5m
       valuemaps:
         -
           uuid: 4e264fbf804648d6b852ca727875170f


### PR DESCRIPTION
Macro for $SNMP.TIMEOUT (line 243) was missing, resulting in status "Unknown" for the trigger