### PR TITLE
Add Windows FSRM Utilization template for Zabbix 7.0

### DIFF
--- a/Operating_Systems/Windows/template_fsrm_utilization_windows/7.0/README.md
+++ b/Operating_Systems/Windows/template_fsrm_utilization_windows/7.0/README.md
@@ -1,6 +1,6 @@
 # FSRM Utilization
 
-This Zabbix template monitors Microsoft File Server Resource Manager (FSRM) quota utilization on DFS/file servers.
+This Zabbix template monitors Microsoft File Server Resource Manager (FSRM) quota utilization on Windows file servers.
 
 It discovers configured FSRM quotas through low-level discovery and creates one utilization item per quota. The utilization value is stored as a percentage.
 
@@ -9,15 +9,16 @@ The template imports as `FSRM Utilization` and is exported for Zabbix `7.0`.
 ## Files
 
 - `template_fsrm_utilization_windows.yaml` - Zabbix template export.
-- `quota-discovery.ps1` - Low-level discovery script for FSRM quotas.
-- `quota-used.ps1` - Per-quota utilization script.
+- `files/quota-discovery.ps1` - Low-level discovery script for FSRM quotas.
+- `files/quota-used.ps1` - Per-quota utilization script.
+- `files/user_parameters.conf` - Example Zabbix Agent2 user parameters.
 
 ## What it does
 
 - Discovers FSRM quotas with `fsrm.quota.discovery` every hour.
-- Creates one item per discovered quota: `fsrm.quota.used[{#QUOTANAME}]`.
+- Creates one item per discovered quota, checked every 5 minutes: `fsrm.quota.used[{#QUOTANAME}]`.
 - Stores quota utilization as a floating-point percentage with `%` units.
-- Tags discovered items with `component=DFS`.
+- Tags discovered items with `component=FSRM`.
 - Raises a warning trigger when quota utilization is above 95%.
 - Raises a high-priority trigger when quota utilization is above 98%.
 
@@ -50,9 +51,9 @@ UserParameter=fsrm.quota.used[*],powershell -NoProfile -ExecutionPolicy Bypass -
 
 ## Installation
 
