### PR TITLE
Add MariaDB Galera HAProxy Keepalived template

### DIFF
--- a/Databases/MariaDB/template_mariadb_galera_haproxy_keepalived/7.4/README.md
+++ b/Databases/MariaDB/template_mariadb_galera_haproxy_keepalived/7.4/README.md
@@ -1,0 +1,142 @@
+# Template MariaDB Galera HAProxy Keepalived
+
+## Overview
+
+Template for monitoring a local MariaDB Galera node with local HAProxy and Keepalived services.
+
+The template is designed for a 3-node Galera cluster where each node runs:
+
+- MariaDB Galera
+- HAProxy with a local MySQL frontend on port `3307`
+- Keepalived with a shared virtual IP address
+- Zabbix agent with custom `UserParameter` checks
+
+The template includes a host dashboard named `MariaDB Galera node overview`.
+
+## Installation
+
+The template uses Zabbix agent `UserParameter` keys. Install the helper script and agent configuration from the upstream project on each Galera node:
+
+```bash
+git clone https://github.com/Sorway/Zabbix-Galera.git
+cd Zabbix-Galera
+sudo install -o root -g root -m 0755 scripts/check.sh /usr/local/bin/galera-check.sh
+sudo install -o root -g root -m 0644 zabbix_agentd.conf.d/agent.conf /etc/zabbix/zabbix_agentd.conf.d/galera.conf
+```
+
+Install the runtime dependencies:
+
+```bash
+sudo apt install -y mariadb-client socat iproute2 procps
+```
+
+Create a MariaDB monitoring user:
+
+```sql
+CREATE USER 'zabbix-monitor'@'localhost' IDENTIFIED BY 'ChangeThisPassword';
+GRANT PROCESS, REPLICATION CLIENT, SELECT ON *.* TO 'zabbix-monitor'@'localhost';
+FLUSH PRIVILEGES;
+```
+
+Create the MariaDB client credentials file used by the script:
+
+```bash
+sudo install -o zabbix -g zabbix -m 0600 /dev/null /etc/zabbix/.my.cnf
+sudo tee /etc/zabbix/.my.cnf >/dev/null <<'EOF'
+[client]
+user=zabbix-monitor
+password=ChangeThisPassword
+host=localhost
+port=3306
+EOF
+sudo chown zabbix:zabbix /etc/zabbix/.my.cnf
+sudo chmod 0600 /etc/zabbix/.my.cnf
+```
+
+Configure the HAProxy stats socket in the `global` section:
+
+```haproxy
+stats socket /run/haproxy/admin.sock user haproxy group zabbix mode 660 level admin
+stats timeout 2s
+```
+
+By default, the helper script counts backend servers that are `UP` in the HAProxy backend named `galera_back`. If your backend has another name, update `/usr/local/bin/galera-check.sh` after installation.
+
+Restart the services after installation:
+
+```bash
+sudo systemctl restart haproxy
+sudo systemctl restart zabbix-agent
+```
+
+Import `template_mariadb_galera_haproxy_keepalived.yaml` in Zabbix and link it to the hosts representing the Galera nodes.
+
+## Local checks
+
+Run these commands on each node to verify data collection:
+
+```bash
+sudo -u zabbix /usr/local/bin/galera-check.sh mysql.ping
+sudo -u zabbix /usr/local/bin/galera-check.sh galera.value wsrep_cluster_size
+sudo -u zabbix /usr/local/bin/galera-check.sh haproxy.backends_up_count
+sudo -u zabbix /usr/local/bin/galera-check.sh keepalived.vip.present 192.168.10.40
+```
+
+## Author
+
+Sorway
+
+## Macros used
+
+|Name|Description|Default|Type|
+|----|-----------|-------|----|
+|{$GALERA.EXPECTED_SIZE}|Expected Galera cluster size.|`3`|Text macro|
+|{$GALERA.FLOW_CONTROL.MAX}|Maximum acceptable `wsrep_flow_control_paused` average.|`0.05`|Text macro|
+|{$GALERA.RECV_QUEUE.MAX}|Maximum acceptable `wsrep_local_recv_queue` average.|`10`|Text macro|
+|{$HAPROXY.MIN_BACKENDS_UP}|Minimum number of available MariaDB backend servers in HAProxy.|`2`|Text macro|
+|{$KEEPALIVED.VIP}|Keepalived virtual IP address.|`<CHANGE_ME>`|Text macro|
+
+## Template links
+
+There are no template links in this template.
+
+## Discovery rules
+
+There are no discovery rules in this template.
+
+## Items collected
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|MariaDB: mysqladmin ping|Checks local MariaDB availability with `mysqladmin ping`.|`Zabbix agent`|mariadb.mysqladmin.ping<p>Update: 30s</p>|
+|Galera: cluster is Primary|Checks whether the node belongs to the Primary component.|`Zabbix agent`|mariadb.galera.primary<p>Update: 30s</p>|
+|Galera: node ready|Checks `wsrep_ready`.|`Zabbix agent`|mariadb.galera.ready<p>Update: 30s</p>|
+|Galera: node connected|Checks `wsrep_connected`.|`Zabbix agent`|mariadb.galera.connected<p>Update: 30s</p>|
+|Galera: node synced|Checks whether the local Galera state comment is `Synced`.|`Zabbix agent`|mariadb.galera.synced<p>Update: 30s</p>|
+|Galera: cluster size|Collects `wsrep_cluster_size`.|`Zabbix agent`|mariadb.galera.value[wsrep_cluster_size]<p>Update: 30s</p>|
+|Galera: local state|Collects `wsrep_local_state`.|`Zabbix agent`|mariadb.galera.value[wsrep_local_state]<p>Update: 30s</p>|
+|Galera: local state comment|Collects `wsrep_local_state_comment`.|`Zabbix agent`|mariadb.galera.value[wsrep_local_state_comment]<p>Update: 30s</p>|
+|Galera: flow control paused|Collects `wsrep_flow_control_paused`.|`Zabbix agent`|mariadb.galera.value[wsrep_flow_control_paused]<p>Update: 30s</p>|
+|Galera: local receive queue|Collects `wsrep_local_recv_queue`.|`Zabbix agent`|mariadb.galera.value[wsrep_local_recv_queue]<p>Update: 30s</p>|
+|HAProxy: process running|Checks the local HAProxy process.|`Zabbix agent`|service.process.running[haproxy]<p>Update: 30s</p>|
+|HAProxy: MySQL frontend port 3307 listening|Checks whether the local MySQL frontend port is listening.|`Zabbix agent`|haproxy.mysql_front.listen<p>Update: 30s</p>|
+|HAProxy local: Galera backends UP count|Counts Galera backends in `UP` state through the HAProxy stats socket.|`Zabbix agent`|haproxy.backends_up_count<p>Update: 30s</p>|
+|Keepalived: process running|Checks the local Keepalived process.|`Zabbix agent`|service.process.running[keepalived]<p>Update: 30s</p>|
+|Keepalived: VIP {$KEEPALIVED.VIP} present on this node|Checks whether the configured VIP is present on the local node.|`Zabbix agent`|keepalived.vip.present[{$KEEPALIVED.VIP}]<p>Update: 10s</p>|
+
+## Triggers
+
+|Name|Description|Expression|Priority|
+|----|-----------|----------|--------|
+|MariaDB is not responding to mysqladmin ping|Local MariaDB does not respond to `mysqladmin ping`.|<p>**Expression**: `last(/Template MariaDB Galera HAProxy Keepalived/mariadb.mysqladmin.ping)=0`</p>|HIGH|
+|Galera node is not in Primary component|The local node is outside the Galera Primary component.|<p>**Expression**: `last(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.primary)=0`</p>|DISASTER|
+|Galera node is not ready|`wsrep_ready` is not `ON`.|<p>**Expression**: `last(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.ready)=0`</p>|HIGH|
+|Galera node is not connected|`wsrep_connected` is not `ON`.|<p>**Expression**: `last(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.connected)=0`</p>|HIGH|
+|Galera node is not Synced|The local Galera state is not `Synced`.|<p>**Expression**: `last(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.synced)=0`</p>|HIGH|
+|Galera cluster size is not {$GALERA.EXPECTED_SIZE}|Current cluster size differs from the expected size macro.|<p>**Expression**: `last(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.value[wsrep_cluster_size])<>{$GALERA.EXPECTED_SIZE}`</p>|HIGH|
+|Galera flow control is high|Average flow control paused value is above the configured threshold.|<p>**Expression**: `avg(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.value[wsrep_flow_control_paused],5m)>{$GALERA.FLOW_CONTROL.MAX}`</p>|WARNING|
+|Galera receive queue is high|Average receive queue value is above the configured threshold.|<p>**Expression**: `avg(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.value[wsrep_local_recv_queue],5m)>{$GALERA.RECV_QUEUE.MAX}`</p>|WARNING|
+|HAProxy process is not running|The local HAProxy process is not running.|<p>**Expression**: `last(/Template MariaDB Galera HAProxy Keepalived/service.process.running[haproxy])=0`</p>|HIGH|
+|HAProxy MySQL frontend port 3307 is not listening|The local HAProxy MySQL frontend port is not listening.|<p>**Expression**: `last(/Template MariaDB Galera HAProxy Keepalived/haproxy.mysql_front.listen)=0`</p>|HIGH|
+|Too few Galera backends are UP in HAProxy|The number of available Galera backends is below the configured minimum.|<p>**Expression**: `last(/Template MariaDB Galera HAProxy Keepalived/haproxy.backends_up_count)<{$HAPROXY.MIN_BACKENDS_UP}`</p>|HIGH|
+|Keepalived process is not running|The local Keepalived process is not running.|<p>**Expression**: `last(/Template MariaDB Galera HAProxy Keepalived/service.process.running[keepalived])=0`</p>|HIGH|

