### PR TITLE
Add OpenVPN Access Server template

### DIFF
--- a/Applications/Others/template_openvpn_access_server/7.0/README.md
+++ b/Applications/Others/template_openvpn_access_server/7.0/README.md
@@ -1,0 +1,120 @@
+# OpenVPN Access Server
+
+This Zabbix template monitors an OpenVPN Access Server through the local `sacli` command.
+
+It monitors the number of connected VPN clients and uses low-level discovery to monitor every internal service returned by `sacli status`. The template imports as `OpenVPN Access Server` and is exported for Zabbix `7.0`.
+
+## Files
+
+- `openvpn_access.yaml` - Zabbix template export.
+
+No external monitoring scripts are required. The Zabbix agent executes the necessary `sacli` and `jq` commands through user parameters.
+
+## What it does
+
+- Collects the current number of connected clients with `openvpn.n_clients`.
+- Collects the complete internal service status object with `openvpn.status` every minute.
+- Does not store history or trends for the raw `openvpn.status` master item.
+- Discovers every property in the OpenVPN `service_status` JSON object.
+- Creates a dependent status item named `openvpn.service.status[{#SERVICE.NAME}]` for every discovered service.
+- Stores 30 days of history for each discovered service status.
+- Tags discovered items and triggers with the service name.
+- Raises a Warning when the number of connected clients exceeds `{$OVPN_CLIENTS}`.
+- Raises a Warning when an internal service status is not `on`.
+- Deletes resources for services that have not been discovered for seven days.
+
+## Requirements
+
+The monitored host must have:
+
+- OpenVPN Access Server with `/usr/local/openvpn_as/scripts/sacli`.
+- Zabbix agent or Zabbix agent 2.
+- `jq` installed and available in the Zabbix agent's execution path.
+- Permission for the Zabbix agent user to execute the required `sacli` commands with `sudo` without an interactive password prompt.
+
+The template expects these Zabbix agent keys:
+
+- `openvpn.n_clients`
+- `openvpn.status`
+
+Add the following user parameters to the Zabbix agent configuration, for example in an included `openvpn.conf` file:
+
+```text
+UserParameter=openvpn.n_clients,sudo /usr/local/openvpn_as/scripts/sacli VPNSummary | jq -r '.n_clients'
+UserParameter=openvpn.status,sudo /usr/local/openvpn_as/scripts/sacli status | jq -r '.service_status'
+```
+
+Configure `sudoers` so the Zabbix agent user can execute `sacli` without an interactive password prompt. Edit the configuration with `visudo` and add:
+
+```text
+# Allow Zabbix to execute sacli
+zabbix ALL=(ALL) NOPASSWD: /usr/local/openvpn_as/scripts/sacli
+```
+
+Validate the `sudoers` change with `visudo` before restarting the agent.
+
+## Installation
+
+1. Install `jq` on the OpenVPN Access Server.
+2. Add the `openvpn.n_clients` and `openvpn.status` user parameters to the Zabbix agent configuration.
+3. Grant the Zabbix agent user passwordless `sudo` access to the two required `sacli` commands.
+4. Restart the Zabbix agent.
+5. Import `openvpn_access.yaml` in Zabbix under `Data collection` -> `Templates` -> `Import`.
+6. Link `OpenVPN Access Server` to the OpenVPN Access Server host.
+7. Adjust `{$OVPN_CLIENTS}` if the default limit of 28 connected clients is not appropriate.
+8. Verify that the raw status item is supported and that the internal services are discovered.
+
+## Items and discovery
+
+| Name | Key | Type | Update interval | History |
+| --- | --- | --- | --- | --- |
+| `OpenVPN – Active Clients` | `openvpn.n_clients` | Zabbix agent | 1 minute | Zabbix default |
+| `OpenVPN – Service status data` | `openvpn.status` | Zabbix agent master item | 1 minute | None |
+| `OpenVPN service discovery` | `openvpn.service.discovery` | Dependent discovery | On master-item update | N/A |
+| `OpenVPN service {#SERVICE.NAME}: Status` | `openvpn.service.status[{#SERVICE.NAME}]` | Dependent item prototype | On master-item update | 30 days |
+
+The `openvpn.status` value must be a JSON object whose property names are service names and whose values are their current states. For example:
+
+```json
+{
+  "api": "on",
+  "iptables_live": "on",
+  "openvpn_0": "on",
+  "web": "on"
+}
+```
+
+## Macros
+
+| Macro | Default | Description |
+| --- | --- | --- |
+| `{$OVPN_CLIENTS}` | `28` | Maximum permitted number of connected OpenVPN clients before a Warning is raised. |
+
+## Triggers
+
+| Trigger | Condition | Severity | Operational data |
+| --- | --- | --- | --- |
+| `OpenVPN – Active Clients` | Connected clients are greater than `{$OVPN_CLIENTS}` | Warning | None |
+| `OpenVPN service {#SERVICE.NAME} is not on` | Discovered service status is not `on` | Warning | `{ITEM.LASTVALUE1}` |
+
+## Troubleshooting
+
+If either item is unsupported or service discovery does not create items, check the following:
+
+- The Zabbix agent configuration includes both user parameters and the agent has been restarted.
+- The `zabbix` user can execute both configured commands without a password prompt.
+- `/usr/local/openvpn_as/scripts/sacli` exists and is executable.
+- `jq` is installed and accessible to the Zabbix agent.
+- `openvpn.n_clients` returns only a numeric value.
+- `openvpn.status` returns a valid JSON object rather than an error message or an empty value.
+- The OpenVPN status object contains `service_status`.
+- The Zabbix server or proxy can reach the agent on the configured interface and port.
+
+To test the commands locally with the same permissions as the agent, run:
+
+```bash
+sudo -u zabbix sh -c "sudo /usr/local/openvpn_as/scripts/sacli VPNSummary | jq -r '.n_clients'"
+sudo -u zabbix sh -c "sudo /usr/local/openvpn_as/scripts/sacli status | jq -r '.service_status'"
+```
+
+The first command should return a number. The second command should return the JSON service status object.

