### PR TITLE
Add port macro (OPNsense by HTTP-JSON)

### DIFF
--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -306,7 +306,7 @@ zabbix_export:
                   }
                   
                   return JSON.stringify(data);
-          url: 'https://{HOST.IP}/api/diagnostics/system/system_disk'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/system/system_disk'
           tags:
             - tag: component
               value: raw
@@ -319,7 +319,7 @@ zabbix_export:
           authtype: BASIC
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
-          url: 'https://{HOST.IP}/api/diagnostics/firewall/stats?group_by=action'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/stats?group_by=action'
           tags:
             - tag: component
               value: raw
@@ -332,7 +332,7 @@ zabbix_export:
           authtype: BASIC
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
-          url: 'https://{HOST.IP}/api/diagnostics/firewall/pf_statistics/interfaces'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/pf_statistics/interfaces'
           tags:
             - tag: component
               value: raw
@@ -345,7 +345,7 @@ zabbix_export:
           authtype: BASIC
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
-          url: 'https://{HOST.IP}/api/diagnostics/firewall/pfStates'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/pfStates'
           tags:
             - tag: component
               value: raw
@@ -362,7 +362,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.items
-          url: 'https://{HOST.IP}/api/routes/gateway/status'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/routes/gateway/status'
           tags:
             - tag: component
               value: raw
@@ -381,7 +381,7 @@ zabbix_export:
           authtype: BASIC
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
-          url: 'https://{HOST.IP}/api/diagnostics/interface/get_vip_status'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/interface/get_vip_status'
           tags:
             - tag: component
               value: raw
@@ -401,7 +401,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - '$.*'
-          url: 'https://{HOST.IP}/api/diagnostics/traffic/_interface'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/traffic/_interface'
           tags:
             - tag: component
               value: raw
@@ -415,7 +415,7 @@ zabbix_export:
           authtype: BASIC
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
-          url: 'https://{HOST.IP}/api/diagnostics/system/system_time'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/system/system_time'
           tags:
             - tag: component
               value: raw
@@ -429,7 +429,7 @@ zabbix_export:
           authtype: BASIC
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
-          url: 'https://{HOST.IP}/api/diagnostics/system/systemResources'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/system/systemResources'
           tags:
             - tag: component
               value: raw
@@ -443,7 +443,7 @@ zabbix_export:
           authtype: BASIC
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
-          url: 'https://{HOST.IP}/api/core/firmware/info'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/core/firmware/info'
           tags:
             - tag: component
               value: raw
@@ -567,7 +567,7 @@ zabbix_export:
                       }
                   }
                   return JSON.stringify(result);
-          url: 'https://{HOST.IP}/api/nut/diagnostics/upsstatus'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/nut/diagnostics/upsstatus'
           tags:
             - tag: component
               value: raw
@@ -1339,6 +1339,9 @@ zabbix_export:
         - macro: '{$OPNS.SECRET}'
         - macro: '{$OPNS.STATE.TABLE.UTIL.MAX}'
           value: '90'
+        - macro: '{$OPNS.PORT}'
+          value: '443'
+          description: 'HTTPS API Port'
       dashboards:
         - uuid: 7a4b378cb31c4d6fb3c4c69731653336
           name: 'OPNsense Info'


### PR DESCRIPTION
This commit adds a macro for specifying a custom port for HTTPS traffic.
Only affects `Network_Devices/OPNsense/template_opnsense_by_http_json`