### PR TITLE
Add Linux access records template (Zabbix agent active, 7.4)

### DIFF
--- a/Operating_Systems/template_linux_access_records/7.4/README.md
+++ b/Operating_Systems/template_linux_access_records/7.4/README.md
@@ -2,7 +2,7 @@
 
 Collects OS-level **access records** (SSH logins, sudo) from the local auth log via
 Zabbix agent (active) `log[]` items — for security auditing and compliance evidence
-(e.g. ISMS-P 2.9.4, ISO/IEC 27001 A.8.15, PIPA access-record duty).
+(e.g. access-logging and audit-trail requirements such as ISO/IEC 27001).
 
 **Author:** saranf
 

--- a/Operating_Systems/template_linux_access_records/7.4/README.md
+++ b/Operating_Systems/template_linux_access_records/7.4/README.md
@@ -1,0 +1,61 @@
+# Linux access records by Zabbix agent active
+
+Collects OS-level **access records** (SSH logins, sudo) from the local auth log via
+Zabbix agent (active) `log[]` items — for security auditing and compliance evidence
+(e.g. ISMS-P 2.9.4, ISO/IEC 27001 A.8.15, PIPA access-record duty).
+
+**Author:** saranf
+
+## Overview
+
+The template reads the local auth log on each monitored host and exposes three access-record
+streams plus one brute-force trigger. It only **reads** the log — no changes to the host
+beyond a Zabbix agent (active) with read access to the log path.
+
+Long-term retention and tamper-proof storage of access records are **out of scope** — forward
+the logs to a log store (Loki/SIEM) if your regulation requires 1–2 year retention.
+
+## Requirements
+
+- Zabbix **7.4**
+- **Zabbix agent (active)** installed on the host, with `ServerActive` configured
+- The `zabbix` user must have **read access** to the auth log path (`{$ACCESSLOG.PATH}`)
+- Set `{$ACCESSLOG.PATH}` to your distribution's auth log:
+  - RHEL / CentOS / Rocky / Alma: `/var/log/secure`
+  - Debian / Ubuntu: `/var/log/auth.log`
+
+## Macros
+
+| Macro | Default | Description |
+|---|---|---|
+| `{$ACCESSLOG.PATH}` | `/var/log/secure` | Auth log path (see Requirements). |
+| `{$ACCESSLOG.ACCEPTED.REGEX}` | `Accepted (password\|publickey\|keyboard-interactive)` | Regex for successful login lines. |
+| `{$ACCESSLOG.FAILED.REGEX}` | `Failed password for` | Regex for failed login lines. |
+| `{$ACCESSLOG.SUDO.REGEX}` | `sudo:.*COMMAND=` | Regex for sudo command lines. |
+| `{$ACCESSLOG.FAILED.WINDOW}` | `5m` | Window used to count failed logins. |
+| `{$ACCESSLOG.FAILED.MAX}` | `10` | Failed logins in the window that raise a Warning. |
+
+## Items
+
+| Item | Key | Type |
+|---|---|---|
+| Access records: accepted logins | `log[{$ACCESSLOG.PATH},"{$ACCESSLOG.ACCEPTED.REGEX}",,,skip]` | Zabbix agent (active), Log |
+| Access records: failed logins | `log[{$ACCESSLOG.PATH},"{$ACCESSLOG.FAILED.REGEX}",,,skip]` | Zabbix agent (active), Log |
+| Access records: sudo commands | `log[{$ACCESSLOG.PATH},"{$ACCESSLOG.SUDO.REGEX}",,,skip]` | Zabbix agent (active), Log |
+
+## Triggers
+
+| Name | Expression | Severity |
+|---|---|---|
+| Too many failed logins on {HOST.NAME} | `count(/.../failed-logins,{$ACCESSLOG.FAILED.WINDOW})>{$ACCESSLOG.FAILED.MAX}` | Warning |
+
+## Setup
+
+1. Import the template into Zabbix 7.4 (*Data collection → Templates → Import*).
+2. Link the template to your Linux host(s).
+3. Override `{$ACCESSLOG.PATH}` on hosts that use `/var/log/auth.log`.
+4. Ensure the Zabbix agent runs in **active** mode and can read the log file.
+
+## License
+
+Published under the MIT license.

