### PR TITLE
Improve LLD discovery and fix value mapping range issue

### DIFF
--- a/Virtualization/Hyper-V/template_hyper-v_replication_by_zabbix_agent/7.4/template_hyper-v_replication_by_zabbix_agent.yaml
+++ b/Virtualization/Hyper-V/template_hyper-v_replication_by_zabbix_agent/7.4/template_hyper-v_replication_by_zabbix_agent.yaml
@@ -230,8 +230,8 @@ zabbix_export:
           value: '^.*$'
           description: 'Defaults to all. Reference: Numerical value for Replication Health on "Value mapping" tab. Use ^(?:item1|item2|item3) format for multiple values.'
         - macro: '{$VM.REPLICATION.NOT_MATCHES}'
-          value: '^(?:0)'
-          description: 'Defaults to "0" (Disabled). Reference: Numerical value for Replication Health on "Value mapping" tab. Use ^(?:item1|item2|item3) format for multiple values.'
+          value: CHANGE_THIS
+          description: 'Use "^(?:0)" (Disabled) if you want to exclude disabled VMs. Reference: Numerical value for Replication Health on "Value mapping" tab. Use ^(?:item1|item2|item3) format for multiple values.'
         - macro: '{$VM.STATE.MATCHES}'
           value: '^.*$'
           description: 'Defaults to all. Reference: Numerical value for VM State on "Value mapping" tab. Use ^(?:item1|item2|item3) format for multiple values.'
@@ -247,11 +247,13 @@ zabbix_export:
           mappings:
             - value: '0'
               newvalue: Disabled
-            - value: 1-2
+            - type: IN_RANGE
+              value: 1-2
               newvalue: 'Pending Initial'
             - value: '3'
               newvalue: Replicating
-            - value: 4-5
+            - type: IN_RANGE
+              value: 4-5
               newvalue: 'Failover Pending'
             - value: '6'
               newvalue: 'Failover Complete'


### PR DESCRIPTION
Low Level Discovery

LLD now also discovers VMs with disabled replication.
This avoids redundant triggers and ensures consistent VM coverage.

Value Mapping

Fixed an issue where values within a certain range were not mapped
because no range was defined in the value mapping configuration.
