### PR TITLE
Add GitLab Pipelines by HTTP template

### DIFF
--- a/Applications/Gitlab/template_gitlab_pipelines_by_http/7.4/README.md
+++ b/Applications/Gitlab/template_gitlab_pipelines_by_http/7.4/README.md
@@ -1,0 +1,151 @@
+# GitLab Pipelines by HTTP
+
+## Overview
+
+Template for monitoring GitLab CI/CD pipeline health across all projects.
+
+Auto-discovers all non-archived projects via the GitLab REST API and tracks pipeline success/failure counts and rates across four time windows (hour, day, week, month). Includes a dashboard for at-a-glance triage.
+
+API documentation: https://docs.gitlab.com/api/pipelines/
+
+## Requirements
+
+Zabbix 7.4 and higher
+
+## Tested versions
+
+This template has been tested on GitLab CE 19.x (self-hosted) with Zabbix 7.4.
+
+## Author
+
+nikosch86
+
+Source repository and issue tracker: https://github.com/nikosch86/zabbix-gitlab-pipelines
+
+## Setup
+
+Create a Personal Access Token with `read_api` scope. For monitoring all projects (including those the token owner is not a member of), use an admin-level token.
+
+Set the resulting token and GitLab URL in the host macros. `{$GITLAB.API.TOKEN}` is a secret macro, so its value is not shown after saving and is not included on export.
+
+The template should be assigned to a host (the Zabbix server itself works fine, since no agent is required).
+
+### Macros used
+
+| Name | Description | Default |
+| ---- | ----------- | ------- |
+| {$GITLAB.URL} | <p>Base URL of the GitLab instance, without a trailing slash (for example, `https://gitlab.example.com`).</p> | |
+| {$GITLAB.API.TOKEN} | <p>GitLab Personal Access Token with the `read_api` scope, used to authenticate to the GitLab REST API.</p> | |
+| {$GITLAB.DISC.INTERVAL} | <p>How often to discover new projects.</p> | `1h` |
+| {$GITLAB.PIPELINE.INTERVAL} | <p>How often to check pipeline status.</p> | `15m` |
+| {$GITLAB.HTTP.TIMEOUT} | <p>Timeout for HTTP requests to the GitLab API.</p> | `15s` |
+| {$GITLAB.FAIL.RATE.DAY.WARN} | <p>Daily pipeline failure rate (%) above which a trigger fires. Supports per-project context, e.g. `{$GITLAB.FAIL.RATE.DAY.WARN:"my-group/my-project"}`.</p> | `75` |
+| {$GITLAB.FAIL.RATE.HOUR.WARN} | <p>Hourly pipeline failure rate (%) above which a trigger fires.</p> | `50` |
+| {$GITLAB.FAIL.RATE.WEEK.WARN} | <p>Weekly pipeline failure rate (%) above which a trigger fires. Supports per-project context, e.g. `{$GITLAB.FAIL.RATE.WEEK.WARN:"my-group/my-project"}`.</p> | `50` |
+
+### Items
+
+| Name | Description | Type | Key and additional info |
+| ---- | ----------- | ---- | ----------------------- |
+| GitLab: API version | <p>GitLab version string from `/api/v4/version`. Serves as the template availability signal: if the GitLab API is unreachable or the token is invalid, this item receives no data.</p> | HTTP agent | gitlab.api.version<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.version`</p></li></ul> |
+
+### LLD rule Project discovery
+
+| Name | Description | Type | Key and additional info |
+| ---- | ----------- | ---- | ----------------------- |
+| GitLab: Discover Projects | <p>Discovers all non-archived projects. Handles pagination for instances with more than 100 projects.</p> | Script | gitlab.project.discovery |
+
+### Item prototypes for Project discovery
+
+| Name | Description | Type | Key and additional info |
+| ---- | ----------- | ---- | ----------------------- |
+| GitLab: {#PROJECT_PATH} Pipelines | <p>Fetches up to 100 recent pipelines for the project. JavaScript preprocessing computes aggregated stats across four time windows.</p> | HTTP agent | gitlab.pipeline.data[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JavaScript: Computes total, failed, success counts and failure rates per hour/day/week/month</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Failed (hour) | <p>Number of failed pipelines in the last hour.</p> | Dependent item | gitlab.pipeline.failed.hour[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.failed_hour`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Failed (day) | <p>Number of failed pipelines in the last day.</p> | Dependent item | gitlab.pipeline.failed.day[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.failed_day`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Failed (week) | <p>Number of failed pipelines in the last week.</p> | Dependent item | gitlab.pipeline.failed.week[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.failed_week`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Failed (month) | <p>Number of failed pipelines in the last month.</p> | Dependent item | gitlab.pipeline.failed.month[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.failed_month`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Successful (hour) | <p>Number of successful pipelines in the last hour.</p> | Dependent item | gitlab.pipeline.success.hour[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.success_hour`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Successful (day) | <p>Number of successful pipelines in the last day.</p> | Dependent item | gitlab.pipeline.success.day[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.success_day`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Successful (week) | <p>Number of successful pipelines in the last week.</p> | Dependent item | gitlab.pipeline.success.week[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.success_week`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Successful (month) | <p>Number of successful pipelines in the last month.</p> | Dependent item | gitlab.pipeline.success.month[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.success_month`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Total (hour) | <p>Total number of pipelines in the last hour.</p> | Dependent item | gitlab.pipeline.total.hour[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.total_hour`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Total (day) | <p>Total number of pipelines in the last day.</p> | Dependent item | gitlab.pipeline.total.day[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.total_day`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Total (week) | <p>Total number of pipelines in the last week.</p> | Dependent item | gitlab.pipeline.total.week[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.total_week`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Total (month) | <p>Total number of pipelines in the last month.</p> | Dependent item | gitlab.pipeline.total.month[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.total_month`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Failure rate (hour) | <p>Percentage of pipelines that failed in the last hour.</p> | Dependent item | gitlab.pipeline.failrate.hour[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.failure_rate_hour`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Failure rate (day) | <p>Percentage of pipelines that failed in the last day.</p> | Dependent item | gitlab.pipeline.failrate.day[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.failure_rate_day`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Failure rate (week) | <p>Percentage of pipelines that failed in the last week.</p> | Dependent item | gitlab.pipeline.failrate.week[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.failure_rate_week`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Failure rate (month) | <p>Percentage of pipelines that failed in the last month.</p> | Dependent item | gitlab.pipeline.failrate.month[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.failure_rate_month`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Latest pipeline status | <p>Status of the most recent pipeline.</p> | Dependent item | gitlab.pipeline.latest.status[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.latest_status`</p></li><li><p>Discard unchanged with heartbeat: `1h`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Latest pipeline ref | <p>Git ref (branch or tag) of the most recent pipeline.</p> | Dependent item | gitlab.pipeline.latest.ref[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.latest_ref`</p></li><li><p>Discard unchanged with heartbeat: `1h`</p></li></ul> |
+| GitLab: {#PROJECT_PATH} Pipelines: Latest pipeline URL | <p>Web URL of the most recent pipeline.</p> | Dependent item | gitlab.pipeline.latest.url[{#PROJECT_ID}]<p>**Preprocessing**</p><ul><li><p>JSONPath: `$.latest_url`</p></li><li><p>Discard unchanged with heartbeat: `1h`</p></li></ul> |
+
+### Calculated items (aggregates across all projects)
+
+| Name | Description | Type | Key and additional info |
+| ---- | ----------- | ---- | ----------------------- |
+| GitLab: All projects: Total pipelines (hour) | <p>Sum of total pipelines across all projects (last hour).</p> | Calculated | gitlab.pipeline.total.hour.all |
+| GitLab: All projects: Total pipelines (day) | <p>Sum of total pipelines across all projects (last day).</p> | Calculated | gitlab.pipeline.total.day.all |
+| GitLab: All projects: Total pipelines (week) | <p>Sum of total pipelines across all projects (last week).</p> | Calculated | gitlab.pipeline.total.week.all |
+| GitLab: All projects: Failed pipelines (hour) | <p>Sum of failed pipelines across all projects (last hour).</p> | Calculated | gitlab.pipeline.failed.hour.all |
+| GitLab: All projects: Failed pipelines (day) | <p>Sum of failed pipelines across all projects (last day).</p> | Calculated | gitlab.pipeline.failed.day.all |
+| GitLab: All projects: Failed pipelines (week) | <p>Sum of failed pipelines across all projects (last week).</p> | Calculated | gitlab.pipeline.failed.week.all |
+| GitLab: All projects: Successful pipelines (hour) | <p>Sum of successful pipelines across all projects (last hour).</p> | Calculated | gitlab.pipeline.success.hour.all |
+| GitLab: All projects: Successful pipelines (day) | <p>Sum of successful pipelines across all projects (last day).</p> | Calculated | gitlab.pipeline.success.day.all |
+| GitLab: All projects: Successful pipelines (week) | <p>Sum of successful pipelines across all projects (last week).</p> | Calculated | gitlab.pipeline.success.week.all |
+| GitLab: All projects: Failure rate (hour) | <p>Overall failure rate across all projects (last hour).</p> | Calculated | gitlab.pipeline.failrate.hour.all |
+| GitLab: All projects: Failure rate (day) | <p>Overall failure rate across all projects (last day).</p> | Calculated | gitlab.pipeline.failrate.day.all |
+
+### Trigger prototypes for Project discovery
+
+| Name | Description | Expression | Severity | Dependencies and additional info |
+| ---- | ----------- | ---------- | -------- | -------------------------------- |
+| GitLab: High daily failure rate on {#PROJECT_PATH} | <p>The daily pipeline failure rate for {#PROJECT_PATH} exceeds {$GITLAB.FAIL.RATE.DAY.WARN}%. Override per project with the context macro {$GITLAB.FAIL.RATE.DAY.WARN:"{#PROJECT_PATH}"}.</p> | `last(/GitLab Pipelines by HTTP/gitlab.pipeline.failrate.day[{#PROJECT_ID}])>{$GITLAB.FAIL.RATE.DAY.WARN:"{#PROJECT_PATH}"}` | Average | <p>Operational data: Failure rate: {ITEM.LASTVALUE}</p><p>Manual close: Yes</p><p>Depends on:</p><ul><li>GitLab: API is unreachable</li></ul> |
+| GitLab: High weekly failure rate on {#PROJECT_PATH} | <p>The weekly pipeline failure rate for {#PROJECT_PATH} exceeds {$GITLAB.FAIL.RATE.WEEK.WARN}%. Override per project with the context macro {$GITLAB.FAIL.RATE.WEEK.WARN:"{#PROJECT_PATH}"}.</p> | `last(/GitLab Pipelines by HTTP/gitlab.pipeline.failrate.week[{#PROJECT_ID}])>{$GITLAB.FAIL.RATE.WEEK.WARN:"{#PROJECT_PATH}"}` | Average | <p>Operational data: Failure rate: {ITEM.LASTVALUE}</p><p>Manual close: Yes</p><p>Depends on:</p><ul><li>GitLab: API is unreachable</li></ul> |
+
+### Triggers (global)
+
+| Name | Description | Expression | Severity | Dependencies and additional info |
+| ---- | ----------- | ---------- | -------- | -------------------------------- |
+| GitLab: High daily failure rate | <p>The daily failure rate of all pipelines is high</p> | `last(/GitLab Pipelines by HTTP/gitlab.pipeline.failrate.day.all)>{$GITLAB.FAIL.RATE.DAY.WARN:"TOTAL"}` | High | <p>Operational data: Failure rate: {ITEM.LASTVALUE}</p><p>Depends on:</p><ul><li>GitLab: API is unreachable</li></ul> |
+| GitLab: High hourly failure rate | <p>The hourly failure rate of all pipelines is high</p> | `last(/GitLab Pipelines by HTTP/gitlab.pipeline.failrate.hour.all)>{$GITLAB.FAIL.RATE.HOUR.WARN:"TOTAL"}` | High | <p>Operational data: Failure rate: {ITEM.LASTVALUE}</p><p>Depends on:</p><ul><li>GitLab: API is unreachable</li></ul> |
+| GitLab: API is unreachable | <p>No data from the GitLab API for 30 minutes. The instance may be down, {$GITLAB.URL} may be wrong, or {$GITLAB.API.TOKEN} may be invalid or lack the read_api scope.</p> | `nodata(/GitLab Pipelines by HTTP/gitlab.api.version,30m)=1` | High | |
+
+### Graphs
+
+| Name | Description |
+| ---- | ----------- |
+| GitLab: All projects pipeline overview (daily) | <p>Graph showing successful (green), failed (red), and total (blue line) pipelines per day across all projects.</p> |
+| GitLab: All projects pipeline overview (weekly) | <p>Graph showing successful (green), failed (red), and total (blue line) pipelines per week across all projects.</p> |
+
+### Graph prototypes
+
+| Name | Description |
+| ---- | ----------- |
+| GitLab: {#PROJECT_PATH} Pipeline overview (daily) | <p>Per-project graph showing successful (green), failed (red), and total (blue line) pipelines per day.</p> |
+
+### Dashboard
+
+The template includes a built-in dashboard "GitLab Pipeline Health" with:
+
+- **Active Problems** — Current pipeline failure alerts, filtered by severity
+- **Overall Health** — Pie chart showing success vs failure split
+- **Project Health Map** — Honeycomb widget showing all projects color-coded by daily failure rate (green → red)
+- **Pipeline Trend** — Stacked graph of total/successful/failed pipelines over time
+- **Failure Rate Trend** — Line graph of overall daily failure rate
+
+## Per-project threshold overrides
+
+Use context macros at the host level to set different thresholds per project:
+
+```
+{$GITLAB.FAIL.RATE.DAY.WARN:"my-group/my-project"} = 100
+```
+
+This effectively silences the trigger for that project (failure rate can never exceed 100%).
+
+## Notes
+
+- The GitLab API returns a maximum of 100 pipelines per request. For high-activity projects (>100 pipelines/week), weekly and monthly counts may be incomplete.
+- The discovery rule uses Zabbix Script type with pagination to handle instances with more than 100 projects.
+- No external scripts or Zabbix agent required — all data is collected via HTTP agent and Script items running on the Zabbix server.

--- a/Applications/Gitlab/template_gitlab_pipelines_by_http/7.4/template_gitlab_pipelines_by_http.yaml
+++ b/Applications/Gitlab/template_gitlab_pipelines_by_http/7.4/template_gitlab_pipelines_by_http.yaml
@@ -1,0 +1,937 @@
+zabbix_export:
+  version: '7.4'
+  template_groups:
+    - uuid: a571c0d144b14fd4a87a9d9b2aa9fcd6
+      name: Templates/Applications
+  templates:
+    - uuid: f07365e563ab4be584bdd848101b92da
+      template: 'GitLab Pipelines by HTTP'
+      name: 'GitLab Pipelines by HTTP'
+      description: |
+        Monitors GitLab CI/CD pipeline health across all projects of a GitLab instance.
+
+        The template auto-discovers all non-archived projects via the GitLab REST API and
+        tracks pipeline success/failure counts and failure rates over multiple time windows
+        (hour, day, week, month). It also ships a ready-made dashboard for at-a-glance triage.
+
+        Setup:
+          1. Create a GitLab Personal Access Token with the read_api scope. To cover projects
+             the token owner is not a member of, use an admin-level token.
+          2. Set {$GITLAB.URL} and {$GITLAB.API.TOKEN} on the host.
+          3. Assign the template to a host. The Zabbix server itself works fine, since no
+             Zabbix agent is required.
+
+        Author: nikosch86
+
+        Template repository and issue tracker:
+        https://github.com/nikosch86/zabbix-gitlab-pipelines
+      groups:
+        - name: Templates/Applications
+      items:
+        - uuid: efb875df6be645d78db04c90ec73381d
+          name: 'GitLab: All projects: Failed pipelines (day)'
+          type: CALCULATED
+          key: gitlab.pipeline.failed.day.all
+          description: 'Sum of failed pipelines across all projects (last day).'
+          delay: '{$GITLAB.PIPELINE.INTERVAL}'
+          params: 'sum(last_foreach(//gitlab.pipeline.failed.day[*]))'
+          tags:
+            - tag: component
+              value: pipeline
+        - uuid: 7f0b3dd52de04e3c835768e4c6ccbdce
+          name: 'GitLab: All projects: Failed pipelines (hour)'
+          type: CALCULATED
+          key: gitlab.pipeline.failed.hour.all
+          description: 'Sum of failed pipelines across all projects (last hour).'
+          delay: '{$GITLAB.PIPELINE.INTERVAL}'
+          params: 'sum(last_foreach(//gitlab.pipeline.failed.hour[*]))'
+          tags:
+            - tag: component
+              value: pipeline
+        - uuid: 79b26678118f4a0db516dc2e7e04e4a4
+          name: 'GitLab: All projects: Failed pipelines (week)'
+          type: CALCULATED
+          key: gitlab.pipeline.failed.week.all
+          description: 'Sum of failed pipelines across all projects (last week).'
+          delay: '{$GITLAB.PIPELINE.INTERVAL}'
+          params: 'sum(last_foreach(//gitlab.pipeline.failed.week[*]))'
+          tags:
+            - tag: component
+              value: pipeline
+        - uuid: 59caa9ecfcba419bb65825c8a57d5c1b
+          name: 'GitLab: All projects: Failure rate (day)'
+          type: CALCULATED
+          key: gitlab.pipeline.failrate.day.all
+          value_type: FLOAT
+          description: 'Overall failure rate across all projects (last day).'
+          delay: '{$GITLAB.PIPELINE.INTERVAL}'
+          units: '%'
+          params: '(last(//gitlab.pipeline.failed.day.all)/(last(//gitlab.pipeline.total.day.all)+(last(//gitlab.pipeline.total.day.all)=0)))*100'
+          tags:
+            - tag: component
+              value: pipeline
+          triggers:
+            - uuid: f252e9b749874e31b14eba6b4204a5d4
+              expression: 'last(/GitLab Pipelines by HTTP/gitlab.pipeline.failrate.day.all)>{$GITLAB.FAIL.RATE.DAY.WARN:"TOTAL"}'
+              name: 'GitLab: High daily failure rate'
+              opdata: 'Failure rate: {ITEM.LASTVALUE}'
+              priority: HIGH
+              description: 'The daily failure rate of all pipelines is high'
+              dependencies:
+                - name: 'GitLab: API is unreachable'
+                  expression: 'nodata(/GitLab Pipelines by HTTP/gitlab.api.version,30m)=1'
+              tags:
+                - tag: component
+                  value: pipeline
+        - uuid: 286f213b27224ab6a9b22545ff941b0c
+          name: 'GitLab: All projects: Failure rate (hour)'
+          type: CALCULATED
+          key: gitlab.pipeline.failrate.hour.all
+          value_type: FLOAT
+          description: 'Overall failure rate across all projects (last hour).'
+          delay: '{$GITLAB.PIPELINE.INTERVAL}'
+          units: '%'
+          params: '(last(//gitlab.pipeline.failed.hour.all)/(last(//gitlab.pipeline.total.hour.all)+(last(//gitlab.pipeline.total.hour.all)=0)))*100'
+          tags:
+            - tag: component
+              value: pipeline
+          triggers:
+            - uuid: 645d40ec2ac5423fac68142d338ad5cb
+              expression: 'last(/GitLab Pipelines by HTTP/gitlab.pipeline.failrate.hour.all)>{$GITLAB.FAIL.RATE.HOUR.WARN:"TOTAL"}'
+              name: 'GitLab: High hourly failure rate'
+              opdata: 'Failure rate: {ITEM.LASTVALUE}'
+              priority: HIGH
+              description: 'The hourly failure rate of all pipelines is high'
+              dependencies:
+                - name: 'GitLab: API is unreachable'
+                  expression: 'nodata(/GitLab Pipelines by HTTP/gitlab.api.version,30m)=1'
+              tags:
+                - tag: component
+                  value: pipeline
+        - uuid: dab6b5ff6346412fa4a3beebbcb59684
+          name: 'GitLab: All projects: Successful pipelines (day)'
+          type: CALCULATED
+          key: gitlab.pipeline.success.day.all
+          description: 'Sum of successful pipelines across all projects (last day).'
+          delay: '{$GITLAB.PIPELINE.INTERVAL}'
+          params: 'sum(last_foreach(//gitlab.pipeline.success.day[*]))'
+          tags:
+            - tag: component
+              value: pipeline
+        - uuid: 8a48cffae78a415c940b3361d72a030f
+          name: 'GitLab: All projects: Successful pipelines (hour)'
+          type: CALCULATED
+          key: gitlab.pipeline.success.hour.all
+          description: 'Sum of successful pipelines across all projects (last hour).'
+          delay: '{$GITLAB.PIPELINE.INTERVAL}'
+          params: 'sum(last_foreach(//gitlab.pipeline.success.hour[*]))'
+          tags:
+            - tag: component
+              value: pipeline
+        - uuid: 894910c7061849d0bac8795b565ba98d
+          name: 'GitLab: All projects: Successful pipelines (week)'
+          type: CALCULATED
+          key: gitlab.pipeline.success.week.all
+          description: 'Sum of successful pipelines across all projects (last week).'
+          delay: '{$GITLAB.PIPELINE.INTERVAL}'
+          params: 'sum(last_foreach(//gitlab.pipeline.success.week[*]))'
+          tags:
+            - tag: component
+              value: pipeline
+        - uuid: 3fa1b78a0aa94e57a63e0e9e3ec816dc
+          name: 'GitLab: All projects: Total pipelines (day)'
+          type: CALCULATED
+          key: gitlab.pipeline.total.day.all
+          description: 'Sum of total pipelines across all projects (last day).'
+          delay: '{$GITLAB.PIPELINE.INTERVAL}'
+          params: 'sum(last_foreach(//gitlab.pipeline.total.day[*]))'
+          tags:
+            - tag: component
+              value: pipeline
+        - uuid: 0dcd32d12226439f961633e44e87cd04
+          name: 'GitLab: All projects: Total pipelines (hour)'
+          type: CALCULATED
+          key: gitlab.pipeline.total.hour.all
+          description: 'Sum of total pipelines across all projects (last hour).'
+          delay: '{$GITLAB.PIPELINE.INTERVAL}'
+          params: 'sum(last_foreach(//gitlab.pipeline.total.hour[*]))'
+          tags:
+            - tag: component
+              value: pipeline
+        - uuid: 381caffcf42d454e87b82711308b9646
+          name: 'GitLab: All projects: Total pipelines (week)'
+          type: CALCULATED
+          key: gitlab.pipeline.total.week.all
+          description: 'Sum of total pipelines across all projects (last week).'
+          delay: '{$GITLAB.PIPELINE.INTERVAL}'
+          params: 'sum(last_foreach(//gitlab.pipeline.total.week[*]))'
+          tags:
+            - tag: component
+              value: pipeline
+        - uuid: 30e505d95acb4f49a8355bfb9654ee32
+          name: 'GitLab: API version'
+          type: HTTP_AGENT
+          key: gitlab.api.version
+          delay: '{$GITLAB.PIPELINE.INTERVAL}'
+          history: 7d
+          value_type: CHAR
+          description: 'GitLab version string from /api/v4/version. Serves as the template availability signal: if the GitLab API is unreachable or the token is invalid, this item receives no data.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.version
+          url: '{$GITLAB.URL}/api/v4/version'
+          headers:
+            - name: PRIVATE-TOKEN
+              value: '{$GITLAB.API.TOKEN}'
+          timeout: '{$GITLAB.HTTP.TIMEOUT}'
+          tags:
+            - tag: component
+              value: availability
+          triggers:
+            - uuid: d8458eb831034859bb764202fdf3fba7
+              expression: 'nodata(/GitLab Pipelines by HTTP/gitlab.api.version,30m)=1'
+              name: 'GitLab: API is unreachable'
+              priority: HIGH
+              description: 'No data from the GitLab API for 30 minutes. The instance may be down, {$GITLAB.URL} may be wrong, or {$GITLAB.API.TOKEN} may be invalid or lack the read_api scope.'
+              tags:
+                - tag: component
+                  value: availability
+      discovery_rules:
+        - uuid: ebe45f80e7ad4aa1854a9d1bf79a9447
+          name: 'GitLab: Discover Projects'
+          type: SCRIPT
+          key: gitlab.project.discovery
+          description: 'Discovers all non-archived projects. Handles pagination for instances with more than 100 projects.'
+          delay: '{$GITLAB.DISC.INTERVAL}'
+          params: |
+            var url = '{$GITLAB.URL}';
+             var token = '{$GITLAB.API.TOKEN}';
+             var request = new HttpRequest();
+             request.addHeader('PRIVATE-TOKEN: ' + token);
+            
+             var page = 1;
+             var allProjects = [];
+             var maxPages = 50; // safety limit (5000 projects max)
+            
+             while (page <= maxPages) {
+               var response = request.get(
+                 url + '/api/v4/projects?archived=false&simple=true&per_page=100&page=' + page
+               );
+            
+               if (request.getStatus() !== 200) {
+                 throw 'GitLab API error: HTTP ' + request.getStatus();
+               }
+            
+               var batch = JSON.parse(response);
+               if (batch.length === 0) break;
+            
+               allProjects = allProjects.concat(batch);
+               if (batch.length < 100) break; // last page
+               page++;
+             }
+            
+             var result = allProjects.map(function(p) {
+               return {
+                 '{#PROJECT_ID}': String(p.id),
+                 '{#PROJECT_NAME}': p.name,
+                 '{#PROJECT_PATH}': p.path_with_namespace
+               };
+             });
+            
+             return JSON.stringify(result);
+          item_prototypes:
+            - uuid: 0f7c38a1f60c405d9b845a0545521e15
+              name: 'GitLab: {#PROJECT_PATH} Pipelines'
+              type: HTTP_AGENT
+              key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              description: 'Fetches up to 100 recent pipelines for the project. JavaScript preprocessing computes aggregated stats across four time windows.'
+              delay: '{$GITLAB.PIPELINE.INTERVAL}'
+              history: '0'
+              value_type: TEXT
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      var pipelines = JSON.parse(value);
+                       var now = Date.now();
+                       var windows = {
+                         hour:  now - 3600000,
+                         day:   now - 86400000,
+                         week:  now - 604800000,
+                         month: now - 2592000000
+                       };
+                      
+                       var stats = {
+                         latest_status: "none", latest_ref: "", latest_url: ""
+                       };
+                      
+                       // Initialize counters for each window
+                       ["hour", "day", "week", "month"].forEach(function(w) {
+                         stats["total_" + w] = 0;
+                         stats["failed_" + w] = 0;
+                         stats["success_" + w] = 0;
+                         stats["failure_rate_" + w] = 0;
+                       });
+                      
+                       if (pipelines.length > 0) {
+                         stats.latest_status = pipelines[0].status;
+                         stats.latest_ref = pipelines[0].ref;
+                         stats.latest_url = pipelines[0].web_url;
+                       }
+                      
+                       pipelines.forEach(function(p) {
+                         var ts = new Date(p.updated_at).getTime();
+                         ["hour", "day", "week", "month"].forEach(function(w) {
+                           if (ts >= windows[w]) {
+                             stats["total_" + w]++;
+                             if (p.status === "failed") stats["failed_" + w]++;
+                             if (p.status === "success") stats["success_" + w]++;
+                           }
+                         });
+                       });
+                      
+                       ["hour", "day", "week", "month"].forEach(function(w) {
+                         if (stats["total_" + w] > 0)
+                           stats["failure_rate_" + w] = Math.round(
+                             stats["failed_" + w] / stats["total_" + w] * 100
+                           );
+                       });
+                      
+                       return JSON.stringify(stats);
+              url: '{$GITLAB.URL}/api/v4/projects/{#PROJECT_ID}/pipelines?per_page=100'
+              headers:
+                - name: PRIVATE-TOKEN
+                  value: '{$GITLAB.API.TOKEN}'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: b36bd777b50945dda23a50d38a15cdab
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Failed (day)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.failed.day[{#PROJECT_ID}]'
+              description: 'Number of failed pipelines in the last day.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.failed_day
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: 2f11a6982ae04db986b9ed1133e65e41
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Failed (hour)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.failed.hour[{#PROJECT_ID}]'
+              description: 'Number of failed pipelines in the last hour.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.failed_hour
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: 7d941082a30946caaeb3278d22beda19
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Failed (month)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.failed.month[{#PROJECT_ID}]'
+              description: 'Number of failed pipelines in the last month.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.failed_month
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: 414cf67364a74560a0777cab9b428116
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Failed (week)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.failed.week[{#PROJECT_ID}]'
+              description: 'Number of failed pipelines in the last week.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.failed_week
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: 7f27a128c1784920950a18340d546801
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Failure rate (day)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.failrate.day[{#PROJECT_ID}]'
+              description: 'Percentage of pipelines that failed in the last day.'
+              units: '%'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.failure_rate_day
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: honeycomb
+                  value: project_failrate_day
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+              trigger_prototypes:
+                - uuid: d8c60b116d5f458493e8f87bd1d42bf6
+                  expression: 'last(/GitLab Pipelines by HTTP/gitlab.pipeline.failrate.day[{#PROJECT_ID}])>{$GITLAB.FAIL.RATE.DAY.WARN:"{#PROJECT_PATH}"}'
+                  name: 'GitLab: High daily failure rate on {#PROJECT_PATH}'
+                  opdata: 'Failure rate: {ITEM.LASTVALUE}'
+                  url_name: Pipelines
+                  url: '{$GITLAB.URL}/{#PROJECT_PATH}/-/pipelines'
+                  priority: AVERAGE
+                  description: 'The daily pipeline failure rate for {#PROJECT_PATH} exceeds {$GITLAB.FAIL.RATE.DAY.WARN}%. Override per project with the context macro {$GITLAB.FAIL.RATE.DAY.WARN:"{#PROJECT_PATH}"}.'
+                  manual_close: 'YES'
+                  dependencies:
+                    - name: 'GitLab: API is unreachable'
+                      expression: 'nodata(/GitLab Pipelines by HTTP/gitlab.api.version,30m)=1'
+                  tags:
+                    - tag: component
+                      value: pipeline
+                    - tag: project
+                      value: '{#PROJECT_PATH}'
+            - uuid: 1297a3496de944faa48829c71eff7158
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Failure rate (hour)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.failrate.hour[{#PROJECT_ID}]'
+              description: 'Percentage of pipelines that failed in the last hour.'
+              units: '%'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.failure_rate_hour
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: fa7598b036fd4b3dad64bb03455321fa
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Failure rate (month)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.failrate.month[{#PROJECT_ID}]'
+              description: 'Percentage of pipelines that failed in the last month.'
+              units: '%'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.failure_rate_month
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: 684251490ce04d3aa06f53d90a9a922a
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Failure rate (week)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.failrate.week[{#PROJECT_ID}]'
+              description: 'Percentage of pipelines that failed in the last week.'
+              units: '%'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.failure_rate_week
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+              trigger_prototypes:
+                - uuid: 68255da5be1447329fcbae1e96535ae2
+                  expression: 'last(/GitLab Pipelines by HTTP/gitlab.pipeline.failrate.week[{#PROJECT_ID}])>{$GITLAB.FAIL.RATE.WEEK.WARN:"{#PROJECT_PATH}"}'
+                  name: 'GitLab: High weekly failure rate on {#PROJECT_PATH}'
+                  opdata: 'Failure rate: {ITEM.LASTVALUE}'
+                  url_name: Pipelines
+                  url: '{$GITLAB.URL}/{#PROJECT_PATH}/-/pipelines'
+                  priority: AVERAGE
+                  description: 'The weekly pipeline failure rate for {#PROJECT_PATH} exceeds {$GITLAB.FAIL.RATE.WEEK.WARN}%. Override per project with the context macro {$GITLAB.FAIL.RATE.WEEK.WARN:"{#PROJECT_PATH}"}.'
+                  manual_close: 'YES'
+                  dependencies:
+                    - name: 'GitLab: API is unreachable'
+                      expression: 'nodata(/GitLab Pipelines by HTTP/gitlab.api.version,30m)=1'
+                  tags:
+                    - tag: component
+                      value: pipeline
+                    - tag: project
+                      value: '{#PROJECT_PATH}'
+            - uuid: c097c02bd8f949638c7c093c97cf6871
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Latest pipeline ref'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.latest.ref[{#PROJECT_ID}]'
+              description: 'Git ref (branch or tag) of the most recent pipeline.'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.latest_ref
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: 565709ede21f4fb3a77806424e58ed19
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Latest pipeline status'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.latest.status[{#PROJECT_ID}]'
+              description: 'Status of the most recent pipeline.'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.latest_status
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: 3a1b9f8148a44dbea758d09b87ff7aa1
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Latest pipeline URL'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.latest.url[{#PROJECT_ID}]'
+              description: 'Web URL of the most recent pipeline.'
+              value_type: CHAR
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.latest_url
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: a230f3e06c1242a5b869d599571b593c
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Successful (day)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.success.day[{#PROJECT_ID}]'
+              description: 'Number of successful pipelines in the last day.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.success_day
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: 798bc7003d1d42deb46aa0e3de364867
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Successful (hour)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.success.hour[{#PROJECT_ID}]'
+              description: 'Number of successful pipelines in the last hour.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.success_hour
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: 3aa77c0cc621464d8bb2ae55d6b80633
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Successful (month)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.success.month[{#PROJECT_ID}]'
+              description: 'Number of successful pipelines in the last month.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.success_month
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: 4d1a39c8418342bc8004017362ba6018
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Successful (week)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.success.week[{#PROJECT_ID}]'
+              description: 'Number of successful pipelines in the last week.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.success_week
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: cb45705a90d14222ab0703b6108a3766
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Total (day)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.total.day[{#PROJECT_ID}]'
+              description: 'Total number of pipelines in the last day.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.total_day
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: aed97cf2ff4c423e86a4854a71aa58c9
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Total (hour)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.total.hour[{#PROJECT_ID}]'
+              description: 'Total number of pipelines in the last hour.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.total_hour
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: 3eb9e38b95ce43cf85304dabe7e619a4
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Total (month)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.total.month[{#PROJECT_ID}]'
+              description: 'Total number of pipelines in the last month.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.total_month
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+            - uuid: 4ce0c804e319460fa8b29965f8a3d525
+              name: 'GitLab: {#PROJECT_PATH} Pipelines: Total (week)'
+              type: DEPENDENT
+              key: 'gitlab.pipeline.total.week[{#PROJECT_ID}]'
+              description: 'Total number of pipelines in the last week.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.total_week
+              master_item:
+                key: 'gitlab.pipeline.data[{#PROJECT_ID}]'
+              tags:
+                - tag: component
+                  value: pipeline
+                - tag: project
+                  value: '{#PROJECT_PATH}'
+          graph_prototypes:
+            - uuid: 6a251eabdd444a178901fdbe88bf50ce
+              name: 'GitLab: {#PROJECT_PATH} Pipeline overview (daily)'
+              graph_items:
+                - drawtype: FILLED_REGION
+                  color: 00AA00
+                  item:
+                    host: 'GitLab Pipelines by HTTP'
+                    key: 'gitlab.pipeline.success.day[{#PROJECT_ID}]'
+                - sortorder: '1'
+                  drawtype: FILLED_REGION
+                  color: CC0000
+                  item:
+                    host: 'GitLab Pipelines by HTTP'
+                    key: 'gitlab.pipeline.failed.day[{#PROJECT_ID}]'
+                - sortorder: '2'
+                  color: 0000CC
+                  item:
+                    host: 'GitLab Pipelines by HTTP'
+                    key: 'gitlab.pipeline.total.day[{#PROJECT_ID}]'
+          timeout: '{$GITLAB.HTTP.TIMEOUT}'
+      tags:
+        - tag: class
+          value: software
+        - tag: target
+          value: gitlab
+      macros:
+        - macro: '{$GITLAB.API.TOKEN}'
+          type: SECRET_TEXT
+          description: 'GitLab Personal Access Token with the read_api scope, used to authenticate to the GitLab REST API.'
+        - macro: '{$GITLAB.URL}'
+          description: 'Base URL of the GitLab instance, without a trailing slash (for example, https://gitlab.example.com).'
+        - macro: '{$GITLAB.DISC.INTERVAL}'
+          value: 1h
+          description: 'How often to discover new projects.'
+        - macro: '{$GITLAB.FAIL.RATE.DAY.WARN}'
+          value: '75'
+          description: 'Daily pipeline failure rate (%) above which a trigger fires. Supports per-project context, e.g. {$GITLAB.FAIL.RATE.DAY.WARN:"my-group/my-project"}.'
+        - macro: '{$GITLAB.FAIL.RATE.HOUR.WARN}'
+          value: '50'
+          description: 'Hourly pipeline failure rate (%) above which a trigger fires.'
+        - macro: '{$GITLAB.FAIL.RATE.WEEK.WARN}'
+          value: '50'
+          description: 'Weekly pipeline failure rate (%) above which a trigger fires. Supports per-project context, e.g. {$GITLAB.FAIL.RATE.WEEK.WARN:"my-group/my-project"}.'
+        - macro: '{$GITLAB.HTTP.TIMEOUT}'
+          value: 15s
+          description: 'Timeout for HTTP requests to the GitLab API.'
+        - macro: '{$GITLAB.PIPELINE.INTERVAL}'
+          value: 15m
+          description: 'How often to check pipeline status.'
+      dashboards:
+        - uuid: f488de9e64fa484da02129f0fe5d0904
+          name: 'GitLab Pipeline Health'
+          pages:
+            - widgets:
+                - type: problems
+                  name: 'Active Problems'
+                  width: '56'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: problem
+                      value: GitLab
+                    - type: STRING
+                      name: reference
+                      value: AJHJT
+                    - type: INTEGER
+                      name: severities.0
+                      value: '2'
+                    - type: INTEGER
+                      name: severities.1
+                      value: '3'
+                    - type: INTEGER
+                      name: severities.2
+                      value: '4'
+                    - type: INTEGER
+                      name: severities.3
+                      value: '5'
+                    - type: INTEGER
+                      name: show
+                      value: '3'
+                - type: honeycomb
+                  name: 'Project Health Map'
+                  'y': '5'
+                  width: '71'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: '*'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '1'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: honeycomb
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: project_failrate_day
+                    - type: STRING
+                      name: primary_label
+                      value: '{ITEM.NAME}'
+                    - type: STRING
+                      name: reference
+                      value: CLVWW
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 00AA00
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFFF00
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '25'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: FF8000
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '50'
+                    - type: STRING
+                      name: thresholds.3.color
+                      value: FF0000
+                    - type: STRING
+                      name: thresholds.3.threshold
+                      value: '75'
+                - type: svggraph
+                  name: 'Pipeline Trend'
+                  'y': '10'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 4000FF
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'GitLab: All projects: Total pipelines (day)'
+                    - type: INTEGER
+                      name: ds.0.stacked
+                      value: '1'
+                    - type: INTEGER
+                      name: ds.1.aggregate_function
+                      value: '3'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 00FF00
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'GitLab: All projects: Successful pipelines (day)'
+                    - type: INTEGER
+                      name: ds.1.stacked
+                      value: '1'
+                    - type: INTEGER
+                      name: ds.2.aggregate_function
+                      value: '3'
+                    - type: STRING
+                      name: ds.2.color
+                      value: FF0000
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: 'GitLab: All projects: Failed pipelines (day)'
+                    - type: INTEGER
+                      name: ds.2.stacked
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: GMQHG
+                    - type: INTEGER
+                      name: righty
+                      value: '0'
+                    - type: INTEGER
+                      name: severities.0
+                      value: '2'
+                    - type: INTEGER
+                      name: severities.1
+                      value: '3'
+                    - type: INTEGER
+                      name: severities.2
+                      value: '4'
+                    - type: INTEGER
+                      name: severities.3
+                      value: '5'
+                    - type: INTEGER
+                      name: show_problems
+                      value: '1'
+                - type: svggraph
+                  name: 'Failure Rate Trend'
+                  x: '36'
+                  'y': '10'
+                  width: '35'
+                  height: '5'
+                  fields:
+                    - type: INTEGER
+                      name: ds.0.color_palette
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'GitLab: All projects: Failure rate (day)'
+                    - type: STRING
+                      name: reference
+                      value: HWZLA
+                    - type: INTEGER
+                      name: righty
+                      value: '0'
+                - type: piechart
+                  name: 'Overall Health'
+                  x: '56'
+                  width: '15'
+                  height: '5'
+                  fields:
+                    - type: INTEGER
+                      name: ds.0.color_palette
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'GitLab: All projects: Successful pipelines (day)'
+                    - type: STRING
+                      name: ds.0.items.1
+                      value: 'GitLab: All projects: Failed pipelines (day)'
+  graphs:
+    - uuid: 964fca0202a444409904ca9f9ec1ccab
+      name: 'GitLab: All projects pipeline overview (daily)'
+      graph_items:
+        - drawtype: FILLED_REGION
+          color: 00AA00
+          calc_fnc: ALL
+          item:
+            host: 'GitLab Pipelines by HTTP'
+            key: gitlab.pipeline.success.day.all
+        - sortorder: '1'
+          drawtype: FILLED_REGION
+          color: CC0000
+          calc_fnc: ALL
+          item:
+            host: 'GitLab Pipelines by HTTP'
+            key: gitlab.pipeline.failed.day.all
+        - sortorder: '2'
+          color: 0000CC
+          calc_fnc: ALL
+          item:
+            host: 'GitLab Pipelines by HTTP'
+            key: gitlab.pipeline.total.day.all
+    - uuid: b0043aaf53b545b68ca57f6ec0544612
+      name: 'GitLab: All projects pipeline overview (weekly)'
+      yaxismax: '0'
+      graph_items:
+        - drawtype: FILLED_REGION
+          color: 00AA00
+          calc_fnc: ALL
+          item:
+            host: 'GitLab Pipelines by HTTP'
+            key: gitlab.pipeline.success.week.all
+        - sortorder: '1'
+          drawtype: FILLED_REGION
+          color: CC0000
+          calc_fnc: ALL
+          item:
+            host: 'GitLab Pipelines by HTTP'
+            key: gitlab.pipeline.failed.week.all
+        - sortorder: '2'
+          color: 0000CC
+          calc_fnc: ALL
+          item:
+            host: 'GitLab Pipelines by HTTP'
+            key: gitlab.pipeline.total.week.all


### PR DESCRIPTION
  Adds a new template that monitors **GitLab CI/CD pipeline health** across all
  projects of a GitLab instance, via the GitLab REST API (`/api/v4`).

  **Location:** `Applications/Gitlab/template_gitlab_pipelines_by_http/7.4/`

  ### What it does
  - Auto-discovers all non-archived projects (Script LLD, paginated) and tracks
    per-project pipeline success / failure / total counts and failure rates over
    four windows: hour, day, week, month.
  - Calculated items roll those up across all projects; trigger prototypes alert
    on per-project failure rate with per-project overrides via context macros
    (e.g. `{$GITLAB.FAIL.RATE.DAY.WARN:"my-group/my-project"}`).
  - Ships a built-in "GitLab Pipeline Health" dashboard (problems, honeycomb
    project map, trend and failure-rate graphs, pie chart).

  ### Collection & auth
  - HTTP agent + Script items only — no external scripts and no Zabbix agent; runs
    fine assigned to the Zabbix server host itself.
  - Auth via `PRIVATE-TOKEN` header set to `{$GITLAB.API.TOKEN}`, a **Secret**
    macro (empty default, stripped on export). A `read_api`-scope Personal Access
    Token is sufficient; an admin token covers projects the owner isn't a member of.

  ### Relationship to the official template
  Complementary to the bundled **GitLab by HTTP** template (which monitors server
  health via the `/-/metrics` Prometheus endpoint). Different template name and a
  disjoint item-key namespace (`gitlab.pipeline.*`, `gitlab.api.version`,
  `gitlab.project.discovery`), so both can be linked to the same host without
  conflict.

  ### Validation
  - Imports cleanly on Zabbix **7.4** (verified against 7.4.11).
  - Monitored product tested: GitLab CE 19.x (self-hosted).
  - Contents: 12 items, 1 LLD rule (20 item prototypes), 3 triggers + 2 trigger
    prototypes, 2 graphs + 1 graph prototype, 1 dashboard, 8 macros. No `vendor:`
    block; no embedded secrets.