### PR TITLE
Add Epson L4260 SNMP template

### DIFF
--- a/Printers/EpsonL4260
+++ b/Printers/EpsonL4260
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+  <version>7.0</version>
+  <template_groups>
+    <template_group>
+      <uuid>115d8060fcc04c9c8ea028cb8ef4a658</uuid>
+      <name>Printers</name>
+    </template_group>
+  </template_groups>
+  <templates>
+    <template>
+      <uuid>34a9e67595e34510b664f31c43eee7bc</uuid>
+      <template>EpsonL4260</template>
+      <name>EpsonL4260</name>
+      <groups>
+        <group>
+          <name>Printers</name>
+        </group>
+      </groups>
+      <macros>
+        <macro>
+          <macro>{$HR_IDX}</macro>
+          <value>1</value>
+          <description>Índice Host-Resources da impressora</description>
+        </macro>
+      </macros>
+      <items>
+        <item>
+          <uuid>b3f86b9f2d0341ee8552b19af7fe63ce</uuid>
+          <name>Total de Páginas Impressas</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.43.10.2.1.4.1.1</snmp_oid>
+          <key>printer.pages.total</key>
+          <value_type>UNSIGNED</value_type>
+          <delay>5m</delay>
+          <history>90d</history>
+          <units>páginas</units>
+        </item>
+        <item>
+          <uuid>d8455c3a03074c43bdc077fc4347ec93</uuid>
+          <name>Total de Páginas P&amp;B</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.4.1.1248.1.2.2.27.1.1.3.1.1</snmp_oid>
+          <key>printer.pages.bw.total</key>
+          <value_type>UNSIGNED</value_type>
+          <delay>5m</delay>
+          <history>90d</history>
+          <units>páginas</units>
+        </item>
+        <item>
+          <uuid>114b5af6e4944d2f8f20448def78048a</uuid>
+          <name>Total de Páginas Coloridas</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.4.1.1248.1.2.2.27.1.1.4.1.1</snmp_oid>
+          <key>printer.pages.color.total</key>
+          <value_type>UNSIGNED</value_type>
+          <delay>5m</delay>
+          <history>90d</history>
+          <units>páginas</units>
+        </item>
+        <item>
+          <uuid>db91f2bc5cdb46d09172bec8d87542cb</uuid>
+          <name>Tinta – Preto (%)</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.43.11.1.1.9.1.1</snmp_oid>
+          <key>printer.ink.black.level</key>
+          <value_type>UNSIGNED</value_type>
+          <delay>5m</delay>
+          <history>90d</history>
+          <units>%</units>
+        </item>
+        <item>
+          <uuid>65af80b80b854478b4a9b09202ae083e</uuid>
+          <name>Tinta – Ciano (%)</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.43.11.1.1.9.1.2</snmp_oid>
+          <key>printer.ink.cyan.level</key>
+          <value_type>UNSIGNED</value_type>
+          <delay>5m</delay>
+          <history>90d</history>
+          <units>%</units>
+        </item>
+        <item>
+          <uuid>e88aa73af979434fb78f9c9ec1901adf</uuid>
+          <name>Tinta – Magenta (%)</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.43.11.1.1.9.1.3</snmp_oid>
+          <key>printer.ink.magenta.level</key>
+          <value_type>UNSIGNED</value_type>
+          <delay>5m</delay>
+          <history>90d</history>
+          <units>%</units>
+        </item>
+        <item>
+          <uuid>366f41db0ef0458bbb6571552572a2d3</uuid>
+          <name>Tinta – Amarelo (%)</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.43.11.1.1.9.1.4</snmp_oid>
+          <key>printer.ink.yellow.level</key>
+          <value_type>UNSIGNED</value_type>
+          <delay>5m</delay>
+          <history>90d</history>
+          <units>%</units>
+        </item>
+        <item>
+          <uuid>ac98c4c9b05a4c018d02c9f5c37b58f9</uuid>
+          <name>Status – Texto</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.43.16.5.1.2.1.1</snmp_oid>
+          <key>printer.status.text</key>
+          <value_type>TEXT</value_type>
+          <delay>1m</delay>
+          <history>90d</history>
+        </item>
+        <item>
+          <uuid>ec7eb54c5a8640f1be25225415657ad6</uuid>
+          <name>Status – hrPrinterStatus</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.25.3.5.1.1.{$HR_IDX}</snmp_oid>
+          <key>printer.hr.status</key>
+          <value_type>UNSIGNED</value_type>
+          <delay>1m</delay>
+          <history>90d</history>
+        </item>
+        <item>
+          <uuid>af9912af59a948e2aadc42dd32feb408</uuid>
+          <name>Erros – hrDetectedErrorState (raw)</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.25.3.5.1.2.{$HR_IDX}</snmp_oid>
+          <key>printer.hr.errorstate.raw</key>
+          <value_type>TEXT</value_type>
+          <delay>1m</delay>
+          <history>90d</history>
+        </item>
+        <item>
+          <uuid>bb50e87ee0104df98ba82808e10fa1bc</uuid>
+          <name>Uptime do Dispositivo</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.1.3.0</snmp_oid>
+          <key>printer.uptime</key>
+          <value_type>UNSIGNED</value_type>
+          <delay>1m</delay>
+          <history>90d</history>
+          <units>s</units>
+        </item>
+        <item>
+          <uuid>3346a689341048b1a9a3fa1988a53910</uuid>
+          <name>Nome do Sistema (sysName)</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.1.5.0</snmp_oid>
+          <key>printer.sysname</key>
+          <value_type>TEXT</value_type>
+          <delay>1h</delay>
+          <history>90d</history>
+        </item>
+        <item>
+          <uuid>7da32d1f97f24d6f864939fc34873337</uuid>
+          <name>Localização (sysLocation)</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.1.6.0</snmp_oid>
+          <key>printer.location</key>
+          <value_type>TEXT</value_type>
+          <delay>1h</delay>
+          <history>90d</history>
+        </item>
+        <item>
+          <uuid>c84552f068a74486a5b84dab7a8dfb79</uuid>
+          <name>Modelo</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.43.5.1.1.16.1</snmp_oid>
+          <key>printer.model</key>
+          <value_type>TEXT</value_type>
+          <delay>1h</delay>
+          <history>90d</history>
+        </item>
+        <item>
+          <uuid>a15022cdbb1e48dda7ac2148e29bbcb6</uuid>
+          <name>Número de Série</name>
+          <type>SNMP_AGENT</type>
+          <snmp_oid>.1.3.6.1.2.1.43.5.1.1.17.1</snmp_oid>
+          <key>printer.serial</key>
+          <value_type>TEXT</value_type>
+          <delay>1h</delay>
+          <history>90d</history>
+        </item>
+      </items>
+    </template>
+  </templates>
+</zabbix_export>


### PR DESCRIPTION
- Itens para total de páginas (geral, P&B e coloridas)
- Níveis de tinta (preto, ciano, magenta, amarelo)
- Status textual e hrPrinterStatus
- hrDetectedErrorState (raw)
- Uptime, sysName, sysLocation
- Modelo e número de série
<img width="1772" height="883" alt="image" src="https://github.com/user-attachments/assets/00414c96-d518-4cae-816c-5db66fbcf9c1" />

Compatível com Zabbix 7.0+.
Utiliza macro {$HR_IDX} para índice da impressora em Host-Resources.