--- a/Operating_Systems/template_linux_access_records/7.4/template_linux_access_records.yaml
+++ b/Operating_Systems/template_linux_access_records/7.4/template_linux_access_records.yaml
@@ -66,6 +66,18 @@ zabbix_export:
               value: security
             - tag: component
               value: access-record
+          triggers:
+            - uuid: dff406e61f6f4213ac7c3805c71f4113
+              expression: 'count(/Linux access records by Zabbix agent active/log[{$ACCESSLOG.PATH},"{$ACCESSLOG.FAILED.REGEX}",,,skip],{$ACCESSLOG.FAILED.WINDOW})>{$ACCESSLOG.FAILED.MAX}'
+              name: 'Too many failed logins on {HOST.NAME} (>{$ACCESSLOG.FAILED.MAX} in {$ACCESSLOG.FAILED.WINDOW})'
+              priority: WARNING
+              description: 'Possible brute-force: failed logins in the window exceed the threshold.'
+              manual_close: 'YES'
+              tags:
+                - tag: class
+                  value: security
+                - tag: source
+                  value: linux-access-records
         - uuid: ad0bc878db754ff79709ba2361bff885
           name: 'Access records: sudo commands'
           type: ZABBIX_ACTIVE
@@ -79,15 +91,3 @@ zabbix_export:
               value: security
             - tag: component
               value: access-record
-      triggers:
-        - uuid: dff406e61f6f4213ac7c3805c71f4113
-          expression: 'count(/Linux access records by Zabbix agent active/log[{$ACCESSLOG.PATH},"{$ACCESSLOG.FAILED.REGEX}",,,skip],{$ACCESSLOG.FAILED.WINDOW})>{$ACCESSLOG.FAILED.MAX}'
-          name: 'Too many failed logins on {HOST.NAME} (>{$ACCESSLOG.FAILED.MAX} in {$ACCESSLOG.FAILED.WINDOW})'
-          priority: WARNING
-          description: 'Possible brute-force: failed logins in the window exceed the threshold.'
-          manual_close: 'YES'
-          tags:
-            - tag: class
-              value: security
-            - tag: source
-              value: linux-access-records