-1. Import `template_dfs_utilization_windows.yaml` in Zabbix under `Data collection` -> `Templates` -> `Import`.
-2. Link `DFS Utilization` to the Windows DFS/file server host.
-3. Copy `quota-discovery.ps1` and `quota-used.ps1` to `C:\Program Files\Zabbix Agent 2\scripts\` on the monitored host.
+1. Import `template_fsrm_utilization_windows.yaml` in Zabbix under `Data collection` -> `Templates` -> `Import`.
+2. Link `FSRM Utilization` to the Windows file server host.
+3. Copy `files/quota-discovery.ps1` and `files/quota-used.ps1` to `C:\Program Files\Zabbix Agent 2\scripts\` on the monitored host.
 4. Add the `fsrm.quota.discovery` and `fsrm.quota.used[*]` user parameters to the Zabbix Agent2 configuration.
 5. Restart the Zabbix Agent2 service.
 6. Verify that discovery returns quota data and that usage items become supported.
@@ -61,8 +62,8 @@ UserParameter=fsrm.quota.used[*],powershell -NoProfile -ExecutionPolicy Bypass -
 
 | Trigger | Expression | Severity |
 | --- | --- | --- |
-| `Quota warning on {#QUOTAPATH}` | `last(/DFS Utilization/fsrm.quota.used[{#QUOTANAME}])>95` | Warning |
-| `Quota warning on {#QUOTAPATH}` | `last(/DFS Utilization/fsrm.quota.used[{#QUOTANAME}])>98` | High |
+| `Quota warning on {#QUOTAPATH}` | `last(/FSRM Utilization/fsrm.quota.used[{#QUOTANAME}])>95` | Warning |
+| `Quota warning on {#QUOTAPATH}` | `last(/FSRM Utilization/fsrm.quota.used[{#QUOTANAME}])>98` | High |
 
 ## Troubleshooting
 
@@ -75,5 +76,4 @@ If discovery or items are unsupported, check the following:
 - `fsrm.quota.discovery` returns valid Zabbix low-level discovery JSON.
 - The discovery JSON contains `{#QUOTANAME}` and `{#QUOTAPATH}` for every quota.
 - `fsrm.quota.used[<quota-name>]` returns a numeric percentage value.
-
 

--- a/Operating_Systems/Windows/template_fsrm_utilization_windows/7.0/README.md
+++ b/Operating_Systems/Windows/template_fsrm_utilization_windows/7.0/README.md
@@ -1,0 +1,79 @@
+# FSRM Utilization
+
+This Zabbix template monitors Microsoft File Server Resource Manager (FSRM) quota utilization on DFS/file servers.
+
+It discovers configured FSRM quotas through low-level discovery and creates one utilization item per quota. The utilization value is stored as a percentage.
+
+The template imports as `FSRM Utilization` and is exported for Zabbix `7.0`.
+
+## Files
+
+- `template_fsrm_utilization_windows.yaml` - Zabbix template export.
+- `quota-discovery.ps1` - Low-level discovery script for FSRM quotas.
+- `quota-used.ps1` - Per-quota utilization script.
+
+## What it does
+
+- Discovers FSRM quotas with `fsrm.quota.discovery` every hour.
+- Creates one item per discovered quota: `fsrm.quota.used[{#QUOTANAME}]`.
+- Stores quota utilization as a floating-point percentage with `%` units.
+- Tags discovered items with `component=DFS`.
+- Raises a warning trigger when quota utilization is above 95%.
+- Raises a high-priority trigger when quota utilization is above 98%.
+
+## Requirements
+
+The monitored Windows host must provide these Zabbix agent keys:
+
+- `fsrm.quota.discovery`
+- `fsrm.quota.used[{#QUOTANAME}]`
+
+The template expects the discovery rule to return low-level discovery data containing at least these macros:
+
+- `{#QUOTANAME}` - the FSRM quota name used by the usage item key.
+- `{#QUOTAPATH}` - the quota path shown in item and trigger names.
+
+FSRM must be installed and configured on the monitored host, and the Zabbix agent service account must be able to query FSRM quota information.
+
+The scripts are expected to be installed on the monitored host in:
+
+```text
+C:\Program Files\Zabbix Agent 2\scripts\
+```
+
+Add these user parameters to the Zabbix Agent2 configuration, for example in an included `.conf` file:
+
+```text
+UserParameter=fsrm.quota.discovery,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent 2\scripts\quota-discovery.ps1"
+UserParameter=fsrm.quota.used[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent 2\scripts\quota-used.ps1" "$1"
+```
+
+## Installation
+
+1. Import `template_dfs_utilization_windows.yaml` in Zabbix under `Data collection` -> `Templates` -> `Import`.
+2. Link `DFS Utilization` to the Windows DFS/file server host.
+3. Copy `quota-discovery.ps1` and `quota-used.ps1` to `C:\Program Files\Zabbix Agent 2\scripts\` on the monitored host.
+4. Add the `fsrm.quota.discovery` and `fsrm.quota.used[*]` user parameters to the Zabbix Agent2 configuration.
+5. Restart the Zabbix Agent2 service.
+6. Verify that discovery returns quota data and that usage items become supported.
+
+## Triggers
+
+| Trigger | Expression | Severity |
+| --- | --- | --- |
+| `Quota warning on {#QUOTAPATH}` | `last(/DFS Utilization/fsrm.quota.used[{#QUOTANAME}])>95` | Warning |
+| `Quota warning on {#QUOTAPATH}` | `last(/DFS Utilization/fsrm.quota.used[{#QUOTANAME}])>98` | High |
+
+## Troubleshooting
+
+If discovery or items are unsupported, check the following:
+
+- The Zabbix agent configuration includes the user parameters for `fsrm.quota.discovery` and `fsrm.quota.used[*]`.
+- `quota-discovery.ps1` and `quota-used.ps1` are present in `C:\Program Files\Zabbix Agent 2\scripts\`.
+- The Zabbix agent service has permission to query FSRM quotas.
+- FSRM is installed on the monitored host.
+- `fsrm.quota.discovery` returns valid Zabbix low-level discovery JSON.
+- The discovery JSON contains `{#QUOTANAME}` and `{#QUOTAPATH}` for every quota.
+- `fsrm.quota.used[<quota-name>]` returns a numeric percentage value.
+
+

--- a/Operating_Systems/Windows/template_fsrm_utilization_windows/7.0/files/quota-discovery.ps1
+++ b/Operating_Systems/Windows/template_fsrm_utilization_windows/7.0/files/quota-discovery.ps1
@@ -1,0 +1,10 @@
+$data = Get-FsrmQuota | ForEach-Object {
+    [PSCustomObject]@{
+        "{#QUOTANAME}" = Split-Path $_.Path -Leaf
+        "{#QUOTAPATH}" = $_.Path
+    }
+}
+
+@{
+    data = $data
+} | ConvertTo-Json -Compress

--- a/Operating_Systems/Windows/template_fsrm_utilization_windows/7.0/files/quota-used.ps1
+++ b/Operating_Systems/Windows/template_fsrm_utilization_windows/7.0/files/quota-used.ps1
@@ -1,0 +1,13 @@
+param($QuotaName)
+
+$q = Get-FsrmQuota | Where-Object {
+    (Split-Path $_.Path -Leaf) -eq $QuotaName
+}
+
+if ($q) {
+    $value = [math]::Round(($q.Usage / $q.Size) * 100, 2)
+    $value.ToString([System.Globalization.CultureInfo]::InvariantCulture)
+}
+else {
+    0
+}

--- a/Operating_Systems/Windows/template_fsrm_utilization_windows/7.0/files/user_parameters.conf
+++ b/Operating_Systems/Windows/template_fsrm_utilization_windows/7.0/files/user_parameters.conf
@@ -1,0 +1,2 @@
+UserParameter=fsrm.quota.discovery,powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent 2\scripts\quota-discovery.ps1"
+UserParameter=fsrm.quota.used[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent 2\scripts\quota-used.ps1" "$1"

--- a/Operating_Systems/Windows/template_fsrm_utilization_windows/7.0/template_fsrm_utilization_windows.yaml
+++ b/Operating_Systems/Windows/template_fsrm_utilization_windows/7.0/template_fsrm_utilization_windows.yaml
@@ -1,0 +1,36 @@
+# Exported Zabbix template for FSRM Utilization (Zabbix 7.0)
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 7df96b18c230490a9a0a9e2307226338
+      name: Templates
+  templates:
+    - uuid: ba3f3324e7af4e219dac6087e2c55d26
+      template: 'FSRM Utilization'
+      name: 'FSRM Utilization'
+      groups:
+        - name: Templates
+      discovery_rules:
+        - uuid: c2efbbbbb0bd4d54bb9ddbc015c951f8
+          name: 'FSRM Quota Discovery'
+          key: fsrm.quota.discovery
+          delay: 1h
+          item_prototypes:
+            - uuid: 9fcd27521c8645f88a07a2d680c377a2
+              name: 'Quota Usage {#QUOTAPATH}'
+              key: 'fsrm.quota.used[{#QUOTANAME}]'
+              delay: 5m
+              value_type: FLOAT
+              units: '%'
+              tags:
+                - tag: component
+                  value: FSRM
+              trigger_prototypes:
+                - uuid: 9703207eee684820adf97ed829a7e00c
+                  expression: 'last(/FSRM Utilization/fsrm.quota.used[{#QUOTANAME}])>95'
+                  name: 'Quota warning on {#QUOTAPATH}'
+                  priority: WARNING
+                - uuid: f78eed0434dd4323a345154b85d261fc
+                  expression: 'last(/FSRM Utilization/fsrm.quota.used[{#QUOTANAME}])>98'
+                  name: 'Quota warning on {#QUOTAPATH}'
+                  priority: HIGH


### PR DESCRIPTION
# Summary
Adds a new community template for monitoring Microsoft File Server Resource Manager quota utilization on Windows hosts using Zabbix low-level discovery and agent user parameters.

## Template details
Name: FSRM Utilization
Zabbix version: 7.0

## Monitored components
- FSRM quota utilization per configured quota
- Discovery of quota objects via low-level discovery
- Triggering for high quota usage

## Discovery rules
**Disk quota discovery**	Discovers configured FSRM quotas and quota paths

## Triggers included
- Quota utilization warning threshold (Warning)
- Quota utilization critical threshold (High)


## Files
- `template_fsrm_utilization_windows.yaml` – Template export file
- `README.md` – Documentation with setup instructions, macro reference, and troubleshooting guidance
- `files/quota-discovery.ps1` – Low-level discovery script for FSRM quotas
- `files/quota-used.ps1` – Per-quota utilization script
- `files/user_parameters.conf` – Example Zabbix Agent2 user parameter configuration

## Testing
Tested for Zabbix 7.0 with Windows Server 2025 host running FSRM and Zabbix Agent2.

