### PR TITLE
Add Zabbix template for Blockbit NGFW HA monitoring

### DIFF
--- a/Network_Devices/Blockbit/template_blockbit_ngfw_snmp/7.0/template_blockbit_ngfw_snmp_template_cluster_monitoring_7_0.yaml
+++ b/Network_Devices/Blockbit/template_blockbit_ngfw_snmp/7.0/template_blockbit_ngfw_snmp_template_cluster_monitoring_7_0.yaml
@@ -1,0 +1,189 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 3a5e882808c747829f5f7d3749c52d31
+      name: Templates/Blockbit
+  templates:
+    - uuid: a4d7f93ed62f429b88358439c8c742fe
+      template: 'Blockbit NGFW HA by SNMP'
+      name: 'Blockbit NGFW HA by SNMP'
+      description: |
+        The template for monitoring the HA Cluster Blockbit NGFW by SNMP.
+        
+        
+        MIB used:
+        
+        NET-SNMP-EXTEND-MIB
+        
+        
+        Created by Acélio Carvalho da Silva
+      groups:
+        - name: Templates/Blockbit
+      items:
+        - uuid: 45921ad6034646c58d87e83be6c6173b
+          name: 'Blockbit NGFW: HA Service Cluster-DB'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.8072.1.3.2.4.1.2.2.72.65.1
+          key: blockbit.cluster
+          history: 90d
+          description: |
+            Coleta de informações sobre a replicação do cluster.
+            
+            Valor 0: Erro na Replicação
+            Valor 1: OK (Replicação)
+            Valor 2: Serviço de Banco de Dados Inativo
+            Valor 3: Serviço de Cluster Inativo
+            Valor 4: Nó do Cluster inativo
+            Valor 5: Serviço de Cluster desabilitado
+          valuemap:
+            name: 'Status Cluster'
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: adfd0f38b5714036a7033b6507e01025
+              expression: 'max(/Blockbit NGFW HA by SNMP/blockbit.cluster,#3)=0'
+              name: 'Blockbit NGFW: Cluster-DB is not replicating'
+              priority: DISASTER
+              description: 'Verificar replicação do Banco de Dados'
+              manual_close: 'YES'
+            - uuid: c4a9f9b302274539bc2c0721a1d996b3
+              expression: 'max(/Blockbit NGFW HA by SNMP/blockbit.cluster,#3)=4'
+              name: 'Blockbit NGFW: Cluster Node is unavailable'
+              priority: AVERAGE
+              manual_close: 'YES'
+            - uuid: c60070786e0648909803f783579eb5a8
+              expression: 'max(/Blockbit NGFW HA by SNMP/blockbit.cluster,#3)=5'
+              name: 'Blockbit NGFW: Cluster Service is disabled'
+              priority: HIGH
+              manual_close: 'YES'
+            - uuid: ea32720056ac48c6be4c790fc4e7ad69
+              expression: 'max(/Blockbit NGFW HA by SNMP/blockbit.cluster,#3)=3'
+              name: 'Blockbit NGFW: Cluster Service is unavailable'
+              priority: WARNING
+              manual_close: 'YES'
+            - uuid: 823e9795480f48848da835984b8ce480
+              expression: 'max(/Blockbit NGFW HA by SNMP/blockbit.cluster,#3)=2'
+              name: 'Blockbit NGFW: Database is unavailable'
+              priority: HIGH
+              manual_close: 'YES'
+        - uuid: 47971a72e61041a999eeb04a6ce12188
+          name: 'Blockbit NGFW: ARPTABLES Service'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.8072.1.3.2.4.1.2.9.65.82.80.84.65.66.76.69.83.1
+          key: blockbit.cluster.arptables
+          history: 90d
+          valuemap:
+            name: 'Status Service'
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: b2c61571405a4d7fa01c891052048eaa
+              expression: 'max(/Blockbit NGFW HA by SNMP/blockbit.cluster.arptables,#3)=0'
+              name: 'Blockbit NGFW: ARPTABLES service is not running'
+              priority: HIGH
+              manual_close: 'YES'
+        - uuid: 5bdbe2a6bdf048d0a99064eee4c9ee85
+          name: 'Blockbit NGFW: CONNTRACKD Service'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.8072.1.3.2.4.1.2.10.67.79.78.78.84.82.65.67.75.68.1
+          key: blockbit.cluster.conntrackd
+          history: 90d
+          valuemap:
+            name: 'Status Service'
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: d25e49fecd734103b90f7ec3d5d43e0b
+              expression: 'max(/Blockbit NGFW HA by SNMP/blockbit.cluster.conntrackd,#3)=0'
+              name: 'Blockbit NGFW: CONNTRACKD service is not running'
+              priority: HIGH
+              manual_close: 'YES'
+        - uuid: bfdc57d97f0b4d2c99ca7d62809a63f5
+          name: 'Blockbit NGFW: FMONITOR Service'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.8072.1.3.2.4.1.2.8.70.77.79.78.73.84.79.82.1
+          key: blockbit.cluster.fmonitor
+          history: 90d
+          valuemap:
+            name: 'Status Service'
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: bec860fe41d149c5a57483f96893d086
+              expression: 'max(/Blockbit NGFW HA by SNMP/blockbit.cluster.fmonitor,#3)=0'
+              name: 'Blockbit NGFW: FMONITOR service is not running'
+              priority: HIGH
+              manual_close: 'YES'
+        - uuid: c17e73eb2d1f47b9aa839f0bdffb0512
+          name: 'Blockbit NGFW: HA Cluster Status'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.8072.1.3.2.4.1.2.8.72.65.83.84.65.84.85.83.1
+          key: blockbit.cluster.status
+          history: 90d
+          description: |
+            Coleta de informações sobre o status do cluster.
+            
+            Valor 0: Desabilitado
+            Valor 1: MASTER
+            Valor 2: BACKUP
+            Valor 3: Habilitado (Desconhecido)
+          valuemap:
+            name: 'State Cluster'
+          tags:
+            - tag: component
+              value: ha
+        - uuid: 52d64a14e4d44eca8433de4ff9c19d20
+          name: 'Blockbit NGFW: UCARP Service'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.8072.1.3.2.4.1.2.5.85.67.65.82.80.1
+          key: blockbit.cluster.ucarp
+          history: 90d
+          valuemap:
+            name: 'Status Service'
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: 21fcda074b7340348b9e0c6b6de4770a
+              expression: 'max(/Blockbit NGFW HA by SNMP/blockbit.cluster.ucarp,#3)=0'
+              name: 'Blockbit NGFW: UCARP service is not running'
+              priority: HIGH
+              manual_close: 'YES'
+      valuemaps:
+        - uuid: b9cb1af3043740baa3d0a52b89d5296d
+          name: 'State Cluster'
+          mappings:
+            - value: '0'
+              newvalue: DISABLED
+            - value: '1'
+              newvalue: MASTER
+            - value: '2'
+              newvalue: BACKUP
+            - value: '3'
+              newvalue: UNKNOWN
+        - uuid: bd04c8545c744412af8f789e5e0c2233
+          name: 'Status Cluster'
+          mappings:
+            - value: '0'
+              newvalue: 'Error (Replication)'
+            - value: '1'
+              newvalue: 'OK (Replication)'
+            - value: '2'
+              newvalue: 'Service Database Down'
+            - value: '3'
+              newvalue: 'Service Cluster Down'
+            - value: '4'
+              newvalue: 'Error (Node Cluster)'
+            - value: '5'
+              newvalue: 'Service Cluster Disabled'
+        - uuid: 38bf3eb4110442ee873419ce2e5546d8
+          name: 'Status Service'
+          mappings:
+            - value: '1'
+              newvalue: Up
+            - value: '0'
+              newvalue: Down


### PR DESCRIPTION
This YAML file defines a Zabbix template for monitoring the HA Cluster of Blockbit NGFW via SNMP, including various services and their statuses.