--- a/Applications/Others/template_openvpn_access_server/7.0/template_openvpn_access_server.yaml
+++ b/Applications/Others/template_openvpn_access_server/7.0/template_openvpn_access_server.yaml
@@ -1,0 +1,92 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 7df96b18c230490a9a0a9e2307226338
+      name: Templates
+  templates:
+    - uuid: 314d0821318c4e719177c204332dd3e2
+      template: 'OpenVPN Access Server'
+      name: 'OpenVPN Access Server'
+      groups:
+        - name: Templates
+      items:
+        - uuid: 8e37bdf1fb56438195950b31a5795846
+          name: 'OpenVPN – Active Clients'
+          key: openvpn.n_clients
+          units: clients
+          tags:
+            - tag: component
+              value: OpenVPN
+          triggers:
+            - uuid: 428dd44ecdf340d1b34f3d3bc4d3533e
+              expression: 'last(/OpenVPN Access Server/openvpn.n_clients)>{$OVPN_CLIENTS}'
+              name: 'OpenVPN – Active Clients'
+              priority: WARNING
+              description: 'Too many concurrent VPN OpenVPN Access Clients'
+        - uuid: 2eab5bb8f3c24ac589a1fa14ada757f0
+          name: 'OpenVPN – Service status data'
+          key: openvpn.status
+          delay: 1m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Raw OpenVPN Access Server service_status JSON used as the master item for service discovery and status items.'
+          tags:
+            - tag: component
+              value: OpenVPN
+      discovery_rules:
+        - uuid: 598cedf425e24559875e83e397628f28
+          name: 'OpenVPN service discovery'
+          type: DEPENDENT
+          key: openvpn.service.discovery
+          delay: '0'
+          description: 'Discovers all services returned in the OpenVPN Access Server service_status object.'
+          lifetime_type: DELETE_AFTER
+          lifetime: 7d
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var services = JSON.parse(value);
+                  return JSON.stringify(Object.keys(services).map(function (name) {
+                      return {'{#SERVICE.NAME}': name};
+                  }));
+          master_item:
+            key: openvpn.status
+          item_prototypes:
+            - uuid: fa974769d69b44d79837cace04850e73
+              name: 'OpenVPN service {#SERVICE.NAME}: Status'
+              type: DEPENDENT
+              key: 'openvpn.service.status[{#SERVICE.NAME}]'
+              delay: '0'
+              history: 30d
+              value_type: CHAR
+              trends: '0'
+              description: 'Current internal OpenVPN Access Server service status. The expected value is on.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$["{#SERVICE.NAME}"]'
+              master_item:
+                key: openvpn.status
+              tags:
+                - tag: component
+                  value: OpenVPN
+                - tag: service
+                  value: '{#SERVICE.NAME}'
+              trigger_prototypes:
+                - uuid: 8dee4c474e00438aac076cff0ae580ab
+                  expression: 'last(/OpenVPN Access Server/openvpn.service.status[{#SERVICE.NAME}])<>"on"'
+                  name: 'OpenVPN service {#SERVICE.NAME} is not on'
+                  opdata: '{ITEM.LASTVALUE1}'
+                  priority: WARNING
+                  description: 'The internal OpenVPN Access Server service is not on.'
+                  tags:
+                    - tag: component
+                      value: OpenVPN
+                    - tag: service
+                      value: '{#SERVICE.NAME}'
+      macros:
+        - macro: '{$OVPN_CLIENTS}'
+          value: '28'
+          description: 'Max concurrent Clients connected to Open VPN Access Server'


### PR DESCRIPTION
# Summary
Adds OpenVPN Access Server monitoring template, based on `sacli` which is shipped with the OpenVPN AS installation. 
No external scripts are required.  

## Template details
Name: OpenVPN Access Server
Zabbix version: 7.0

## Monitored components
- Concurrent active Users
- Internal OpenVPN AS services

## Discovery rules
- Internal OpenVPN AS services (e.g. api, web, user) 

## Triggers included
- Concurrent active Users
- Internal Services not "on"

## Files
template_openvpn_access_server.yaml – Template export file
README.md – Documentation with setup instructions and troubleshooting guidance

## Testing
Tested for Zabbix 7.0 with OpenVPN Access Server 3.2