### PR TITLE
Create ssh-get

### DIFF
--- a/Operating_Systems/Linux/template_Linux_by_Agentless/7.0/files/ssh-get
+++ b/Operating_Systems/Linux/template_Linux_by_Agentless/7.0/files/ssh-get
@@ -1,0 +1,43 @@
+#################################################################################
+# SSH Metrics Collector with ProxyJump Support
+# Save this file to Zabbix Server or Proxy /usr/lib/zabbix/externalscripts/ssh-get 
+# Version: 1.0
+# Author: Karthick [ https://github.com/karthick-dkk ]
+# Used on Zabbix Server/Proxy
+##################################################################################
+
+#!/bin/bash
+SSH_KEY="/var/lib/zabbix/id_ecdsa"
+HOST=$1
+TIMEOUT=15
+USER=$2
+PORT=$3
+CONFIG_FILE="/var/lib/zabbix/.ssh/config"
+
+[ -z "$HOST" ] && missing+=" HOST"
+[ -z "$USER" ] && missing+=" USER"
+[ -z "$PORT" ] && missing+=" PORT"
+
+if [ -n "$missing" ]; then
+    echo "Missing required variable(s):$missing"
+    echo "Usage: $0 <HOST> <USER> <PORT> -J [jump-host] <COMMAND>"
+    echo "Usage: $0 <HOST> <USER> <PORT> <COMMAND>"
+    exit 1;
+fi
+
+shift 3
+
+# Check if next arg is "-J"
+if [ "$1" == "-J" ];then
+    JUMP_OPTION="-J $2"
+    shift 2
+else
+    JUMP_OPTION=""
+fi
+# Remaining args are the command
+COMMAND="$*"
+
+timeout $TIMEOUT ssh -F"$CONFIG_FILE" -i "$SSH_KEY" $JUMP_OPTION -p "$PORT" "$USER"@"$HOST" $COMMAND
+#timeout $TIMEOUT ssh $JUMP_OPTION -i "$SSH_KEY"  -o "StrictHostKeyChecking=no" -p "$PORT" "$USER"@"$HOST" "$COMMAND"
+
+exit 0;


### PR DESCRIPTION
SSH Metrics Collector with ProxyJump Support
Save this file to Zabbix Server or Proxy /usr/lib/zabbix/externalscripts/ssh-get  Used on Zabbix Server/Proxy