### PR TITLE
feat(hyper-v): improve replication alerting and reduce unchanged item…

### DIFF
--- a/Virtualization/Hyper-V/template_hyper-v_replication_by_zabbix_agent/7.4/template_hyper-v_replication_by_zabbix_agent.yaml
+++ b/Virtualization/Hyper-V/template_hyper-v_replication_by_zabbix_agent/7.4/template_hyper-v_replication_by_zabbix_agent.yaml
@@ -46,6 +46,10 @@ zabbix_export:
             To troubleshoot at this level, change "History" to "Store up to" and you'll be able to see the output in Latest Values next time it's run.
             
             {$WQL_QUERY} Template Macro holds the WMI Query if you want to adjust it.
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
           tags:
             - tag: component
               value: raw
@@ -116,6 +120,9 @@ zabbix_export:
                 - type: RTRIM
                   parameters:
                     - ']'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: 'wmi.getall["root\virtualization\v2","{$WQL_QUERY}"]'
               tags:
@@ -131,12 +138,77 @@ zabbix_export:
                   name: 'VM [{#VM.NAME}]: Replication status is Critical'
                   priority: HIGH
                   dependencies:
+                    - name: 'VM [{#VM.NAME}]: Replication status is Critical for 7 days'
+                      expression: |
+                        min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],7d)<>0
+                        and
+                        min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],7d)<>3
+                        and
+                        min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],7d)<>7
                     - name: 'VM [{#VM.NAME}]: Replication status is Disabled'
                       expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0'
                       recovery_expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3'
                     - name: 'VM [{#VM.NAME}]: Replication status is Paused'
                       expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=7'
                       recovery_expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3 or last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0'
+                  tags:
+                    - tag: component
+                      value: health
+                    - tag: component
+                      value: replication
+                - uuid: 7c448eec459349dcb8d45118050a61b9
+                  expression: |
+                    min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],7d)<>0
+                    and
+                    min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],7d)<>3
+                    and
+                    min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],7d)<>7
+                  name: 'VM [{#VM.NAME}]: Replication status is Critical for 7 days'
+                  priority: HIGH
+                  dependencies:
+                    - name: 'VM [{#VM.NAME}]: Replication status is Critical for 14 days'
+                      expression: |
+                        min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],14d)<>0
+                        and
+                        min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],14d)<>3
+                        and
+                        min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],14d)<>7
+                  tags:
+                    - tag: component
+                      value: health
+                    - tag: component
+                      value: replication
+                - uuid: 8fed3e047a564aebbf8186d591039532
+                  expression: |
+                    min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],14d)<>0
+                    and
+                    min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],14d)<>3
+                    and
+                    min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],14d)<>7
+                  name: 'VM [{#VM.NAME}]: Replication status is Critical for 14 days'
+                  priority: HIGH
+                  dependencies:
+                    - name: 'VM [{#VM.NAME}]: Replication status is Critical for 30 days'
+                      expression: |
+                        min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],30d)<>0
+                        and
+                        min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],30d)<>3
+                        and
+                        min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],30d)<>7
+                  tags:
+                    - tag: component
+                      value: health
+                    - tag: component
+                      value: replication
+                - uuid: cbf20b00ff5f4b138a6e83cfdc35abf4
+                  expression: |
+                    min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],30d)<>0
+                    and
+                    min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],30d)<>3
+                    and
+                    min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],30d)<>7
+                  name: 'VM [{#VM.NAME}]: Replication status is Critical for 30 days'
+                  priority: HIGH
                   tags:
                     - tag: component
                       value: health
@@ -179,6 +251,9 @@ zabbix_export:
                 - type: RTRIM
                   parameters:
                     - ']'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: 'wmi.getall["root\virtualization\v2","{$WQL_QUERY}"]'
               tags:

