### PR TITLE
Fix workflow: Add file existence check before sed command

### DIFF
--- a/.github/workflows/review_pr.yaml
+++ b/.github/workflows/review_pr.yaml
@@ -1,10 +1,8 @@
 name: Review PR
-
 on:
   pull_request:
     branches:
       - main
-
 jobs:
   # Check changed files in PR
   changed_files:
@@ -12,7 +10,6 @@ jobs:
     name: Check changed files in PR
     permissions:
       pull-requests: read
-
     services:
       postgres-server_74:
         image: postgres
@@ -25,7 +22,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
       zabbix-server_74:
         image: zabbix/zabbix-server-pgsql:7.4-alpine-latest
         env:
@@ -33,7 +29,6 @@ jobs:
           POSTGRES_DB: zabbix
           POSTGRES_USER: zabbix
           POSTGRES_PASSWORD: zabbix
-
       zabbix-web_74:
         image: zabbix/zabbix-web-nginx-pgsql:7.4-alpine-latest
         ports:
@@ -44,7 +39,6 @@ jobs:
           POSTGRES_USER: zabbix
           POSTGRES_PASSWORD: zabbix
           PHP_TZ: Europe/Riga
-
       postgres-server_70:
         image: postgres
         env:
@@ -56,7 +50,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
       zabbix-server_70:
         image: zabbix/zabbix-server-pgsql:7.0-alpine-latest
         env:
@@ -64,7 +57,6 @@ jobs:
           POSTGRES_DB: zabbix
           POSTGRES_USER: zabbix
           POSTGRES_PASSWORD: zabbix
-
       zabbix-web_70:
         image: zabbix/zabbix-web-nginx-pgsql:7.0-alpine-latest
         ports:
@@ -75,7 +67,6 @@ jobs:
           POSTGRES_USER: zabbix
           POSTGRES_PASSWORD: zabbix
           PHP_TZ: Europe/Riga
-
       postgres-server_60:
         image: postgres
         env:
@@ -87,7 +78,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
       zabbix-server_60:
         image: zabbix/zabbix-server-pgsql:6.0-alpine-latest
         env:
@@ -95,7 +85,6 @@ jobs:
           POSTGRES_DB: zabbix
           POSTGRES_USER: zabbix
           POSTGRES_PASSWORD: zabbix
-
       zabbix-web_60:
         image: zabbix/zabbix-web-nginx-pgsql:6.0-alpine-latest
         ports:
@@ -106,7 +95,6 @@ jobs:
           POSTGRES_USER: zabbix
           POSTGRES_PASSWORD: zabbix
           PHP_TZ: Europe/Riga
-
       postgres-server_50:
         image: postgres
         env:
@@ -118,7 +106,6 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
       zabbix-server_50:
         image: zabbix/zabbix-server-pgsql:5.0-alpine-latest
         env:
@@ -126,7 +113,6 @@ jobs:
           POSTGRES_DB: zabbix
           POSTGRES_USER: zabbix
           POSTGRES_PASSWORD: zabbix
-
       zabbix-web_50:
         image: zabbix/zabbix-web-nginx-pgsql:5.0-alpine-latest
         ports:
@@ -137,7 +123,6 @@ jobs:
           POSTGRES_USER: zabbix
           POSTGRES_PASSWORD: zabbix
           PHP_TZ: Europe/Riga
-
     steps:
       - uses: actions/checkout@v4
       - name: Get changed files
@@ -147,14 +132,13 @@ jobs:
           json: true
           escape_json: false
           write_output_files: true
-
       - name: Install python3
         run: |
           sudo apt update
           sudo apt install -y python3 python3-pip python-is-python3
           pip3 install -r .github/workflows/scripts/requirements.txt
-
       - name: Run checks
         run: |
+          [ -f .github/outputs/all_changed_files.json ] || echo '{}' > .github/outputs/all_changed_files.json
           sed -i 's/\\//g' .github/outputs/all_changed_files.json
           .github/workflows/scripts/check_rules_pr.py > $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Add a file existence check before running the sed command to ensure .github/outputs/all_changed_files.json exists. If the file doesn't exist, create it with empty JSON ({}) to prevent sed from failing. This fixes the workflow error where sed fails when the file is missing.