### PR TITLE
Add IBM Power HMC monitoring template

### DIFF
--- a/Server_Hardware/IBM/template_ibm-power-hmc-zabbix-rest/6.0/README.md
+++ b/Server_Hardware/IBM/template_ibm-power-hmc-zabbix-rest/6.0/README.md
@@ -1,0 +1,78 @@
+# IBM Power HMC – Zabbix REST Monitoring
+This repository provides a **working** Zabbix integration for
+**IBM Power Hardware Management Console (HMC)** using the **REST UOM API**.
+
+###Author
+
+Rosen Georgiev (rosen.georgiev1@ibm.com)
+https://github.com/rgeorgie
+
+### Disclaimer
+
+This project is an independent open source work.
+It is not an official IBM product and is not supported by IBM.
+
+It was built and validated against:
+
+- **HMC V10R3**
+- **Zabbix 6.2**
+- Session‑based REST authentication
+- Atom XML responses (HMC REST quirk safe)
+
+> This is **not** a demo or example.
+> Every script and template here has been tested against a real HMC.
+
+---
+
+## ✅ What this monitors
+
+### Managed Systems
+- Automatic discovery
+- State monitoring (`Operating`, `Standby`, etc.)
+
+### LPARs
+- Automatic discovery
+- State monitoring (`Running`, `Not Activated`, etc.)
+
+### HMC REST availability
+- Simple health check using authenticated REST login
+
+---
+
+## ❌ What this does NOT do (by design)
+
+- No SSH
+- No PCM / performance metrics
+- No VIOS metrics
+- No Quick APIs
+- No UUID dependency
+
+Those can be added later, **after** a stable base.
+
+---
+
+## 📁 Files
+
+### `files/hmc_api_zb.sh`
+Zabbix external script that:
+- Logs in via `/rest/api/web/Logon`
+- Uses `X‑Audit‑Memento` (required on HMC V10R3)
+- Fetches UOM data via Atom XML
+- Outputs Zabbix‑compatible discovery JSON
+
+### `template_ibm_power_hmc_rest_external_6.2.yaml`
+Zabbix **6.2‑compliant** template:
+- All required UUIDs
+- Valid YAML
+- Valid trigger expressions
+- Matches the script **exactly**
+
+---
+
+## 🚀 Installation
+
+### 1️⃣ Install the external script
+
+```bash
+install -m 755 files/hmc_api_zbx.sh /usr/lib/zabbix/externalscripts/hmc_api_zbx.sh
+chown zabbix:zabbix /usr/lib/zabbix/externalscripts/hmc_api_zbx.sh

--- a/Server_Hardware/IBM/template_ibm-power-hmc-zabbix-rest/6.0/files/hmc_api_zbx.sh
+++ b/Server_Hardware/IBM/template_ibm-power-hmc-zabbix-rest/6.0/files/hmc_api_zbx.sh
@@ -1,0 +1,521 @@
+[root@zabbix-rh ~]# cat /usr/lib/zabbix/externalscripts/hmc_api_zbx.sh 
+#!/usr/bin/env bash
+set -euo pipefail
+
+HMC_HOST="${1:-}"
+HMC_USER="${2:-}"
+HMC_PASS="${3:-}"
+MODE="${4:-}"
+ARG1="${5:-}"
+
+[[ -n "$HMC_HOST" && -n "$HMC_USER" && -n "$HMC_PASS" && -n "$MODE" ]] || { echo "[]"; exit 0; }
+
+BASE="https://${HMC_HOST}:12443"
+WEB="${BASE}/rest/api/web"
+UOM="${BASE}/rest/api/uom"
+PCM="${BASE}/rest/api/pcm"
+
+# ---- temp file management (no leaks) ----
+TMPFILES=()
+mktempf() { local f; f="$(mktemp "$1")"; TMPFILES+=("$f"); printf "%s" "$f"; }
+cleanup() { rm -f "${TMPFILES[@]}" 2>/dev/null || true; }
+trap cleanup EXIT
+
+COOKIE="$(mktempf /tmp/hmc_cookie.XXXXXX)"
+LOGIN_XML="$(mktempf /tmp/hmc_login.XXXXXX)"
+HDR="$(mktempf /tmp/hmc_hdr.XXXXXX)"
+BODY="$(mktempf /tmp/hmc_body.XXXXXX)"
+
+# Bounded runtime for Zabbix external checks
+CURL=(-sS -k --connect-timeout 5 --max-time 20)
+
+# ---- Build real XML (NOT HTML escaped) ----
+python3 - "$HMC_USER" "$HMC_PASS" >"$LOGIN_XML" <<'PY'
+import sys
+from xml.sax.saxutils import escape
+u = escape(sys.argv[1])
+p = escape(sys.argv[2])
+print(f'''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<LogonRequest xmlns="http://www.ibm.com/xmlns/systems/power/firmware/web/mc/2012_10/" schemaVersion="V1_0">
+  <UserID>{u}</UserID>
+  <Password>{p}</Password>
+</LogonRequest>''')
+PY
+
+logon() {
+  local code
+  code="$(
+    curl "${CURL[@]}" -c "$COOKIE" -o /dev/null -w "%{http_code}" \
+      -X PUT \
+      -H "Content-Type: application/vnd.ibm.powervm.web+xml; type=LogonRequest" \
+      -H "Accept: */*" \
+      -H "X-Audit-Memento: zabbix" \
+      -d @"$LOGIN_XML" \
+      "${WEB}/Logon"
+  )" || code="000"
+  [[ "$code" == "200" ]] || return 1
+  grep -qE 'JSESSIONID|CCFWSESSION' "$COOKIE" || return 1
+  return 0
+}
+
+logoff() {
+  curl "${CURL[@]}" -b "$COOKIE" -X DELETE "${WEB}/Logon" >/dev/null 2>&1 || true
+}
+
+http_code() {
+  awk 'BEGIN{c=""} /^HTTP\//{c=$2} END{print c}' "$HDR"
+}
+
+# ---- UOM fetch (Atom) ----
+fetch_uom() {
+  local url="$1"
+  : >"$HDR"; : >"$BODY"
+
+  curl "${CURL[@]}" -b "$COOKIE" -D "$HDR" -o "$BODY" \
+    -H "Accept: application/atom+xml; charset=UTF-8" \
+    -H "X-Audit-Memento: zabbix" \
+    "$url" || true
+
+  # Retry without charset if 500
+  if awk 'BEGIN{c=""} /^HTTP\//{c=$2} END{exit !(c=="500")}' "$HDR"; then
+    : >"$HDR"; : >"$BODY"
+    curl "${CURL[@]}" -b "$COOKIE" -D "$HDR" -o "$BODY" \
+      -H "Accept: application/atom+xml" \
+      -H "X-Audit-Memento: zabbix" \
+      "$url" || true
+  fi
+}
+
+# ---- Normalize state strings for stable triggers ----
+# operating -> Operating, running -> Running, unknown unchanged
+norm_state_py='
+def norm(s):
+    s=(s or "").strip()
+    if not s: return ""
+    if s.lower()=="unknown": return "unknown"
+    return s[:1].upper() + s[1:].lower()
+'
+
+# ---- Parse UOM atom feed ----
+parse_uom() {
+  local kind="$1" needle="$2"
+  python3 - "$kind" "$needle" "$BODY" <<PY
+import sys, json, xml.etree.ElementTree as ET
+$norm_state_py
+
+kind = sys.argv[1]
+needle = sys.argv[2]
+path = sys.argv[3]
+
+xml = open(path, encoding="utf-8", errors="ignore").read().strip()
+if not xml:
+    print("[]" if kind.startswith("discover") else "unknown")
+    sys.exit(0)
+
+ATOM="http://www.w3.org/2005/Atom"
+def a(t): return "{%s}%s"%(ATOM,t)
+def ln(t): return t.split("}",1)[-1] if "}" in t else t
+
+try:
+    root = ET.fromstring(xml)
+except Exception:
+    print("[]" if kind.startswith("discover") else "unknown")
+    sys.exit(0)
+
+entries=[]
+if ln(root.tag)=="feed":
+    entries=root.findall(a("entry"))
+elif ln(root.tag)=="entry":
+    entries=[root]
+
+def payload(ent):
+    c=ent.find(a("content"))
+    if c is None: return None
+    kids=list(c)
+    return kids[0] if kids else None
+
+def text(obj, want):
+    for e in obj.iter():
+        if ln(e.tag)==want and e.text and e.text.strip():
+            return e.text.strip()
+    return ""
+
+if kind=="discover.systems":
+    out=[]
+    for ent in entries:
+        obj=payload(ent)
+        if obj is None: continue
+        name=text(obj,"SystemName")
+        state=norm(text(obj,"State"))
+        if name:
+            out.append({"{#MS_NAME}":name,"{#MS_STATE}":state})
+    print(json.dumps(out, ensure_ascii=False))
+    sys.exit(0)
+
+if kind=="system.state":
+    for ent in entries:
+        obj=payload(ent)
+        if obj is None: continue
+        name=text(obj,"SystemName")
+        if name!=needle: continue
+        st=norm(text(obj,"State"))
+        print(st if st else "unknown")
+        sys.exit(0)
+    print("unknown"); sys.exit(0)
+
+if kind=="discover.lpars":
+    out=[]
+    for ent in entries:
+        obj=payload(ent)
+        if obj is None: continue
+        name=text(obj,"PartitionName")
+        state=norm(text(obj,"PartitionState"))
+        ms=text(obj,"AssociatedManagedSystem")
+        if name:
+            d={"{#LPAR_NAME}":name,"{#LPAR_STATE}":state}
+            if ms: d["{#MS_NAME}"]=ms
+            out.append(d)
+    print(json.dumps(out, ensure_ascii=False))
+    sys.exit(0)
+
+if kind=="lpar.state":
+    for ent in entries:
+        obj=payload(ent)
+        if obj is None: continue
+        name=text(obj,"PartitionName")
+        if name!=needle: continue
+        st=norm(text(obj,"PartitionState"))
+        print(st if st else "unknown")
+        sys.exit(0)
+    print("unknown"); sys.exit(0)
+
+print("unknown")
+PY
+}
+
+# ---- ManagedSystem UUID by SystemName ----
+ms_uuid_by_name() {
+  local ms_name="$1"
+  fetch_uom "${UOM}/ManagedSystem"
+  [[ "$(http_code)" == "200" ]] || { echo ""; return; }
+
+  python3 - "$ms_name" "$BODY" <<'PY'
+import sys, xml.etree.ElementTree as ET
+ms_name=sys.argv[1]
+path=sys.argv[2]
+
+ATOM="http://www.w3.org/2005/Atom"
+def a(t): return "{%s}%s"%(ATOM,t)
+def ln(t): return t.split("}",1)[-1] if "}" in t else t
+
+xml=open(path, encoding="utf-8", errors="ignore").read().strip()
+if not xml: sys.exit(0)
+root=ET.fromstring(xml)
+entries=root.findall(a("entry"))
+
+def payload(ent):
+    c=ent.find(a("content"))
+    if c is None: return None
+    kids=list(c)
+    return kids[0] if kids else None
+
+def text(obj, want):
+    for e in obj.iter():
+        if ln(e.tag)==want and e.text and e.text.strip():
+            return e.text.strip()
+    return ""
+
+for ent in entries:
+    obj=payload(ent)
+    if obj is None: continue
+    name=text(obj,"SystemName")
+    if name!=ms_name: continue
+    mid=ent.find(a("id"))
+    if mid is not None and mid.text:
+        print(mid.text.strip())
+        break
+PY
+}
+
+# ---- PCM: fetch newest EnergyMonitor JSON ----
+pcm_latest_energy_json() {
+  local ms_uuid="$1"
+  local feed jsonfile
+  feed="$(mktempf /tmp/pcm_energy_feed.XXXXXX)"
+  jsonfile="$(mktempf /tmp/pcm_energy_json.XXXXXX)"
+
+  # Atom-first (your HMC returns Atom feed)
+  curl "${CURL[@]}" -b "$COOKIE" \
+    -H "Accept: application/atom+xml; charset=UTF-8" \
+    -H "X-Audit-Memento: zabbix" \
+    "${PCM}/ManagedSystem/${ms_uuid}/RawMetrics/EnergyMonitor" >"$feed" || true
+
+  # Fallback if empty
+  if [[ ! -s "$feed" ]]; then
+    curl "${CURL[@]}" -b "$COOKIE" \
+      -H "Accept: application/xml" \
+      -H "X-Audit-Memento: zabbix" \
+      "${PCM}/ManagedSystem/${ms_uuid}/RawMetrics/EnergyMonitor" >"$feed" || true
+  fi
+
+  [[ -s "$feed" ]] || { echo ""; return; }
+
+  # Pick newest <entry> by <updated>, extract its JSON href
+  local href
+  href="$(python3 - "$feed" <<'PY'
+import sys, xml.etree.ElementTree as ET
+ATOM="http://www.w3.org/2005/Atom"
+def a(t): return "{%s}%s"%(ATOM,t)
+def ln(t): return t.split("}",1)[-1] if "}" in t else t
+
+xml=open(sys.argv[1], encoding="utf-8", errors="ignore").read().strip()
+if not xml: sys.exit(0)
+root=ET.fromstring(xml)
+entries = root.findall(a("entry")) if ln(root.tag)=="feed" else []
+
+best_ts=""
+best_href=""
+for ent in entries:
+    upd=ent.find(a("updated"))
+    ts=(upd.text or "").strip() if upd is not None else ""
+    href=""
+    for link in ent.findall(a("link")):
+        t=link.get("type","")
+        h=link.get("href","")
+        if "application/vnd.ibm.powervm.pcm.json" in t and h.endswith(".json"):
+            href=h; break
+    if href and ts >= best_ts:
+        best_ts=ts; best_href=href
+
+if best_href:
+    print(best_href)
+PY
+)"
+  [[ -z "$href" ]] && { echo ""; return; }
+
+  href="${href/:443/:12443}"
+
+  # Download JSON (quoted URL handles '*')
+  curl "${CURL[@]}" -b "$COOKIE" \
+    -H "Accept: application/json" \
+    -H "X-Audit-Memento: zabbix" \
+    "$href" >"$jsonfile" || { echo ""; return; }
+
+  echo "$jsonfile"
+}
+
+pcm_max_temp() {
+  local json="$1" kind="$2"
+  python3 - "$json" "$kind" <<'PY'
+import sys, json
+fn=sys.argv[1]; kind=sys.argv[2]
+try:
+    d=json.load(open(fn))
+except Exception:
+    print("0"); sys.exit(0)
+
+# Only accept good samples
+if d.get("status") != 0:
+    print("0"); sys.exit(0)
+
+therm = d.get("thermalEnergyReading", {}) or {}
+key = {"inlet":"inletTemperatures","cpu":"cpuTemperatures","baseboard":"baseboardTemperatures"}.get(kind,"")
+arr = therm.get(key, []) or []
+
+vals=[]
+for it in arr:
+    v=it.get("temperatureData", None)
+    if isinstance(v,(int,float)):
+        vals.append(float(v))
+print(str(max(vals)) if vals else "0")
+PY
+}
+
+pcm_watts() {
+  local json="$1"
+  python3 - "$json" <<'PY'
+import sys, json
+fn=sys.argv[1]
+try:
+    d=json.load(open(fn))
+except Exception:
+    print("0"); sys.exit(0)
+
+if d.get("status") != 0:
+    print("0"); sys.exit(0)
+
+p = d.get("powerEnergyReading", {}) or {}
+v = p.get("currentPowerReading", None)
+print(str(v) if isinstance(v,(int,float)) else "0")
+PY
+}
+
+# ---- VIOS discovery via VirtualIOServer child resource ----
+discover_vios() {
+  fetch_uom "${UOM}/ManagedSystem"
+  [[ "$(http_code)" == "200" ]] || { echo "[]"; return; }
+
+  python3 - "$BODY" "$COOKIE" "$BASE" <<'PY'
+import sys, json, subprocess, xml.etree.ElementTree as ET
+
+ms_xml_path=sys.argv[1]
+cookie_file=sys.argv[2]
+base_url=sys.argv[3].rstrip("/")
+
+ATOM="http://www.w3.org/2005/Atom"
+def a(t): return "{%s}%s"%(ATOM,t)
+def ln(t): return t.split("}",1)[-1] if "}" in t else t
+
+ms_xml=open(ms_xml_path, encoding="utf-8", errors="ignore").read().strip()
+if not ms_xml:
+    print("[]"); sys.exit(0)
+
+root=ET.fromstring(ms_xml)
+entries=root.findall(a("entry"))
+
+def payload(ent):
+    c=ent.find(a("content"))
+    if c is None: return None
+    kids=list(c)
+    return kids[0] if kids else None
+
+def text(obj, want):
+    for e in obj.iter():
+        if ln(e.tag)==want and e.text and e.text.strip():
+            return e.text.strip()
+    return ""
+
+ms_map={}
+for ent in entries:
+    mid=ent.find(a("id"))
+    obj=payload(ent)
+    if mid is None or obj is None:
+        continue
+    msid=(mid.text or "").strip()
+    msname=text(obj,"SystemName")
+    if msid and msname:
+        ms_map[msid]=msname
+
+out=[]
+for msid, msname in ms_map.items():
+    url=f"{base_url}/rest/api/uom/ManagedSystem/{msid}/VirtualIOServer"
+    cmd=["curl","-sS","-k","--connect-timeout","5","--max-time","20",
+         "-b",cookie_file,
+         "-H","Accept: application/atom+xml; charset=UTF-8",
+         "-H","X-Audit-Memento: zabbix",
+         url]
+    try:
+        vxml=subprocess.check_output(cmd).decode("utf-8","ignore").strip()
+    except Exception:
+        continue
+    if not vxml:
+        continue
+    try:
+        vr=ET.fromstring(vxml)
+    except Exception:
+        continue
+
+    vents=vr.findall(a("entry")) if ln(vr.tag)=="feed" else ([vr] if ln(vr.tag)=="entry" else [])
+    for ent in vents:
+        obj=payload(ent)
+        if obj is None:
+            continue
+        name=text(obj,"PartitionName")
+        state=text(obj,"PartitionState")
+        if name:
+            out.append({"{#VIOS_NAME}":name,"{#VIOS_STATE}":state,"{#MS_NAME}":msname})
+
+print(json.dumps(out, ensure_ascii=False))
+PY
+}
+
+# ---- main dispatcher ----
+case "$MODE" in
+  hmc.ping)
+    if logon; then logoff; echo 1; else echo 0; fi
+    ;;
+
+  discover.systems)
+    logon || { echo "[]"; exit 0; }
+    fetch_uom "${UOM}/ManagedSystem"
+    code="$(http_code)"
+    [[ "$code" == "302" || -z "$code" || "$code" == "500" ]] && { logoff; echo "[]"; exit 0; }
+    parse_uom discover.systems ""
+    logoff
+    ;;
+
+  discover.lpars)
+    logon || { echo "[]"; exit 0; }
+    fetch_uom "${UOM}/LogicalPartition"
+    code="$(http_code)"
+    [[ "$code" == "302" || -z "$code" || "$code" == "500" ]] && { logoff; echo "[]"; exit 0; }
+    parse_uom discover.lpars ""
+    logoff
+    ;;
+
+  system.state)
+    logon || { echo "unknown"; exit 0; }
+    fetch_uom "${UOM}/ManagedSystem"
+    code="$(http_code)"
+    [[ "$code" == "302" || -z "$code" || "$code" == "500" ]] && { logoff; echo "unknown"; exit 0; }
+    parse_uom system.state "$ARG1"
+    logoff
+    ;;
+
+  lpar.state)
+    logon || { echo "unknown"; exit 0; }
+    fetch_uom "${UOM}/LogicalPartition"
+    code="$(http_code)"
+    [[ "$code" == "302" || -z "$code" || "$code" == "500" ]] && { logoff; echo "unknown"; exit 0; }
+    parse_uom lpar.state "$ARG1"
+    logoff
+    ;;
+
+  discover.vios)
+    logon || { echo "[]"; exit 0; }
+    discover_vios
+    logoff
+    ;;
+
+  system.temp.inlet)
+    logon || { echo 0; exit 0; }
+    ms_uuid="$(ms_uuid_by_name "$ARG1")"
+    [[ -z "$ms_uuid" ]] && { logoff; echo 0; exit 0; }
+    jf="$(pcm_latest_energy_json "$ms_uuid")"
+    [[ -z "$jf" ]] && { logoff; echo 0; exit 0; }
+    pcm_max_temp "$jf" inlet
+    logoff
+    ;;
+
+  system.temp.cpu)
+    logon || { echo 0; exit 0; }
+    ms_uuid="$(ms_uuid_by_name "$ARG1")"
+    [[ -z "$ms_uuid" ]] && { logoff; echo 0; exit 0; }
+    jf="$(pcm_latest_energy_json "$ms_uuid")"
+    [[ -z "$jf" ]] && { logoff; echo 0; exit 0; }
+    pcm_max_temp "$jf" cpu
+    logoff
+    ;;
+
+  system.power.watts)
+    logon || { echo 0; exit 0; }
+    ms_uuid="$(ms_uuid_by_name "$ARG1")"
+    [[ -z "$ms_uuid" ]] && { logoff; echo 0; exit 0; }
+    jf="$(pcm_latest_energy_json "$ms_uuid")"
+    [[ -z "$jf" ]] && { logoff; echo 0; exit 0; }
+    pcm_watts "$jf"
+    logoff
+    ;;
+   system.temp.baseboard)
+    logon || { echo 0; exit 0; }
+    ms_uuid="$(ms_uuid_by_name "$ARG1")"
+    [[ -z "$ms_uuid" ]] && { logoff; echo 0; exit 0; }
+    jf="$(pcm_latest_energy_json "$ms_uuid")"
+    [[ -z "$jf" ]] && { logoff; echo 0; exit 0; }
+    pcm_max_temp "$jf" baseboard
+    logoff
+    ;;
+  *)
+    echo "[]"
+    ;;
+esac

--- a/Server_Hardware/IBM/template_ibm-power-hmc-zabbix-rest/6.0/files/hmc_api_zbx.sh
+++ b/Server_Hardware/IBM/template_ibm-power-hmc-zabbix-rest/6.0/files/hmc_api_zbx.sh
@@ -1,4 +1,3 @@
-[root@zabbix-rh ~]# cat /usr/lib/zabbix/externalscripts/hmc_api_zbx.sh 
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -15,16 +14,19 @@ WEB="${BASE}/rest/api/web"
 UOM="${BASE}/rest/api/uom"
 PCM="${BASE}/rest/api/pcm"
 
-# ---- temp file management (no leaks) ----
-TMPFILES=()
-mktempf() { local f; f="$(mktemp "$1")"; TMPFILES+=("$f"); printf "%s" "$f"; }
-cleanup() { rm -f "${TMPFILES[@]}" 2>/dev/null || true; }
-trap cleanup EXIT
+# ---- Zabbix-safe temp workspace (single directory, atomic cleanup) ----
+# Even if Zabbix kills the script, worst case is ONE directory per killed run,
+# not dozens of mktemp files. (SIGKILL can't be trapped.)
+umask 077
+TMPDIR="$(mktemp -d /tmp/hmc_zbx.XXXXXX)"
+trap 'rm -rf "$TMPDIR"' EXIT INT TERM
 
-COOKIE="$(mktempf /tmp/hmc_cookie.XXXXXX)"
-LOGIN_XML="$(mktempf /tmp/hmc_login.XXXXXX)"
-HDR="$(mktempf /tmp/hmc_hdr.XXXXXX)"
-BODY="$(mktempf /tmp/hmc_body.XXXXXX)"
+COOKIE="$TMPDIR/cookie.txt"
+LOGIN_XML="$TMPDIR/login.xml"
+HDR="$TMPDIR/headers.txt"
+BODY="$TMPDIR/body.xml"
+PCM_FEED="$TMPDIR/pcm_energy_feed.xml"
+PCM_JSON="$TMPDIR/pcm_energy.json"
 
 # Bounded runtime for Zabbix external checks
 CURL=(-sS -k --connect-timeout 5 --max-time 20)
@@ -88,7 +90,7 @@ fetch_uom() {
 
 # ---- Normalize state strings for stable triggers ----
 # operating -> Operating, running -> Running, unknown unchanged
-norm_state_py='
+NORM_STATE_PY='
 def norm(s):
     s=(s or "").strip()
     if not s: return ""
@@ -101,7 +103,7 @@ parse_uom() {
   local kind="$1" needle="$2"
   python3 - "$kind" "$needle" "$BODY" <<PY
 import sys, json, xml.etree.ElementTree as ET
-$norm_state_py
+$NORM_STATE_PY
 
 kind = sys.argv[1]
 needle = sys.argv[2]
@@ -240,29 +242,27 @@ PY
 # ---- PCM: fetch newest EnergyMonitor JSON ----
 pcm_latest_energy_json() {
   local ms_uuid="$1"
-  local feed jsonfile
-  feed="$(mktempf /tmp/pcm_energy_feed.XXXXXX)"
-  jsonfile="$(mktempf /tmp/pcm_energy_json.XXXXXX)"
+  : >"$PCM_FEED"
+  : >"$PCM_JSON"
 
-  # Atom-first (your HMC returns Atom feed)
+  # Atom-first (matches your HMC feed format)
   curl "${CURL[@]}" -b "$COOKIE" \
     -H "Accept: application/atom+xml; charset=UTF-8" \
     -H "X-Audit-Memento: zabbix" \
-    "${PCM}/ManagedSystem/${ms_uuid}/RawMetrics/EnergyMonitor" >"$feed" || true
+    "${PCM}/ManagedSystem/${ms_uuid}/RawMetrics/EnergyMonitor" >"$PCM_FEED" || true
 
   # Fallback if empty
-  if [[ ! -s "$feed" ]]; then
+  if [[ ! -s "$PCM_FEED" ]]; then
     curl "${CURL[@]}" -b "$COOKIE" \
       -H "Accept: application/xml" \
       -H "X-Audit-Memento: zabbix" \
-      "${PCM}/ManagedSystem/${ms_uuid}/RawMetrics/EnergyMonitor" >"$feed" || true
+      "${PCM}/ManagedSystem/${ms_uuid}/RawMetrics/EnergyMonitor" >"$PCM_FEED" || true
   fi
 
-  [[ -s "$feed" ]] || { echo ""; return; }
+  [[ -s "$PCM_FEED" ]] || { echo ""; return; }
 
-  # Pick newest <entry> by <updated>, extract its JSON href
   local href
-  href="$(python3 - "$feed" <<'PY'
+  href="$(python3 - "$PCM_FEED" <<'PY'
 import sys, xml.etree.ElementTree as ET
 ATOM="http://www.w3.org/2005/Atom"
 def a(t): return "{%s}%s"%(ATOM,t)
@@ -299,9 +299,9 @@ PY
   curl "${CURL[@]}" -b "$COOKIE" \
     -H "Accept: application/json" \
     -H "X-Audit-Memento: zabbix" \
-    "$href" >"$jsonfile" || { echo ""; return; }
+    "$href" >"$PCM_JSON" || { echo ""; return; }
 
-  echo "$jsonfile"
+  echo "$PCM_JSON"
 }
 
 pcm_max_temp() {
@@ -429,7 +429,6 @@ print(json.dumps(out, ensure_ascii=False))
 PY
 }
 
-# ---- main dispatcher ----
 case "$MODE" in
   hmc.ping)
     if logon; then logoff; echo 1; else echo 0; fi
@@ -497,6 +496,16 @@ case "$MODE" in
     logoff
     ;;
 
+  system.temp.baseboard)
+    logon || { echo 0; exit 0; }
+    ms_uuid="$(ms_uuid_by_name "$ARG1")"
+    [[ -z "$ms_uuid" ]] && { logoff; echo 0; exit 0; }
+    jf="$(pcm_latest_energy_json "$ms_uuid")"
+    [[ -z "$jf" ]] && { logoff; echo 0; exit 0; }
+    pcm_max_temp "$jf" baseboard
+    logoff
+    ;;
+
   system.power.watts)
     logon || { echo 0; exit 0; }
     ms_uuid="$(ms_uuid_by_name "$ARG1")"
@@ -506,16 +515,7 @@ case "$MODE" in
     pcm_watts "$jf"
     logoff
     ;;
-   system.temp.baseboard)
-    logon || { echo 0; exit 0; }
-    ms_uuid="$(ms_uuid_by_name "$ARG1")"
-    [[ -z "$ms_uuid" ]] && { logoff; echo 0; exit 0; }
-    jf="$(pcm_latest_energy_json "$ms_uuid")"
-    [[ -z "$jf" ]] && { logoff; echo 0; exit 0; }
-    pcm_max_temp "$jf" baseboard
-    logoff
-    ;;
+
   *)
     echo "[]"
     ;;
-esac

--- a/Server_Hardware/IBM/template_ibm-power-hmc-zabbix-rest/6.0/template_ibm_power_hmc_rest_external_6.2.yaml
+++ b/Server_Hardware/IBM/template_ibm-power-hmc-zabbix-rest/6.0/template_ibm_power_hmc_rest_external_6.2.yaml
@@ -1,0 +1,138 @@
+zabbix_export:
+  version: '6.2'
+  date: '2026-04-02T14:10:00Z'
+
+  templates:
+    - uuid: 9f3a6c4b1e2d4f84a9b3c6d1e2f4a8b7
+      template: IBM_Power_HMC_REST_External
+      name: "IBM Power HMC by REST (External)"
+      description: |
+        IBM Power HMC monitoring via REST (UOM) and PCM EnergyMonitor.
+
+        Includes:
+        - Managed System discovery + state
+        - LPAR discovery + state
+        - VIOS discovery + state
+        - VIOS redundancy via trigger logic
+        - PCM inlet temperature
+        - PCM CPU temperature
+        - PCM power consumption (Watts)
+
+      groups:
+        - name: Templates
+
+      macros:
+        - macro: '{$HMC.USER}'
+          value: zabbixapi
+        - macro: '{$HMC.PASSWORD}'
+          value: ''
+
+      items:
+        - uuid: a1b2c3d44e5f4a8b9c1d2e3f4a5b6c7d
+          name: "HMC REST availability"
+          type: EXTERNAL
+          key: hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},hmc.ping]
+          delay: 5m
+          history: 7d
+          value_type: UNSIGNED
+
+      discovery_rules:
+        # ---------------- Managed Systems ----------------
+        - uuid: b2c3d4e55f6a4b8c9d1e2f3a4b5c6d7e
+          name: "HMC REST: Managed Systems discovery"
+          type: EXTERNAL
+          key: hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},discover.systems]
+          delay: 1h
+
+          item_prototypes:
+            - uuid: c3d4e5f66a7b4c8d9e1f2a3b4c5d6e7f
+              name: "HMC REST: System {#MS_NAME} state"
+              type: EXTERNAL
+              key: hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},system.state,{#MS_NAME}]
+              delay: 5m
+              value_type: TEXT
+
+            - uuid: d4e5f6a77b8c4d9e8a1b2c3d4e5f6a7b
+              name: "HMC PCM: Inlet temperature {#MS_NAME}"
+              type: EXTERNAL
+              key: hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},system.temp.inlet,{#MS_NAME}]
+              delay: 5m
+              value_type: FLOAT
+              units: "°C"
+
+            - uuid: e5f6a7b88c9d4e8f9a1b2c3d4e5f6a7b
+              name: "HMC PCM: CPU temperature {#MS_NAME}"
+              type: EXTERNAL
+              key: hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},system.temp.cpu,{#MS_NAME}]
+              delay: 5m
+              value_type: FLOAT
+              units: "°C"
+
+            - uuid: f6a7b8c99d0e4f8a9b1c2d3e4f5a6b7c
+              name: "HMC PCM: Power consumption {#MS_NAME}"
+              type: EXTERNAL
+              key: hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},system.power.watts,{#MS_NAME}]
+              delay: 5m
+              value_type: FLOAT
+              units: "W"
+            - uuid: 8f3c2a74-9e4a-4d9a-b6d2-3c1e9c4f7a21
+              name: "HMC PCM: Baseboard temperature {#MS_NAME}"
+              type: EXTERNAL
+              key: hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},system.temp.baseboard,{#MS_NAME}]
+              delay: 5m
+              value_type: FLOAT
+              units: "°C"
+          trigger_prototypes:
+            - uuid: a7b8c9d00e1f4a8b9c1d2e3f4a5b6c7d
+              name: "HMC REST: System {#MS_NAME} not Operating"
+              expression: last(/IBM_Power_HMC_REST_External/hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},system.state,{#MS_NAME}])<>"Operating"
+                          and last(/IBM_Power_HMC_REST_External/hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},system.state,{#MS_NAME}])<>"unknown"
+              priority: HIGH
+            - uuid: 1a6c9d30-2f1a-4c78-9b55-6c7a8e0f4b91
+              name: "HMC PCM: High baseboard temperature on {#MS_NAME}"
+              expression: last(/IBM_Power_HMC_REST_External/hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},system.temp.baseboard,{#MS_NAME}])>60
+              priority: WARNING
+
+        # ---------------- LPARs ----------------
+        - uuid: b8c9d0e11f2a4b8c9d1e2f3a4b5c6d7e
+          name: "HMC REST: LPAR discovery"
+          type: EXTERNAL
+          key: hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},discover.lpars]
+          delay: 1h
+
+          item_prototypes:
+            - uuid: c9d0e1f22a3b4c8d9e1f2a3b4c5d6e7f
+              name: "HMC REST: LPAR {#LPAR_NAME} state"
+              type: EXTERNAL
+              key: hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},lpar.state,{#LPAR_NAME}]
+              delay: 5m
+              value_type: TEXT
+
+          trigger_prototypes:
+            - uuid: d0e1f2a33b4c4d8e9f1a2b3c4d5e6f7a
+              name: "HMC REST: LPAR {#LPAR_NAME} not Running"
+              expression: last(/IBM_Power_HMC_REST_External/hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},lpar.state,{#LPAR_NAME}])<>"Running"
+                          and last(/IBM_Power_HMC_REST_External/hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},lpar.state,{#LPAR_NAME}])<>"unknown"
+              priority: WARNING
+
+        # ---------------- VIOS ----------------
+        - uuid: e1f2a3b44c5d4e8f9a1b2c3d4e5f6a7b
+          name: "HMC REST: VIOS discovery"
+          type: EXTERNAL
+          key: hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},discover.vios]
+          delay: 1h
+
+          item_prototypes:
+            - uuid: f2a3b4c55d6e4a8b9c1d2e3f4a5b6c7d
+              name: "HMC REST: VIOS {#VIOS_NAME} state"
+              type: EXTERNAL
+              key: hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},lpar.state,{#VIOS_NAME}]
+              delay: 5m
+              value_type: TEXT
+
+          trigger_prototypes:
+            - uuid: a3b4c5d66e7f4a8b9c1d2e3f4a5b6c7d
+              name: "HMC REST: VIOS {#VIOS_NAME} not Running"
+              expression: last(/IBM_Power_HMC_REST_External/hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},lpar.state,{#VIOS_NAME}])<>"Running"
+                          and last(/IBM_Power_HMC_REST_External/hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},lpar.state,{#VIOS_NAME}])<>"unknown"
+              priority: HIGH

--- a/Server_Hardware/IBM/template_ibm-power-hmc-zabbix-rest/6.0/template_ibm_power_hmc_rest_external_6.2.yaml
+++ b/Server_Hardware/IBM/template_ibm-power-hmc-zabbix-rest/6.0/template_ibm_power_hmc_rest_external_6.2.yaml
@@ -75,7 +75,7 @@ zabbix_export:
               delay: 5m
               value_type: FLOAT
               units: "W"
-            - uuid: 8f3c2a74-9e4a-4d9a-b6d2-3c1e9c4f7a21
+            - uuid: 8f3c2a749e4a4d9ab6d23c1e9c4f7a21
               name: "HMC PCM: Baseboard temperature {#MS_NAME}"
               type: EXTERNAL
               key: hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},system.temp.baseboard,{#MS_NAME}]
@@ -88,7 +88,7 @@ zabbix_export:
               expression: last(/IBM_Power_HMC_REST_External/hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},system.state,{#MS_NAME}])<>"Operating"
                           and last(/IBM_Power_HMC_REST_External/hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},system.state,{#MS_NAME}])<>"unknown"
               priority: HIGH
-            - uuid: 1a6c9d30-2f1a-4c78-9b55-6c7a8e0f4b91
+            - uuid: 1a6c9d302f1a4c789b556c7a8e0f4b91
               name: "HMC PCM: High baseboard temperature on {#MS_NAME}"
               expression: last(/IBM_Power_HMC_REST_External/hmc_api_zbx.sh[{HOST.CONN},{$HMC.USER},{$HMC.PASSWORD},system.temp.baseboard,{#MS_NAME}])>60
               priority: WARNING


### PR DESCRIPTION
## Description
Adds a community template for monitoring IBM Power Hardware Management Console (HMC)
using the REST (UOM) API.

The template provides automatic discovery and state monitoring of
managed systems and logical partitions.

## Tested on
- IBM Power HMC V10R3
- Zabbix 6.2 (template export)

## Author
Rosen Georgiev (@rgeorgie)