--- a/Databases/MariaDB/template_mariadb_galera_haproxy_keepalived/7.4/template_mariadb_galera_haproxy_keepalived.yaml
+++ b/Databases/MariaDB/template_mariadb_galera_haproxy_keepalived/7.4/template_mariadb_galera_haproxy_keepalived.yaml
@@ -1,0 +1,718 @@
+zabbix_export:
+  version: '7.4'
+  template_groups:
+    - uuid: 8a504be9917d4fda9f6ef03c4f54b100
+      name: Templates/Databases
+  templates:
+    - uuid: c95c0bfa4e6641368d7d95d213a9a101
+      template: Template MariaDB Galera HAProxy Keepalived
+      name: Template MariaDB Galera HAProxy Keepalived
+      description: |
+        Monitoring local MariaDB Galera node, local HAProxy instance and local Keepalived VIP ownership.
+        Designed for a 3-node Galera cluster with HAProxy backend galera_back and Keepalived VIP configured by macro.
+      groups:
+        - name: Templates/Databases
+      macros:
+        - macro: '{$GALERA.EXPECTED_SIZE}'
+          value: '3'
+          description: Expected Galera cluster size.
+        - macro: '{$GALERA.FLOW_CONTROL.MAX}'
+          value: '0.05'
+          description: Maximum acceptable wsrep_flow_control_paused average.
+        - macro: '{$GALERA.RECV_QUEUE.MAX}'
+          value: '10'
+          description: Maximum acceptable wsrep_local_recv_queue average.
+        - macro: '{$HAPROXY.MIN_BACKENDS_UP}'
+          value: '2'
+          description: Minimum number of available MariaDB backend servers in HAProxy.
+        - macro: '{$KEEPALIVED.VIP}'
+          value: '<CHANGE_ME>'
+          description: Keepalived virtual IP address.
+      items:
+        - uuid: 09ad9da3990343598b857152bdcb8901
+          name: 'MariaDB: mysqladmin ping'
+          type: ZABBIX_PASSIVE
+          key: mariadb.mysqladmin.ping
+          delay: 30s
+          history: 30d
+          trends: 365d
+          valuemap:
+            name: Service state
+          tags:
+            - tag: component
+              value: mariadb
+          triggers:
+            - uuid: 72e038ecab44492bad751dfefef39001
+              expression: 'last(/Template MariaDB Galera HAProxy Keepalived/mariadb.mysqladmin.ping)=0'
+              name: 'MariaDB is not responding to mysqladmin ping'
+              priority: HIGH
+        - uuid: 2e473a5136a84992981212d3acfed702
+          name: 'Galera: cluster is Primary'
+          type: ZABBIX_PASSIVE
+          key: mariadb.galera.primary
+          delay: 30s
+          history: 30d
+          trends: 365d
+          valuemap:
+            name: Boolean state
+          tags:
+            - tag: component
+              value: galera
+          triggers:
+            - uuid: 3d1ab1fef9284d00aaeece3528882702
+              expression: 'last(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.primary)=0'
+              name: 'Galera node is not in Primary component'
+              priority: DISASTER
+        - uuid: 3a214b2079014ed9b0de4e6c060f4803
+          name: 'Galera: node ready'
+          type: ZABBIX_PASSIVE
+          key: mariadb.galera.ready
+          delay: 30s
+          history: 30d
+          trends: 365d
+          valuemap:
+            name: Boolean state
+          tags:
+            - tag: component
+              value: galera
+          triggers:
+            - uuid: cc00bc9b0bd04ca1a41dfce2783a3202
+              expression: 'last(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.ready)=0'
+              name: 'Galera node is not ready'
+              priority: HIGH
+        - uuid: 464cb3d55fd94915b69802e06b784c04
+          name: 'Galera: node connected'
+          type: ZABBIX_PASSIVE
+          key: mariadb.galera.connected
+          delay: 30s
+          history: 30d
+          trends: 365d
+          valuemap:
+            name: Boolean state
+          tags:
+            - tag: component
+              value: galera
+          triggers:
+            - uuid: 8c03db7a8a3c49f1b28fbc880e7f4203
+              expression: 'last(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.connected)=0'
+              name: 'Galera node is not connected'
+              priority: HIGH
+        - uuid: edd6b2eb94c94f3c96447d5351703505
+          name: 'Galera: node synced'
+          type: ZABBIX_PASSIVE
+          key: mariadb.galera.synced
+          delay: 30s
+          history: 30d
+          trends: 365d
+          valuemap:
+            name: Boolean state
+          tags:
+            - tag: component
+              value: galera
+          triggers:
+            - uuid: 4ac36d7ea93a44f5b5923111b755e501
+              expression: 'last(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.synced)=0'
+              name: 'Galera node is not Synced'
+              priority: HIGH
+        - uuid: 4733cde2f6e44631b0e626cb1ea69f1b
+          name: 'Galera: cluster size'
+          type: ZABBIX_PASSIVE
+          key: 'mariadb.galera.value[wsrep_cluster_size]'
+          delay: 30s
+          history: 30d
+          trends: 365d
+          tags:
+            - tag: component
+              value: galera
+          triggers:
+            - uuid: f0f1b3223f064c7fb7e8265fa60d4001
+              expression: 'last(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.value[wsrep_cluster_size])<>{$GALERA.EXPECTED_SIZE}'
+              name: 'Galera cluster size is not {$GALERA.EXPECTED_SIZE}'
+              priority: HIGH
+        - uuid: 7493fa694d2945e89c1f5c7836f89301
+          name: 'Galera: local state'
+          type: ZABBIX_PASSIVE
+          key: 'mariadb.galera.value[wsrep_local_state]'
+          delay: 30s
+          history: 30d
+          trends: 365d
+          tags:
+            - tag: component
+              value: galera
+        - uuid: 26bdc4446e5e4d6ba126f881624e1f01
+          name: 'Galera: local state comment'
+          type: ZABBIX_PASSIVE
+          key: 'mariadb.galera.value[wsrep_local_state_comment]'
+          delay: 30s
+          history: 30d
+          value_type: CHAR
+          tags:
+            - tag: component
+              value: galera
+        - uuid: f0fd050937d542f8861e67424e870e01
+          name: 'Galera: flow control paused'
+          type: ZABBIX_PASSIVE
+          key: 'mariadb.galera.value[wsrep_flow_control_paused]'
+          delay: 30s
+          history: 30d
+          trends: 365d
+          value_type: FLOAT
+          tags:
+            - tag: component
+              value: galera
+          triggers:
+            - uuid: 7a5e66cbefbb40b58bf9f93fce724801
+              expression: 'avg(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.value[wsrep_flow_control_paused],5m)>{$GALERA.FLOW_CONTROL.MAX}'
+              name: 'Galera flow control is high'
+              priority: WARNING
+        - uuid: 4c630bbac31a4d10a578ec76f54f9a01
+          name: 'Galera: local receive queue'
+          type: ZABBIX_PASSIVE
+          key: 'mariadb.galera.value[wsrep_local_recv_queue]'
+          delay: 30s
+          history: 30d
+          trends: 365d
+          value_type: FLOAT
+          tags:
+            - tag: component
+              value: galera
+          triggers:
+            - uuid: d78344c82f8b44dc89a983b23101ee01
+              expression: 'avg(/Template MariaDB Galera HAProxy Keepalived/mariadb.galera.value[wsrep_local_recv_queue],5m)>{$GALERA.RECV_QUEUE.MAX}'
+              name: 'Galera receive queue is high'
+              priority: WARNING
+        - uuid: 1f6d7f86e7a6477da339ac980d38f501
+          name: 'HAProxy: process running'
+          type: ZABBIX_PASSIVE
+          key: 'service.process.running[haproxy]'
+          delay: 30s
+          history: 30d
+          trends: 365d
+          valuemap:
+            name: Service state
+          tags:
+            - tag: component
+              value: haproxy
+          triggers:
+            - uuid: d0f33199b0a341c39af49f582573c310
+              expression: 'last(/Template MariaDB Galera HAProxy Keepalived/service.process.running[haproxy])=0'
+              name: 'HAProxy process is not running'
+              priority: HIGH
+        - uuid: 5fa0d13c22904c26a998806db2b51901
+          name: 'HAProxy: MySQL frontend port 3307 listening'
+          type: ZABBIX_PASSIVE
+          key: haproxy.mysql_front.listen
+          delay: 30s
+          history: 30d
+          trends: 365d
+          valuemap:
+            name: Service state
+          tags:
+            - tag: component
+              value: haproxy
+          triggers:
+            - uuid: 2c2eb41f225c49d085952265ee6c6a01
+              expression: 'last(/Template MariaDB Galera HAProxy Keepalived/haproxy.mysql_front.listen)=0'
+              name: 'HAProxy MySQL frontend port 3307 is not listening'
+              priority: HIGH
+        - uuid: 7fd8daff91024880a4fbdf37d42bbf01
+          name: 'HAProxy local: Galera backends UP count'
+          type: ZABBIX_PASSIVE
+          key: haproxy.backends_up_count
+          delay: 30s
+          history: 30d
+          trends: 365d
+          tags:
+            - tag: component
+              value: haproxy
+          triggers:
+            - uuid: 1118f131ad78453982a74e444696cc01
+              expression: 'last(/Template MariaDB Galera HAProxy Keepalived/haproxy.backends_up_count)<{$HAPROXY.MIN_BACKENDS_UP}'
+              name: 'Too few Galera backends are UP in HAProxy'
+              priority: HIGH
+        - uuid: 54498ca2a71c4b93a95ab48da4ac2601
+          name: 'Keepalived: process running'
+          type: ZABBIX_PASSIVE
+          key: 'service.process.running[keepalived]'
+          delay: 30s
+          history: 30d
+          trends: 365d
+          valuemap:
+            name: Service state
+          tags:
+            - tag: component
+              value: keepalived
+          triggers:
+            - uuid: 88ad821bf84a44d09573bdb530e3b301
+              expression: 'last(/Template MariaDB Galera HAProxy Keepalived/service.process.running[keepalived])=0'
+              name: 'Keepalived process is not running'
+              priority: HIGH
+        - uuid: 3e09c503dcfb4717a057e7f8e9d1f001
+          name: 'Keepalived: VIP {$KEEPALIVED.VIP} present on this node'
+          type: ZABBIX_PASSIVE
+          key: 'keepalived.vip.present[{$KEEPALIVED.VIP}]'
+          delay: 10s
+          history: 30d
+          trends: 365d
+          valuemap:
+            name: VIP ownership
+          tags:
+            - tag: component
+              value: keepalived
+      dashboards:
+        - uuid: 95f13355a9424b5aaf0a5e8f82c7d4a1
+          name: 'MariaDB Galera node overview'
+          pages:
+            - name: 'Node overview'
+              widgets:
+                - type: item
+                  name: 'MariaDB status'
+                  width: '12'
+                  height: '4'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: mariadb.mysqladmin.ping
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: value_size
+                      value: '22'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E58F8F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 7BC99A
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: item
+                  name: 'Galera Primary'
+                  x: '12'
+                  width: '12'
+                  height: '4'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: mariadb.galera.primary
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: value_size
+                      value: '22'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E58F8F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 7BC99A
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: item
+                  name: 'Galera ready'
+                  x: '24'
+                  width: '12'
+                  height: '4'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: mariadb.galera.ready
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: value_size
+                      value: '22'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E58F8F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 7BC99A
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: item
+                  name: 'Galera connected'
+                  x: '36'
+                  width: '12'
+                  height: '4'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: mariadb.galera.connected
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: value_size
+                      value: '22'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E58F8F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 7BC99A
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: item
+                  name: 'Galera synced'
+                  x: '48'
+                  width: '12'
+                  height: '4'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: mariadb.galera.synced
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: value_size
+                      value: '22'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E58F8F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 7BC99A
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: item
+                  name: 'VIP owner'
+                  x: '60'
+                  width: '12'
+                  height: '4'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: 'keepalived.vip.present[{$KEEPALIVED.VIP}]'
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: value_size
+                      value: '22'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 94A3B8
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 7BC99A
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: item
+                  name: 'Cluster size'
+                  'y': '4'
+                  width: '12'
+                  height: '4'
+                  fields:
+                    - type: INTEGER
+                      name: decimal_places
+                      value: '0'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: 'mariadb.galera.value[wsrep_cluster_size]'
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: value_size
+                      value: '22'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E58F8F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E8B45F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: 7BC99A
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '3'
+                - type: item
+                  name: 'Galera local state'
+                  x: '12'
+                  'y': '4'
+                  width: '12'
+                  height: '4'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: 'mariadb.galera.value[wsrep_local_state_comment]'
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: value_size
+                      value: '22'
+                - type: item
+                  name: 'HAProxy process'
+                  x: '24'
+                  'y': '4'
+                  width: '12'
+                  height: '4'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: 'service.process.running[haproxy]'
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: value_size
+                      value: '22'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E58F8F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 7BC99A
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: item
+                  name: 'HAProxy port 3307'
+                  x: '36'
+                  'y': '4'
+                  width: '12'
+                  height: '4'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: haproxy.mysql_front.listen
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: value_size
+                      value: '22'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E58F8F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 7BC99A
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: item
+                  name: 'HAProxy backends UP'
+                  x: '48'
+                  'y': '4'
+                  width: '12'
+                  height: '4'
+                  fields:
+                    - type: INTEGER
+                      name: decimal_places
+                      value: '0'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: haproxy.backends_up_count
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: value_size
+                      value: '22'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E58F8F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E8B45F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: 7BC99A
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '2'
+                - type: item
+                  name: 'Keepalived process'
+                  x: '60'
+                  'y': '4'
+                  width: '12'
+                  height: '4'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: 'service.process.running[keepalived]'
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: value_size
+                      value: '22'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E58F8F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 7BC99A
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: graph
+                  name: 'Galera flow control'
+                  'y': '8'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: 'mariadb.galera.value[wsrep_flow_control_paused]'
+                    - type: STRING
+                      name: reference
+                      value: AAAAA
+                    - type: INTEGER
+                      name: source_type
+                      value: '1'
+                - type: graph
+                  name: 'Galera receive queue'
+                  x: '36'
+                  'y': '8'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: 'mariadb.galera.value[wsrep_local_recv_queue]'
+                    - type: STRING
+                      name: reference
+                      value: AAAAB
+                    - type: INTEGER
+                      name: source_type
+                      value: '1'
+                - type: graph
+                  name: 'Galera cluster size'
+                  'y': '14'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: 'mariadb.galera.value[wsrep_cluster_size]'
+                    - type: STRING
+                      name: reference
+                      value: AAAAC
+                    - type: INTEGER
+                      name: source_type
+                      value: '1'
+                - type: graph
+                  name: 'HAProxy local backends UP count'
+                  x: '36'
+                  'y': '14'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template MariaDB Galera HAProxy Keepalived'
+                        key: haproxy.backends_up_count
+                    - type: STRING
+                      name: reference
+                      value: AAAAD
+                    - type: INTEGER
+                      name: source_type
+                      value: '1'
+      valuemaps:
+        - uuid: b55efe63540842b7a798978e97fd3e01
+          name: Boolean state
+          mappings:
+            - value: '0'
+              newvalue: 'NO'
+            - value: '1'
+              newvalue: 'OK'
+        - uuid: 7e586e57e9494c188692c0d5f2a76701
+          name: Service state
+          mappings:
+            - value: '0'
+              newvalue: 'DOWN'
+            - value: '1'
+              newvalue: 'UP'
+        - uuid: 0384a41f3c994edc91f0b8e2f9c6a101
+          name: VIP ownership
+          mappings:
+            - value: '0'
+              newvalue: 'Standby'
+            - value: '1'
+              newvalue: 'Owner'
+


### PR DESCRIPTION
## Summary

Add a Zabbix 7.4 template for monitoring MariaDB Galera nodes with local HAProxy and Keepalived.

The template monitors:
- MariaDB availability
- Galera node state and cluster size
- Galera flow control and receive queue
- HAProxy process, frontend listener and backend availability
- Keepalived process and VIP ownership

## Notes

This template uses Zabbix agent UserParameter checks. The required helper script and agent configuration are documented in the README

## Files added

- `Databases/MariaDB/template_mariadb_galera_haproxy_keepalived/7.4/template_mariadb_galera_haproxy_keepalived.yaml`
- `Databases/MariaDB/template_mariadb_galera_haproxy_keepalived/7.4/README.md`