--- a/Virtualization/Hyper-V/template_hyper-v_replication_by_zabbix_agent/7.4/template_hyper-v_replication_by_zabbix_agent.yaml
+++ b/Virtualization/Hyper-V/template_hyper-v_replication_by_zabbix_agent/7.4/template_hyper-v_replication_by_zabbix_agent.yaml
@@ -120,9 +120,6 @@ zabbix_export:
                 - type: RTRIM
                   parameters:
                     - ']'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
               master_item:
                 key: 'wmi.getall["root\virtualization\v2","{$WQL_QUERY}"]'
               tags:
@@ -145,6 +142,12 @@ zabbix_export:
                         min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],7d)<>3
                         and
                         min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],7d)<>7
+                      recovery_expression: |
+                        last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0
+                        or
+                        last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3
+                        or
+                        last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=7
                     - name: 'VM [{#VM.NAME}]: Replication status is Disabled'
                       expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0'
                       recovery_expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3'
@@ -163,6 +166,13 @@ zabbix_export:
                     min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],7d)<>3
                     and
                     min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],7d)<>7
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: |
+                    last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0
+                    or
+                    last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3
+                    or
+                    last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=7
                   name: 'VM [{#VM.NAME}]: Replication status is Critical for 7 days'
                   priority: HIGH
                   dependencies:
@@ -173,6 +183,18 @@ zabbix_export:
                         min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],14d)<>3
                         and
                         min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],14d)<>7
+                      recovery_expression: |
+                        last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0
+                        or
+                        last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3
+                        or
+                        last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=7
+                    - name: 'VM [{#VM.NAME}]: Replication status is Disabled'
+                      expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0'
+                      recovery_expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3'
+                    - name: 'VM [{#VM.NAME}]: Replication status is Paused'
+                      expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=7'
+                      recovery_expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3 or last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0'
                   tags:
                     - tag: component
                       value: health
@@ -185,6 +207,13 @@ zabbix_export:
                     min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],14d)<>3
                     and
                     min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],14d)<>7
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: |
+                    last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0
+                    or
+                    last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3
+                    or
+                    last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=7
                   name: 'VM [{#VM.NAME}]: Replication status is Critical for 14 days'
                   priority: HIGH
                   dependencies:
@@ -195,6 +224,18 @@ zabbix_export:
                         min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],30d)<>3
                         and
                         min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],30d)<>7
+                      recovery_expression: |
+                        last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0
+                        or
+                        last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3
+                        or
+                        last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=7
+                    - name: 'VM [{#VM.NAME}]: Replication status is Disabled'
+                      expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0'
+                      recovery_expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3'
+                    - name: 'VM [{#VM.NAME}]: Replication status is Paused'
+                      expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=7'
+                      recovery_expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3 or last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0'
                   tags:
                     - tag: component
                       value: health
@@ -207,8 +248,22 @@ zabbix_export:
                     min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],30d)<>3
                     and
                     min(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}],30d)<>7
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: |
+                    last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0
+                    or
+                    last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3
+                    or
+                    last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=7
                   name: 'VM [{#VM.NAME}]: Replication status is Critical for 30 days'
                   priority: HIGH
+                  dependencies:
+                    - name: 'VM [{#VM.NAME}]: Replication status is Disabled'
+                      expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0'
+                      recovery_expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3'
+                    - name: 'VM [{#VM.NAME}]: Replication status is Paused'
+                      expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=7'
+                      recovery_expression: 'last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=3 or last(/Hyper-V Replication by Zabbix Agent/hv.vm.replication.[{#VM.ID}])=0'
                   tags:
                     - tag: component
                       value: health
@@ -240,7 +295,7 @@ zabbix_export:
               name: 'State: {#VM.NAME}'
               type: DEPENDENT
               key: 'hv.vm.state.[{#VM.ID}]'
-              value_type: TEXT
+              trends: '0'
               preprocessing:
                 - type: JSONPATH
                   parameters:


### PR DESCRIPTION
… noise

- add DISCARD_UNCHANGED_HEARTBEAT (1h) preprocessing to replication data items
- add escalation triggers for replication-critical states persisting 7d/14d/30d
- use trigger dependencies to avoid duplicate critical alerts