### PR TITLE
Create Fiberhome_PON_e_ONUS-V001

### DIFF
--- a/Network_Devices/Fiberhome_PON_e_ONUS-V001
+++ b/Network_Devices/Fiberhome_PON_e_ONUS-V001
@@ -1,0 +1,160 @@
+zabbix_export:
+  version: '7.4'
+  template_groups:
+    - uuid: 2339d63df9eb4f7ebba4696bb100a3ef
+      name: KLINK
+  templates:
+    - uuid: 42db160d1be9457488c89c62d8a809f8
+      template: Fiberhome_PON_e_ONUS-V001
+      name: Fiberhome_PON_e_ONUS-V001
+      description: |
+        ## Overview
+        
+        Fiberhome_PON_e_ONUS-V001
+        
+        Montei esse template para monitorar várias informações de portas PON e  ONUS em OLTs Fiberhome. Nele foram criados protótipos de itens na regra de descoberta para quantidade de ONUs autorizadas, Online e Offline em cada porta PON. Existe também outros protótipos de itens para Status da porta PON (up ou down) e tipo de SFP na porta PON (C+, C++, ou SFP ausente). Existe um item, que soma todas as quantidade de ONUs Online descobertas nas portas PONs e retorna o valro total de ONUs Online na OLT.
+        
+        
+        
+        ## Author
+        
+        Luiz Felipe Barroso Mourão
+        +55 33 99986 6940
+      groups:
+        - name: KLINK
+      items:
+        - uuid: c53f30cea5c7439a980fb0b1a6633315
+          name: 'Total de ONUs online'
+          type: CALCULATED
+          key: oltPonOnlineTotal
+          params: 'sum(last_foreach(/HOST/oltPonOnlineONU.[*]))'
+          description: |
+            ATENÇÃO! Editar o "HOST" com o nome do host criado.
+            
+            Soma a quantidade de ONUs Online de todas as portas PON descobertas.
+      discovery_rules:
+        - uuid: 8d9d61961e9547969f054dfebdbbfd4d
+          name: 'PON Info e ONUs'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery2[{#OLTPONDESC},1.3.6.1.4.1.5875.800.3.9.3.4.1.3]'
+          key: discovery.pon.onu
+          delay: 1h
+          item_prototypes:
+            - uuid: 92bfb0e057664c29a4d9ec3e29506e5c
+              name: 'Quantidade de ONUs Autorizadas na {#OLTPONDESC}'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.5875.800.3.9.3.4.1.12.{#SNMPINDEX}'
+              key: 'oltPonAuthOnuNum.["{#OLTPONDESC}"]'
+              delay: 1h
+              history: 90d
+              description: 'Retorna a quantidade de ONUs autorizadas por porta PON'
+            - uuid: a93969843fb84b93b5520e9361c99e91
+              name: 'Quantidade de ONUs Offline {#OLTPONDESC}'
+              type: SNMP_AGENT
+              snmp_oid: 'iso.3.6.1.4.1.5875.800.3.9.3.4.1.23.{#SNMPINDEX}'
+              key: 'oltPonOfflineONU.["{#OLTPONDESC}"]'
+              delay: 2m
+              description: 'Retorna a quantidade de ONUs Offline por porta PON'
+            - uuid: 212db908f86644b3b5442616aab11299
+              name: 'Quantidade de ONUs Online {#OLTPONDESC}'
+              type: SNMP_AGENT
+              snmp_oid: 'iso.3.6.1.4.1.5875.800.3.9.3.4.1.22.{#SNMPINDEX}'
+              key: 'oltPonOnlineONU.["{#OLTPONDESC}"]'
+              delay: 2m
+              description: 'Retorna a quantidade de ONUs Online por porta PON'
+              trigger_prototypes:
+                - uuid: 5fe25c6846744e6e9d3d0c54fa8867fc
+                  expression: 'last(/Fiberhome_PON_e_ONUS-V001/oltPonOnlineONU.["{#OLTPONDESC}"])=0'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/Fiberhome_PON_e_ONUS-V001/oltPonOnlineONU.["{#OLTPONDESC}"])>0'
+                  name: 'Atenção!  0 ONUs Online na Porta PON {#OLTPONDESC}'
+                  priority: AVERAGE
+                  description: 'Nenhuma ONU Online, verifique o status da porta PON {#OLTPONDESC}'
+                  manual_close: 'YES'
+                - uuid: 7c1811e4237e4b0c9630c1dadb6061ac
+                  expression: |
+                    last(/Fiberhome_PON_e_ONUS-V001/oltPonOnlineONU.["{#OLTPONDESC}"]) 
+                    < (max(/Fiberhome_PON_e_ONUS-V001/oltPonOnlineONU.["{#OLTPONDESC}"],6h) * 0.7)
+                    and
+                    last(/Fiberhome_PON_e_ONUS-V001/oltPonOnlineONU.["{#OLTPONDESC}"]) 
+                    > (max(/Fiberhome_PON_e_ONUS-V001/oltPonOnlineONU.["{#OLTPONDESC}"],6h) * 0.1)
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: |
+                    last(/Fiberhome_PON_e_ONUS-V001/oltPonOnlineONU.["{#OLTPONDESC}"]) 
+                    >= 
+                    (max(/Fiberhome_PON_e_ONUS-V001/oltPonOnlineONU.["{#OLTPONDESC}"],6h) * 0.85)
+                  name: 'Atenção! Queda de muitas ONUs na PON {#OLTPONDESC}'
+                  priority: WARNING
+                  description: |
+                    A trigger deve disparar SE:
+                    
+                    ONUs atuais < 70% do máximo das últimas 6 horas
+                    
+                    E ONUs atuais > 10% do máximo das últimas 6 horas
+                    → (para ignorar valores muito baixos, como 0, 1, 2 ONUs etc.)
+                    
+                    
+                    Expressão final do PROBLEMA
+                    
+                    last(/Fiberhome-ONUs-por-PON/oltPonOnlineONU.["{#OLTPONDESC}"]) 
+                    < (max(/Fiberhome-ONUs-por-PON/oltPonOnlineONU.["{#OLTPONDESC}"],6h) * 0.7)
+                    and
+                    last(/Fiberhome-ONUs-por-PON/oltPonOnlineONU.["{#OLTPONDESC}"]) 
+                    > (max(/Fiberhome-ONUs-por-PON/oltPonOnlineONU.["{#OLTPONDESC}"],6h) * 0.1)
+                    
+                    
+                    Como funciona isso?
+                    
+                    Primeiro termo: Vai alarmar quando cair abaixo de 70%
+                    
+                    Segundo termo: Só deixa alarmar quando estiver acima de 10%, evitando alarmes quando a porta está quase vazia (0 ONUs, 1 ONU, etc.)
+                    
+                    Isso impede conflito com sua trigger de porta offline/parada.
+                    
+                    Exemplo prático
+                    
+                    Supondo que máximo nas últimas 6h = 100 ONUs:
+                    
+                    Trigger dispara quando cair para 69, 60, 50, 40, 20 ONUs
+                    
+                    MAS não dispara se cair para 0, 1, 2, 3, 9 ONUs,
+                    porque isso cai abaixo de 10 ONUs (10% de 100).
+                    
+                    Sua trigger “PON Off” continua sendo quem cuida da situação de 0 ONUs.
+                    
+                    
+                    Expressão de RECUPERAÇÃO (85%)
+                    
+                    last(/Fiberhome-ONUs-por-PON/oltPonOnlineONU.["{#OLTPONDESC}"]) 
+                    >= (max(/Fiberhome-ONUs-por-PON/oltPonOnlineONU.["{#OLTPONDESC}"],6h) * 0.85)
+                    
+                    
+                    Agora sua trigger só dispara quando houver queda real incomum, mas não interfere com a trigger de porta PON parada.
+            - uuid: f5b9e9409a114cb19a5fc4cff83ad429
+              name: 'Status da porta {#OLTPONDESC}'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.5875.800.3.9.3.4.1.5.{#SNMPINDEX}'
+              key: 'oltPonOnlineStatus.["{#OLTPONDESC}"]'
+              history: 90d
+              description: 'Retorna Status da porta PON, UP ou Down.'
+              trigger_prototypes:
+                - uuid: 20e96181ab494d9eb3264307e8164403
+                  expression: 'last(/Fiberhome_PON_e_ONUS-V001/oltPonOnlineStatus.["{#OLTPONDESC}"])=0'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/Fiberhome_PON_e_ONUS-V001/oltPonOnlineStatus.["{#OLTPONDESC}"])=1'
+                  name: 'Atenção! Porta PON {#OLTPONDESC} está offline'
+                  priority: HIGH
+                  description: 'A porta PON {#OLTPONDESC} está offline. Verifique a OLT e possíveis falhas na rede.'
+                  manual_close: 'YES'
+            - uuid: d234861548a0418bb786adee758381cb
+              name: 'Tipo do SFP {#OLTPONDESC}'
+              type: SNMP_AGENT
+              snmp_oid: 'iso.3.6.1.4.1.5875.800.3.9.3.4.1.15.{#SNMPINDEX}'
+              key: 'oltPonTipoSFP.["{#OLTPONDESC}"]'
+              delay: 6h
+              description: |
+                Retorna o tipo de SFP, ou se está ausente (não possui SFP conectado na porta).
+                
+                12 = Ausente
+                3 = C+
+                13 = C++


### PR DESCRIPTION
        Montei esse template para monitorar várias informações de portas PON e  ONUS em OLTs Fiberhome. Nele foram criados protótipos de itens na regra de descoberta para quantidade de ONUs autorizadas, Online e Offline em cada porta PON. Existe também outros protótipos de itens para Status da porta PON (up ou down) e tipo de SFP na porta PON (C+, C++, ou SFP ausente). Existe um item, que soma todas as quantidade de ONUs Online descobertas nas portas PONs e retorna o valro total de ONUs Online na OLT.