### PR TITLE
Fix typo in ZFS on Linux userparams files

### DIFF
--- a/Operating_Systems/Linux/template_zfs_on_linux/7.0/files/userparams_zol_with_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux/7.0/files/userparams_zol_with_sudo.conf
@@ -54,7 +54,7 @@ UserParameter=zfs.zpool.resilver.length[*],/usr/bin/sudo /sbin/zfs get -Ho value
 UserParameter=zfs.zpool.resilver.errors[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-resilver-errors $1
 
 # vdev state
-UserParameter=zfs.vdev.state[*],/usr/bin/sudo /sbin/zpool status | grep 1 "$1" | awk '{ print $$2 }'
+UserParameter=zfs.vdev.state[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$2 }'
 # vdev READ error counter
 UserParameter=zfs.vdev.error_counter.read[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$3 }' | numfmt --from=si
 # vdev WRITE error counter

--- a/Operating_Systems/Linux/template_zfs_on_linux_active/7.0/files/userparams_zol_with_sudo.conf
+++ b/Operating_Systems/Linux/template_zfs_on_linux_active/7.0/files/userparams_zol_with_sudo.conf
@@ -54,7 +54,7 @@ UserParameter=zfs.zpool.resilver.length[*],/usr/bin/sudo /sbin/zfs get -Ho value
 UserParameter=zfs.zpool.resilver.errors[*],/usr/bin/sudo /sbin/zfs get -Ho value zabbix:last-resilver-errors $1
 
 # vdev state
-UserParameter=zfs.vdev.state[*],/usr/bin/sudo /sbin/zpool status | grep 1 "$1" | awk '{ print $$2 }'
+UserParameter=zfs.vdev.state[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$2 }'
 # vdev READ error counter
 UserParameter=zfs.vdev.error_counter.read[*],/usr/bin/sudo /sbin/zpool status | grep "$1" | awk '{ print $$3 }' | numfmt --from=si
 # vdev WRITE error counter


### PR DESCRIPTION
This PR removes a couple '1s' that I accidentally left in the ZFS on Linux userparams files when I modified them to use Posix grep (See commit [824e4ad0](https://github.com/zabbix/community-templates/commit/824e4ad0a6ce66b008d896090ef0cf027fd434b4#r173284844) from #501)

This was brought to my attention via a comment someone left on the commit itself, however that comment appears to have been deleted so I can't link it.