### PR TITLE
Add HWG Poseidon2 monitoring template for Zabbix 6.0 LTS

### DIFF
--- a/SCADA_IoT_Energy_Home_Automation_Industrial_monitoring/Monitoring_Equipment/template_hwg-poseidon2/6.0/hwg-poseidon2_3468.yaml
+++ b/SCADA_IoT_Energy_Home_Automation_Industrial_monitoring/Monitoring_Equipment/template_hwg-poseidon2/6.0/hwg-poseidon2_3468.yaml
@@ -1,0 +1,343 @@
+zabbix_export:
+  version: '6.0'
+  date: '2026-05-18T05:22:03Z'
+  groups:
+    - uuid: 36bff6c29af64692839d077febfc7079
+      name: 'Templates/Network devices'
+  templates:
+    - uuid: 211e50f3d39e4d8098f8e5a8ad0e99cf
+      template: 'HWG Poseidon2 3468'
+      name: 'HWG Poseidon2 3468'
+      description: |
+        Template for HW Group Poseidon2 family devices (e.g. Poseidon2 3468).
+        Monitors sensors (temperature, humidity, voltage, etc.), digital inputs,
+        digital outputs, and active alarms via SNMP.
+        
+        MIB: POSEIDON-MIB v2.10
+        Enterprise OID: 1.3.6.1.4.1.21796.3.3
+        Supports SNMPv2c and SNMPv3.
+      groups:
+        - name: 'Templates/Network devices'
+      items:
+        - uuid: 6a8facf3331f40d88bc65c635f302fc8
+          name: 'Alarms: Active count'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.21796.3.3.50.1.0
+          key: poseidon.alarms.present
+          delay: 30s
+          history: 30d
+          description: 'Number of currently active alarm conditions (tsAlarmsPresent).'
+          tags:
+            - tag: component
+              value: alarms
+          triggers:
+            - uuid: dc60e264c69d4f51967151d53cc9cc2a
+              expression: 'last(/HWG Poseidon2 3468/poseidon.alarms.present)>0'
+              name: 'Poseidon: {HOST.NAME} has {ITEM.LASTVALUE} active alarm(s)'
+              priority: WARNING
+              description: 'One or more alarm conditions are currently active on the device.'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: e98c37ff6e974dc2892f783c56782afd
+          name: 'Device: MAC address'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.21796.3.3.70.1.0
+          key: poseidon.info.mac
+          delay: 1h
+          history: 7d
+          trends: '0'
+          value_type: CHAR
+          description: 'MAC address of the device (infoAddressMAC). Useful to identify the unit in trap messages.'
+          inventory_link: MACADDRESS_A
+          tags:
+            - tag: component
+              value: device
+      discovery_rules:
+        - uuid: d8fc95da49374bbfb1d16259685ce56d
+          name: 'Digital input discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#INPNAME},1.3.6.1.4.1.21796.3.3.1.1.3]'
+          key: poseidon.input.discovery
+          delay: 1h
+          filter:
+            conditions:
+              - macro: '{#INPNAME}'
+                value: 'Comm Monitor|Binary'
+                operator: NOT_MATCHES_REGEX
+                formulaid: A
+          description: 'Discovers digital inputs via inpTable.'
+          item_prototypes:
+            - uuid: d21090c5d858491d841becad2573a60a
+              name: 'Input {#INPNAME}: Alarm state'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.21796.3.3.1.1.5.{#SNMPINDEX}'
+              key: 'poseidon.input.alarmstate[{#SNMPINDEX}]'
+              delay: 30s
+              history: 30d
+              description: 'Binary input alarm state (inpAlarmState): 0=Normal, 1=Alarm.'
+              valuemap:
+                name: 'HWG Poseidon input alarm state'
+              tags:
+                - tag: component
+                  value: input
+              trigger_prototypes:
+                - uuid: 202cb20c8d894f55aee11f5d1d963913
+                  expression: 'last(/HWG Poseidon2 3468/poseidon.input.alarmstate[{#SNMPINDEX}])=1'
+                  name: 'Input {#INPNAME}: Alarm condition active'
+                  priority: HIGH
+                  description: 'Digital input has entered its configured alarm state.'
+                  tags:
+                    - tag: scope
+                      value: availability
+            - uuid: ef41b01eb007406aba53bd87cf914c70
+              name: 'Input {#INPNAME}: Pulse counter'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.21796.3.3.1.1.6.{#SNMPINDEX}'
+              key: 'poseidon.input.counter[{#SNMPINDEX}]'
+              delay: 30s
+              history: 30d
+              description: 'Pulse counter for this input (inpCounter). Counts rising edges longer than sampling interval.'
+              tags:
+                - tag: component
+                  value: input
+            - uuid: 4fd3e6d4bcfe4e1ebc5d7c9c258494cf
+              name: 'Input {#INPNAME}: Value'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.21796.3.3.1.1.2.{#SNMPINDEX}'
+              key: 'poseidon.input.value[{#SNMPINDEX}]'
+              delay: 30s
+              history: 30d
+              description: 'Binary input state (inpValue): 0=Off (open), 1=On (closed).'
+              valuemap:
+                name: 'HWG Poseidon OnOff'
+              tags:
+                - tag: component
+                  value: input
+          graph_prototypes:
+            - uuid: bf83ebaebfc14d2f8aab602cbde06eb7
+              name: 'Input {#INPNAME}: State'
+              graph_items:
+                - drawtype: BOLD_LINE
+                  color: FF6600
+                  item:
+                    host: 'HWG Poseidon2 3468'
+                    key: 'poseidon.input.value[{#SNMPINDEX}]'
+        - uuid: f3ff9ce0062f49dcb67b238dfe5dd6ed
+          name: 'Digital output discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#OUTNAME},1.3.6.1.4.1.21796.3.3.2.1.3]'
+          key: poseidon.output.discovery
+          delay: 1h
+          description: 'Discovers digital outputs via outTable.'
+          item_prototypes:
+            - uuid: 0c0ce8be21424322b6fb93359ad92e72
+              name: 'Output {#OUTNAME}: Mode'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.21796.3.3.2.1.5.{#SNMPINDEX}'
+              key: 'poseidon.output.mode[{#SNMPINDEX}]'
+              delay: 1h
+              history: 30d
+              description: 'Output operating mode (outMode): 0=Manual, 1=Auto alarm, 2=Auto trigger EQ, 3=Auto trigger Hi, 4=Auto trigger Lo.'
+              valuemap:
+                name: 'HWG Poseidon output mode'
+              tags:
+                - tag: component
+                  value: output
+            - uuid: a52e996234af4cc9a18b6066ea6291aa
+              name: 'Output {#OUTNAME}: Value'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.21796.3.3.2.1.2.{#SNMPINDEX}'
+              key: 'poseidon.output.value[{#SNMPINDEX}]'
+              delay: 30s
+              history: 30d
+              description: 'Binary output state (outValue): 0=Off (open), 1=On (closed).'
+              valuemap:
+                name: 'HWG Poseidon OnOff'
+              tags:
+                - tag: component
+                  value: output
+        - uuid: 7a422380050a47c5ac1f8bb7c844f935
+          name: 'Sensor discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SENSNAME},1.3.6.1.4.1.21796.3.3.3.1.2,{#SENSUNIT},1.3.6.1.4.1.21796.3.3.3.1.10]'
+          key: poseidon.sensor.discovery
+          delay: 1h
+          description: 'Discovers connected sensors via sensTable. {#SENSNAME} = sensor name, {#SENSUNIT} = unit string (e.g. C, %).'
+          item_prototypes:
+            - uuid: 02eb4c76f2404555bf807d09ae28f9a8
+              name: 'Sensor {#SENSNAME}: State'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.21796.3.3.3.1.4.{#SNMPINDEX}'
+              key: 'poseidon.sensor.state[{#SNMPINDEX}]'
+              delay: 30s
+              history: 30d
+              description: 'Sensor state (sensState): 0=Invalid, 1=Normal, 2=Alarm state, 3=Alarm.'
+              valuemap:
+                name: 'HWG Poseidon sensor state'
+              tags:
+                - tag: component
+                  value: sensor
+              trigger_prototypes:
+                - uuid: 7798157139a74e8dbc82c3b18746c85c
+                  expression: 'last(/HWG Poseidon2 3468/poseidon.sensor.state[{#SNMPINDEX}])>={$SENSOR_ALARM_HIGH}'
+                  name: 'Sensor {#SENSNAME}: Alarm (value out of limits)'
+                  priority: HIGH
+                  description: 'Sensor has reached alarm state — value is outside configured limits.'
+                  tags:
+                    - tag: scope
+                      value: availability
+                - uuid: 10ef40ca9308472caa0d1c1b89bd83a6
+                  expression: 'last(/HWG Poseidon2 3468/poseidon.sensor.state[{#SNMPINDEX}])={$SENSOR_ALARM_WARN}'
+                  name: 'Sensor {#SENSNAME}: Approaching alarm (alarm state)'
+                  priority: WARNING
+                  description: 'Sensor state is 2 (alarmstate) — alarm condition detected but not yet confirmed or alarm not enabled.'
+                  dependencies:
+                    - name: 'Sensor {#SENSNAME}: Alarm (value out of limits)'
+                      expression: 'last(/HWG Poseidon2 3468/poseidon.sensor.state[{#SNMPINDEX}])>={$SENSOR_ALARM_HIGH}'
+                  tags:
+                    - tag: scope
+                      value: availability
+                - uuid: 6eef26cedfca4feeb5f1ffd799a710b2
+                  expression: 'last(/HWG Poseidon2 3468/poseidon.sensor.state[{#SNMPINDEX}])=0'
+                  name: 'Sensor {#SENSNAME}: Invalid (disconnected or error)'
+                  priority: WARNING
+                  description: 'Sensor state is invalid — sensor may be unplugged or have a communication error.'
+                  tags:
+                    - tag: scope
+                      value: availability
+            - uuid: 02fa0d8fc3724e5c85f5a93a63120242
+              name: 'Sensor {#SENSNAME}: String value'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.21796.3.3.3.1.5.{#SNMPINDEX}'
+              key: 'poseidon.sensor.string[{#SNMPINDEX}]'
+              delay: 30s
+              history: 7d
+              trends: '0'
+              value_type: CHAR
+              description: 'Human-readable string representation of the sensor value (sensString).'
+              tags:
+                - tag: component
+                  value: sensor
+            - uuid: 454be0e3238a4e32bed629bfe60b71c5
+              name: 'Sensor {#SENSNAME}: Value'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.21796.3.3.3.1.6.{#SNMPINDEX}'
+              key: 'poseidon.sensor.value[{#SNMPINDEX}]'
+              delay: 30s
+              history: 30d
+              value_type: FLOAT
+              units: '{#SENSUNIT}'
+              description: |
+                Sensor reading (sensValue). Device returns integer × 10, preprocessed here to actual value.
+                e.g. raw 253 → 25.3 °C
+              preprocessing:
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.1'
+              tags:
+                - tag: component
+                  value: sensor
+          graph_prototypes:
+            - uuid: ee1aeb3d861c444997d85fad0c49d629
+              name: 'Sensor {#SENSNAME}: Value'
+              graph_items:
+                - drawtype: GRADIENT_LINE
+                  color: 0080FF
+                  item:
+                    host: 'HWG Poseidon2 3468'
+                    key: 'poseidon.sensor.value[{#SNMPINDEX}]'
+      macros:
+        - macro: '{$SENSOR_ALARM_HIGH}'
+          value: '3'
+          description: 'Sensor state value for HIGH trigger (3 = alarm confirmed)'
+        - macro: '{$SENSOR_ALARM_WARN}'
+          value: '2'
+          description: 'Sensor state value for WARNING trigger (2 = alarm state, alarm not yet confirmed)'
+      dashboards:
+        - uuid: e573aa67e4ff40f59982847fb44e355f
+          name: PoseidonValues
+          display_period: '10'
+          pages:
+            - widgets:
+                - type: GRAPH_PROTOTYPE
+                  name: 'All Values'
+                  width: '24'
+                  height: '32'
+                  fields:
+                    - type: GRAPH_PROTOTYPE
+                      name: graphid
+                      value:
+                        host: 'HWG Poseidon2 3468'
+                        name: 'Sensor {#SENSNAME}: Value'
+                    - type: INTEGER
+                      name: rows
+                      value: '6'
+      valuemaps:
+        - uuid: fb604052496a40a0907694cd45174b7b
+          name: 'HWG Poseidon input alarm state'
+          mappings:
+            - value: '0'
+              newvalue: Normal
+            - value: '1'
+              newvalue: Alarm
+        - uuid: 79374edad628474a8125f8a2a3a19211
+          name: 'HWG Poseidon OnOff'
+          mappings:
+            - value: '0'
+              newvalue: 'Off'
+            - value: '1'
+              newvalue: 'On'
+        - uuid: 9c1cb807a9044bebbddd84d792d229db
+          name: 'HWG Poseidon output mode'
+          mappings:
+            - value: '0'
+              newvalue: Manual
+            - value: '1'
+              newvalue: 'Auto alarm'
+            - value: '2'
+              newvalue: 'Auto trigger EQ'
+            - value: '3'
+              newvalue: 'Auto trigger Hi'
+            - value: '4'
+              newvalue: 'Auto trigger Lo'
+        - uuid: 3720b7124ad1479b8dd34f9f92eaee1e
+          name: 'HWG Poseidon sensor state'
+          mappings:
+            - value: '0'
+              newvalue: Invalid
+            - value: '1'
+              newvalue: Normal
+            - value: '2'
+              newvalue: 'Alarm state'
+            - value: '3'
+              newvalue: Alarm
+        - uuid: 631354db8a9a4c1e98c2b1804ff9d144
+          name: 'HWG Poseidon unit type'
+          mappings:
+            - value: '0'
+              newvalue: Celsius
+            - value: '1'
+              newvalue: Fahrenheit
+            - value: '2'
+              newvalue: Kelvin
+            - value: '3'
+              newvalue: Percent
+            - value: '4'
+              newvalue: Volt
+            - value: '5'
+              newvalue: Milliamp
+            - value: '6'
+              newvalue: 'No unit'
+            - value: '7'
+              newvalue: Pulse
+            - value: '8'
+              newvalue: Switch
+            - value: '9'
+              newvalue: 'Dew point'
+            - value: '10'
+              newvalue: 'Absolute humidity'
+            - value: '11'
+              newvalue: Pressure
+            - value: '12'
+              newvalue: Universal


### PR DESCRIPTION
New template for the HWG Poseidon2 environmental monitoring device, covering sensors via SNMP enterprise OID 3468.