--- a/Operating_Systems/template_linux_access_records/7.4/template_linux_access_records.yaml
+++ b/Operating_Systems/template_linux_access_records/7.4/template_linux_access_records.yaml
@@ -1,0 +1,93 @@
+zabbix_export:
+  version: '7.4'
+  template_groups:
+    - uuid: a7b3f1c9d24e4a6f8b1c0e5d9f2a4c60
+      name: Templates/Operating systems
+  templates:
+    - uuid: 3f9c1e7a5b2d4c8e9a0f1b3d5e7c9a11
+      template: 'Linux access records by Zabbix agent active'
+      name: 'Linux access records by Zabbix agent active'
+      description: |
+        Collects OS-level access records (SSH logins, sudo) from the local auth log via
+        Zabbix agent (active) log items, for security auditing and compliance evidence
+        (e.g. ISMS-P 2.9.4, ISO/IEC 27001 A.8.15, PIPA access-record duty).
+
+        The template only reads the auth log — no changes to the monitored host beyond a
+        Zabbix agent (active) with ServerActive configured and read access to the log path.
+
+        Set {$ACCESSLOG.PATH} to /var/log/secure (RHEL/CentOS/Rocky) or /var/log/auth.log
+        (Debian/Ubuntu). Long-term retention & tamper-proof storage of access records is
+        out of scope of this template — forward to a log store (Loki/SIEM) if required by law.
+      groups:
+        - name: Templates/Operating systems
+      macros:
+        - macro: '{$ACCESSLOG.PATH}'
+          value: '/var/log/secure'
+          description: 'Auth log path. RHEL family: /var/log/secure ; Debian family: /var/log/auth.log'
+        - macro: '{$ACCESSLOG.ACCEPTED.REGEX}'
+          value: 'Accepted (password|publickey|keyboard-interactive)'
+          description: 'Regex matching successful login lines (sshd).'
+        - macro: '{$ACCESSLOG.FAILED.REGEX}'
+          value: 'Failed password for'
+          description: 'Regex matching failed login lines (sshd).'
+        - macro: '{$ACCESSLOG.SUDO.REGEX}'
+          value: 'sudo:.*COMMAND='
+          description: 'Regex matching sudo command execution lines.'
+        - macro: '{$ACCESSLOG.FAILED.WINDOW}'
+          value: '5m'
+          description: 'Window used to count failed logins for the brute-force trigger.'
+        - macro: '{$ACCESSLOG.FAILED.MAX}'
+          value: '10'
+          description: 'Failed logins within the window above that raise a Warning.'
+      items:
+        - uuid: 1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f
+          name: 'Access records: accepted logins'
+          type: ZABBIX_ACTIVE
+          key: 'log[{$ACCESSLOG.PATH},"{$ACCESSLOG.ACCEPTED.REGEX}",,,skip]'
+          delay: '30s'
+          history: '90d'
+          value_type: LOG
+          description: 'Successful login lines (who/when/from) captured from the auth log.'
+          tags:
+            - tag: class
+              value: security
+            - tag: component
+              value: access-record
+        - uuid: 2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f70
+          name: 'Access records: failed logins'
+          type: ZABBIX_ACTIVE
+          key: 'log[{$ACCESSLOG.PATH},"{$ACCESSLOG.FAILED.REGEX}",,,skip]'
+          delay: '30s'
+          history: '90d'
+          value_type: LOG
+          description: 'Failed login lines — feeds the brute-force trigger below.'
+          tags:
+            - tag: class
+              value: security
+            - tag: component
+              value: access-record
+        - uuid: 3e4f5a6b7c8d9e0f1a2b3c4d5e6f7081
+          name: 'Access records: sudo commands'
+          type: ZABBIX_ACTIVE
+          key: 'log[{$ACCESSLOG.PATH},"{$ACCESSLOG.SUDO.REGEX}",,,skip]'
+          delay: '30s'
+          history: '90d'
+          value_type: LOG
+          description: 'Privilege-escalation (sudo) command lines from the auth log.'
+          tags:
+            - tag: class
+              value: security
+            - tag: component
+              value: access-record
+      triggers:
+        - uuid: 4f5a6b7c8d9e0f1a2b3c4d5e6f708192
+          expression: 'count(/Linux access records by Zabbix agent active/log[{$ACCESSLOG.PATH},"{$ACCESSLOG.FAILED.REGEX}",,,skip],{$ACCESSLOG.FAILED.WINDOW})>{$ACCESSLOG.FAILED.MAX}'
+          name: 'Too many failed logins on {HOST.NAME} (>{$ACCESSLOG.FAILED.MAX} in {$ACCESSLOG.FAILED.WINDOW})'
+          priority: WARNING
+          description: 'Possible brute-force: failed logins in the window exceed the threshold.'
+          manual_close: 'YES'
+          tags:
+            - tag: class
+              value: security
+            - tag: source
+              value: linux-access-records

--- a/Operating_Systems/template_linux_access_records/7.4/template_linux_access_records.yaml
+++ b/Operating_Systems/template_linux_access_records/7.4/template_linux_access_records.yaml
@@ -10,7 +10,7 @@ zabbix_export:
       description: |
         Collects OS-level access records (SSH logins, sudo) from the local auth log via
         Zabbix agent (active) log items, for security auditing and compliance evidence
-        (e.g. ISMS-P 2.9.4, ISO/IEC 27001 A.8.15, PIPA access-record duty).
+        (e.g. access-logging and audit-trail requirements such as ISO/IEC 27001).
 
         The template only reads the auth log — no changes to the monitored host beyond a
         Zabbix agent (active) with ServerActive configured and read access to the log path.

--- a/Operating_Systems/template_linux_access_records/7.4/template_linux_access_records.yaml
+++ b/Operating_Systems/template_linux_access_records/7.4/template_linux_access_records.yaml
@@ -1,10 +1,10 @@
 zabbix_export:
   version: '7.4'
   template_groups:
-    - uuid: a7b3f1c9d24e4a6f8b1c0e5d9f2a4c60
+    - uuid: a2fe048faf234ebbadc901d9ff88c312
       name: Templates/Operating systems
   templates:
-    - uuid: 3f9c1e7a5b2d4c8e9a0f1b3d5e7c9a11
+    - uuid: d7163e4e037f47a18524e7cd0a85f3e4
       template: 'Linux access records by Zabbix agent active'
       name: 'Linux access records by Zabbix agent active'
       description: |
@@ -40,7 +40,7 @@ zabbix_export:
           value: '10'
           description: 'Failed logins within the window above that raise a Warning.'
       items:
