### PR TITLE
Ignore UPS battery self-test in FSP UPS ViewPower triggers

### DIFF
--- a/Power_(UPS)/FSP/template_fsp_ups_viewpower_by_usb/7.4/template_fsp_ups_viewpower_by_usb.yaml
+++ b/Power_(UPS)/FSP/template_fsp_ups_viewpower_by_usb/7.4/template_fsp_ups_viewpower_by_usb.yaml
@@ -7,7 +7,7 @@ zabbix_export:
     - uuid: 3a7e1c908f424e13b2a49c7d5f0e5678
       template: 'FSP UPS ViewPower by USB'
       name: 'FSP UPS ViewPower by USB'
-      description: 'Sledování stavu UPS FSP přes USB připojení'
+      description: 'Monitoring FSP UPS status over local USB connection'
       groups:
         - name: Templates/Power
       items:
@@ -17,47 +17,42 @@ zabbix_export:
           delay: 30s
           value_type: FLOAT
           units: '%'
-          description: 'Kapacita baterie'
-          triggers:
-            - uuid: 9d3a7e214c554b88a2d16f0c9e1d4444
-              expression: 'last(/FSP UPS ViewPower by USB/ups.battery[battery,{$UPS.PORT}])<30'
-              name: 'UPS battery low (<30%)'
-              priority: HIGH
+          description: 'Battery Capacity'
         - uuid: a01c8af57b614c9c883d62e1b043ec8c
           name: 'UPS Run time'
           key: 'ups.battery[runtime,{$UPS.PORT}]'
           delay: 30s
           value_type: FLOAT
           units: min
-          description: 'Zbývající čas'
+          description: 'Run time'
         - uuid: 2e9d4c776b214a5f8d3c4f7e9a0b2222
           name: 'UPS Input Voltage'
           key: 'ups.input[inputV,{$UPS.PORT}]'
           delay: 30s
           value_type: FLOAT
           units: V
-          description: 'Vstupní napětí'
+          description: 'Input Voltage'
         - uuid: bbf5e01aef72498dbfafd4347d02d99e
-          name: 'UPS Frequncy'
+          name: 'UPS Frequency'
           key: 'ups.mode[freq,{$UPS.PORT}]'
           delay: 30s
           value_type: FLOAT
           trends: '0'
           units: Hz
-          description: Frekvence
+          description: Frequency
         - uuid: ad8b2afe3bf64610b918a34ff0bfeabf
           name: 'UPS Load'
           key: 'ups.mode[load,{$UPS.PORT}]'
           delay: 30s
           trends: '0'
           units: '%'
-          description: Zátěž
+          description: Load
         - uuid: 5c7a8b901d334c77a9e13f6d0b9c3333
           name: 'UPS Mode'
           key: 'ups.mode[mode,{$UPS.PORT}]'
           delay: 30s
           value_type: TEXT
-          description: Stav
+          description: Mode
           triggers:
             - uuid: 7a2b5c908d114f66b3a25c9e0f2a5555
               expression: |
@@ -73,7 +68,17 @@ zabbix_export:
           value_type: FLOAT
           trends: '0'
           units: °C
-          description: Teplota
+          description: Temperature
       macros:
         - macro: '{$UPS.PORT}'
-          description: 'ID sledovaného USB zařízení'
+          description: 'ID monitored USB device'
+  triggers:
+    - uuid: 9d3a7e214c554b88a2d16f0c9e1d4444
+      expression: |
+        last(/FSP UPS ViewPower by USB/ups.battery[battery,{$UPS.PORT}])<30
+        and
+        find(/FSP UPS ViewPower by USB/ups.mode[mode,{$UPS.PORT}],,"like","Battery")=1
+        and
+        find(/FSP UPS ViewPower by USB/ups.mode[mode,{$UPS.PORT}],,"like","test")=0
+      name: 'UPS battery low (<30%)'
+      priority: HIGH


### PR DESCRIPTION
This update improves the trigger logic for FSP UPS ViewPower by USB.

The previous low battery trigger was based only on battery percentage, which could generate false High severity alerts during scheduled monthly UPS battery discharge tests.

The battery-related triggers now ignore UPS modes containing "test", while still alerting when the UPS is actually running on battery outside of a test condition.

Changed triggers:
- UPS running on battery
- UPS battery low (<30%)

The low battery trigger now requires:
- battery capacity below 30%
- UPS mode containing "Battery"
- UPS mode not containing "test"

This prevents false alerts during planned UPS battery tests.