### PR TITLE
template_zfs_on_linux: fix collecting last scrub and resilevering metrics

### DIFF
--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/files/scan_finish-zabbix.sh
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/files/scan_finish-zabbix.sh
@@ -9,27 +9,31 @@
 # Then restart zed so it picks up the new scripts.
 
 status=$(${ZPOOL} status ${ZEVENT_POOL} | egrep 'scrub repaired|resilvered')
+# The $status string value has two extra words if the duration is longer than 24 hours.
+# Example without days:
+# scan: scrub repaired 0B in 00:07:05 with 0 errors on Sun Jun 8 00:31:06 2025
+# Example with days:
+# scan: scrub repaired 0B in 5 days 01:55:40 with 0 errors on Fri Oct 17 02:19:41 2025
+[[ $status == *"days"* ]] && { days_offset=2; days=$(awk '{print $6}' <<<${status}); } || { days_offset=0; days=0; }
 
 if echo "${status}" | grep 'scrub' >/dev/null; then
     # Most recent scan was a scrub
     type='scrub'
-
-    # Example:
-    # scan: scrub repaired 0B in 00:07:05 with 0 errors on Sun Jun  8 00:31:06 2025
-    repaired=$(awk '{print $4}' <<<${status})
-    length=$(awk '{print $6}' <<<${status})
-    errors=$(awk '{print $8}' <<<${status})
-    timestamp=$(awk '{print substr($0, index($0, $11))}' <<<${status})
+    repaired=$(awk "{print \$4}" <<<${status})
+    length=$(awk "{print \$$((6 + days_offset))}" <<<${status})
+    errors=$(awk "{print \$$((8 + days_offset))}" <<<${status})
+    timestamp=$(awk "{print substr(\$0, index(\$0, \$$((11 + days_offset))))}" <<<${status})
 elif echo "${status}" | grep 'resilver' >/dev/null; then
     type='resilver'
-
-    # Example:
+    # Example without days:
     # scan: resilvered 4.01M in 00:00:00 with 0 errors on Tue Jun 10 22:55:22 2025
-    repaired=$(awk '{print $3}' <<<${status})
-    length=$(awk '{print $5}' <<<${status})
-    errors=$(awk '{print $7}' <<<${status})
-    timestamp=$(awk '{print substr($0, index($0, $10))}' <<<${status})
-else
+    # Example with days:
+    # scan: resilvered 900.34M in 5 days 01:55:40 with 0 errors on Fri Oct 17 05:44:41 2025
+    repaired=$(awk "{print \$3}" <<<${status})
+    length=$(awk "{print \$$((5 + days_offset))}" <<<${status})
+    errors=$(awk "{print \$$((7 + days_offset))}" <<<${status})
+    timestamp=$(awk "{print substr(\$0, index(\$0, \$$((10 + days_offset))))}" <<<${status})
+   else
     # Unknown most recent scan type, or no recent scan
     exit 1
 fi
@@ -40,7 +44,7 @@ ${ZFS} set "zabbix:last-${type}-repaired=${repaired}"   "${ZEVENT_POOL}"
 
 # Length of most recent scan in seconds
 IFS=: read h m s <<<"${length}"
-length=$(( 10#${s} + (10#${m} * 60) + (10#${h} * 3600) ))
+length=$(( 10#${s} + (10#${m} * 60) + (10#${h} * 3600) + ($days * 3600 * 24) ))
 ${ZFS} set "zabbix:last-${type}-length=${length}"       "${ZEVENT_POOL}"
 
 # Errors detected by most recent scan


### PR DESCRIPTION
This PR fix template_zfs_on_linux script collecting last scrub and resilver metrics when duration more than 24h.

Affected items:
 Zpool {#POOLNAME}: Last scrub errors
 zfs.zpool.scrub.errors[{#POOLNAME}]
 Unsupported item error: Value of type "string" is not suitable for value type "Numeric (unsigned)". Value "xx:xx:xx"

 Zpool {#POOLNAME}: Last scrub timestamp
 zfs.zpool.scrub.timestamp[{#POOLNAME}]
 Unsupported item error: Value of type "string" is not suitable for value type "Numeric (unsigned)". Value ""

 Zpool {#POOLNAME}: Last scrub length
 zfs.zpool.scrub.length[{#POOLNAME}]
 Item has garbage value.

 Zpool {#POOLNAME}: Last resilver errors
 zfs.zpool.resilver.errors[{#POOLNAME}]
 Unsupported item error: Value of type "string" is not suitable for value type "Numeric (unsigned)". Value "xx:xx:xx"

 Zpool {#POOLNAME}: Last resilver timestamp
 zfs.zpool.resilver.timestamp[{#POOLNAME}]
 Unsupported item error: Value of type "string" is not suitable for value type "Numeric (unsigned)". Value ""

 Zpool {#POOLNAME}: Last resilver length
 zfs.zpool.resilver.length[{#POOLNAME}]
 Item has garbage value.

Affected triggers, not work as expected when duration more than 24h:
 Zpool {#POOLNAME} has recently resilvered on {HOST.NAME}
 Zpool {#POOLNAME} no scrub for over {$ZPOOL_MAX_SCRUB_INTERVAL} days on {HOST.NAME}

 The PR makes the listed items and triggers work correctly.