-        - uuid: 1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f
+        - uuid: 0ea0c4a0f77d41a5809f8fba55266980
           name: 'Access records: accepted logins'
           type: ZABBIX_ACTIVE
           key: 'log[{$ACCESSLOG.PATH},"{$ACCESSLOG.ACCEPTED.REGEX}",,,skip]'
@@ -53,7 +53,7 @@ zabbix_export:
               value: security
             - tag: component
               value: access-record
-        - uuid: 2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f70
+        - uuid: bddc9d6e414a40fb8ca8e45028316f41
           name: 'Access records: failed logins'
           type: ZABBIX_ACTIVE
           key: 'log[{$ACCESSLOG.PATH},"{$ACCESSLOG.FAILED.REGEX}",,,skip]'
@@ -66,7 +66,7 @@ zabbix_export:
               value: security
             - tag: component
               value: access-record
-        - uuid: 3e4f5a6b7c8d9e0f1a2b3c4d5e6f7081
+        - uuid: ad0bc878db754ff79709ba2361bff885
           name: 'Access records: sudo commands'
           type: ZABBIX_ACTIVE
           key: 'log[{$ACCESSLOG.PATH},"{$ACCESSLOG.SUDO.REGEX}",,,skip]'
@@ -80,7 +80,7 @@ zabbix_export:
             - tag: component
               value: access-record
       triggers:
-        - uuid: 4f5a6b7c8d9e0f1a2b3c4d5e6f708192
+        - uuid: dff406e61f6f4213ac7c3805c71f4113
           expression: 'count(/Linux access records by Zabbix agent active/log[{$ACCESSLOG.PATH},"{$ACCESSLOG.FAILED.REGEX}",,,skip],{$ACCESSLOG.FAILED.WINDOW})>{$ACCESSLOG.FAILED.MAX}'
           name: 'Too many failed logins on {HOST.NAME} (>{$ACCESSLOG.FAILED.MAX} in {$ACCESSLOG.FAILED.WINDOW})'
           priority: WARNING


### PR DESCRIPTION
## What this is

A Linux **access-records** template for Zabbix agent (active). It collects
OS-level access events — SSH accepted logins, failed logins, and sudo command
execution — from the local auth log via `log[]` items, so they can be used as
security-audit and compliance evidence.

## Why this template

This is not resource monitoring — it complements the stock Linux templates
rather than overlapping with them:

- **Access-record focus** — captures *who logged in, when, from where* and
  *what was run via sudo*, straight from the auth log. Stock Linux templates
  don't cover this.
- **Read-only** — only reads the auth log; no changes to the host beyond a
  Zabbix agent (active) with read access to the log path.
- **Tunable per distribution** — log path and all match patterns are macros,
  so it works on both RHEL-family (`/var/log/secure`) and Debian-family
  (`/var/log/auth.log`) hosts.

## Contents

- **Group:** `Templates/Operating systems`
- **Items (Zabbix agent active, Log):**
  - Accepted logins — `log[{$ACCESSLOG.PATH},"{$ACCESSLOG.ACCEPTED.REGEX}",,,skip]`
  - Failed logins — `log[{$ACCESSLOG.PATH},"{$ACCESSLOG.FAILED.REGEX}",,,skip]`
  - Sudo commands — `log[{$ACCESSLOG.PATH},"{$ACCESSLOG.SUDO.REGEX}",,,skip]`
- **Trigger:** Too many failed logins (brute-force), Warning — count of failed
  logins in `{$ACCESSLOG.FAILED.WINDOW}` exceeds `{$ACCESSLOG.FAILED.MAX}`
- **Macros:** `{$ACCESSLOG.PATH}`, `{$ACCESSLOG.ACCEPTED.REGEX}`,
  `{$ACCESSLOG.FAILED.REGEX}`, `{$ACCESSLOG.SUDO.REGEX}`,
  `{$ACCESSLOG.FAILED.WINDOW}` (5m), `{$ACCESSLOG.FAILED.MAX}` (10)

## Requirements

- Zabbix **7.4**
- Zabbix agent (active) with `ServerActive` configured
- The `zabbix` user must have read access to the auth log path

## Scope

Long-term retention and tamper-proof storage of access records are intentionally
**out of scope** — forward the logs to a log store (Loki/SIEM) if your regulation
requires long-term retention.

## Validation

- Zabbix **7.4** export format
- Folder structure and naming follow the community guidelines
  (`Operating_Systems/template_linux_access_records/7.4/`)
