### PR TITLE
Add Zabbix template for Blockbit NGFW VPN IPSec monitoring

### DIFF
--- a/Network_Devices/Blockbit/template_blockbit_ngfw_snmp/7.0/template_blockbit_ngfw_snmp_template_ipsec_monitoring_7_0.yaml
+++ b/Network_Devices/Blockbit/template_blockbit_ngfw_snmp/7.0/template_blockbit_ngfw_snmp_template_ipsec_monitoring_7_0.yaml
@@ -1,0 +1,86 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 3a5e882808c747829f5f7d3749c52d31
+      name: Templates/Blockbit
+  templates:
+    - uuid: ed64ca65d5f84881a4b32ea3ddc3dd39
+      template: 'Blockbit NGFW VPN IPSec by SNMP'
+      name: 'Blockbit NGFW VPN IPSec by SNMP'
+      description: |
+        Template VPN IPSec NGFW
+        
+        Created by Acelio Carvalho
+      groups:
+        - name: Templates/Blockbit
+      items:
+        - uuid: 2640d0f9f0bf45539163e4b3d28fbcfc
+          name: 'Blockbit NGFW: SNMP Walk VPN IPSec'
+          type: SNMP_AGENT
+          snmp_oid: 'walk[1.3.6.1.4.1.8072.1.3.2.4.1.2.9.73.80.83.69.67.78.65.77.69,1.3.6.1.4.1.8072.1.3.2.4.1.2.11.73.80.83.69.67.83.84.65.84.85.83,1.3.6.1.4.1.8072.1.3.2.4.1.2.7.73.80.83.69.67.83.65]'
+          key: blockbit.vpn.ipsec.raw
+          history: 90d
+          value_type: CHAR
+          valuemap:
+            name: 'NGFW Service Status'
+      discovery_rules:
+        - uuid: 64c4d65e211d4051a9f36b4ea04891fe
+          name: 'SNMP VPN IPSec Discovery'
+          type: DEPENDENT
+          key: blockbit.vpn.ipsec.discovery
+          lifetime: 30d
+          enabled_lifetime_type: DISABLE_NEVER
+          item_prototypes:
+            - uuid: 76329d1dda034b1385f7b89af086424f
+              name: 'Tunel VPN IPSec [{#TUNNAME}]: Child SAs'
+              type: DEPENDENT
+              key: 'blockbit.vpn.ipsec.sa.[{#SNMPINDEX}]'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.8072.1.3.2.4.1.2.7.73.80.83.69.67.83.65.{#SNMPINDEX}'
+                    - '0'
+              master_item:
+                key: blockbit.vpn.ipsec.raw
+              trigger_prototypes:
+                - uuid: cc27dc975280468e93a8697170fb9d03
+                  expression: 'max(/Blockbit NGFW VPN IPSec by SNMP/blockbit.vpn.ipsec.sa.[{#SNMPINDEX}],#3)>=100'
+                  name: 'Tunel VPN IPSec [{#TUNNAME}]: High number of child SAs'
+                  priority: HIGH
+            - uuid: fb14361a43aa4f3c9ff44143ee6f60ca
+              name: 'Tunel VPN IPSec [{#TUNNAME}]: Status'
+              type: DEPENDENT
+              key: 'blockbit.vpn.ipsec.[{#SNMPINDEX}]'
+              valuemap:
+                name: 'NGFW Service Status'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.8072.1.3.2.4.1.2.11.73.80.83.69.67.83.84.65.84.85.83.{#SNMPINDEX}'
+                    - '0'
+              master_item:
+                key: blockbit.vpn.ipsec.raw
+              trigger_prototypes:
+                - uuid: 7b79ec69b6b64501aba2237585eb4a2a
+                  expression: 'last(/Blockbit NGFW VPN IPSec by SNMP/blockbit.vpn.ipsec.[{#SNMPINDEX}])=0'
+                  name: 'Tunel VPN IPSec [{#TUNNAME}] is down'
+                  priority: WARNING
+                  manual_close: 'YES'
+          master_item:
+            key: blockbit.vpn.ipsec.raw
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#TUNNAME}'
+                - 1.3.6.1.4.1.8072.1.3.2.4.1.2.9.73.80.83.69.67.78.65.77.69
+                - '1'
+      valuemaps:
+        - uuid: e2c6f0a81bc545b2ac855321c02451bd
+          name: 'NGFW Service Status'
+          mappings:
+            - value: '1'
+              newvalue: up
+            - value: '0'
+              newvalue: down
+            - value: '2'
+              newvalue: disable


### PR DESCRIPTION
Added a new Zabbix template for monitoring Blockbit NGFW VPN IPSec via SNMP, including items, discovery rules, and valuemaps.