### PR TITLE
New main category Power_Inverters, new template APsystems EZ1-M1

### DIFF
--- a/Power_Inverter/APsystems/template_ez1-m1/7.0/README.md
+++ b/Power_Inverter/APsystems/template_ez1-m1/7.0/README.md
@@ -1,0 +1,29 @@
+# Template for APsystems EZ1-M1 inverters
+
+The data from APsystems EZ1-M1 inverters is not only accessible by bluetooth but also via an API.
+
+
+## Includes queries
+
+With this template you can query:
+- Energy generation stats
+- Alarm status
+- Generic device infos
+
+
+## Triggers
+
+To get notified there are triggers configured for
+- DC short circuit
+- AC offgrid / output fault
+
+
+## Configuration needed for API access
+
+1. Connect to the inverter with the "AP EasyPower" app via bluetooth
+2. Open settings (gear symbol at top right)
+3. Select "Local Mode"
+4. Enable the "Enable Local Mode" setting
+
+To test if this worked you can open the following URL with your browser (replace the IP with your inverters IP address):
+http://INVERTER_IP:8050/getDeviceInfo

--- a/Power_Inverter/APsystems/template_ez1-m1/7.0/template_ez1-m1.yaml
+++ b/Power_Inverter/APsystems/template_ez1-m1/7.0/template_ez1-m1.yaml
@@ -1,0 +1,293 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 7df96b18c230490a9a0a9e2307226338
+      name: Templates
+  templates:
+    - uuid: 78905e4166d845e4a9ac3a69904b3fb6
+      template: 'APsystems EZ1-M1'
+      name: 'APsystems EZ1-M1'
+      description: 'APsystems EZ1-M1 API'
+      groups:
+        - name: Templates
+      items:
+        - uuid: 8344ee4af87743f5b5c1c3129229d3d1
+          name: 'Alarm status DC1 short circuit'
+          type: DEPENDENT
+          key: apsystems.alarm_information.isce1
+          delay: '0'
+          trends: '0'
+          description: isce1(string)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.isce1
+          master_item:
+            key: apsystems_ez1.alarm_information
+          triggers:
+            - uuid: f7ecd1b4c61f4ecd8dc0074bfe29dab9
+              expression: 'last(/APsystems EZ1-M1/apsystems.alarm_information.isce1)=1'
+              name: 'Inverter {HOST.NAME} has a short circuit on DC1'
+              priority: HIGH
+        - uuid: d330d352418944fcb19510e3ba9fc581
+          name: 'Alarm status DC2 short circuit'
+          type: DEPENDENT
+          key: apsystems.alarm_information.isce2
+          delay: '0'
+          trends: '0'
+          description: isce2(string)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.isce2
+          master_item:
+            key: apsystems_ez1.alarm_information
+          triggers:
+            - uuid: 071e236dc2b84fdea757b62e753dac31
+              expression: 'last(/APsystems EZ1-M1/apsystems.alarm_information.isce2)=1'
+              name: 'Inverter {HOST.NAME} has a short circuit on DC2'
+              priority: HIGH
+        - uuid: ec5afbe29a394d6bb6b87a906a7cd455
+          name: 'Alarm status output fault'
+          type: DEPENDENT
+          key: apsystems.alarm_information.oe
+          delay: '0'
+          trends: '0'
+          description: oe(string)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.oe
+          master_item:
+            key: apsystems_ez1.alarm_information
+          triggers:
+            - uuid: f603743a37374bdf807bcb43f48b22be
+              expression: 'last(/APsystems EZ1-M1/apsystems.alarm_information.oe)=1'
+              name: 'Inverter {HOST.NAME} has an output fault'
+              priority: HIGH
+        - uuid: c2189c43823b4535a8bf05f6efdd9fa2
+          name: 'Alarm status off grid'
+          type: DEPENDENT
+          key: apsystems.alarm_information.og
+          delay: '0'
+          trends: '0'
+          description: og(string)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.og
+          master_item:
+            key: apsystems_ez1.alarm_information
+          triggers:
+            - uuid: 37780f414b2947079c846ce100db14c4
+              expression: 'last(/APsystems EZ1-M1/apsystems.alarm_information.og)=1'
+              name: 'Inverter {HOST.NAME} is off grid'
+              priority: HIGH
+        - uuid: 65205b625f464f48824ffb6f5cbfa8c6
+          name: 'Device ID'
+          type: DEPENDENT
+          key: apsystems.device_information.deviceId
+          delay: '0'
+          value_type: TEXT
+          trends: '0'
+          description: deviceId(string)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.deviceId
+          master_item:
+            key: apsystems_ez1.device_information
+        - uuid: 1c34933c73484d90a3df43d3943082c9
+          name: 'Device Version'
+          type: DEPENDENT
+          key: apsystems.device_information.deviceVer
+          delay: '0'
+          value_type: TEXT
+          trends: '0'
+          description: devVer(string)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.devVer
+          master_item:
+            key: apsystems_ez1.device_information
+        - uuid: 66d0a3bfa76242ef8bcffdb38e315e98
+          name: 'IP address'
+          type: DEPENDENT
+          key: apsystems.device_information.ipAddr
+          delay: '0'
+          value_type: TEXT
+          trends: '0'
+          description: ipAddr(string)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.ipAddr
+          master_item:
+            key: apsystems_ez1.device_information
+        - uuid: bef049cdceef47359fab9fa3c7ba1679
+          name: 'Maximum Power'
+          type: DEPENDENT
+          key: apsystems.device_information.maxPower
+          delay: '0'
+          value_type: TEXT
+          trends: '0'
+          description: maxPower(String)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.maxPower
+          master_item:
+            key: apsystems_ez1.device_information
+        - uuid: d6684cc428194bb5aec87f2e3579d5be
+          name: 'Minimum Power'
+          type: DEPENDENT
+          key: apsystems.device_information.minPower
+          delay: '0'
+          value_type: TEXT
+          trends: '0'
+          description: minPower(string)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.minPower
+          master_item:
+            key: apsystems_ez1.device_information
+        - uuid: 7fc1789f3ccf466c87738bac8aaa92ab
+          name: SSID
+          type: DEPENDENT
+          key: apsystems.device_information.ssid
+          delay: '0'
+          value_type: TEXT
+          trends: '0'
+          description: ssid(string)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.ssid
+          master_item:
+            key: apsystems_ez1.device_information
+        - uuid: 3c1ee977c75247f78be7686c9e84b75e
+          name: 'Energy generation since startup - Channel 1'
+          type: DEPENDENT
+          key: apsystems.outputdata.e1
+          delay: '0'
+          value_type: FLOAT
+          units: kWh
+          description: |
+            Energy generation after startup
+            Channel 1
+            e1(float)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.e1
+          master_item:
+            key: apsystems_ez1.getOutputData
+        - uuid: 09eea2e021124e8b99ae36cd783c1d8d
+          name: 'Energy generation since startup - Channel 2'
+          type: DEPENDENT
+          key: apsystems.outputdata.e2
+          delay: '0'
+          value_type: FLOAT
+          units: kWh
+          description: |
+            Energy generation after startup
+            Channel 2
+            e1(float)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.e2
+          master_item:
+            key: apsystems_ez1.getOutputData
+        - uuid: b51567e06ec541aaa2d60a7cfbb8c68a
+          name: 'Power - Channel 1'
+          type: DEPENDENT
+          key: apsystems.outputdata.p1
+          delay: '0'
+          value_type: FLOAT
+          units: W
+          description: |
+            Power-Channel 1
+            p1(float)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.p1
+          master_item:
+            key: apsystems_ez1.getOutputData
+        - uuid: 7209b5404cd1410a881e9eaaac0f6bb4
+          name: 'Power - Channel 2'
+          type: DEPENDENT
+          key: apsystems.outputdata.p2
+          delay: '0'
+          value_type: FLOAT
+          units: W
+          description: |
+            Power-Channel 2
+            p2(float)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.p2
+          master_item:
+            key: apsystems_ez1.getOutputData
+        - uuid: 6d63df4615914f20ba287e4c87bc0cad
+          name: 'Energy generation lifetime - Channel 1'
+          type: DEPENDENT
+          key: apsystems.outputdata.te1
+          delay: '0'
+          value_type: FLOAT
+          units: kWh
+          description: |
+            Energy generation after startup
+            Channel 1
+            te1(float)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.te1
+          master_item:
+            key: apsystems_ez1.getOutputData
+        - uuid: 66336a2e589e4ff0ab27971cbafeb328
+          name: 'Energy generation lifetime - Channel 2'
+          type: DEPENDENT
+          key: apsystems.outputdata.te2
+          delay: '0'
+          value_type: FLOAT
+          units: kWh
+          description: |
+            Energy generation after startup
+            Channel 2
+            te2(float)
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.te2
+          master_item:
+            key: apsystems_ez1.getOutputData
+        - uuid: 73542b0011ca4a59a20abfd89bd3342d
+          name: 'Get EZ1 alarm information'
+          type: HTTP_AGENT
+          key: apsystems_ez1.alarm_information
+          value_type: TEXT
+          trends: '0'
+          description: 'APsystems EZ1 alarm information'
+          url: 'http://{HOST.IP}:8050/getAlarm'
+        - uuid: 647553b88ac844359cc1d3da409fb514
+          name: 'Get EZ1 device information'
+          type: HTTP_AGENT
+          key: apsystems_ez1.device_information
+          value_type: TEXT
+          trends: '0'
+          description: 'APsystems EZ1 device information'
+          url: 'http://{HOST.IP}:8050/getDeviceInfo'
+        - uuid: 3a50deae968342ef83b929bcb986d251
+          name: 'Get EZ1 output data'
+          type: HTTP_AGENT
+          key: apsystems_ez1.getOutputData
+          value_type: TEXT
+          trends: '0'
+          description: 'APsystems EZ1 current output data'
+          url: 'http://{HOST.IP}:8050/getOutputData'


### PR DESCRIPTION
"Power_(UPS)" doesn't fit for inverters, since they (usually) are not an UPS, so I've added a new main category "Power_Inverters".

A template for the inverter APsystems EZ1-M1 was added.