### PR TITLE
EMC Isilon: Change CPU usage trigger from last to average

### DIFF
--- a/Storage_Devices/EMC/template_emc_isilon_onefs_snmp/6.0/template_emc_isilon_onefs_snmp.yaml
+++ b/Storage_Devices/EMC/template_emc_isilon_onefs_snmp/6.0/template_emc_isilon_onefs_snmp.yaml
@@ -623,7 +623,7 @@ zabbix_export:
           triggers:
             -
               uuid: f2484fce190c4221a4701fa8ebd66a6d
-              expression: 'last(/SNMP EMC Isilon Node/nodeCPUIdle.0,#3)<10'
+              expression: 'avg(/SNMP EMC Isilon Node/nodeCPUIdle.0,#3)<10'
               name: 'Node CPU Usage'
               priority: AVERAGE
         -


### PR DESCRIPTION
Corrected from "trigger on the last third value" to "trigger on the average of the last 3 values"