### PR TITLE
Add Sharp printer supplies SNMP template (Printer-MIB)

### DIFF
--- a/Printers/Sharp/template_sharp_printer_supplies/7.0/README.md
+++ b/Printers/Sharp/template_sharp_printer_supplies/7.0/README.md
@@ -1,0 +1,22 @@
+# Sharp Printer Supplies SNMP Template
+
+Zabbix template for monitoring printer consumables via SNMP (Printer-MIB).
+
+## Features
+- Automatic discovery of supplies (toner, drum, developer, waste toner)
+- Works with monochrome and color printers
+- Filters invalid values (-1, -2, -3) via preprocessing
+- No manual OID configuration required
+
+## Requirements
+- SNMP v2c enabled on printer
+- Printer supports Printer-MIB (RFC 3805)
+
+## Tested on
+- Sharp MX-M3570
+- Sharp MX-2630N
+- Sharp MX-B355W
+
+## Notes
+- Values are interpreted as percentage where supported by the device
+- Some printers may return absolute values instead of percentages

--- a/Printers/Sharp/template_sharp_printer_supplies/7.0/template_sharp_printer_supplies.yaml
+++ b/Printers/Sharp/template_sharp_printer_supplies/7.0/template_sharp_printer_supplies.yaml
@@ -1,0 +1,47 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 7df96b18c230490a9a0a9e2307226338
+      name: Templates
+  templates:
+    - uuid: 4af8cea914534a1ab2c515a5b3c8db93
+      template: 'Template Printer Sharp Supplies SNMP'
+      name: 'Template Printer Sharp Supplies SNMP'
+      groups:
+        - name: Templates
+      discovery_rules:
+        - uuid: 9a4624c78dec4f7590af4837f2a842b5
+          name: 'Printer supplies discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},1.3.6.1.2.1.43.11.1.1.6.1]'
+          key: snmp.printer.supplies.discovery
+          delay: 1h
+          item_prototypes:
+            - uuid: 0da29ddeff4e4fe99b9d56b8dab0d42b
+              name: '{#SNMPVALUE} level'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.43.11.1.1.9.1.{#SNMPINDEX}'
+              key: 'printer.supply.level[{#SNMPINDEX}]'
+              delay: 10m
+              units: '%'
+              preprocessing:
+                - type: CHECK_NOT_SUPPORTED
+                  parameters:
+                    - '-1'
+                - type: REGEX
+                  parameters:
+                    - '^[0-9]+$'
+                    - \0
+                  error_handler: DISCARD_VALUE
+              trigger_prototypes:
+                - uuid: c55e06ef90264d57ba927428ef8e0cdf
+                  expression: 'last(/Template Printer Sharp Supplies SNMP/printer.supply.level[{#SNMPINDEX}])<10'
+                  name: '{#SNMPVALUE} low (<10%)'
+                  priority: HIGH
+                - uuid: c44d2694866041248968114c9ed390e9
+                  expression: 'last(/Template Printer Sharp Supplies SNMP/printer.supply.level[{#SNMPINDEX}])<20'
+                  name: '{#SNMPVALUE} low (<20%)'
+                  priority: AVERAGE
+                  dependencies:
+                    - name: '{#SNMPVALUE} low (<10%)'
+                      expression: 'last(/Template Printer Sharp Supplies SNMP/printer.supply.level[{#SNMPINDEX}])<10'


### PR DESCRIPTION
This PR adds a Zabbix template for monitoring Sharp printer consumables via SNMP using Printer-MIB.

Features:
- Low-level discovery of supplies (toner, drum, waste toner, etc.)
- No manual OID configuration required
- Preprocessing to handle invalid values (-1, -2, -3)

Tested on:
- Sharp MX-M3570
- Sharp MX-2630N
- Sharp MX-B355W

Compatible with Zabbix 7.0 LTS.