### PR TITLE
Add Flowtriq Agent by HTTP template (Zabbix 7.0)

### DIFF
--- a/Applications/Security/template_flowtriq_agent_http/7.0/README.md
+++ b/Applications/Security/template_flowtriq_agent_http/7.0/README.md
@@ -1,0 +1,107 @@
+# Flowtriq Agent by HTTP (Zabbix 7.0)
+
+Monitors a [Flowtriq](https://flowtriq.com) DDoS detection agent via its Prometheus-compatible metrics endpoint.
+
+## Overview
+
+Flowtriq is a DDoS detection and mitigation platform. The Flowtriq agent (`ftagent`) analyzes sFlow/NetFlow traffic data and exposes a `/metrics` endpoint in Prometheus exposition format on port 9145 by default.
+
+This template uses the Zabbix HTTP agent to scrape that endpoint and extract metrics with Prometheus preprocessing. No Zabbix agent installation is needed on the monitored host.
+
+## What you get
+
+### Items
+
+| Item | Key | Type | Description |
+|------|-----|------|-------------|
+| Get metrics | `flowtriq.metrics.get` | HTTP agent (master) | Raw scrape of the Prometheus endpoint |
+| Traffic PPS | `flowtriq.traffic.pps` | Dependent | Packets per second across all interfaces |
+| Traffic BPS | `flowtriq.traffic.bps` | Dependent | Bits per second across all interfaces |
+| Active flows | `flowtriq.traffic.flows` | Dependent | Number of flows currently tracked |
+| Active attacks | `flowtriq.active_attacks` | Dependent | Number of attacks in progress |
+| Total incidents | `flowtriq.incidents.total` | Dependent | Incident detection rate (per second) |
+| Mitigated incidents | `flowtriq.incidents.mitigated` | Dependent | Mitigation trigger rate (per second) |
+| Agent uptime | `flowtriq.agent.uptime` | Dependent | Seconds since agent process start |
+| Flow sources | `flowtriq.agent.flow_sources` | Dependent | Active sFlow/NetFlow collector count |
+| Last API report | `flowtriq.agent.last_report` | Dependent | Timestamp of last successful API report |
+
+### Triggers
+
+| Trigger | Severity | Description |
+|---------|----------|-------------|
+| Metrics endpoint not responding | High | No data received within `{$FLOWTRIQ.NODATA.TIMEOUT}` |
+| Active DDoS attack detected | Warning | One or more attacks currently in progress |
+| Sustained DDoS attack (5+ minutes) | High | Attack ongoing for at least 5 minutes continuously |
+| Agent recently restarted | Info | Agent uptime is less than 10 minutes |
+| No active flow sources | High | Agent is not receiving any flow data |
+| Agent not reporting to API | Average | Agent has not reported to the Flowtriq API within expected interval |
+
+### Dashboard
+
+The template includes a **Flowtriq Agent** dashboard with four panels:
+
+- **Traffic rates** - PPS and BPS over time
+- **Attack activity** - Active attack count over time
+- **Incident rate** - New incidents and mitigations per second
+- **Agent health** - Uptime and flow source count
+
+## Prerequisites
+
+1. A running Flowtriq agent (v1.9+) with the metrics endpoint enabled (enabled by default).
+2. Zabbix 7.0 or newer with HTTP agent support.
+3. Network connectivity from the Zabbix server or proxy to the agent on port 9145 (TCP).
+
+Verify the endpoint is reachable:
+
+```
+curl http://<agent-host>:9145/metrics
+```
+
+You should see Prometheus exposition format output with lines like `flowtriq_traffic_pps`, `flowtriq_active_attacks`, etc.
+
+## Setup
+
+1. Import `template_flowtriq_agent_http.yaml` into Zabbix via **Data collection > Templates > Import**.
+2. Create a host for each Flowtriq agent node.
+3. Link the **Flowtriq Agent by HTTP** template to the host.
+4. Set the following macro on the host (host-level override):
+   - `{$FLOWTRIQ.AGENT.HOST}` = hostname or IP of the Flowtriq agent
+
+   Other macros have sensible defaults but can be overridden:
+   - `{$FLOWTRIQ.AGENT.PORT}` = `9145`
+   - `{$FLOWTRIQ.AGENT.SCHEME}` = `http`
+   - `{$FLOWTRIQ.METRICS.PATH}` = `/metrics`
+   - `{$FLOWTRIQ.SCRAPE.INTERVAL}` = `30s`
+   - `{$FLOWTRIQ.NODATA.TIMEOUT}` = `10m`
+   - `{$FLOWTRIQ.API.LAG.WARN}` = `600` (seconds)
+
+5. Wait for the first scrape interval or click **Execute now** on the master item.
+6. Check **Monitoring > Latest data** for items with key prefix `flowtriq.`.
+
+## Agent configuration
+
+The Flowtriq agent metrics endpoint is enabled by default. If it has been disabled, add these lines to the agent configuration file (`/etc/flowtriq/agent.yml`):
+
+```yaml
+metrics_enabled: true
+metrics_port: 9145
+metrics_path: /metrics
+```
+
+Restart the agent after changing the configuration.
+
+## Macros reference
+
+| Macro | Default | Description |
+|-------|---------|-------------|
+| `{$FLOWTRIQ.AGENT.HOST}` | *(required)* | Agent hostname or IP |
+| `{$FLOWTRIQ.AGENT.PORT}` | `9145` | Agent metrics port |
+| `{$FLOWTRIQ.AGENT.SCHEME}` | `http` | URL scheme (`http` or `https`) |
+| `{$FLOWTRIQ.METRICS.PATH}` | `/metrics` | Path to the metrics endpoint |
+| `{$FLOWTRIQ.SCRAPE.INTERVAL}` | `30s` | Polling interval |
+| `{$FLOWTRIQ.NODATA.TIMEOUT}` | `10m` | No-data trigger threshold |
+| `{$FLOWTRIQ.API.LAG.WARN}` | `600` | API reporting lag warning (seconds) |
+
+## Feedback
+
+Report issues or suggest improvements via the [community-templates](https://github.com/zabbix/community-templates) repository.

--- a/Applications/Security/template_flowtriq_agent_http/7.0/template_flowtriq_agent_http.yaml
+++ b/Applications/Security/template_flowtriq_agent_http/7.0/template_flowtriq_agent_http.yaml
@@ -1,0 +1,340 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: cb68518647b34d6482aba902b9bed25d
+      name: Templates/Applications
+  templates:
+    - uuid: 5dbba782fd0046a593c102204a8f3bed
+      template: 'Flowtriq Agent by HTTP'
+      name: 'Flowtriq Agent by HTTP'
+      description: |
+        Monitors a Flowtriq DDoS detection agent via its Prometheus-compatible
+        metrics endpoint (default port 9145, path /metrics).
+
+        Collects traffic rates (PPS/BPS), active attack status, incident
+        counters, mitigation activity, and agent health metrics.
+
+        Setup: create a Zabbix host for each Flowtriq agent node. Set the
+        {$FLOWTRIQ.AGENT.HOST} and {$FLOWTRIQ.AGENT.PORT} macros to point at
+        the agent's metrics endpoint. Link this template.
+
+        Requires Zabbix 7.0+ with HTTP agent support. The Zabbix server or
+        proxy must be able to reach the agent metrics port.
+      vendor:
+        name: Flowtriq
+        version: '7.0'
+      groups:
+        - name: Templates/Applications
+      items:
+        - uuid: f1f0c491590649679a25b0de1bdb6f1b
+          name: 'Flowtriq: Get metrics'
+          type: HTTP_AGENT
+          key: flowtriq.metrics.get
+          delay: '{$FLOWTRIQ.SCRAPE.INTERVAL}'
+          history: 0d
+          trends: '0'
+          value_type: TEXT
+          description: 'Raw Prometheus metrics from the Flowtriq agent /metrics endpoint. Used as a master item for dependent items.'
+          url: '{$FLOWTRIQ.AGENT.SCHEME}://{$FLOWTRIQ.AGENT.HOST}:{$FLOWTRIQ.AGENT.PORT}{$FLOWTRIQ.METRICS.PATH}'
+          request_method: GET
+          timeout: 15s
+          tags:
+            - tag: component
+              value: raw
+          triggers:
+            - uuid: 339d44481df94016aa805dfbd713833a
+              expression: 'nodata(/Flowtriq Agent by HTTP/flowtriq.metrics.get,{$FLOWTRIQ.NODATA.TIMEOUT})=1'
+              name: 'Flowtriq: Metrics endpoint not responding'
+              priority: HIGH
+              description: 'No data received from the Flowtriq agent metrics endpoint. Verify that the agent process is running and the endpoint is reachable from the Zabbix server or proxy.'
+        - uuid: fbbbec3635e446fda44b5823c75ee315
+          name: 'Flowtriq: Agent uptime'
+          type: DEPENDENT
+          key: flowtriq.agent.uptime
+          delay: '0'
+          units: s
+          description: 'Seconds since the Flowtriq agent process started.'
+          preprocessing:
+            - type: PROMETHEUS_PATTERN
+              parameters:
+                - 'flowtriq_agent_uptime_seconds'
+                - ''
+          master_item:
+            key: flowtriq.metrics.get
+          tags:
+            - tag: component
+              value: health
+          triggers:
+            - uuid: 3896119e99b94776b5b297535473edc8
+              expression: 'last(/Flowtriq Agent by HTTP/flowtriq.agent.uptime)<600'
+              name: 'Flowtriq: Agent recently restarted'
+              priority: INFO
+              description: 'The Flowtriq agent has been running for less than 10 minutes, indicating a recent restart.'
+        - uuid: f719718a41f8433c9a4cb694ea4ef360
+          name: 'Flowtriq: Flow sources'
+          type: DEPENDENT
+          key: flowtriq.agent.flow_sources
+          delay: '0'
+          description: 'Number of active flow sources (sFlow/NetFlow collectors) feeding this agent.'
+          preprocessing:
+            - type: PROMETHEUS_PATTERN
+              parameters:
+                - 'flowtriq_agent_flow_sources'
+                - ''
+          master_item:
+            key: flowtriq.metrics.get
+          tags:
+            - tag: component
+              value: health
+          triggers:
+            - uuid: e728ee10d1c94f29bd62a674b8862e7b
+              expression: 'last(/Flowtriq Agent by HTTP/flowtriq.agent.flow_sources)=0'
+              name: 'Flowtriq: No active flow sources'
+              priority: HIGH
+              description: 'The agent has zero active flow sources. It is not receiving any sFlow or NetFlow data and cannot detect attacks.'
+        - uuid: 9a81c2e1b60a4303aaace3a016701f9a
+          name: 'Flowtriq: Last API report'
+          type: DEPENDENT
+          key: flowtriq.agent.last_report
+          delay: '0'
+          units: unixtime
+          description: 'Unix timestamp of the last successful report from this agent to the Flowtriq API.'
+          preprocessing:
+            - type: PROMETHEUS_PATTERN
+              parameters:
+                - 'flowtriq_agent_last_report_timestamp'
+                - ''
+          master_item:
+            key: flowtriq.metrics.get
+          tags:
+            - tag: component
+              value: health
+          triggers:
+            - uuid: dcb15177c0a64571978596e8fedc5309
+              expression: '(now()-last(/Flowtriq Agent by HTTP/flowtriq.agent.last_report))>{$FLOWTRIQ.API.LAG.WARN}'
+              name: 'Flowtriq: Agent not reporting to API'
+              priority: AVERAGE
+              description: 'The agent has not successfully reported to the Flowtriq API within the expected interval. Check network connectivity to the Flowtriq API and agent logs.'
+        - uuid: 795ff7db1fe24408b62fb32afd56fb2b
+          name: 'Flowtriq: Traffic PPS'
+          type: DEPENDENT
+          key: flowtriq.traffic.pps
+          delay: '0'
+          units: pps
+          description: 'Current packets per second observed by the agent across all monitored interfaces.'
+          preprocessing:
+            - type: PROMETHEUS_PATTERN
+              parameters:
+                - 'flowtriq_traffic_pps'
+                - ''
+          master_item:
+            key: flowtriq.metrics.get
+          tags:
+            - tag: component
+              value: traffic
+        - uuid: fec1e5550eb848f4abe4ebb14288e362
+          name: 'Flowtriq: Traffic BPS'
+          type: DEPENDENT
+          key: flowtriq.traffic.bps
+          delay: '0'
+          units: bps
+          description: 'Current bits per second observed by the agent across all monitored interfaces.'
+          preprocessing:
+            - type: PROMETHEUS_PATTERN
+              parameters:
+                - 'flowtriq_traffic_bps'
+                - ''
+          master_item:
+            key: flowtriq.metrics.get
+          tags:
+            - tag: component
+              value: traffic
+        - uuid: 943e6436b0d2423a81115a15ece5a5b1
+          name: 'Flowtriq: Active flows'
+          type: DEPENDENT
+          key: flowtriq.traffic.flows
+          delay: '0'
+          description: 'Number of active flows currently tracked by the agent.'
+          preprocessing:
+            - type: PROMETHEUS_PATTERN
+              parameters:
+                - 'flowtriq_traffic_flows'
+                - ''
+          master_item:
+            key: flowtriq.metrics.get
+          tags:
+            - tag: component
+              value: traffic
+        - uuid: eef4a0c955654626959a721dfbfa6de6
+          name: 'Flowtriq: Active attacks'
+          type: DEPENDENT
+          key: flowtriq.active_attacks
+          delay: '0'
+          description: 'Number of DDoS attacks currently in progress as detected by this agent.'
+          preprocessing:
+            - type: PROMETHEUS_PATTERN
+              parameters:
+                - 'flowtriq_active_attacks'
+                - ''
+          master_item:
+            key: flowtriq.metrics.get
+          tags:
+            - tag: component
+              value: attacks
+          triggers:
+            - uuid: 253bf9143f2a4eecb30c0d2df0715ae1
+              expression: 'last(/Flowtriq Agent by HTTP/flowtriq.active_attacks)>0'
+              name: 'Flowtriq: Active DDoS attack detected'
+              priority: WARNING
+              description: 'The agent is currently detecting one or more active DDoS attacks. Check the Flowtriq dashboard for attack details including target IPs, vectors, and severity.'
+              manual_close: 'YES'
+            - uuid: 1ecc7513cc014f7582ebb83228e54adf
+              expression: 'min(/Flowtriq Agent by HTTP/flowtriq.active_attacks,5m)>0'
+              name: 'Flowtriq: Sustained DDoS attack (5+ minutes)'
+              priority: HIGH
+              description: 'One or more DDoS attacks have been continuously active for at least 5 minutes. This may indicate a persistent volumetric or application-layer attack requiring attention.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'Flowtriq: Active DDoS attack detected'
+                  expression: 'last(/Flowtriq Agent by HTTP/flowtriq.active_attacks)>0'
+        - uuid: 01546a3bec454306b2a2804d9ad76597
+          name: 'Flowtriq: Total incidents'
+          type: DEPENDENT
+          key: flowtriq.incidents.total
+          delay: '0'
+          description: 'Total number of incidents detected since agent start. This is a monotonically increasing counter.'
+          preprocessing:
+            - type: PROMETHEUS_PATTERN
+              parameters:
+                - 'flowtriq_incidents_total'
+                - ''
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: flowtriq.metrics.get
+          tags:
+            - tag: component
+              value: attacks
+        - uuid: ce56418bc7fe4071bd4372fc582020a5
+          name: 'Flowtriq: Mitigated incidents'
+          type: DEPENDENT
+          key: flowtriq.incidents.mitigated
+          delay: '0'
+          description: 'Total number of incidents where automated mitigation was triggered. This is a monotonically increasing counter.'
+          preprocessing:
+            - type: PROMETHEUS_PATTERN
+              parameters:
+                - 'flowtriq_incidents_mitigated_total'
+                - ''
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: flowtriq.metrics.get
+          tags:
+            - tag: component
+              value: attacks
+      tags:
+        - tag: class
+          value: security
+        - tag: target
+          value: flowtriq
+      macros:
+        - macro: '{$FLOWTRIQ.AGENT.HOST}'
+          description: 'Hostname or IP of the Flowtriq agent metrics endpoint.'
+        - macro: '{$FLOWTRIQ.AGENT.PORT}'
+          value: '9145'
+          description: 'Port of the Flowtriq agent metrics endpoint.'
+        - macro: '{$FLOWTRIQ.AGENT.SCHEME}'
+          value: 'http'
+          description: 'URL scheme for the metrics endpoint (http or https).'
+        - macro: '{$FLOWTRIQ.METRICS.PATH}'
+          value: '/metrics'
+          description: 'Path to the Prometheus metrics endpoint on the agent.'
+        - macro: '{$FLOWTRIQ.SCRAPE.INTERVAL}'
+          value: '30s'
+          description: 'How often to poll the metrics endpoint.'
+        - macro: '{$FLOWTRIQ.NODATA.TIMEOUT}'
+          value: '10m'
+          description: 'Trigger if no data is received within this interval.'
+        - macro: '{$FLOWTRIQ.API.LAG.WARN}'
+          value: '600'
+          description: 'Seconds of API reporting lag before triggering a warning.'
+      dashboards:
+        - uuid: 9a916b88720840668d993549b499100c
+          name: 'Flowtriq Agent'
+          pages:
+            - name: Overview
+              widgets:
+                - type: GRAPH_CLASSIC
+                  name: 'Traffic rates'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Flowtriq Agent by HTTP'
+                        key: flowtriq.traffic.pps
+                    - type: ITEM
+                      name: itemid.1
+                      value:
+                        host: 'Flowtriq Agent by HTTP'
+                        key: flowtriq.traffic.bps
+                    - type: INTEGER
+                      name: source_type
+                      value: '1'
+                - type: GRAPH_CLASSIC
+                  name: 'Attack activity'
+                  x: '12'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Flowtriq Agent by HTTP'
+                        key: flowtriq.active_attacks
+                    - type: INTEGER
+                      name: source_type
+                      value: '1'
+                - type: GRAPH_CLASSIC
+                  name: 'Incident rate'
+                  'y': '5'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Flowtriq Agent by HTTP'
+                        key: flowtriq.incidents.total
+                    - type: ITEM
+                      name: itemid.1
+                      value:
+                        host: 'Flowtriq Agent by HTTP'
+                        key: flowtriq.incidents.mitigated
+                    - type: INTEGER
+                      name: source_type
+                      value: '1'
+                - type: GRAPH_CLASSIC
+                  name: 'Agent health'
+                  x: '12'
+                  'y': '5'
+                  width: '12'
+                  height: '5'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Flowtriq Agent by HTTP'
+                        key: flowtriq.agent.uptime
+                    - type: ITEM
+                      name: itemid.1
+                      value:
+                        host: 'Flowtriq Agent by HTTP'
+                        key: flowtriq.agent.flow_sources
+                    - type: INTEGER
+                      name: source_type
+                      value: '1'

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ This repository is dedicated to templates that are created and maintained by Zab
         * [Canary](Applications/Security/template_canary_files_monitoring)
         * [cve-2016-0728](Applications/Security/template_cve-2016-0728_check)
         * [DEVLINE](Applications/Security/template_devline_windows_monitoring_cctv)
+        * [Flowtriq Agent by HTTP](Applications/Security/template_flowtriq_agent_http)
     * [TV_Broadcasting](Applications/TV_Broadcasting)
         * [Service HLS](Applications/TV_Broadcasting/template_service_hls)
         * [Vizrt SNMP](Applications/TV_Broadcasting/template_vizrt_viz_engine_snmp)


### PR DESCRIPTION
## Summary

- Adds a Zabbix 7.0 template for monitoring [Flowtriq](https://flowtriq.com) DDoS detection agents
- Uses HTTP agent to scrape the agent's Prometheus-compatible `/metrics` endpoint (default port 9145)
- Collects traffic rates (PPS/BPS), active attack count, incident counters, mitigation activity, flow source count, agent uptime, and API reporting status
- Includes 6 triggers covering agent down, active attacks, sustained attacks, flow source loss, API lag, and recent restarts
- Includes a 4-panel dashboard (traffic rates, attack activity, incident rate, agent health)
- All items use dependent item + PROMETHEUS_PATTERN preprocessing from a single master HTTP item

## Template details

| | |
|---|---|
| **Category** | Applications/Security |
| **Zabbix version** | 7.0 |
| **Format** | YAML |
| **Collection method** | HTTP agent (Prometheus endpoint) |
| **Items** | 10 (1 master + 9 dependent) |
| **Triggers** | 6 |
| **Dashboard** | 1 (4 widgets) |
| **Macros** | 7 (all with defaults except host) |

## Test plan

- [ ] CI import check passes on Zabbix 7.0
- [ ] YAML validates without errors
- [ ] Template folder name and structure match repository conventions
- [ ] README documents all items, triggers, macros, and setup steps