### PR TITLE
Add SAP Host Agent by Zabbix agent 2 template

### DIFF
--- a/Applications/Others/template_sap_host_agent/5.0/README.md
+++ b/Applications/Others/template_sap_host_agent/5.0/README.md
@@ -1,0 +1,187 @@
+# Template SAP Host Agent by Zabbix agent 2
+
+## Description
+
+This template is designed for monitoring **SAP Host Agent** performance and system status using **Zabbix Agent 2** with a native custom plugin. It discovers and monitors key host parameters collected via the SAP Host Agent, including CPU, Memory, Swap, Disk I/O, Filesystems, Network Interfaces, Instance processes and OS details.
+
+## Requirements
+
+To use this template, the following components are required:
+
+1. **Zabbix Agent 2** installed on the same host running the SAP Host Agent or on any other host that can reach it via the network.
+2. Native **SAP Host Agent** Zabbix plugin installed on the same host where Zabbix Agent 2 is running.
+3. **SAP Host Agent** must be active and configured with read access to its web service interface (typically running on port `1128` HTTP or `1129` HTTPS).
+
+## Installation
+
+1. **Install the Zabbix Agent 2 Plugin**:
+   - **Native Packages**: You can use pre-compiled packages for Debian/Ubuntu, SUSE (SLES) or Red Hat (RHEL/CentOS) ecosystems. Detailed instructions on adding repositories and installing these packages can be found on the [Documentation Website](https://docs.ravenlayer.com/plugins/zabbix-agent2-plugin-sapagent/).
+   - **Build from Source**: Alternatively, you can build the plugin directly from the source code available in the [GitHub Repository](https://github.com/RavenLayer/zabbix-agent2-plugin-sapagent/).
+
+2. **Import the Template**:
+   - Download the `template_sap_host_agent.xml` file.
+   - Import the XML file into your Zabbix server (**Configuration** -> **Templates** -> **Import**).
+
+3. **Configure Host Macros**:
+   - Link the template to your target host.
+   - Adjust the user macro values (e.g., `{$SAP.AGENT.URI}`, `{$SAP.AGENT.USER}` and `{$SAP.AGENT.PASSWORD}`) according to your target SAP Host Agent deployment.
+
+---
+
+## Macros
+
+| Name | Default Value | Description |
+| --- | --- | --- |
+| `{$SAP.AGENT.PASSWORD}` | | Password for SAP Host Agent basic authentication. |
+| `{$SAP.AGENT.URI}` | `http://localhost:1128` | URI of the SAP Host Agent API. |
+| `{$SAP.AGENT.USER}` | `sapadm` | Username for SAP Host Agent basic authentication. |
+| `{$CPU.UTIL.CRIT}` | `90` | Critical threshold for CPU utilization. |
+| `{$IF.ERRORS.WARN}` | `2` | Warning threshold for network interface errors. |
+| `{$LOAD_AVG_PER_CPU.MAX.WARN}` | `1.5` | Load per CPU considered sustainable. |
+| `{$MEMORY.AVAILABLE.MIN}` | `20M` | The warning threshold of the available memory. |
+| `{$MEMORY.UTIL.MAX}` | `90` | The warning threshold of the memory utilization. |
+| `{$SWAP.PFREE.MIN.WARN}` | `50` | Warning threshold for minimum percentage of free swap space. |
+| `{$VFS.DEV.AWAIT.WARN}` | `20` | Disk average wait time (in ms) before the trigger would fire |
+| `{$VFS.FS.FREE.MIN.CRIT}` | `5G` | The critical threshold of the filesystem utilization. |
+| `{$VFS.FS.FREE.MIN.WARN}` | `10G` | The warning threshold of the filesystem utilization. |
+| `{$VFS.FS.PUSED.MAX.CRIT}` | `90` | Critical threshold for filesystem utilization percentage. |
+| `{$VFS.FS.PUSED.MAX.WARN}` | `80` | Warning threshold for filesystem utilization percentage. |
+
+---
+
+## Items
+
+| Name | Type | Key |
+| --- | --- | --- |
+| Interrupts per second | Zabbix agent | `sap.agent.cpu.intr[<common_params>]` |
+| Load average (1m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg1]` |
+| Load average (5m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg5]` |
+| Load average (15m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg15]` |
+| Number of CPUs | Zabbix agent | `sap.agent.cpu.num[<common_params>]` |
+| Context switches per second | Zabbix agent | `sap.agent.cpu.switches[<common_params>]` |
+| CPU utilization | DEPENDENT | `sap.agent.cpu.util` |
+| CPU idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,idle]` |
+| CPU iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,iowait]` |
+| CPU steal time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,steal]` |
+| CPU system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,system]` |
+| CPU user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,user]` |
+| Memory utilization | CALCULATED | `sap.agent.mem.util` |
+| Available physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,available]` |
+| Free physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,free]` |
+| Total physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,size]` |
+| Total virtual memory | Zabbix agent | `sap.agent.mem[<common_params>,virt,size]` |
+| Operating system name | Zabbix agent | `sap.agent.os.name[<common_params>]` |
+| Operating system version | Zabbix agent | `sap.agent.os.version[<common_params>]` |
+| SAP agent ping | Zabbix agent | `sap.agent.ping[<common_params>]` |
+| Swap-in bytes per second | Zabbix agent | `sap.agent.swap.in[<common_params>,bytes]` |
+| Swap-in pages per second | Zabbix agent | `sap.agent.swap.in[<common_params>,pages]` |
+| Swap-out bytes per second | Zabbix agent | `sap.agent.swap.out[<common_params>,bytes]` |
+| Swap-out pages per second | Zabbix agent | `sap.agent.swap.out[<common_params>,pages]` |
+| Free swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,free]` |
+| Total swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,total]` |
+| Used swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,used]` |
+| Swap utilization | CALCULATED | `sap.agent.swap.util` |
+| Version of SAP agent running | Zabbix agent | `sap.agent.version[<common_params>]` |
+
+---
+
+## Discovery Rules
+
+### CPU discovery
+
+**Key**: `sap.agent.cpu.discovery[<common_params>]`  
+**Description**: Discovery of CPUs.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| CPU {#CPU.ID} utilization | DEPENDENT | `sap.agent.cpu.util["{#CPU.ID}]` |
+| CPU {#CPU.ID} idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},idle]` |
+| CPU {#CPU.ID} iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},iowait]` |
+| CPU {#CPU.ID} system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},system]` |
+| CPU {#CPU.ID} user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},user]` |
+
+### Block devices discovery
+
+**Key**: `sap.agent.dev.discovery[<common_params>]`  
+**Description**: Discovery of block devices.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Device {#DEVNAME}: IO rate | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},io]` |
+| Device {#DEVNAME}: Queue length | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},queue]` |
+| Device {#DEVNAME}: Service time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},svc]` |
+| Device {#DEVNAME}: Throughput | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},tput]` |
+| Device {#DEVNAME}: Utilization | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},util]` |
+| Device {#DEVNAME}: Wait time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},wait]` |
+
+### Mounted filesystem discovery
+
+**Key**: `sap.agent.fs.discovery[<common_params>]`  
+**Description**: Discovery of file systems of different types.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Filesystem {#FSNAME}: Free space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},free]` |
+| Filesystem {#FSNAME}: Total space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},total]` |
+| Filesystem {#FSNAME}: Space utilization | CALCULATED | `sap.agent.fs.util["{#FSNAME}]` |
+
+### Network interface discovery
+
+**Key**: `sap.agent.net.discovery[<common_params>]`  
+**Description**: Discovery of network interfaces.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Interface {#IFNAME}: Incoming traffic | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Incoming errors | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Incoming packets | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},packets]` |
+| Interface {#IFNAME}: Outgoing traffic | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Outgoing errors | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Outgoing packets | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},packets]` |
+
+### Process discovery
+
+**Key**: `sap.agent.proc.discovery[<common_params>]`  
+**Description**: Discovery of instance processes.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Process {#PROCESS.DESC}: Get info | Zabbix agent | `sap.agent.proc.get[<common_params>,{#INSTANCE.NAME},{#PROCESS.NAME}]` |
+| Process {#PROCESS.DESC} pid | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},pid]` |
+| Process {#PROCESS.DESC} start time | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},starttime]` |
+| Process {#PROCESS.DESC} status | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},status]` |
+
+### SAP Database discovery
+
+**Key**: `sap.agent.db.discovery[<common_params>]`  
+**Description**: Discovery of all SAP databases running on the host. Returns a JSON array containing database discovery macros (`{#DB.NAME}`, `{#DB.PROTOCOL}`, `{#DB.HOST}` and `{#DB.PORT}`).
+
+No pre-defined item prototypes are included in this template, but this rule can be used to configure custom monitoring for each discovered database.
+
+---
+
+## Screenshots
+
+Below are standard visual layouts and dashboards generated by this template:
+
+* **Problems**: Triggers for processes and filesystems
+
+<img width="847" height="421" alt="problems" src="https://github.com/user-attachments/assets/e7109a08-f9a4-4d02-9b61-604c8d58d910" />
+
+* **System Performance**: Displays CPU usage, system load, memory and swap utilization.
+
+<img width="616" height="296" alt="cpuutil" src="https://github.com/user-attachments/assets/aeab6168-a44f-45c2-a973-b4fd0a8b1265" />
+<img width="671" height="296" alt="sysload" src="https://github.com/user-attachments/assets/5ef814dc-8286-4458-b2ea-fc89fb9c1948" />
+<img width="616" height="268" alt="memusage" src="https://github.com/user-attachments/assets/e404c22a-b214-4bd5-a6eb-ea6f815561ed" />
+<img width="616" height="268" alt="swapusage" src="https://github.com/user-attachments/assets/50414451-ee9a-4b0e-91a9-f1d7b5f55d34" />
+
+* **Block Devices**: Real-time visualization of disk utilization, queue length and IO rate per device.
+
+<img width="671" height="268" alt="diskutil" src="https://github.com/user-attachments/assets/0fd0e356-c5cd-4aec-84f1-6da081fa49ab" />
+<img width="671" height="282" alt="diskio" src="https://github.com/user-attachments/assets/62a0670a-5075-4a2a-ae05-f88b35fa84e8" />
+<img width="616" height="254" alt="diskthru" src="https://github.com/user-attachments/assets/a88a45c3-13cc-4c8e-b0aa-a561f4d879cd" />
+
+* **Network Interfaces**: Incoming/outgoing bandwidth utilization and packet rates.
+
+<img width="616" height="268" alt="nettraffic" src="https://github.com/user-attachments/assets/80b5948a-15ae-463d-9d73-9258713c5e09" />
+<img width="616" height="296" alt="netpackets" src="https://github.com/user-attachments/assets/b24107d2-f160-4857-83bb-8c37d1bdb676" />

--- a/Applications/Others/template_sap_host_agent/5.0/template_sap_host_agent.xml
+++ b/Applications/Others/template_sap_host_agent/5.0/template_sap_host_agent.xml
@@ -1,0 +1,1731 @@
+<zabbix_export>
+  <version>5.0</version>
+  <date>2026-07-17T06:31:14Z</date>
+  <groups>
+    <group>
+      <name>Templates/Applications</name>
+    </group>
+  </groups>
+  <templates>
+    <template>
+      <template>Template SAP Host Agent by Zabbix agent 2</template>
+      <name>Template SAP Host Agent by Zabbix agent 2</name>
+      <description>Version: 8-36e3d05</description>
+      <groups>
+        <group>
+          <name>Templates/Applications</name>
+        </group>
+      </groups>
+      <applications>
+        <application>
+          <name>Block devices</name>
+        </application>
+        <application>
+          <name>CPU</name>
+        </application>
+        <application>
+          <name>Filesystems</name>
+        </application>
+        <application>
+          <name>Memory</name>
+        </application>
+        <application>
+          <name>Monitoring agent</name>
+        </application>
+        <application>
+          <name>Network interfaces</name>
+        </application>
+        <application>
+          <name>Operating system</name>
+        </application>
+        <application>
+          <name>Processes</name>
+        </application>
+      </applications>
+      <items>
+        <item>
+          <name>Interrupts per second</name>
+          <key>sap.agent.cpu.intr["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Load average (1m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Load average (5m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Load average (15m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Number of CPUs</name>
+          <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <params>1d</params>
+            </step>
+          </preprocessing>
+        </item>
+        <item>
+          <name>Context switches per second</name>
+          <key>sap.agent.cpu.switches["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>sps</units>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>CPU utilization</name>
+          <type>DEPENDENT</type>
+          <key>sap.agent.cpu.util</key>
+          <delay>0</delay>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <description>CPU utilization in %.</description>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+          <preprocessing>
+            <step>
+              <type>JAVASCRIPT</type>
+              <params>//Calculate utilization
+return (100 - value)</params>
+            </step>
+          </preprocessing>
+          <master_item>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          </master_item>
+          <triggers>
+            <trigger>
+              <expression>{min(5m)}&gt;{$CPU.UTIL.CRIT}</expression>
+              <name>High CPU utilization (over {$CPU.UTIL.CRIT}% for 5m)</name>
+              <opdata>Current utilization: {ITEM.LASTVALUE1}</opdata>
+              <priority>WARNING</priority>
+              <description>CPU utilization is too high. The system might be slow to respond.</description>
+              <dependencies>
+                <dependency>
+                  <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+                  <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"].min(5m)}/{Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"].last()}&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}&#13;
+and {Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"].last()}&gt;0&#13;
+and {Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"].last()}&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <name>CPU idle time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>CPU iowait time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>CPU steal time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>CPU system time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>CPU user time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Memory utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.mem.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last("sap.agent.mem[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"phy\",\"available\"]") / last("sap.agent.mem[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"phy\",\"size\"]")) * 100</params>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+          <triggers>
+            <trigger>
+              <expression>{min(5m)}&gt;{$MEMORY.UTIL.MAX}</expression>
+              <name>High memory utilization (&gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+              <priority>AVERAGE</priority>
+              <description>The system is running out of free memory.</description>
+              <dependencies>
+                <dependency>
+                  <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+                  <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"].max(5m)}&lt;{$MEMORY.AVAILABLE.MIN} and {Template SAP Host Agent by Zabbix agent 2:sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"].last()}&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <name>Available physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Free physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Total physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Total virtual memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","virt","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Operating system name</name>
+          <key>sap.agent.os.name["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <applications>
+            <application>
+              <name>Operating system</name>
+            </application>
+          </applications>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <params>1d</params>
+            </step>
+          </preprocessing>
+        </item>
+        <item>
+          <name>Operating system version</name>
+          <key>sap.agent.os.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <applications>
+            <application>
+              <name>Operating system</name>
+            </application>
+          </applications>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <params>1d</params>
+            </step>
+          </preprocessing>
+        </item>
+        <item>
+          <name>SAP agent ping</name>
+          <key>sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <applications>
+            <application>
+              <name>Monitoring agent</name>
+            </application>
+          </applications>
+          <valuemap>
+            <name>Service state</name>
+          </valuemap>
+          <triggers>
+            <trigger>
+              <expression>{last()}=0</expression>
+              <name>SAP agent is unreachable</name>
+              <priority>AVERAGE</priority>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <name>Swap-in bytes per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Swap-in pages per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Swap-out bytes per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Swap-out pages per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Free swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Total swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Used swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Swap utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.swap.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last("sap.agent.swap.size[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"free\"]") / last("sap.agent.swap.size[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"total\"]")) * 100</params>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Version of SAP agent running</name>
+          <key>sap.agent.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <applications>
+            <application>
+              <name>Monitoring agent</name>
+            </application>
+          </applications>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <params>1d</params>
+            </step>
+          </preprocessing>
+        </item>
+      </items>
+      <discovery_rules>
+        <discovery_rule>
+          <name>CPU discovery</name>
+          <key>sap.agent.cpu.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of CPUs.</description>
+          <item_prototypes>
+            <item_prototype>
+              <name>CPU {#CPU.ID} utilization</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <applications>
+                <application>
+                  <name>CPU</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>CPU {#CPU.ID}</name>
+                </application_prototype>
+              </application_prototypes>
+              <preprocessing>
+                <step>
+                  <type>JAVASCRIPT</type>
+                  <params>//Calculate utilization
+return (100 - value)</params>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              </master_item>
+            </item_prototype>
+            <item_prototype>
+              <name>CPU {#CPU.ID} idle time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <applications>
+                <application>
+                  <name>CPU</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>CPU {#CPU.ID}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>CPU {#CPU.ID} iowait time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <applications>
+                <application>
+                  <name>CPU</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>CPU {#CPU.ID}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>CPU {#CPU.ID} system time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <applications>
+                <application>
+                  <name>CPU</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>CPU {#CPU.ID}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>CPU {#CPU.ID} user time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <applications>
+                <application>
+                  <name>CPU</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>CPU {#CPU.ID}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <name>CPU {#CPU.ID} usage</name>
+              <type>STACKED</type>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <name>CPU {#CPU.ID} utilization</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <name>Block devices discovery</name>
+          <key>sap.agent.dev.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of block devices.</description>
+          <item_prototypes>
+            <item_prototype>
+              <name>Device {#DEVNAME}: IO rate</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>!io/s</units>
+              <applications>
+                <application>
+                  <name>Block devices</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Disk {#DEVNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Device {#DEVNAME}: Queue length</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <applications>
+                <application>
+                  <name>Block devices</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Disk {#DEVNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Device {#DEVNAME}: Service time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <applications>
+                <application>
+                  <name>Block devices</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Disk {#DEVNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <params>0.001</params>
+                </step>
+              </preprocessing>
+            </item_prototype>
+            <item_prototype>
+              <name>Device {#DEVNAME}: Throughput</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <applications>
+                <application>
+                  <name>Block devices</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Disk {#DEVNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Device {#DEVNAME}: Utilization</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <applications>
+                <application>
+                  <name>Block devices</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Disk {#DEVNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Device {#DEVNAME}: Wait time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <applications>
+                <application>
+                  <name>Block devices</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Disk {#DEVNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <params>0.001</params>
+                </step>
+              </preprocessing>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <expression>{min(15m)} &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"}</expression>
+                  <name>{#DEVNAME}: Disk wait time is too high (wait &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"} ms for 15m)</name>
+                  <priority>WARNING</priority>
+                  <description>This trigger might indicate disk {#DEVNAME} saturation.</description>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <name>Device {#DEVNAME}: Disk IO rate</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63100</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <name>Device {#DEVNAME}: Disk throughput</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <name>Device {#DEVNAME}: Disk utilization and queue</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <name>Mounted filesystem discovery</name>
+          <key>sap.agent.fs.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of file systems of different types.</description>
+          <item_prototypes>
+            <item_prototype>
+              <name>Filesystem {#FSNAME}: Free space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <applications>
+                <application>
+                  <name>Filesystems</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Filesystem {#FSNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Filesystem {#FSNAME}: Total space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <applications>
+                <application>
+                  <name>Filesystems</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Filesystem {#FSNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Filesystem {#FSNAME}: Space utilization</name>
+              <type>CALCULATED</type>
+              <key>sap.agent.fs.util["{#FSNAME}"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <params>100*(last("sap.agent.fs.size[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"{#FSNAME}\",\"total\"]")-last("sap.agent.fs.size[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"{#FSNAME}\",\"free\"]"))/last("sap.agent.fs.size[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"{#FSNAME}\",\"total\"]")</params>
+              <applications>
+                <application>
+                  <name>Filesystems</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Filesystem {#FSNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.util["{#FSNAME}"].last()}&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and&#13;
+({Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"].last()}&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or {Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.util["{#FSNAME}"].timeleft(1h,,100)}&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>AVERAGE</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}.&#13;
+ Second condition should be one of the following:&#13;
+ - The disk free space is less than {$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"}.&#13;
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+            <trigger_prototype>
+              <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.util["{#FSNAME}"].last()}&gt;{$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"} and&#13;
+({Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"].last()}&lt;{$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"} or {Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.util["{#FSNAME}"].timeleft(1h,,100)}&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>WARNING</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}.&#13;
+ Second condition should be one of the following:&#13;
+ - The disk free space is less than {$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"}.&#13;
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+              <dependencies>
+                <dependency>
+                  <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+                  <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.util["{#FSNAME}"].last()}&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and&#13;
+({Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"].last()}&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or {Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.util["{#FSNAME}"].timeleft(1h,,100)}&lt;1d)</expression>
+                </dependency>
+              </dependencies>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <name>{#FSNAME}: Filesystem space usage</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <name>Network interface discovery</name>
+          <key>sap.agent.net.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of network interfaces.</description>
+          <item_prototypes>
+            <item_prototype>
+              <name>Interface {#IFNAME}: Incoming traffic</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <applications>
+                <application>
+                  <name>Network interfaces</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Interface {#IFNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Interface {#IFNAME}: Incoming errors</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <applications>
+                <application>
+                  <name>Network interfaces</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Interface {#IFNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Interface {#IFNAME}: Incoming packets</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <applications>
+                <application>
+                  <name>Network interfaces</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Interface {#IFNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Interface {#IFNAME}: Outgoing traffic</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <applications>
+                <application>
+                  <name>Network interfaces</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Interface {#IFNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Interface {#IFNAME}: Outgoing errors</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <applications>
+                <application>
+                  <name>Network interfaces</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Interface {#IFNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Interface {#IFNAME}: Outgoing packets</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <applications>
+                <application>
+                  <name>Network interfaces</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Interface {#IFNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"].min(5m)}&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}&#13;
+or {Template SAP Host Agent by Zabbix agent 2:sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"].min(5m)}&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}</expression>
+              <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+              <recovery_expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"].max(5m)}&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8&#13;
+and {Template SAP Host Agent by Zabbix agent 2:sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"].max(5m)}&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8</recovery_expression>
+              <name>Interface {#IFNAME}: High error rate (&gt;{$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)</name>
+              <opdata>errors in: {ITEM.LASTVALUE1}, errors out: {ITEM.LASTVALUE2}</opdata>
+              <priority>WARNING</priority>
+              <description>Recovers when below 80% of {$IF.ERRORS.WARN:"{#IFNAME}"} threshold</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <name>Interface {#IFNAME}: Network packets</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>F63100</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>4</sortorder>
+                  <color>A54F10</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <name>Interface {#IFNAME}: Network traffic</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>BOLD_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <name>Process discovery</name>
+          <key>sap.agent.proc.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of instance processes.</description>
+          <item_prototypes>
+            <item_prototype>
+              <name>Process {#PROCESS.DESC}: Get info</name>
+              <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              <history>0</history>
+              <trends>0</trends>
+              <value_type>TEXT</value_type>
+              <applications>
+                <application>
+                  <name>Processes</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Instance {#INSTANCE.NAME}</name>
+                </application_prototype>
+                <application_prototype>
+                  <name>Process {#PROCESS.DESC}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Process {#PROCESS.DESC} pid</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <applications>
+                <application>
+                  <name>Processes</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Instance {#INSTANCE.NAME}</name>
+                </application_prototype>
+                <application_prototype>
+                  <name>Process {#PROCESS.DESC}</name>
+                </application_prototype>
+              </application_prototypes>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <params>$.pid</params>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <params>1h</params>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <expression>{diff()}&gt;0</expression>
+                  <name>Process {#PROCESS.DESC} has been restarted</name>
+                  <priority>INFO</priority>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Process {#PROCESS.DESC} start time</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","starttime"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <value_type>CHAR</value_type>
+              <applications>
+                <application>
+                  <name>Processes</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Instance {#INSTANCE.NAME}</name>
+                </application_prototype>
+                <application_prototype>
+                  <name>Process {#PROCESS.DESC}</name>
+                </application_prototype>
+              </application_prototypes>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <params>$.starttime</params>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <params>1h</params>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+            </item_prototype>
+            <item_prototype>
+              <name>Process {#PROCESS.DESC} status</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <value_type>CHAR</value_type>
+              <applications>
+                <application>
+                  <name>Processes</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Instance {#INSTANCE.NAME}</name>
+                </application_prototype>
+                <application_prototype>
+                  <name>Process {#PROCESS.DESC}</name>
+                </application_prototype>
+              </application_prototypes>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <params>$.textstatus</params>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <params>1h</params>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <expression>{regexp(^Running$)}=0</expression>
+                  <name>Process {#PROCESS.DESC}: Unexpected status</name>
+                  <opdata>Current status: {ITEM.LASTVALUE1}</opdata>
+                  <priority>HIGH</priority>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+        </discovery_rule>
+      </discovery_rules>
+      <macros>
+        <macro>
+          <macro>{$CPU.UTIL.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$IF.ERRORS.WARN}</macro>
+          <value>2</value>
+        </macro>
+        <macro>
+          <macro>{$LOAD_AVG_PER_CPU.MAX.WARN}</macro>
+          <value>1.5</value>
+          <description>Load per CPU considered sustainable.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.AVAILABLE.MIN}</macro>
+          <value>20M</value>
+          <description>The warning threshold of the available memory.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.UTIL.MAX}</macro>
+          <value>90</value>
+          <description>The warning threshold of the memory utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.PASSWORD}</macro>
+          <type>SECRET_TEXT</type>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.URI}</macro>
+          <value>http://localhost:1128</value>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.USER}</macro>
+          <value>sapadm</value>
+        </macro>
+        <macro>
+          <macro>{$SWAP.PFREE.MIN.WARN}</macro>
+          <value>50</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.DEV.AWAIT.WARN}</macro>
+          <value>20</value>
+          <description>Disk average wait time (in ms) before the trigger would fire</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.CRIT}</macro>
+          <value>5G</value>
+          <description>The critical threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.WARN}</macro>
+          <value>10G</value>
+          <description>The warning threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.WARN}</macro>
+          <value>80</value>
+        </macro>
+      </macros>
+      <screens>
+        <screen>
+          <name>Block devices</name>
+          <hsize>3</hsize>
+          <vsize>1</vsize>
+          <screen_items>
+            <screen_item>
+              <resourcetype>20</resourcetype>
+              <style>0</style>
+              <resource>
+                <name>Device {#DEVNAME}: Disk utilization and queue</name>
+                <host>Template SAP Host Agent by Zabbix agent 2</host>
+              </resource>
+              <width>500</width>
+              <height>100</height>
+              <x>0</x>
+              <y>0</y>
+              <colspan>1</colspan>
+              <rowspan>1</rowspan>
+              <elements>0</elements>
+              <valign>0</valign>
+              <halign>0</halign>
+              <dynamic>0</dynamic>
+              <sort_triggers>0</sort_triggers>
+              <url/>
+              <application/>
+              <max_columns>1</max_columns>
+            </screen_item>
+            <screen_item>
+              <resourcetype>20</resourcetype>
+              <style>0</style>
+              <resource>
+                <name>Device {#DEVNAME}: Disk IO rate</name>
+                <host>Template SAP Host Agent by Zabbix agent 2</host>
+              </resource>
+              <width>500</width>
+              <height>100</height>
+              <x>1</x>
+              <y>0</y>
+              <colspan>1</colspan>
+              <rowspan>1</rowspan>
+              <elements>0</elements>
+              <valign>0</valign>
+              <halign>0</halign>
+              <dynamic>0</dynamic>
+              <sort_triggers>0</sort_triggers>
+              <url/>
+              <application/>
+              <max_columns>1</max_columns>
+            </screen_item>
+            <screen_item>
+              <resourcetype>20</resourcetype>
+              <style>0</style>
+              <resource>
+                <name>Device {#DEVNAME}: Disk throughput</name>
+                <host>Template SAP Host Agent by Zabbix agent 2</host>
+              </resource>
+              <width>500</width>
+              <height>100</height>
+              <x>2</x>
+              <y>0</y>
+              <colspan>1</colspan>
+              <rowspan>1</rowspan>
+              <elements>0</elements>
+              <valign>0</valign>
+              <halign>0</halign>
+              <dynamic>0</dynamic>
+              <sort_triggers>0</sort_triggers>
+              <url/>
+              <application/>
+              <max_columns>1</max_columns>
+            </screen_item>
+          </screen_items>
+        </screen>
+        <screen>
+          <name>Network interfaces</name>
+          <hsize>2</hsize>
+          <vsize>1</vsize>
+          <screen_items>
+            <screen_item>
+              <resourcetype>20</resourcetype>
+              <style>0</style>
+              <resource>
+                <name>Interface {#IFNAME}: Network traffic</name>
+                <host>Template SAP Host Agent by Zabbix agent 2</host>
+              </resource>
+              <width>500</width>
+              <height>100</height>
+              <x>0</x>
+              <y>0</y>
+              <colspan>1</colspan>
+              <rowspan>1</rowspan>
+              <elements>0</elements>
+              <valign>0</valign>
+              <halign>0</halign>
+              <dynamic>0</dynamic>
+              <sort_triggers>0</sort_triggers>
+              <url/>
+              <application/>
+              <max_columns>1</max_columns>
+            </screen_item>
+            <screen_item>
+              <resourcetype>20</resourcetype>
+              <style>0</style>
+              <resource>
+                <name>Interface {#IFNAME}: Network packets</name>
+                <host>Template SAP Host Agent by Zabbix agent 2</host>
+              </resource>
+              <width>500</width>
+              <height>100</height>
+              <x>1</x>
+              <y>0</y>
+              <colspan>1</colspan>
+              <rowspan>1</rowspan>
+              <elements>0</elements>
+              <valign>0</valign>
+              <halign>0</halign>
+              <dynamic>0</dynamic>
+              <sort_triggers>0</sort_triggers>
+              <url/>
+              <application/>
+              <max_columns>1</max_columns>
+            </screen_item>
+          </screen_items>
+        </screen>
+        <screen>
+          <name>System performance</name>
+          <hsize>2</hsize>
+          <vsize>2</vsize>
+          <screen_items>
+            <screen_item>
+              <resourcetype>0</resourcetype>
+              <style>0</style>
+              <resource>
+                <name>System load</name>
+                <host>Template SAP Host Agent by Zabbix agent 2</host>
+              </resource>
+              <width>500</width>
+              <height>100</height>
+              <x>0</x>
+              <y>0</y>
+              <colspan>1</colspan>
+              <rowspan>1</rowspan>
+              <elements>0</elements>
+              <valign>0</valign>
+              <halign>0</halign>
+              <dynamic>0</dynamic>
+              <sort_triggers>0</sort_triggers>
+              <url/>
+              <application/>
+              <max_columns>3</max_columns>
+            </screen_item>
+            <screen_item>
+              <resourcetype>0</resourcetype>
+              <style>0</style>
+              <resource>
+                <name>CPU usage</name>
+                <host>Template SAP Host Agent by Zabbix agent 2</host>
+              </resource>
+              <width>500</width>
+              <height>100</height>
+              <x>1</x>
+              <y>0</y>
+              <colspan>1</colspan>
+              <rowspan>1</rowspan>
+              <elements>0</elements>
+              <valign>0</valign>
+              <halign>0</halign>
+              <dynamic>0</dynamic>
+              <sort_triggers>0</sort_triggers>
+              <url/>
+              <application/>
+              <max_columns>3</max_columns>
+            </screen_item>
+            <screen_item>
+              <resourcetype>0</resourcetype>
+              <style>0</style>
+              <resource>
+                <name>Memory usage</name>
+                <host>Template SAP Host Agent by Zabbix agent 2</host>
+              </resource>
+              <width>500</width>
+              <height>100</height>
+              <x>0</x>
+              <y>1</y>
+              <colspan>1</colspan>
+              <rowspan>1</rowspan>
+              <elements>0</elements>
+              <valign>0</valign>
+              <halign>0</halign>
+              <dynamic>0</dynamic>
+              <sort_triggers>0</sort_triggers>
+              <url/>
+              <application/>
+              <max_columns>3</max_columns>
+            </screen_item>
+            <screen_item>
+              <resourcetype>0</resourcetype>
+              <style>0</style>
+              <resource>
+                <name>Swap usage</name>
+                <host>Template SAP Host Agent by Zabbix agent 2</host>
+              </resource>
+              <width>500</width>
+              <height>100</height>
+              <x>1</x>
+              <y>1</y>
+              <colspan>1</colspan>
+              <rowspan>1</rowspan>
+              <elements>0</elements>
+              <valign>0</valign>
+              <halign>0</halign>
+              <dynamic>0</dynamic>
+              <sort_triggers>0</sort_triggers>
+              <url/>
+              <application/>
+              <max_columns>3</max_columns>
+            </screen_item>
+          </screen_items>
+        </screen>
+      </screens>
+    </template>
+  </templates>
+  <triggers>
+    <trigger>
+      <expression>100 - {Template SAP Host Agent by Zabbix agent 2:sap.agent.swap.util.max(5m)}&lt;{$SWAP.PFREE.MIN.WARN} and {Template SAP Host Agent by Zabbix agent 2:sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"].last()}&gt;0</expression>
+      <name>High swap space usage (less than {$SWAP.PFREE.MIN.WARN}% free)</name>
+      <opdata>Free: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>WARNING</priority>
+      <description>This trigger is ignored, if there is no swap configured.</description>
+    </trigger>
+    <trigger>
+      <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"].max(5m)}&lt;{$MEMORY.AVAILABLE.MIN} and {Template SAP Host Agent by Zabbix agent 2:sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"].last()}&gt;0</expression>
+      <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+      <opdata>Available: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+    </trigger>
+    <trigger>
+      <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"].min(5m)}/{Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"].last()}&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}&#13;
+and {Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"].last()}&gt;0&#13;
+and {Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"].last()}&gt;0</expression>
+      <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+      <opdata>Load averages(1m 5m 15m): ({ITEM.LASTVALUE1} {ITEM.LASTVALUE3} {ITEM.LASTVALUE4}), # of CPUs: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+      <description>Per CPU load average is too high. Your system may be slow to respond.</description>
+    </trigger>
+  </triggers>
+  <graphs>
+    <graph>
+      <name>CPU usage</name>
+      <type>STACKED</type>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>A54F10</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>FC6EA3</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <name>CPU utilization</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <name>Memory usage</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>BOLD_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <name>Swap usage</name>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>F63131</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <name>System load</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>F63100</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>A54F10</color>
+          <yaxisside>RIGHT</yaxisside>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+  </graphs>
+  <value_maps>
+    <value_map>
+      <name>Service state</name>
+      <mappings>
+        <mapping>
+          <value>0</value>
+          <newvalue>Down</newvalue>
+        </mapping>
+        <mapping>
+          <value>1</value>
+          <newvalue>Up</newvalue>
+        </mapping>
+      </mappings>
+    </value_map>
+  </value_maps>
+</zabbix_export>

--- a/Applications/Others/template_sap_host_agent/5.2/README.md
+++ b/Applications/Others/template_sap_host_agent/5.2/README.md
@@ -1,0 +1,187 @@
+# Template SAP Host Agent by Zabbix agent 2
+
+## Description
+
+This template is designed for monitoring **SAP Host Agent** performance and system status using **Zabbix Agent 2** with a native custom plugin. It discovers and monitors key host parameters collected via the SAP Host Agent, including CPU, Memory, Swap, Disk I/O, Filesystems, Network Interfaces, Instance processes and OS details.
+
+## Requirements
+
+To use this template, the following components are required:
+
+1. **Zabbix Agent 2** installed on the same host running the SAP Host Agent or on any other host that can reach it via the network.
+2. Native **SAP Host Agent** Zabbix plugin installed on the same host where Zabbix Agent 2 is running.
+3. **SAP Host Agent** must be active and configured with read access to its web service interface (typically running on port `1128` HTTP or `1129` HTTPS).
+
+## Installation
+
+1. **Install the Zabbix Agent 2 Plugin**:
+   - **Native Packages**: You can use pre-compiled packages for Debian/Ubuntu, SUSE (SLES) or Red Hat (RHEL/CentOS) ecosystems. Detailed instructions on adding repositories and installing these packages can be found on the [Documentation Website](https://docs.ravenlayer.com/plugins/zabbix-agent2-plugin-sapagent/).
+   - **Build from Source**: Alternatively, you can build the plugin directly from the source code available in the [GitHub Repository](https://github.com/RavenLayer/zabbix-agent2-plugin-sapagent/).
+
+2. **Import the Template**:
+   - Download the `template_sap_host_agent.xml` file.
+   - Import the XML file into your Zabbix server (**Configuration** -> **Templates** -> **Import**).
+
+3. **Configure Host Macros**:
+   - Link the template to your target host.
+   - Adjust the user macro values (e.g., `{$SAP.AGENT.URI}`, `{$SAP.AGENT.USER}` and `{$SAP.AGENT.PASSWORD}`) according to your target SAP Host Agent deployment.
+
+---
+
+## Macros
+
+| Name | Default Value | Description |
+| --- | --- | --- |
+| `{$SAP.AGENT.PASSWORD}` | | Password for SAP Host Agent basic authentication. |
+| `{$SAP.AGENT.URI}` | `http://localhost:1128` | URI of the SAP Host Agent API. |
+| `{$SAP.AGENT.USER}` | `sapadm` | Username for SAP Host Agent basic authentication. |
+| `{$CPU.UTIL.CRIT}` | `90` | Critical threshold for CPU utilization. |
+| `{$IF.ERRORS.WARN}` | `2` | Warning threshold for network interface errors. |
+| `{$LOAD_AVG_PER_CPU.MAX.WARN}` | `1.5` | Load per CPU considered sustainable. |
+| `{$MEMORY.AVAILABLE.MIN}` | `20M` | The warning threshold of the available memory. |
+| `{$MEMORY.UTIL.MAX}` | `90` | The warning threshold of the memory utilization. |
+| `{$SWAP.PFREE.MIN.WARN}` | `50` | Warning threshold for minimum percentage of free swap space. |
+| `{$VFS.DEV.AWAIT.WARN}` | `20` | Disk average wait time (in ms) before the trigger would fire |
+| `{$VFS.FS.FREE.MIN.CRIT}` | `5G` | The critical threshold of the filesystem utilization. |
+| `{$VFS.FS.FREE.MIN.WARN}` | `10G` | The warning threshold of the filesystem utilization. |
+| `{$VFS.FS.PUSED.MAX.CRIT}` | `90` | Critical threshold for filesystem utilization percentage. |
+| `{$VFS.FS.PUSED.MAX.WARN}` | `80` | Warning threshold for filesystem utilization percentage. |
+
+---
+
+## Items
+
+| Name | Type | Key |
+| --- | --- | --- |
+| Interrupts per second | Zabbix agent | `sap.agent.cpu.intr[<common_params>]` |
+| Load average (1m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg1]` |
+| Load average (5m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg5]` |
+| Load average (15m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg15]` |
+| Number of CPUs | Zabbix agent | `sap.agent.cpu.num[<common_params>]` |
+| Context switches per second | Zabbix agent | `sap.agent.cpu.switches[<common_params>]` |
+| CPU utilization | DEPENDENT | `sap.agent.cpu.util` |
+| CPU idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,idle]` |
+| CPU iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,iowait]` |
+| CPU steal time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,steal]` |
+| CPU system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,system]` |
+| CPU user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,user]` |
+| Memory utilization | CALCULATED | `sap.agent.mem.util` |
+| Available physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,available]` |
+| Free physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,free]` |
+| Total physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,size]` |
+| Total virtual memory | Zabbix agent | `sap.agent.mem[<common_params>,virt,size]` |
+| Operating system name | Zabbix agent | `sap.agent.os.name[<common_params>]` |
+| Operating system version | Zabbix agent | `sap.agent.os.version[<common_params>]` |
+| SAP agent ping | Zabbix agent | `sap.agent.ping[<common_params>]` |
+| Swap-in bytes per second | Zabbix agent | `sap.agent.swap.in[<common_params>,bytes]` |
+| Swap-in pages per second | Zabbix agent | `sap.agent.swap.in[<common_params>,pages]` |
+| Swap-out bytes per second | Zabbix agent | `sap.agent.swap.out[<common_params>,bytes]` |
+| Swap-out pages per second | Zabbix agent | `sap.agent.swap.out[<common_params>,pages]` |
+| Free swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,free]` |
+| Total swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,total]` |
+| Used swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,used]` |
+| Swap utilization | CALCULATED | `sap.agent.swap.util` |
+| Version of SAP agent running | Zabbix agent | `sap.agent.version[<common_params>]` |
+
+---
+
+## Discovery Rules
+
+### CPU discovery
+
+**Key**: `sap.agent.cpu.discovery[<common_params>]`  
+**Description**: Discovery of CPUs.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| CPU {#CPU.ID} utilization | DEPENDENT | `sap.agent.cpu.util["{#CPU.ID}]` |
+| CPU {#CPU.ID} idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},idle]` |
+| CPU {#CPU.ID} iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},iowait]` |
+| CPU {#CPU.ID} system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},system]` |
+| CPU {#CPU.ID} user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},user]` |
+
+### Block devices discovery
+
+**Key**: `sap.agent.dev.discovery[<common_params>]`  
+**Description**: Discovery of block devices.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Device {#DEVNAME}: IO rate | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},io]` |
+| Device {#DEVNAME}: Queue length | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},queue]` |
+| Device {#DEVNAME}: Service time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},svc]` |
+| Device {#DEVNAME}: Throughput | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},tput]` |
+| Device {#DEVNAME}: Utilization | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},util]` |
+| Device {#DEVNAME}: Wait time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},wait]` |
+
+### Mounted filesystem discovery
+
+**Key**: `sap.agent.fs.discovery[<common_params>]`  
+**Description**: Discovery of file systems of different types.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Filesystem {#FSNAME}: Free space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},free]` |
+| Filesystem {#FSNAME}: Total space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},total]` |
+| Filesystem {#FSNAME}: Space utilization | CALCULATED | `sap.agent.fs.util["{#FSNAME}]` |
+
+### Network interface discovery
+
+**Key**: `sap.agent.net.discovery[<common_params>]`  
+**Description**: Discovery of network interfaces.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Interface {#IFNAME}: Incoming traffic | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Incoming errors | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Incoming packets | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},packets]` |
+| Interface {#IFNAME}: Outgoing traffic | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Outgoing errors | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Outgoing packets | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},packets]` |
+
+### Process discovery
+
+**Key**: `sap.agent.proc.discovery[<common_params>]`  
+**Description**: Discovery of instance processes.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Process {#PROCESS.DESC}: Get info | Zabbix agent | `sap.agent.proc.get[<common_params>,{#INSTANCE.NAME},{#PROCESS.NAME}]` |
+| Process {#PROCESS.DESC} pid | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},pid]` |
+| Process {#PROCESS.DESC} start time | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},starttime]` |
+| Process {#PROCESS.DESC} status | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},status]` |
+
+### SAP Database discovery
+
+**Key**: `sap.agent.db.discovery[<common_params>]`  
+**Description**: Discovery of all SAP databases running on the host. Returns a JSON array containing database discovery macros (`{#DB.NAME}`, `{#DB.PROTOCOL}`, `{#DB.HOST}` and `{#DB.PORT}`).
+
+No pre-defined item prototypes are included in this template, but this rule can be used to configure custom monitoring for each discovered database.
+
+---
+
+## Screenshots
+
+Below are standard visual layouts and dashboards generated by this template:
+
+* **Problems**: Triggers for processes and filesystems
+
+<img width="847" height="421" alt="problems" src="https://github.com/user-attachments/assets/e7109a08-f9a4-4d02-9b61-604c8d58d910" />
+
+* **System Performance**: Displays CPU usage, system load, memory and swap utilization.
+
+<img width="616" height="296" alt="cpuutil" src="https://github.com/user-attachments/assets/aeab6168-a44f-45c2-a973-b4fd0a8b1265" />
+<img width="671" height="296" alt="sysload" src="https://github.com/user-attachments/assets/5ef814dc-8286-4458-b2ea-fc89fb9c1948" />
+<img width="616" height="268" alt="memusage" src="https://github.com/user-attachments/assets/e404c22a-b214-4bd5-a6eb-ea6f815561ed" />
+<img width="616" height="268" alt="swapusage" src="https://github.com/user-attachments/assets/50414451-ee9a-4b0e-91a9-f1d7b5f55d34" />
+
+* **Block Devices**: Real-time visualization of disk utilization, queue length and IO rate per device.
+
+<img width="671" height="268" alt="diskutil" src="https://github.com/user-attachments/assets/0fd0e356-c5cd-4aec-84f1-6da081fa49ab" />
+<img width="671" height="282" alt="diskio" src="https://github.com/user-attachments/assets/62a0670a-5075-4a2a-ae05-f88b35fa84e8" />
+<img width="616" height="254" alt="diskthru" src="https://github.com/user-attachments/assets/a88a45c3-13cc-4c8e-b0aa-a561f4d879cd" />
+
+* **Network Interfaces**: Incoming/outgoing bandwidth utilization and packet rates.
+
+<img width="616" height="268" alt="nettraffic" src="https://github.com/user-attachments/assets/80b5948a-15ae-463d-9d73-9258713c5e09" />
+<img width="616" height="296" alt="netpackets" src="https://github.com/user-attachments/assets/b24107d2-f160-4857-83bb-8c37d1bdb676" />

--- a/Applications/Others/template_sap_host_agent/5.2/template_sap_host_agent.xml
+++ b/Applications/Others/template_sap_host_agent/5.2/template_sap_host_agent.xml
@@ -1,0 +1,1722 @@
+<zabbix_export>
+  <version>5.2</version>
+  <date>2026-07-17T06:31:53Z</date>
+  <groups>
+    <group>
+      <name>Templates/Applications</name>
+    </group>
+  </groups>
+  <templates>
+    <template>
+      <template>Template SAP Host Agent by Zabbix agent 2</template>
+      <name>Template SAP Host Agent by Zabbix agent 2</name>
+      <description>Version: 8-36e3d05</description>
+      <groups>
+        <group>
+          <name>Templates/Applications</name>
+        </group>
+      </groups>
+      <applications>
+        <application>
+          <name>Block devices</name>
+        </application>
+        <application>
+          <name>CPU</name>
+        </application>
+        <application>
+          <name>Filesystems</name>
+        </application>
+        <application>
+          <name>Memory</name>
+        </application>
+        <application>
+          <name>Monitoring agent</name>
+        </application>
+        <application>
+          <name>Network interfaces</name>
+        </application>
+        <application>
+          <name>Operating system</name>
+        </application>
+        <application>
+          <name>Processes</name>
+        </application>
+      </applications>
+      <items>
+        <item>
+          <name>Interrupts per second</name>
+          <key>sap.agent.cpu.intr["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Load average (1m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Load average (5m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Load average (15m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Number of CPUs</name>
+          <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+        </item>
+        <item>
+          <name>Context switches per second</name>
+          <key>sap.agent.cpu.switches["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>sps</units>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>CPU utilization</name>
+          <type>DEPENDENT</type>
+          <key>sap.agent.cpu.util</key>
+          <delay>0</delay>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <description>CPU utilization in %.</description>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+          <preprocessing>
+            <step>
+              <type>JAVASCRIPT</type>
+              <parameters>
+                <parameter>//Calculate utilization
+return (100 - value)</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <master_item>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          </master_item>
+          <triggers>
+            <trigger>
+              <expression>{min(5m)}&gt;{$CPU.UTIL.CRIT}</expression>
+              <name>High CPU utilization (over {$CPU.UTIL.CRIT}% for 5m)</name>
+              <opdata>Current utilization: {ITEM.LASTVALUE1}</opdata>
+              <priority>WARNING</priority>
+              <description>CPU utilization is too high. The system might be slow to respond.</description>
+              <dependencies>
+                <dependency>
+                  <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+                  <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"].min(5m)}/{Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"].last()}&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and {Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"].last()}&gt;0
+and {Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"].last()}&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <name>CPU idle time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>CPU iowait time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>CPU steal time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>CPU system time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>CPU user time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <applications>
+            <application>
+              <name>CPU</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Memory utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.mem.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last("sap.agent.mem[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"phy\",\"available\"]") / last("sap.agent.mem[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"phy\",\"size\"]")) * 100</params>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+          <triggers>
+            <trigger>
+              <expression>{min(5m)}&gt;{$MEMORY.UTIL.MAX}</expression>
+              <name>High memory utilization (&gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+              <priority>AVERAGE</priority>
+              <description>The system is running out of free memory.</description>
+              <dependencies>
+                <dependency>
+                  <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+                  <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"].max(5m)}&lt;{$MEMORY.AVAILABLE.MIN} and {Template SAP Host Agent by Zabbix agent 2:sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"].last()}&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <name>Available physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Free physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Total physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Total virtual memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","virt","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Operating system name</name>
+          <key>sap.agent.os.name["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <applications>
+            <application>
+              <name>Operating system</name>
+            </application>
+          </applications>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+        </item>
+        <item>
+          <name>Operating system version</name>
+          <key>sap.agent.os.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <applications>
+            <application>
+              <name>Operating system</name>
+            </application>
+          </applications>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+        </item>
+        <item>
+          <name>SAP agent ping</name>
+          <key>sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <applications>
+            <application>
+              <name>Monitoring agent</name>
+            </application>
+          </applications>
+          <valuemap>
+            <name>Service state</name>
+          </valuemap>
+          <triggers>
+            <trigger>
+              <expression>{last()}=0</expression>
+              <name>SAP agent is unreachable</name>
+              <priority>AVERAGE</priority>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <name>Swap-in bytes per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Swap-in pages per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Swap-out bytes per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Swap-out pages per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Free swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Total swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Used swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Swap utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.swap.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last("sap.agent.swap.size[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"free\"]") / last("sap.agent.swap.size[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"total\"]")) * 100</params>
+          <applications>
+            <application>
+              <name>Memory</name>
+            </application>
+          </applications>
+        </item>
+        <item>
+          <name>Version of SAP agent running</name>
+          <key>sap.agent.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <applications>
+            <application>
+              <name>Monitoring agent</name>
+            </application>
+          </applications>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+        </item>
+      </items>
+      <discovery_rules>
+        <discovery_rule>
+          <name>CPU discovery</name>
+          <key>sap.agent.cpu.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of CPUs.</description>
+          <item_prototypes>
+            <item_prototype>
+              <name>CPU {#CPU.ID} utilization</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <applications>
+                <application>
+                  <name>CPU</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>CPU {#CPU.ID}</name>
+                </application_prototype>
+              </application_prototypes>
+              <preprocessing>
+                <step>
+                  <type>JAVASCRIPT</type>
+                  <parameters>
+                    <parameter>//Calculate utilization
+return (100 - value)</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              </master_item>
+            </item_prototype>
+            <item_prototype>
+              <name>CPU {#CPU.ID} idle time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <applications>
+                <application>
+                  <name>CPU</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>CPU {#CPU.ID}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>CPU {#CPU.ID} iowait time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <applications>
+                <application>
+                  <name>CPU</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>CPU {#CPU.ID}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>CPU {#CPU.ID} system time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <applications>
+                <application>
+                  <name>CPU</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>CPU {#CPU.ID}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>CPU {#CPU.ID} user time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <applications>
+                <application>
+                  <name>CPU</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>CPU {#CPU.ID}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <name>CPU {#CPU.ID} usage</name>
+              <type>STACKED</type>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <name>CPU {#CPU.ID} utilization</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <name>Block devices discovery</name>
+          <key>sap.agent.dev.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of block devices.</description>
+          <item_prototypes>
+            <item_prototype>
+              <name>Device {#DEVNAME}: IO rate</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>!io/s</units>
+              <applications>
+                <application>
+                  <name>Block devices</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Disk {#DEVNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Device {#DEVNAME}: Queue length</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <applications>
+                <application>
+                  <name>Block devices</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Disk {#DEVNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Device {#DEVNAME}: Service time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <applications>
+                <application>
+                  <name>Block devices</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Disk {#DEVNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+            </item_prototype>
+            <item_prototype>
+              <name>Device {#DEVNAME}: Throughput</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <applications>
+                <application>
+                  <name>Block devices</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Disk {#DEVNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Device {#DEVNAME}: Utilization</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <applications>
+                <application>
+                  <name>Block devices</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Disk {#DEVNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Device {#DEVNAME}: Wait time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <applications>
+                <application>
+                  <name>Block devices</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Disk {#DEVNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <expression>{min(15m)} &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"}</expression>
+                  <name>{#DEVNAME}: Disk wait time is too high (wait &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"} ms for 15m)</name>
+                  <priority>WARNING</priority>
+                  <description>This trigger might indicate disk {#DEVNAME} saturation.</description>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <name>Device {#DEVNAME}: Disk IO rate</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63100</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <name>Device {#DEVNAME}: Disk throughput</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <name>Device {#DEVNAME}: Disk utilization and queue</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <name>Mounted filesystem discovery</name>
+          <key>sap.agent.fs.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of file systems of different types.</description>
+          <item_prototypes>
+            <item_prototype>
+              <name>Filesystem {#FSNAME}: Free space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <applications>
+                <application>
+                  <name>Filesystems</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Filesystem {#FSNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Filesystem {#FSNAME}: Total space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <applications>
+                <application>
+                  <name>Filesystems</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Filesystem {#FSNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Filesystem {#FSNAME}: Space utilization</name>
+              <type>CALCULATED</type>
+              <key>sap.agent.fs.util["{#FSNAME}"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <params>100*(last("sap.agent.fs.size[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"{#FSNAME}\",\"total\"]")-last("sap.agent.fs.size[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"{#FSNAME}\",\"free\"]"))/last("sap.agent.fs.size[\"{$SAP.AGENT.URI}\",\"{$SAP.AGENT.USER}\",\"{$SAP.AGENT.PASSWORD}\",\"{#FSNAME}\",\"total\"]")</params>
+              <applications>
+                <application>
+                  <name>Filesystems</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Filesystem {#FSNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.util["{#FSNAME}"].last()}&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+({Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"].last()}&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or {Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.util["{#FSNAME}"].timeleft(1h,,100)}&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>AVERAGE</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+            <trigger_prototype>
+              <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.util["{#FSNAME}"].last()}&gt;{$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"} and
+({Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"].last()}&lt;{$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"} or {Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.util["{#FSNAME}"].timeleft(1h,,100)}&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>WARNING</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+              <dependencies>
+                <dependency>
+                  <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+                  <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.util["{#FSNAME}"].last()}&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+({Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"].last()}&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or {Template SAP Host Agent by Zabbix agent 2:sap.agent.fs.util["{#FSNAME}"].timeleft(1h,,100)}&lt;1d)</expression>
+                </dependency>
+              </dependencies>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <name>{#FSNAME}: Filesystem space usage</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <name>Network interface discovery</name>
+          <key>sap.agent.net.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of network interfaces.</description>
+          <item_prototypes>
+            <item_prototype>
+              <name>Interface {#IFNAME}: Incoming traffic</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <applications>
+                <application>
+                  <name>Network interfaces</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Interface {#IFNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Interface {#IFNAME}: Incoming errors</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <applications>
+                <application>
+                  <name>Network interfaces</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Interface {#IFNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Interface {#IFNAME}: Incoming packets</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <applications>
+                <application>
+                  <name>Network interfaces</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Interface {#IFNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Interface {#IFNAME}: Outgoing traffic</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <applications>
+                <application>
+                  <name>Network interfaces</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Interface {#IFNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Interface {#IFNAME}: Outgoing errors</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <applications>
+                <application>
+                  <name>Network interfaces</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Interface {#IFNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Interface {#IFNAME}: Outgoing packets</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <applications>
+                <application>
+                  <name>Network interfaces</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Interface {#IFNAME}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"].min(5m)}&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}
+or {Template SAP Host Agent by Zabbix agent 2:sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"].min(5m)}&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}</expression>
+              <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+              <recovery_expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"].max(5m)}&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8
+and {Template SAP Host Agent by Zabbix agent 2:sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"].max(5m)}&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8</recovery_expression>
+              <name>Interface {#IFNAME}: High error rate (&gt;{$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)</name>
+              <opdata>errors in: {ITEM.LASTVALUE1}, errors out: {ITEM.LASTVALUE2}</opdata>
+              <priority>WARNING</priority>
+              <description>Recovers when below 80% of {$IF.ERRORS.WARN:"{#IFNAME}"} threshold</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <name>Interface {#IFNAME}: Network packets</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>F63100</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>4</sortorder>
+                  <color>A54F10</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <name>Interface {#IFNAME}: Network traffic</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>BOLD_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <name>Process discovery</name>
+          <key>sap.agent.proc.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of instance processes.</description>
+          <item_prototypes>
+            <item_prototype>
+              <name>Process {#PROCESS.DESC}: Get info</name>
+              <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              <history>0</history>
+              <trends>0</trends>
+              <value_type>TEXT</value_type>
+              <applications>
+                <application>
+                  <name>Processes</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Instance {#INSTANCE.NAME}</name>
+                </application_prototype>
+                <application_prototype>
+                  <name>Process {#PROCESS.DESC}</name>
+                </application_prototype>
+              </application_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Process {#PROCESS.DESC} pid</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <applications>
+                <application>
+                  <name>Processes</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Instance {#INSTANCE.NAME}</name>
+                </application_prototype>
+                <application_prototype>
+                  <name>Process {#PROCESS.DESC}</name>
+                </application_prototype>
+              </application_prototypes>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.pid</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <expression>{diff()}&gt;0</expression>
+                  <name>Process {#PROCESS.DESC} has been restarted</name>
+                  <priority>INFO</priority>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <name>Process {#PROCESS.DESC} start time</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","starttime"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <value_type>CHAR</value_type>
+              <applications>
+                <application>
+                  <name>Processes</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Instance {#INSTANCE.NAME}</name>
+                </application_prototype>
+                <application_prototype>
+                  <name>Process {#PROCESS.DESC}</name>
+                </application_prototype>
+              </application_prototypes>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.starttime</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+            </item_prototype>
+            <item_prototype>
+              <name>Process {#PROCESS.DESC} status</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <value_type>CHAR</value_type>
+              <applications>
+                <application>
+                  <name>Processes</name>
+                </application>
+              </applications>
+              <application_prototypes>
+                <application_prototype>
+                  <name>Instance {#INSTANCE.NAME}</name>
+                </application_prototype>
+                <application_prototype>
+                  <name>Process {#PROCESS.DESC}</name>
+                </application_prototype>
+              </application_prototypes>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.textstatus</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <expression>{regexp(^Running$)}=0</expression>
+                  <name>Process {#PROCESS.DESC}: Unexpected status</name>
+                  <opdata>Current status: {ITEM.LASTVALUE1}</opdata>
+                  <priority>HIGH</priority>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+        </discovery_rule>
+      </discovery_rules>
+      <macros>
+        <macro>
+          <macro>{$CPU.UTIL.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$IF.ERRORS.WARN}</macro>
+          <value>2</value>
+        </macro>
+        <macro>
+          <macro>{$LOAD_AVG_PER_CPU.MAX.WARN}</macro>
+          <value>1.5</value>
+          <description>Load per CPU considered sustainable.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.AVAILABLE.MIN}</macro>
+          <value>20M</value>
+          <description>The warning threshold of the available memory.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.UTIL.MAX}</macro>
+          <value>90</value>
+          <description>The warning threshold of the memory utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.PASSWORD}</macro>
+          <type>SECRET_TEXT</type>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.URI}</macro>
+          <value>http://localhost:1128</value>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.USER}</macro>
+          <value>sapadm</value>
+        </macro>
+        <macro>
+          <macro>{$SWAP.PFREE.MIN.WARN}</macro>
+          <value>50</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.DEV.AWAIT.WARN}</macro>
+          <value>20</value>
+          <description>Disk average wait time (in ms) before the trigger would fire</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.CRIT}</macro>
+          <value>5G</value>
+          <description>The critical threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.WARN}</macro>
+          <value>10G</value>
+          <description>The warning threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.WARN}</macro>
+          <value>80</value>
+        </macro>
+      </macros>
+      <dashboards>
+        <dashboard>
+          <name>Block devices</name>
+          <widgets>
+            <widget>
+              <type>GRAPH_PROTOTYPE</type>
+              <width>8</width>
+              <height>5</height>
+              <fields>
+                <field>
+                  <type>INTEGER</type>
+                  <name>columns</name>
+                  <value>1</value>
+                </field>
+                <field>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <name>graphid</name>
+                  <value>
+                    <name>Device {#DEVNAME}: Disk utilization and queue</name>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                  </value>
+                </field>
+              </fields>
+            </widget>
+            <widget>
+              <type>GRAPH_PROTOTYPE</type>
+              <x>8</x>
+              <width>8</width>
+              <height>5</height>
+              <fields>
+                <field>
+                  <type>INTEGER</type>
+                  <name>columns</name>
+                  <value>1</value>
+                </field>
+                <field>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <name>graphid</name>
+                  <value>
+                    <name>Device {#DEVNAME}: Disk IO rate</name>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                  </value>
+                </field>
+              </fields>
+            </widget>
+            <widget>
+              <type>GRAPH_PROTOTYPE</type>
+              <x>16</x>
+              <width>8</width>
+              <height>5</height>
+              <fields>
+                <field>
+                  <type>INTEGER</type>
+                  <name>columns</name>
+                  <value>1</value>
+                </field>
+                <field>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <name>graphid</name>
+                  <value>
+                    <name>Device {#DEVNAME}: Disk throughput</name>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                  </value>
+                </field>
+              </fields>
+            </widget>
+          </widgets>
+        </dashboard>
+        <dashboard>
+          <name>Network interfaces</name>
+          <widgets>
+            <widget>
+              <type>GRAPH_PROTOTYPE</type>
+              <width>12</width>
+              <height>5</height>
+              <fields>
+                <field>
+                  <type>INTEGER</type>
+                  <name>columns</name>
+                  <value>1</value>
+                </field>
+                <field>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <name>graphid</name>
+                  <value>
+                    <name>Interface {#IFNAME}: Network traffic</name>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                  </value>
+                </field>
+              </fields>
+            </widget>
+            <widget>
+              <type>GRAPH_PROTOTYPE</type>
+              <x>12</x>
+              <width>12</width>
+              <height>5</height>
+              <fields>
+                <field>
+                  <type>INTEGER</type>
+                  <name>columns</name>
+                  <value>1</value>
+                </field>
+                <field>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <name>graphid</name>
+                  <value>
+                    <name>Interface {#IFNAME}: Network packets</name>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                  </value>
+                </field>
+              </fields>
+            </widget>
+          </widgets>
+        </dashboard>
+        <dashboard>
+          <name>System performance</name>
+          <widgets>
+            <widget>
+              <type>GRAPH_CLASSIC</type>
+              <width>12</width>
+              <height>5</height>
+              <fields>
+                <field>
+                  <type>GRAPH</type>
+                  <name>graphid</name>
+                  <value>
+                    <name>System load</name>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                  </value>
+                </field>
+              </fields>
+            </widget>
+            <widget>
+              <type>GRAPH_CLASSIC</type>
+              <x>12</x>
+              <width>12</width>
+              <height>5</height>
+              <fields>
+                <field>
+                  <type>GRAPH</type>
+                  <name>graphid</name>
+                  <value>
+                    <name>CPU usage</name>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                  </value>
+                </field>
+              </fields>
+            </widget>
+            <widget>
+              <type>GRAPH_CLASSIC</type>
+              <y>5</y>
+              <width>12</width>
+              <height>5</height>
+              <fields>
+                <field>
+                  <type>GRAPH</type>
+                  <name>graphid</name>
+                  <value>
+                    <name>Memory usage</name>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                  </value>
+                </field>
+              </fields>
+            </widget>
+            <widget>
+              <type>GRAPH_CLASSIC</type>
+              <x>12</x>
+              <y>5</y>
+              <width>12</width>
+              <height>5</height>
+              <fields>
+                <field>
+                  <type>GRAPH</type>
+                  <name>graphid</name>
+                  <value>
+                    <name>Swap usage</name>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                  </value>
+                </field>
+              </fields>
+            </widget>
+          </widgets>
+        </dashboard>
+      </dashboards>
+    </template>
+  </templates>
+  <triggers>
+    <trigger>
+      <expression>100 - {Template SAP Host Agent by Zabbix agent 2:sap.agent.swap.util.max(5m)}&lt;{$SWAP.PFREE.MIN.WARN} and {Template SAP Host Agent by Zabbix agent 2:sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"].last()}&gt;0</expression>
+      <name>High swap space usage (less than {$SWAP.PFREE.MIN.WARN}% free)</name>
+      <opdata>Free: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>WARNING</priority>
+      <description>This trigger is ignored, if there is no swap configured.</description>
+    </trigger>
+    <trigger>
+      <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"].max(5m)}&lt;{$MEMORY.AVAILABLE.MIN} and {Template SAP Host Agent by Zabbix agent 2:sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"].last()}&gt;0</expression>
+      <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+      <opdata>Available: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+    </trigger>
+    <trigger>
+      <expression>{Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"].min(5m)}/{Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"].last()}&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and {Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"].last()}&gt;0
+and {Template SAP Host Agent by Zabbix agent 2:sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"].last()}&gt;0</expression>
+      <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+      <opdata>Load averages(1m 5m 15m): ({ITEM.LASTVALUE1} {ITEM.LASTVALUE3} {ITEM.LASTVALUE4}), # of CPUs: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+      <description>Per CPU load average is too high. Your system may be slow to respond.</description>
+    </trigger>
+  </triggers>
+  <graphs>
+    <graph>
+      <name>CPU usage</name>
+      <type>STACKED</type>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>A54F10</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>FC6EA3</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <name>CPU utilization</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <name>Memory usage</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>BOLD_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <name>Swap usage</name>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>F63131</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <name>System load</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>F63100</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>A54F10</color>
+          <yaxisside>RIGHT</yaxisside>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+  </graphs>
+  <value_maps>
+    <value_map>
+      <name>Service state</name>
+      <mappings>
+        <mapping>
+          <value>0</value>
+          <newvalue>Down</newvalue>
+        </mapping>
+        <mapping>
+          <value>1</value>
+          <newvalue>Up</newvalue>
+        </mapping>
+      </mappings>
+    </value_map>
+  </value_maps>
+</zabbix_export>

--- a/Applications/Others/template_sap_host_agent/5.4/README.md
+++ b/Applications/Others/template_sap_host_agent/5.4/README.md
@@ -1,0 +1,187 @@
+# Template SAP Host Agent by Zabbix agent 2
+
+## Description
+
+This template is designed for monitoring **SAP Host Agent** performance and system status using **Zabbix Agent 2** with a native custom plugin. It discovers and monitors key host parameters collected via the SAP Host Agent, including CPU, Memory, Swap, Disk I/O, Filesystems, Network Interfaces, Instance processes and OS details.
+
+## Requirements
+
+To use this template, the following components are required:
+
+1. **Zabbix Agent 2** installed on the same host running the SAP Host Agent or on any other host that can reach it via the network.
+2. Native **SAP Host Agent** Zabbix plugin installed on the same host where Zabbix Agent 2 is running.
+3. **SAP Host Agent** must be active and configured with read access to its web service interface (typically running on port `1128` HTTP or `1129` HTTPS).
+
+## Installation
+
+1. **Install the Zabbix Agent 2 Plugin**:
+   - **Native Packages**: You can use pre-compiled packages for Debian/Ubuntu, SUSE (SLES) or Red Hat (RHEL/CentOS) ecosystems. Detailed instructions on adding repositories and installing these packages can be found on the [Documentation Website](https://docs.ravenlayer.com/plugins/zabbix-agent2-plugin-sapagent/).
+   - **Build from Source**: Alternatively, you can build the plugin directly from the source code available in the [GitHub Repository](https://github.com/RavenLayer/zabbix-agent2-plugin-sapagent/).
+
+2. **Import the Template**:
+   - Download the `template_sap_host_agent.xml` file.
+   - Import the XML file into your Zabbix server (**Configuration** -> **Templates** -> **Import**).
+
+3. **Configure Host Macros**:
+   - Link the template to your target host.
+   - Adjust the user macro values (e.g., `{$SAP.AGENT.URI}`, `{$SAP.AGENT.USER}` and `{$SAP.AGENT.PASSWORD}`) according to your target SAP Host Agent deployment.
+
+---
+
+## Macros
+
+| Name | Default Value | Description |
+| --- | --- | --- |
+| `{$SAP.AGENT.PASSWORD}` | | Password for SAP Host Agent basic authentication. |
+| `{$SAP.AGENT.URI}` | `http://localhost:1128` | URI of the SAP Host Agent API. |
+| `{$SAP.AGENT.USER}` | `sapadm` | Username for SAP Host Agent basic authentication. |
+| `{$CPU.UTIL.CRIT}` | `90` | Critical threshold for CPU utilization. |
+| `{$IF.ERRORS.WARN}` | `2` | Warning threshold for network interface errors. |
+| `{$LOAD_AVG_PER_CPU.MAX.WARN}` | `1.5` | Load per CPU considered sustainable. |
+| `{$MEMORY.AVAILABLE.MIN}` | `20M` | The warning threshold of the available memory. |
+| `{$MEMORY.UTIL.MAX}` | `90` | The warning threshold of the memory utilization. |
+| `{$SWAP.PFREE.MIN.WARN}` | `50` | Warning threshold for minimum percentage of free swap space. |
+| `{$VFS.DEV.AWAIT.WARN}` | `20` | Disk average wait time (in ms) before the trigger would fire |
+| `{$VFS.FS.FREE.MIN.CRIT}` | `5G` | The critical threshold of the filesystem utilization. |
+| `{$VFS.FS.FREE.MIN.WARN}` | `10G` | The warning threshold of the filesystem utilization. |
+| `{$VFS.FS.PUSED.MAX.CRIT}` | `90` | Critical threshold for filesystem utilization percentage. |
+| `{$VFS.FS.PUSED.MAX.WARN}` | `80` | Warning threshold for filesystem utilization percentage. |
+
+---
+
+## Items
+
+| Name | Type | Key |
+| --- | --- | --- |
+| Interrupts per second | Zabbix agent | `sap.agent.cpu.intr[<common_params>]` |
+| Load average (1m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg1]` |
+| Load average (5m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg5]` |
+| Load average (15m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg15]` |
+| Number of CPUs | Zabbix agent | `sap.agent.cpu.num[<common_params>]` |
+| Context switches per second | Zabbix agent | `sap.agent.cpu.switches[<common_params>]` |
+| CPU utilization | DEPENDENT | `sap.agent.cpu.util` |
+| CPU idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,idle]` |
+| CPU iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,iowait]` |
+| CPU steal time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,steal]` |
+| CPU system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,system]` |
+| CPU user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,user]` |
+| Memory utilization | CALCULATED | `sap.agent.mem.util` |
+| Available physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,available]` |
+| Free physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,free]` |
+| Total physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,size]` |
+| Total virtual memory | Zabbix agent | `sap.agent.mem[<common_params>,virt,size]` |
+| Operating system name | Zabbix agent | `sap.agent.os.name[<common_params>]` |
+| Operating system version | Zabbix agent | `sap.agent.os.version[<common_params>]` |
+| SAP agent ping | Zabbix agent | `sap.agent.ping[<common_params>]` |
+| Swap-in bytes per second | Zabbix agent | `sap.agent.swap.in[<common_params>,bytes]` |
+| Swap-in pages per second | Zabbix agent | `sap.agent.swap.in[<common_params>,pages]` |
+| Swap-out bytes per second | Zabbix agent | `sap.agent.swap.out[<common_params>,bytes]` |
+| Swap-out pages per second | Zabbix agent | `sap.agent.swap.out[<common_params>,pages]` |
+| Free swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,free]` |
+| Total swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,total]` |
+| Used swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,used]` |
+| Swap utilization | CALCULATED | `sap.agent.swap.util` |
+| Version of SAP agent running | Zabbix agent | `sap.agent.version[<common_params>]` |
+
+---
+
+## Discovery Rules
+
+### CPU discovery
+
+**Key**: `sap.agent.cpu.discovery[<common_params>]`  
+**Description**: Discovery of CPUs.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| CPU {#CPU.ID} utilization | DEPENDENT | `sap.agent.cpu.util["{#CPU.ID}]` |
+| CPU {#CPU.ID} idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},idle]` |
+| CPU {#CPU.ID} iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},iowait]` |
+| CPU {#CPU.ID} system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},system]` |
+| CPU {#CPU.ID} user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},user]` |
+
+### Block devices discovery
+
+**Key**: `sap.agent.dev.discovery[<common_params>]`  
+**Description**: Discovery of block devices.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Device {#DEVNAME}: IO rate | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},io]` |
+| Device {#DEVNAME}: Queue length | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},queue]` |
+| Device {#DEVNAME}: Service time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},svc]` |
+| Device {#DEVNAME}: Throughput | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},tput]` |
+| Device {#DEVNAME}: Utilization | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},util]` |
+| Device {#DEVNAME}: Wait time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},wait]` |
+
+### Mounted filesystem discovery
+
+**Key**: `sap.agent.fs.discovery[<common_params>]`  
+**Description**: Discovery of file systems of different types.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Filesystem {#FSNAME}: Free space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},free]` |
+| Filesystem {#FSNAME}: Total space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},total]` |
+| Filesystem {#FSNAME}: Space utilization | CALCULATED | `sap.agent.fs.util["{#FSNAME}]` |
+
+### Network interface discovery
+
+**Key**: `sap.agent.net.discovery[<common_params>]`  
+**Description**: Discovery of network interfaces.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Interface {#IFNAME}: Incoming traffic | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Incoming errors | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Incoming packets | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},packets]` |
+| Interface {#IFNAME}: Outgoing traffic | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Outgoing errors | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Outgoing packets | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},packets]` |
+
+### Process discovery
+
+**Key**: `sap.agent.proc.discovery[<common_params>]`  
+**Description**: Discovery of instance processes.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Process {#PROCESS.DESC}: Get info | Zabbix agent | `sap.agent.proc.get[<common_params>,{#INSTANCE.NAME},{#PROCESS.NAME}]` |
+| Process {#PROCESS.DESC} pid | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},pid]` |
+| Process {#PROCESS.DESC} start time | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},starttime]` |
+| Process {#PROCESS.DESC} status | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},status]` |
+
+### SAP Database discovery
+
+**Key**: `sap.agent.db.discovery[<common_params>]`  
+**Description**: Discovery of all SAP databases running on the host. Returns a JSON array containing database discovery macros (`{#DB.NAME}`, `{#DB.PROTOCOL}`, `{#DB.HOST}` and `{#DB.PORT}`).
+
+No pre-defined item prototypes are included in this template, but this rule can be used to configure custom monitoring for each discovered database.
+
+---
+
+## Screenshots
+
+Below are standard visual layouts and dashboards generated by this template:
+
+* **Problems**: Triggers for processes and filesystems
+
+<img width="847" height="421" alt="problems" src="https://github.com/user-attachments/assets/e7109a08-f9a4-4d02-9b61-604c8d58d910" />
+
+* **System Performance**: Displays CPU usage, system load, memory and swap utilization.
+
+<img width="616" height="296" alt="cpuutil" src="https://github.com/user-attachments/assets/aeab6168-a44f-45c2-a973-b4fd0a8b1265" />
+<img width="671" height="296" alt="sysload" src="https://github.com/user-attachments/assets/5ef814dc-8286-4458-b2ea-fc89fb9c1948" />
+<img width="616" height="268" alt="memusage" src="https://github.com/user-attachments/assets/e404c22a-b214-4bd5-a6eb-ea6f815561ed" />
+<img width="616" height="268" alt="swapusage" src="https://github.com/user-attachments/assets/50414451-ee9a-4b0e-91a9-f1d7b5f55d34" />
+
+* **Block Devices**: Real-time visualization of disk utilization, queue length and IO rate per device.
+
+<img width="671" height="268" alt="diskutil" src="https://github.com/user-attachments/assets/0fd0e356-c5cd-4aec-84f1-6da081fa49ab" />
+<img width="671" height="282" alt="diskio" src="https://github.com/user-attachments/assets/62a0670a-5075-4a2a-ae05-f88b35fa84e8" />
+<img width="616" height="254" alt="diskthru" src="https://github.com/user-attachments/assets/a88a45c3-13cc-4c8e-b0aa-a561f4d879cd" />
+
+* **Network Interfaces**: Incoming/outgoing bandwidth utilization and packet rates.
+
+<img width="616" height="268" alt="nettraffic" src="https://github.com/user-attachments/assets/80b5948a-15ae-463d-9d73-9258713c5e09" />
+<img width="616" height="296" alt="netpackets" src="https://github.com/user-attachments/assets/b24107d2-f160-4857-83bb-8c37d1bdb676" />

--- a/Applications/Others/template_sap_host_agent/5.4/template_sap_host_agent.xml
+++ b/Applications/Others/template_sap_host_agent/5.4/template_sap_host_agent.xml
@@ -1,0 +1,1830 @@
+<zabbix_export>
+  <version>5.4</version>
+  <date>2026-07-17T06:33:15Z</date>
+  <groups>
+    <group>
+      <uuid>a571c0d144b14fd4a87a9d9b2aa9fcd6</uuid>
+      <name>Templates/Applications</name>
+    </group>
+  </groups>
+  <templates>
+    <template>
+      <uuid>bcecec7d7a494dd995c45768057d4b43</uuid>
+      <template>Template SAP Host Agent by Zabbix agent 2</template>
+      <name>Template SAP Host Agent by Zabbix agent 2</name>
+      <description>Version: 8-36e3d05</description>
+      <groups>
+        <group>
+          <name>Templates/Applications</name>
+        </group>
+      </groups>
+      <items>
+        <item>
+          <uuid>b38fcdb6eb464c80bde1461a031afbc7</uuid>
+          <name>Interrupts per second</name>
+          <key>sap.agent.cpu.intr["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a2d335b4eef247b7abb06e3f90b13cdd</uuid>
+          <name>Load average (1m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1bd363e79a18490482e98334435eea7c</uuid>
+          <name>Load average (5m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c70c2e2ace0f455c8a241951cbcdf877</uuid>
+          <name>Load average (15m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f0bbe4be7e974dd49a05ea9ee6c95752</uuid>
+          <name>Number of CPUs</name>
+          <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bb00db5dc9fa411a96ec27fc9777ec62</uuid>
+          <name>Context switches per second</name>
+          <key>sap.agent.cpu.switches["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>sps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5064eead91d042aca0643d8e4fe7a13d</uuid>
+          <name>CPU utilization</name>
+          <type>DEPENDENT</type>
+          <key>sap.agent.cpu.util</key>
+          <delay>0</delay>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <description>CPU utilization in %.</description>
+          <preprocessing>
+            <step>
+              <type>JAVASCRIPT</type>
+              <parameters>
+                <parameter>//Calculate utilization
+return (100 - value)</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <master_item>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          </master_item>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>9e4a461766774602b087971817a26853</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.util,5m)&gt;{$CPU.UTIL.CRIT}</expression>
+              <name>High CPU utilization (over {$CPU.UTIL.CRIT}% for 5m)</name>
+              <opdata>Current utilization: {ITEM.LASTVALUE1}</opdata>
+              <priority>WARNING</priority>
+              <description>CPU utilization is too high. The system might be slow to respond.</description>
+              <dependencies>
+                <dependency>
+                  <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>43fa692269324ff7895c0746d66d0ea3</uuid>
+          <name>CPU idle time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>d9cc089714a0457388558c7b803040ff</uuid>
+          <name>CPU iowait time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c9e264a4ea4d418abf4b9b745685c435</uuid>
+          <name>CPU steal time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1259e4d32fa2405b971b696ea1f6dae5</uuid>
+          <name>CPU system time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f39da36a50564dc19bc54e3302dc27f8</uuid>
+          <name>CPU user time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>7f7c090809b3426681d62a5d9f532306</uuid>
+          <name>Memory utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.mem.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]) / last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>377658ded81c4580b6c7d7105a0bf64c</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem.util,5m)&gt;{$MEMORY.UTIL.MAX}</expression>
+              <name>High memory utilization (&gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+              <priority>AVERAGE</priority>
+              <description>The system is running out of free memory.</description>
+              <dependencies>
+                <dependency>
+                  <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+                  <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>9252bce6c9294c2e88ccf7e0dbcf3bde</uuid>
+          <name>Available physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>731d63fd55084cdb8951fdc5422bfcff</uuid>
+          <name>Free physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bef0fbf41aa3469684d1b3d1d47afa8f</uuid>
+          <name>Total physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a7d1a71a1a7b46a293604a6b44b4c8fe</uuid>
+          <name>Total virtual memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","virt","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f1a2abfdc14e4c80a56a555dc017a882</uuid>
+          <name>Operating system name</name>
+          <key>sap.agent.os.name["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>e51be36494c2472ab68cac0d1af3cc4a</uuid>
+          <name>Operating system version</name>
+          <key>sap.agent.os.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>46a198c67ccd47d69d3ca5508623dacc</uuid>
+          <name>SAP agent ping</name>
+          <key>sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <valuemap>
+            <name>Service state</name>
+          </valuemap>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>5c4d2858a04347298a0420a894a0e98d</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])=0</expression>
+              <name>SAP agent is unreachable</name>
+              <priority>AVERAGE</priority>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>f1e3e6eca35f48fab00c9b69b4dd8131</uuid>
+          <name>Swap-in bytes per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>82d8c82d98cc4ea0ac7f422e6c5f286d</uuid>
+          <name>Swap-in pages per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>b3223cb8189d4f4681ff2eff291f39d6</uuid>
+          <name>Swap-out bytes per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5db104cbcec54da5b09843c262958f2e</uuid>
+          <name>Swap-out pages per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1d20e12ef81647feb041434698a798e9</uuid>
+          <name>Free swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f967228dd57d4645811381b25fd75b80</uuid>
+          <name>Total swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>ecdf4fecceb549458c041f5b7f2e257d</uuid>
+          <name>Used swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>9640358636f04b9a9e61ebb0c1d365cd</uuid>
+          <name>Swap utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.swap.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]) / last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>8875ea6208cc4776a08084d43a16bf0d</uuid>
+          <name>Version of SAP agent running</name>
+          <key>sap.agent.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+        </item>
+      </items>
+      <discovery_rules>
+        <discovery_rule>
+          <uuid>300062a6d59f4c3a9bbcbb1f022f82ee</uuid>
+          <name>CPU discovery</name>
+          <key>sap.agent.cpu.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of CPUs.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>48125cd76ccb4df086cca7608f4d06e2</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <preprocessing>
+                <step>
+                  <type>JAVASCRIPT</type>
+                  <parameters>
+                    <parameter>//Calculate utilization
+return (100 - value)</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>9361f5fef88d4372949ac069515b6e89</uuid>
+              <name>CPU {#CPU.ID} idle time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4af8b69ef96145898f77d873b3cba423</uuid>
+              <name>CPU {#CPU.ID} iowait time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5595b2dbfb9843f293770972ea1aaa0d</uuid>
+              <name>CPU {#CPU.ID} system time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>afccff22b07c437aa71320015b159405</uuid>
+              <name>CPU {#CPU.ID} user time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>ccf335d326f44658be124463890012b3</uuid>
+              <name>CPU {#CPU.ID} usage</name>
+              <type>STACKED</type>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>fa5c92dbff2b45df978b79c4095ac23b</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>846f9b13aeea41ac9ab6327674ead1d0</uuid>
+          <name>Block devices discovery</name>
+          <key>sap.agent.dev.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of block devices.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>d8e6cb5e31d34a67905c4a7aa40affaa</uuid>
+              <name>Device {#DEVNAME}: IO rate</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>!io/s</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4b36092e28b4483bb3d92261150cf212</uuid>
+              <name>Device {#DEVNAME}: Queue length</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ba34c528fc644a688338588e7f5852d7</uuid>
+              <name>Device {#DEVNAME}: Service time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b53817901b0f4453982fa5d664c2d21a</uuid>
+              <name>Device {#DEVNAME}: Throughput</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ab4a897513a6413892d1a2bebc658b42</uuid>
+              <name>Device {#DEVNAME}: Utilization</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>f59bf6edb66c4a09a70c30ccb118f7dc</uuid>
+              <name>Device {#DEVNAME}: Wait time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>c16718f216654b08aa7c400c0219a64b</uuid>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"],15m) &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"}</expression>
+                  <name>{#DEVNAME}: Disk wait time is too high (wait &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"} ms for 15m)</name>
+                  <priority>WARNING</priority>
+                  <description>This trigger might indicate disk {#DEVNAME} saturation.</description>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>0939d82652154db7a27979c7379a5421</uuid>
+              <name>Device {#DEVNAME}: Disk IO rate</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63100</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>335087f8dfd047ddb3cc7f4e4d862fcd</uuid>
+              <name>Device {#DEVNAME}: Disk throughput</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>e2974723a6384fb0b2b29ed891dff025</uuid>
+              <name>Device {#DEVNAME}: Disk utilization and queue</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>bddd317b5a384816a695fb7053b48f49</uuid>
+          <name>Mounted filesystem discovery</name>
+          <key>sap.agent.fs.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of file systems of different types.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>b15be907c36440cab3225534a5d0ad1f</uuid>
+              <name>Filesystem {#FSNAME}: Free space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5d68aff2f769468eb057fcea2cfea511</uuid>
+              <name>Filesystem {#FSNAME}: Total space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>2b8f6969bd294a219ca05dddd11cdecb</uuid>
+              <name>Filesystem {#FSNAME}: Space utilization</name>
+              <type>CALCULATED</type>
+              <key>sap.agent.fs.util["{#FSNAME}"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <params>100*(last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])-last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]))/last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])</params>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>53a22cae29a943379436356c43811994</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>AVERAGE</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+            <trigger_prototype>
+              <uuid>e506eaddd3da4c9e94f69d0010e266e8</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>WARNING</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+              <dependencies>
+                <dependency>
+                  <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+                  <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+                </dependency>
+              </dependencies>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>f924384a8fb84b0ea22a3a92a792a31c</uuid>
+              <name>{#FSNAME}: Filesystem space usage</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>9bd171f82bdc4a488c8951cb9a88eb01</uuid>
+          <name>Network interface discovery</name>
+          <key>sap.agent.net.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of network interfaces.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>e4033b992d7c4a81a65fa2d680160722</uuid>
+              <name>Interface {#IFNAME}: Incoming traffic</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>96d6761c118a47edb252068a3b53f210</uuid>
+              <name>Interface {#IFNAME}: Incoming errors</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>faa96f2518ae4c5690e250580334fb47</uuid>
+              <name>Interface {#IFNAME}: Incoming packets</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>da877eba0133413f991b29118a793a6b</uuid>
+              <name>Interface {#IFNAME}: Outgoing traffic</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b6b00c9090ef4050ae1eac0809662e15</uuid>
+              <name>Interface {#IFNAME}: Outgoing errors</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ca5118209e5146f09d06353d2581e43e</uuid>
+              <name>Interface {#IFNAME}: Outgoing packets</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>a1c0eb431fc84e92996647173716fd1f</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}
+or min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}</expression>
+              <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+              <recovery_expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8
+and max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8</recovery_expression>
+              <name>Interface {#IFNAME}: High error rate (&gt;{$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)</name>
+              <opdata>errors in: {ITEM.LASTVALUE1}, errors out: {ITEM.LASTVALUE2}</opdata>
+              <priority>WARNING</priority>
+              <description>Recovers when below 80% of {$IF.ERRORS.WARN:"{#IFNAME}"} threshold</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>c5155ce8c4e14f7997e253f01944ece4</uuid>
+              <name>Interface {#IFNAME}: Network packets</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>F63100</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>4</sortorder>
+                  <color>A54F10</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>c779f37d42da4e5ca2f45fac5a35a045</uuid>
+              <name>Interface {#IFNAME}: Network traffic</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>BOLD_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>b18af0d372f34b13b4c43cc73b1edaa5</uuid>
+          <name>Process discovery</name>
+          <key>sap.agent.proc.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of instance processes.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>982ad677f38548c6af3b57efaa3944fc</uuid>
+              <name>Process {#PROCESS.DESC}: Get info</name>
+              <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              <history>0</history>
+              <trends>0</trends>
+              <value_type>TEXT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>825ff9efabbb409f909a42205d070805</uuid>
+              <name>Process {#PROCESS.DESC} pid</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.pid</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>5ba3199ecc3f4eea8994ec3ddb2fb71c</uuid>
+                  <expression>(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#1)&lt;&gt;last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#2))&gt;0</expression>
+                  <name>Process {#PROCESS.DESC} has been restarted</name>
+                  <priority>INFO</priority>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <uuid>c7bdd2e4cc8c470d8fa3a0a42bbcaced</uuid>
+              <name>Process {#PROCESS.DESC} start time</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","starttime"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <value_type>CHAR</value_type>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.starttime</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>83a838d9f126419a8ad25cef054c1b72</uuid>
+              <name>Process {#PROCESS.DESC} status</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <value_type>CHAR</value_type>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.textstatus</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>b2e718cdb5394437b59bbbef3a9646be</uuid>
+                  <expression>find(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"],,"regexp","^Running$")=0</expression>
+                  <name>Process {#PROCESS.DESC}: Unexpected status</name>
+                  <opdata>Current status: {ITEM.LASTVALUE1}</opdata>
+                  <priority>HIGH</priority>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+        </discovery_rule>
+      </discovery_rules>
+      <macros>
+        <macro>
+          <macro>{$CPU.UTIL.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$IF.ERRORS.WARN}</macro>
+          <value>2</value>
+        </macro>
+        <macro>
+          <macro>{$LOAD_AVG_PER_CPU.MAX.WARN}</macro>
+          <value>1.5</value>
+          <description>Load per CPU considered sustainable.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.AVAILABLE.MIN}</macro>
+          <value>20M</value>
+          <description>The warning threshold of the available memory.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.UTIL.MAX}</macro>
+          <value>90</value>
+          <description>The warning threshold of the memory utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.PASSWORD}</macro>
+          <type>SECRET_TEXT</type>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.URI}</macro>
+          <value>http://localhost:1128</value>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.USER}</macro>
+          <value>sapadm</value>
+        </macro>
+        <macro>
+          <macro>{$SWAP.PFREE.MIN.WARN}</macro>
+          <value>50</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.DEV.AWAIT.WARN}</macro>
+          <value>20</value>
+          <description>Disk average wait time (in ms) before the trigger would fire</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.CRIT}</macro>
+          <value>5G</value>
+          <description>The critical threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.WARN}</macro>
+          <value>10G</value>
+          <description>The warning threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.WARN}</macro>
+          <value>80</value>
+        </macro>
+      </macros>
+      <dashboards>
+        <dashboard>
+          <uuid>53e533040c1b4d83bea057509dd5b2cd</uuid>
+          <name>Block devices</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <width>8</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <name>Device {#DEVNAME}: Disk utilization and queue</name>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <x>8</x>
+                  <width>8</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <name>Device {#DEVNAME}: Disk IO rate</name>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <x>16</x>
+                  <width>8</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <name>Device {#DEVNAME}: Disk throughput</name>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>72ca7e79acb54b968222424995eb35b4</uuid>
+          <name>Network interfaces</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <name>Interface {#IFNAME}: Network traffic</name>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <x>12</x>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <name>Interface {#IFNAME}: Network packets</name>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>903c4a9c190e44a49b3c8075e37795c7</uuid>
+          <name>System performance</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>GRAPH_CLASSIC</type>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <name>System load</name>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_CLASSIC</type>
+                  <x>12</x>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <name>CPU usage</name>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_CLASSIC</type>
+                  <y>5</y>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <name>Memory usage</name>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_CLASSIC</type>
+                  <x>12</x>
+                  <y>5</y>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <name>Swap usage</name>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+      </dashboards>
+      <valuemaps>
+        <valuemap>
+          <uuid>33feeafd9e2a4fe9950ee35198ccba02</uuid>
+          <name>Service state</name>
+          <mappings>
+            <mapping>
+              <value>0</value>
+              <newvalue>Down</newvalue>
+            </mapping>
+            <mapping>
+              <value>1</value>
+              <newvalue>Up</newvalue>
+            </mapping>
+          </mappings>
+        </valuemap>
+      </valuemaps>
+    </template>
+  </templates>
+  <triggers>
+    <trigger>
+      <uuid>0eb022f5eb694feb9b2da1ffd58312e4</uuid>
+      <expression>100 - max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.util,5m)&lt;{$SWAP.PFREE.MIN.WARN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])&gt;0</expression>
+      <name>High swap space usage (less than {$SWAP.PFREE.MIN.WARN}% free)</name>
+      <opdata>Free: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>WARNING</priority>
+      <description>This trigger is ignored, if there is no swap configured.</description>
+    </trigger>
+    <trigger>
+      <uuid>a9fea933fb46485aa18381402db46299</uuid>
+      <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+      <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+      <opdata>Available: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+    </trigger>
+    <trigger>
+      <uuid>bb1df76871fa447ba9c8cc7598275c2e</uuid>
+      <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+      <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+      <opdata>Load averages(1m 5m 15m): ({ITEM.LASTVALUE1} {ITEM.LASTVALUE3} {ITEM.LASTVALUE4}), # of CPUs: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+      <description>Per CPU load average is too high. Your system may be slow to respond.</description>
+    </trigger>
+  </triggers>
+  <graphs>
+    <graph>
+      <uuid>b30f986eac8345dea04d8351a6945459</uuid>
+      <name>CPU usage</name>
+      <type>STACKED</type>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>A54F10</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>FC6EA3</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>ff15c2bb38664127a34399fc05ed460a</uuid>
+      <name>CPU utilization</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>1e571d14c7c44bbcbfbb58d48969d487</uuid>
+      <name>Memory usage</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>BOLD_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>38242ed637884247ac7806847878e50d</uuid>
+      <name>Swap usage</name>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>F63131</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>b64e8d50de4b426a84a11e0e66208d5f</uuid>
+      <name>System load</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>F63100</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>A54F10</color>
+          <yaxisside>RIGHT</yaxisside>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+  </graphs>
+</zabbix_export>

--- a/Applications/Others/template_sap_host_agent/6.0/README.md
+++ b/Applications/Others/template_sap_host_agent/6.0/README.md
@@ -1,0 +1,187 @@
+# Template SAP Host Agent by Zabbix agent 2
+
+## Description
+
+This template is designed for monitoring **SAP Host Agent** performance and system status using **Zabbix Agent 2** with a native custom plugin. It discovers and monitors key host parameters collected via the SAP Host Agent, including CPU, Memory, Swap, Disk I/O, Filesystems, Network Interfaces, Instance processes and OS details.
+
+## Requirements
+
+To use this template, the following components are required:
+
+1. **Zabbix Agent 2** installed on the same host running the SAP Host Agent or on any other host that can reach it via the network.
+2. Native **SAP Host Agent** Zabbix plugin installed on the same host where Zabbix Agent 2 is running.
+3. **SAP Host Agent** must be active and configured with read access to its web service interface (typically running on port `1128` HTTP or `1129` HTTPS).
+
+## Installation
+
+1. **Install the Zabbix Agent 2 Plugin**:
+   - **Native Packages**: You can use pre-compiled packages for Debian/Ubuntu, SUSE (SLES) or Red Hat (RHEL/CentOS) ecosystems. Detailed instructions on adding repositories and installing these packages can be found on the [Documentation Website](https://docs.ravenlayer.com/plugins/zabbix-agent2-plugin-sapagent/).
+   - **Build from Source**: Alternatively, you can build the plugin directly from the source code available in the [GitHub Repository](https://github.com/RavenLayer/zabbix-agent2-plugin-sapagent/).
+
+2. **Import the Template**:
+   - Download the `template_sap_host_agent.xml` file.
+   - Import the XML file into your Zabbix server (**Configuration** -> **Templates** -> **Import**).
+
+3. **Configure Host Macros**:
+   - Link the template to your target host.
+   - Adjust the user macro values (e.g., `{$SAP.AGENT.URI}`, `{$SAP.AGENT.USER}` and `{$SAP.AGENT.PASSWORD}`) according to your target SAP Host Agent deployment.
+
+---
+
+## Macros
+
+| Name | Default Value | Description |
+| --- | --- | --- |
+| `{$SAP.AGENT.PASSWORD}` | | Password for SAP Host Agent basic authentication. |
+| `{$SAP.AGENT.URI}` | `http://localhost:1128` | URI of the SAP Host Agent API. |
+| `{$SAP.AGENT.USER}` | `sapadm` | Username for SAP Host Agent basic authentication. |
+| `{$CPU.UTIL.CRIT}` | `90` | Critical threshold for CPU utilization. |
+| `{$IF.ERRORS.WARN}` | `2` | Warning threshold for network interface errors. |
+| `{$LOAD_AVG_PER_CPU.MAX.WARN}` | `1.5` | Load per CPU considered sustainable. |
+| `{$MEMORY.AVAILABLE.MIN}` | `20M` | The warning threshold of the available memory. |
+| `{$MEMORY.UTIL.MAX}` | `90` | The warning threshold of the memory utilization. |
+| `{$SWAP.PFREE.MIN.WARN}` | `50` | Warning threshold for minimum percentage of free swap space. |
+| `{$VFS.DEV.AWAIT.WARN}` | `20` | Disk average wait time (in ms) before the trigger would fire |
+| `{$VFS.FS.FREE.MIN.CRIT}` | `5G` | The critical threshold of the filesystem utilization. |
+| `{$VFS.FS.FREE.MIN.WARN}` | `10G` | The warning threshold of the filesystem utilization. |
+| `{$VFS.FS.PUSED.MAX.CRIT}` | `90` | Critical threshold for filesystem utilization percentage. |
+| `{$VFS.FS.PUSED.MAX.WARN}` | `80` | Warning threshold for filesystem utilization percentage. |
+
+---
+
+## Items
+
+| Name | Type | Key |
+| --- | --- | --- |
+| Interrupts per second | Zabbix agent | `sap.agent.cpu.intr[<common_params>]` |
+| Load average (1m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg1]` |
+| Load average (5m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg5]` |
+| Load average (15m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg15]` |
+| Number of CPUs | Zabbix agent | `sap.agent.cpu.num[<common_params>]` |
+| Context switches per second | Zabbix agent | `sap.agent.cpu.switches[<common_params>]` |
+| CPU utilization | DEPENDENT | `sap.agent.cpu.util` |
+| CPU idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,idle]` |
+| CPU iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,iowait]` |
+| CPU steal time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,steal]` |
+| CPU system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,system]` |
+| CPU user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,user]` |
+| Memory utilization | CALCULATED | `sap.agent.mem.util` |
+| Available physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,available]` |
+| Free physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,free]` |
+| Total physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,size]` |
+| Total virtual memory | Zabbix agent | `sap.agent.mem[<common_params>,virt,size]` |
+| Operating system name | Zabbix agent | `sap.agent.os.name[<common_params>]` |
+| Operating system version | Zabbix agent | `sap.agent.os.version[<common_params>]` |
+| SAP agent ping | Zabbix agent | `sap.agent.ping[<common_params>]` |
+| Swap-in bytes per second | Zabbix agent | `sap.agent.swap.in[<common_params>,bytes]` |
+| Swap-in pages per second | Zabbix agent | `sap.agent.swap.in[<common_params>,pages]` |
+| Swap-out bytes per second | Zabbix agent | `sap.agent.swap.out[<common_params>,bytes]` |
+| Swap-out pages per second | Zabbix agent | `sap.agent.swap.out[<common_params>,pages]` |
+| Free swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,free]` |
+| Total swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,total]` |
+| Used swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,used]` |
+| Swap utilization | CALCULATED | `sap.agent.swap.util` |
+| Version of SAP agent running | Zabbix agent | `sap.agent.version[<common_params>]` |
+
+---
+
+## Discovery Rules
+
+### CPU discovery
+
+**Key**: `sap.agent.cpu.discovery[<common_params>]`  
+**Description**: Discovery of CPUs.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| CPU {#CPU.ID} utilization | DEPENDENT | `sap.agent.cpu.util["{#CPU.ID}]` |
+| CPU {#CPU.ID} idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},idle]` |
+| CPU {#CPU.ID} iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},iowait]` |
+| CPU {#CPU.ID} system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},system]` |
+| CPU {#CPU.ID} user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},user]` |
+
+### Block devices discovery
+
+**Key**: `sap.agent.dev.discovery[<common_params>]`  
+**Description**: Discovery of block devices.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Device {#DEVNAME}: IO rate | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},io]` |
+| Device {#DEVNAME}: Queue length | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},queue]` |
+| Device {#DEVNAME}: Service time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},svc]` |
+| Device {#DEVNAME}: Throughput | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},tput]` |
+| Device {#DEVNAME}: Utilization | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},util]` |
+| Device {#DEVNAME}: Wait time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},wait]` |
+
+### Mounted filesystem discovery
+
+**Key**: `sap.agent.fs.discovery[<common_params>]`  
+**Description**: Discovery of file systems of different types.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Filesystem {#FSNAME}: Free space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},free]` |
+| Filesystem {#FSNAME}: Total space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},total]` |
+| Filesystem {#FSNAME}: Space utilization | CALCULATED | `sap.agent.fs.util["{#FSNAME}]` |
+
+### Network interface discovery
+
+**Key**: `sap.agent.net.discovery[<common_params>]`  
+**Description**: Discovery of network interfaces.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Interface {#IFNAME}: Incoming traffic | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Incoming errors | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Incoming packets | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},packets]` |
+| Interface {#IFNAME}: Outgoing traffic | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Outgoing errors | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Outgoing packets | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},packets]` |
+
+### Process discovery
+
+**Key**: `sap.agent.proc.discovery[<common_params>]`  
+**Description**: Discovery of instance processes.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Process {#PROCESS.DESC}: Get info | Zabbix agent | `sap.agent.proc.get[<common_params>,{#INSTANCE.NAME},{#PROCESS.NAME}]` |
+| Process {#PROCESS.DESC} pid | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},pid]` |
+| Process {#PROCESS.DESC} start time | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},starttime]` |
+| Process {#PROCESS.DESC} status | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},status]` |
+
+### SAP Database discovery
+
+**Key**: `sap.agent.db.discovery[<common_params>]`  
+**Description**: Discovery of all SAP databases running on the host. Returns a JSON array containing database discovery macros (`{#DB.NAME}`, `{#DB.PROTOCOL}`, `{#DB.HOST}` and `{#DB.PORT}`).
+
+No pre-defined item prototypes are included in this template, but this rule can be used to configure custom monitoring for each discovered database.
+
+---
+
+## Screenshots
+
+Below are standard visual layouts and dashboards generated by this template:
+
+* **Problems**: Triggers for processes and filesystems
+
+<img width="847" height="421" alt="problems" src="https://github.com/user-attachments/assets/e7109a08-f9a4-4d02-9b61-604c8d58d910" />
+
+* **System Performance**: Displays CPU usage, system load, memory and swap utilization.
+
+<img width="616" height="296" alt="cpuutil" src="https://github.com/user-attachments/assets/aeab6168-a44f-45c2-a973-b4fd0a8b1265" />
+<img width="671" height="296" alt="sysload" src="https://github.com/user-attachments/assets/5ef814dc-8286-4458-b2ea-fc89fb9c1948" />
+<img width="616" height="268" alt="memusage" src="https://github.com/user-attachments/assets/e404c22a-b214-4bd5-a6eb-ea6f815561ed" />
+<img width="616" height="268" alt="swapusage" src="https://github.com/user-attachments/assets/50414451-ee9a-4b0e-91a9-f1d7b5f55d34" />
+
+* **Block Devices**: Real-time visualization of disk utilization, queue length and IO rate per device.
+
+<img width="671" height="268" alt="diskutil" src="https://github.com/user-attachments/assets/0fd0e356-c5cd-4aec-84f1-6da081fa49ab" />
+<img width="671" height="282" alt="diskio" src="https://github.com/user-attachments/assets/62a0670a-5075-4a2a-ae05-f88b35fa84e8" />
+<img width="616" height="254" alt="diskthru" src="https://github.com/user-attachments/assets/a88a45c3-13cc-4c8e-b0aa-a561f4d879cd" />
+
+* **Network Interfaces**: Incoming/outgoing bandwidth utilization and packet rates.
+
+<img width="616" height="268" alt="nettraffic" src="https://github.com/user-attachments/assets/80b5948a-15ae-463d-9d73-9258713c5e09" />
+<img width="616" height="296" alt="netpackets" src="https://github.com/user-attachments/assets/b24107d2-f160-4857-83bb-8c37d1bdb676" />

--- a/Applications/Others/template_sap_host_agent/6.0/template_sap_host_agent.xml
+++ b/Applications/Others/template_sap_host_agent/6.0/template_sap_host_agent.xml
@@ -1,0 +1,1830 @@
+<zabbix_export>
+  <version>6.0</version>
+  <date>2026-07-17T06:34:01Z</date>
+  <groups>
+    <group>
+      <uuid>a571c0d144b14fd4a87a9d9b2aa9fcd6</uuid>
+      <name>Templates/Applications</name>
+    </group>
+  </groups>
+  <templates>
+    <template>
+      <uuid>bcecec7d7a494dd995c45768057d4b43</uuid>
+      <template>Template SAP Host Agent by Zabbix agent 2</template>
+      <name>Template SAP Host Agent by Zabbix agent 2</name>
+      <description>Version: 8-36e3d05</description>
+      <groups>
+        <group>
+          <name>Templates/Applications</name>
+        </group>
+      </groups>
+      <items>
+        <item>
+          <uuid>b38fcdb6eb464c80bde1461a031afbc7</uuid>
+          <name>Interrupts per second</name>
+          <key>sap.agent.cpu.intr["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a2d335b4eef247b7abb06e3f90b13cdd</uuid>
+          <name>Load average (1m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1bd363e79a18490482e98334435eea7c</uuid>
+          <name>Load average (5m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c70c2e2ace0f455c8a241951cbcdf877</uuid>
+          <name>Load average (15m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f0bbe4be7e974dd49a05ea9ee6c95752</uuid>
+          <name>Number of CPUs</name>
+          <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bb00db5dc9fa411a96ec27fc9777ec62</uuid>
+          <name>Context switches per second</name>
+          <key>sap.agent.cpu.switches["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>sps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5064eead91d042aca0643d8e4fe7a13d</uuid>
+          <name>CPU utilization</name>
+          <type>DEPENDENT</type>
+          <key>sap.agent.cpu.util</key>
+          <delay>0</delay>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <description>CPU utilization in %.</description>
+          <preprocessing>
+            <step>
+              <type>JAVASCRIPT</type>
+              <parameters>
+                <parameter>//Calculate utilization
+return (100 - value)</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <master_item>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          </master_item>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>9e4a461766774602b087971817a26853</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.util,5m)&gt;{$CPU.UTIL.CRIT}</expression>
+              <name>High CPU utilization (over {$CPU.UTIL.CRIT}% for 5m)</name>
+              <opdata>Current utilization: {ITEM.LASTVALUE1}</opdata>
+              <priority>WARNING</priority>
+              <description>CPU utilization is too high. The system might be slow to respond.</description>
+              <dependencies>
+                <dependency>
+                  <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>43fa692269324ff7895c0746d66d0ea3</uuid>
+          <name>CPU idle time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>d9cc089714a0457388558c7b803040ff</uuid>
+          <name>CPU iowait time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c9e264a4ea4d418abf4b9b745685c435</uuid>
+          <name>CPU steal time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1259e4d32fa2405b971b696ea1f6dae5</uuid>
+          <name>CPU system time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f39da36a50564dc19bc54e3302dc27f8</uuid>
+          <name>CPU user time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>7f7c090809b3426681d62a5d9f532306</uuid>
+          <name>Memory utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.mem.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]) / last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>377658ded81c4580b6c7d7105a0bf64c</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem.util,5m)&gt;{$MEMORY.UTIL.MAX}</expression>
+              <name>High memory utilization (&gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+              <priority>AVERAGE</priority>
+              <description>The system is running out of free memory.</description>
+              <dependencies>
+                <dependency>
+                  <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+                  <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>9252bce6c9294c2e88ccf7e0dbcf3bde</uuid>
+          <name>Available physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>731d63fd55084cdb8951fdc5422bfcff</uuid>
+          <name>Free physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bef0fbf41aa3469684d1b3d1d47afa8f</uuid>
+          <name>Total physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a7d1a71a1a7b46a293604a6b44b4c8fe</uuid>
+          <name>Total virtual memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","virt","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f1a2abfdc14e4c80a56a555dc017a882</uuid>
+          <name>Operating system name</name>
+          <key>sap.agent.os.name["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>e51be36494c2472ab68cac0d1af3cc4a</uuid>
+          <name>Operating system version</name>
+          <key>sap.agent.os.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>46a198c67ccd47d69d3ca5508623dacc</uuid>
+          <name>SAP agent ping</name>
+          <key>sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <valuemap>
+            <name>Service state</name>
+          </valuemap>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>5c4d2858a04347298a0420a894a0e98d</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])=0</expression>
+              <name>SAP agent is unreachable</name>
+              <priority>AVERAGE</priority>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>f1e3e6eca35f48fab00c9b69b4dd8131</uuid>
+          <name>Swap-in bytes per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>82d8c82d98cc4ea0ac7f422e6c5f286d</uuid>
+          <name>Swap-in pages per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>b3223cb8189d4f4681ff2eff291f39d6</uuid>
+          <name>Swap-out bytes per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5db104cbcec54da5b09843c262958f2e</uuid>
+          <name>Swap-out pages per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1d20e12ef81647feb041434698a798e9</uuid>
+          <name>Free swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f967228dd57d4645811381b25fd75b80</uuid>
+          <name>Total swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>ecdf4fecceb549458c041f5b7f2e257d</uuid>
+          <name>Used swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>9640358636f04b9a9e61ebb0c1d365cd</uuid>
+          <name>Swap utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.swap.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]) / last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>8875ea6208cc4776a08084d43a16bf0d</uuid>
+          <name>Version of SAP agent running</name>
+          <key>sap.agent.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+        </item>
+      </items>
+      <discovery_rules>
+        <discovery_rule>
+          <uuid>300062a6d59f4c3a9bbcbb1f022f82ee</uuid>
+          <name>CPU discovery</name>
+          <key>sap.agent.cpu.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of CPUs.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>48125cd76ccb4df086cca7608f4d06e2</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <preprocessing>
+                <step>
+                  <type>JAVASCRIPT</type>
+                  <parameters>
+                    <parameter>//Calculate utilization
+return (100 - value)</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>9361f5fef88d4372949ac069515b6e89</uuid>
+              <name>CPU {#CPU.ID} idle time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4af8b69ef96145898f77d873b3cba423</uuid>
+              <name>CPU {#CPU.ID} iowait time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5595b2dbfb9843f293770972ea1aaa0d</uuid>
+              <name>CPU {#CPU.ID} system time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>afccff22b07c437aa71320015b159405</uuid>
+              <name>CPU {#CPU.ID} user time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>ccf335d326f44658be124463890012b3</uuid>
+              <name>CPU {#CPU.ID} usage</name>
+              <type>STACKED</type>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>fa5c92dbff2b45df978b79c4095ac23b</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>846f9b13aeea41ac9ab6327674ead1d0</uuid>
+          <name>Block devices discovery</name>
+          <key>sap.agent.dev.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of block devices.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>d8e6cb5e31d34a67905c4a7aa40affaa</uuid>
+              <name>Device {#DEVNAME}: IO rate</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>!io/s</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4b36092e28b4483bb3d92261150cf212</uuid>
+              <name>Device {#DEVNAME}: Queue length</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ba34c528fc644a688338588e7f5852d7</uuid>
+              <name>Device {#DEVNAME}: Service time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b53817901b0f4453982fa5d664c2d21a</uuid>
+              <name>Device {#DEVNAME}: Throughput</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ab4a897513a6413892d1a2bebc658b42</uuid>
+              <name>Device {#DEVNAME}: Utilization</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>f59bf6edb66c4a09a70c30ccb118f7dc</uuid>
+              <name>Device {#DEVNAME}: Wait time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>c16718f216654b08aa7c400c0219a64b</uuid>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"],15m) &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"}</expression>
+                  <name>{#DEVNAME}: Disk wait time is too high (wait &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"} ms for 15m)</name>
+                  <priority>WARNING</priority>
+                  <description>This trigger might indicate disk {#DEVNAME} saturation.</description>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>0939d82652154db7a27979c7379a5421</uuid>
+              <name>Device {#DEVNAME}: Disk IO rate</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63100</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>335087f8dfd047ddb3cc7f4e4d862fcd</uuid>
+              <name>Device {#DEVNAME}: Disk throughput</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>e2974723a6384fb0b2b29ed891dff025</uuid>
+              <name>Device {#DEVNAME}: Disk utilization and queue</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>bddd317b5a384816a695fb7053b48f49</uuid>
+          <name>Mounted filesystem discovery</name>
+          <key>sap.agent.fs.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of file systems of different types.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>b15be907c36440cab3225534a5d0ad1f</uuid>
+              <name>Filesystem {#FSNAME}: Free space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5d68aff2f769468eb057fcea2cfea511</uuid>
+              <name>Filesystem {#FSNAME}: Total space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>2b8f6969bd294a219ca05dddd11cdecb</uuid>
+              <name>Filesystem {#FSNAME}: Space utilization</name>
+              <type>CALCULATED</type>
+              <key>sap.agent.fs.util["{#FSNAME}"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <params>100*(last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])-last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]))/last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])</params>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>53a22cae29a943379436356c43811994</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>AVERAGE</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+            <trigger_prototype>
+              <uuid>e506eaddd3da4c9e94f69d0010e266e8</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>WARNING</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+              <dependencies>
+                <dependency>
+                  <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+                  <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+                </dependency>
+              </dependencies>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>f924384a8fb84b0ea22a3a92a792a31c</uuid>
+              <name>{#FSNAME}: Filesystem space usage</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>9bd171f82bdc4a488c8951cb9a88eb01</uuid>
+          <name>Network interface discovery</name>
+          <key>sap.agent.net.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of network interfaces.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>e4033b992d7c4a81a65fa2d680160722</uuid>
+              <name>Interface {#IFNAME}: Incoming traffic</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>96d6761c118a47edb252068a3b53f210</uuid>
+              <name>Interface {#IFNAME}: Incoming errors</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>faa96f2518ae4c5690e250580334fb47</uuid>
+              <name>Interface {#IFNAME}: Incoming packets</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>da877eba0133413f991b29118a793a6b</uuid>
+              <name>Interface {#IFNAME}: Outgoing traffic</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b6b00c9090ef4050ae1eac0809662e15</uuid>
+              <name>Interface {#IFNAME}: Outgoing errors</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ca5118209e5146f09d06353d2581e43e</uuid>
+              <name>Interface {#IFNAME}: Outgoing packets</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>a1c0eb431fc84e92996647173716fd1f</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}
+or min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}</expression>
+              <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+              <recovery_expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8
+and max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8</recovery_expression>
+              <name>Interface {#IFNAME}: High error rate (&gt;{$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)</name>
+              <opdata>errors in: {ITEM.LASTVALUE1}, errors out: {ITEM.LASTVALUE2}</opdata>
+              <priority>WARNING</priority>
+              <description>Recovers when below 80% of {$IF.ERRORS.WARN:"{#IFNAME}"} threshold</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>c5155ce8c4e14f7997e253f01944ece4</uuid>
+              <name>Interface {#IFNAME}: Network packets</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>F63100</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>4</sortorder>
+                  <color>A54F10</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>c779f37d42da4e5ca2f45fac5a35a045</uuid>
+              <name>Interface {#IFNAME}: Network traffic</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>BOLD_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>b18af0d372f34b13b4c43cc73b1edaa5</uuid>
+          <name>Process discovery</name>
+          <key>sap.agent.proc.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of instance processes.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>982ad677f38548c6af3b57efaa3944fc</uuid>
+              <name>Process {#PROCESS.DESC}: Get info</name>
+              <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              <history>0</history>
+              <trends>0</trends>
+              <value_type>TEXT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>825ff9efabbb409f909a42205d070805</uuid>
+              <name>Process {#PROCESS.DESC} pid</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.pid</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>5ba3199ecc3f4eea8994ec3ddb2fb71c</uuid>
+                  <expression>(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#1)&lt;&gt;last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#2))&gt;0</expression>
+                  <name>Process {#PROCESS.DESC} has been restarted</name>
+                  <priority>INFO</priority>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <uuid>c7bdd2e4cc8c470d8fa3a0a42bbcaced</uuid>
+              <name>Process {#PROCESS.DESC} start time</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","starttime"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <value_type>CHAR</value_type>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.starttime</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>83a838d9f126419a8ad25cef054c1b72</uuid>
+              <name>Process {#PROCESS.DESC} status</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <value_type>CHAR</value_type>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.textstatus</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>b2e718cdb5394437b59bbbef3a9646be</uuid>
+                  <expression>find(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"],,"regexp","^Running$")=0</expression>
+                  <name>Process {#PROCESS.DESC}: Unexpected status</name>
+                  <opdata>Current status: {ITEM.LASTVALUE1}</opdata>
+                  <priority>HIGH</priority>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+        </discovery_rule>
+      </discovery_rules>
+      <macros>
+        <macro>
+          <macro>{$CPU.UTIL.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$IF.ERRORS.WARN}</macro>
+          <value>2</value>
+        </macro>
+        <macro>
+          <macro>{$LOAD_AVG_PER_CPU.MAX.WARN}</macro>
+          <value>1.5</value>
+          <description>Load per CPU considered sustainable.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.AVAILABLE.MIN}</macro>
+          <value>20M</value>
+          <description>The warning threshold of the available memory.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.UTIL.MAX}</macro>
+          <value>90</value>
+          <description>The warning threshold of the memory utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.PASSWORD}</macro>
+          <type>SECRET_TEXT</type>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.URI}</macro>
+          <value>http://localhost:1128</value>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.USER}</macro>
+          <value>sapadm</value>
+        </macro>
+        <macro>
+          <macro>{$SWAP.PFREE.MIN.WARN}</macro>
+          <value>50</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.DEV.AWAIT.WARN}</macro>
+          <value>20</value>
+          <description>Disk average wait time (in ms) before the trigger would fire</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.CRIT}</macro>
+          <value>5G</value>
+          <description>The critical threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.WARN}</macro>
+          <value>10G</value>
+          <description>The warning threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.WARN}</macro>
+          <value>80</value>
+        </macro>
+      </macros>
+      <dashboards>
+        <dashboard>
+          <uuid>53e533040c1b4d83bea057509dd5b2cd</uuid>
+          <name>Block devices</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <width>8</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk utilization and queue</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <x>8</x>
+                  <width>8</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk IO rate</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <x>16</x>
+                  <width>8</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk throughput</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>72ca7e79acb54b968222424995eb35b4</uuid>
+          <name>Network interfaces</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Interface {#IFNAME}: Network traffic</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <x>12</x>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Interface {#IFNAME}: Network packets</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>903c4a9c190e44a49b3c8075e37795c7</uuid>
+          <name>System performance</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>GRAPH_CLASSIC</type>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>System load</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_CLASSIC</type>
+                  <y>5</y>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Memory usage</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_CLASSIC</type>
+                  <x>12</x>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>CPU usage</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_CLASSIC</type>
+                  <x>12</x>
+                  <y>5</y>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Swap usage</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+      </dashboards>
+      <valuemaps>
+        <valuemap>
+          <uuid>33feeafd9e2a4fe9950ee35198ccba02</uuid>
+          <name>Service state</name>
+          <mappings>
+            <mapping>
+              <value>0</value>
+              <newvalue>Down</newvalue>
+            </mapping>
+            <mapping>
+              <value>1</value>
+              <newvalue>Up</newvalue>
+            </mapping>
+          </mappings>
+        </valuemap>
+      </valuemaps>
+    </template>
+  </templates>
+  <triggers>
+    <trigger>
+      <uuid>0eb022f5eb694feb9b2da1ffd58312e4</uuid>
+      <expression>100 - max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.util,5m)&lt;{$SWAP.PFREE.MIN.WARN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])&gt;0</expression>
+      <name>High swap space usage (less than {$SWAP.PFREE.MIN.WARN}% free)</name>
+      <opdata>Free: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>WARNING</priority>
+      <description>This trigger is ignored, if there is no swap configured.</description>
+    </trigger>
+    <trigger>
+      <uuid>a9fea933fb46485aa18381402db46299</uuid>
+      <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+      <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+      <opdata>Available: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+    </trigger>
+    <trigger>
+      <uuid>bb1df76871fa447ba9c8cc7598275c2e</uuid>
+      <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+      <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+      <opdata>Load averages(1m 5m 15m): ({ITEM.LASTVALUE1} {ITEM.LASTVALUE3} {ITEM.LASTVALUE4}), # of CPUs: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+      <description>Per CPU load average is too high. Your system may be slow to respond.</description>
+    </trigger>
+  </triggers>
+  <graphs>
+    <graph>
+      <uuid>b30f986eac8345dea04d8351a6945459</uuid>
+      <name>CPU usage</name>
+      <type>STACKED</type>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>A54F10</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>FC6EA3</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>ff15c2bb38664127a34399fc05ed460a</uuid>
+      <name>CPU utilization</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>1e571d14c7c44bbcbfbb58d48969d487</uuid>
+      <name>Memory usage</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>BOLD_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>38242ed637884247ac7806847878e50d</uuid>
+      <name>Swap usage</name>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>F63131</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>b64e8d50de4b426a84a11e0e66208d5f</uuid>
+      <name>System load</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>F63100</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>A54F10</color>
+          <yaxisside>RIGHT</yaxisside>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+  </graphs>
+</zabbix_export>

--- a/Applications/Others/template_sap_host_agent/6.2/README.md
+++ b/Applications/Others/template_sap_host_agent/6.2/README.md
@@ -1,0 +1,187 @@
+# Template SAP Host Agent by Zabbix agent 2
+
+## Description
+
+This template is designed for monitoring **SAP Host Agent** performance and system status using **Zabbix Agent 2** with a native custom plugin. It discovers and monitors key host parameters collected via the SAP Host Agent, including CPU, Memory, Swap, Disk I/O, Filesystems, Network Interfaces, Instance processes and OS details.
+
+## Requirements
+
+To use this template, the following components are required:
+
+1. **Zabbix Agent 2** installed on the same host running the SAP Host Agent or on any other host that can reach it via the network.
+2. Native **SAP Host Agent** Zabbix plugin installed on the same host where Zabbix Agent 2 is running.
+3. **SAP Host Agent** must be active and configured with read access to its web service interface (typically running on port `1128` HTTP or `1129` HTTPS).
+
+## Installation
+
+1. **Install the Zabbix Agent 2 Plugin**:
+   - **Native Packages**: You can use pre-compiled packages for Debian/Ubuntu, SUSE (SLES) or Red Hat (RHEL/CentOS) ecosystems. Detailed instructions on adding repositories and installing these packages can be found on the [Documentation Website](https://docs.ravenlayer.com/plugins/zabbix-agent2-plugin-sapagent/).
+   - **Build from Source**: Alternatively, you can build the plugin directly from the source code available in the [GitHub Repository](https://github.com/RavenLayer/zabbix-agent2-plugin-sapagent/).
+
+2. **Import the Template**:
+   - Download the `template_sap_host_agent.xml` file.
+   - Import the XML file into your Zabbix server (**Configuration** -> **Templates** -> **Import**).
+
+3. **Configure Host Macros**:
+   - Link the template to your target host.
+   - Adjust the user macro values (e.g., `{$SAP.AGENT.URI}`, `{$SAP.AGENT.USER}` and `{$SAP.AGENT.PASSWORD}`) according to your target SAP Host Agent deployment.
+
+---
+
+## Macros
+
+| Name | Default Value | Description |
+| --- | --- | --- |
+| `{$SAP.AGENT.PASSWORD}` | | Password for SAP Host Agent basic authentication. |
+| `{$SAP.AGENT.URI}` | `http://localhost:1128` | URI of the SAP Host Agent API. |
+| `{$SAP.AGENT.USER}` | `sapadm` | Username for SAP Host Agent basic authentication. |
+| `{$CPU.UTIL.CRIT}` | `90` | Critical threshold for CPU utilization. |
+| `{$IF.ERRORS.WARN}` | `2` | Warning threshold for network interface errors. |
+| `{$LOAD_AVG_PER_CPU.MAX.WARN}` | `1.5` | Load per CPU considered sustainable. |
+| `{$MEMORY.AVAILABLE.MIN}` | `20M` | The warning threshold of the available memory. |
+| `{$MEMORY.UTIL.MAX}` | `90` | The warning threshold of the memory utilization. |
+| `{$SWAP.PFREE.MIN.WARN}` | `50` | Warning threshold for minimum percentage of free swap space. |
+| `{$VFS.DEV.AWAIT.WARN}` | `20` | Disk average wait time (in ms) before the trigger would fire |
+| `{$VFS.FS.FREE.MIN.CRIT}` | `5G` | The critical threshold of the filesystem utilization. |
+| `{$VFS.FS.FREE.MIN.WARN}` | `10G` | The warning threshold of the filesystem utilization. |
+| `{$VFS.FS.PUSED.MAX.CRIT}` | `90` | Critical threshold for filesystem utilization percentage. |
+| `{$VFS.FS.PUSED.MAX.WARN}` | `80` | Warning threshold for filesystem utilization percentage. |
+
+---
+
+## Items
+
+| Name | Type | Key |
+| --- | --- | --- |
+| Interrupts per second | Zabbix agent | `sap.agent.cpu.intr[<common_params>]` |
+| Load average (1m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg1]` |
+| Load average (5m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg5]` |
+| Load average (15m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg15]` |
+| Number of CPUs | Zabbix agent | `sap.agent.cpu.num[<common_params>]` |
+| Context switches per second | Zabbix agent | `sap.agent.cpu.switches[<common_params>]` |
+| CPU utilization | DEPENDENT | `sap.agent.cpu.util` |
+| CPU idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,idle]` |
+| CPU iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,iowait]` |
+| CPU steal time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,steal]` |
+| CPU system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,system]` |
+| CPU user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,user]` |
+| Memory utilization | CALCULATED | `sap.agent.mem.util` |
+| Available physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,available]` |
+| Free physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,free]` |
+| Total physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,size]` |
+| Total virtual memory | Zabbix agent | `sap.agent.mem[<common_params>,virt,size]` |
+| Operating system name | Zabbix agent | `sap.agent.os.name[<common_params>]` |
+| Operating system version | Zabbix agent | `sap.agent.os.version[<common_params>]` |
+| SAP agent ping | Zabbix agent | `sap.agent.ping[<common_params>]` |
+| Swap-in bytes per second | Zabbix agent | `sap.agent.swap.in[<common_params>,bytes]` |
+| Swap-in pages per second | Zabbix agent | `sap.agent.swap.in[<common_params>,pages]` |
+| Swap-out bytes per second | Zabbix agent | `sap.agent.swap.out[<common_params>,bytes]` |
+| Swap-out pages per second | Zabbix agent | `sap.agent.swap.out[<common_params>,pages]` |
+| Free swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,free]` |
+| Total swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,total]` |
+| Used swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,used]` |
+| Swap utilization | CALCULATED | `sap.agent.swap.util` |
+| Version of SAP agent running | Zabbix agent | `sap.agent.version[<common_params>]` |
+
+---
+
+## Discovery Rules
+
+### CPU discovery
+
+**Key**: `sap.agent.cpu.discovery[<common_params>]`  
+**Description**: Discovery of CPUs.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| CPU {#CPU.ID} utilization | DEPENDENT | `sap.agent.cpu.util["{#CPU.ID}]` |
+| CPU {#CPU.ID} idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},idle]` |
+| CPU {#CPU.ID} iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},iowait]` |
+| CPU {#CPU.ID} system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},system]` |
+| CPU {#CPU.ID} user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},user]` |
+
+### Block devices discovery
+
+**Key**: `sap.agent.dev.discovery[<common_params>]`  
+**Description**: Discovery of block devices.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Device {#DEVNAME}: IO rate | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},io]` |
+| Device {#DEVNAME}: Queue length | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},queue]` |
+| Device {#DEVNAME}: Service time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},svc]` |
+| Device {#DEVNAME}: Throughput | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},tput]` |
+| Device {#DEVNAME}: Utilization | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},util]` |
+| Device {#DEVNAME}: Wait time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},wait]` |
+
+### Mounted filesystem discovery
+
+**Key**: `sap.agent.fs.discovery[<common_params>]`  
+**Description**: Discovery of file systems of different types.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Filesystem {#FSNAME}: Free space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},free]` |
+| Filesystem {#FSNAME}: Total space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},total]` |
+| Filesystem {#FSNAME}: Space utilization | CALCULATED | `sap.agent.fs.util["{#FSNAME}]` |
+
+### Network interface discovery
+
+**Key**: `sap.agent.net.discovery[<common_params>]`  
+**Description**: Discovery of network interfaces.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Interface {#IFNAME}: Incoming traffic | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Incoming errors | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Incoming packets | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},packets]` |
+| Interface {#IFNAME}: Outgoing traffic | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Outgoing errors | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Outgoing packets | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},packets]` |
+
+### Process discovery
+
+**Key**: `sap.agent.proc.discovery[<common_params>]`  
+**Description**: Discovery of instance processes.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Process {#PROCESS.DESC}: Get info | Zabbix agent | `sap.agent.proc.get[<common_params>,{#INSTANCE.NAME},{#PROCESS.NAME}]` |
+| Process {#PROCESS.DESC} pid | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},pid]` |
+| Process {#PROCESS.DESC} start time | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},starttime]` |
+| Process {#PROCESS.DESC} status | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},status]` |
+
+### SAP Database discovery
+
+**Key**: `sap.agent.db.discovery[<common_params>]`  
+**Description**: Discovery of all SAP databases running on the host. Returns a JSON array containing database discovery macros (`{#DB.NAME}`, `{#DB.PROTOCOL}`, `{#DB.HOST}` and `{#DB.PORT}`).
+
+No pre-defined item prototypes are included in this template, but this rule can be used to configure custom monitoring for each discovered database.
+
+---
+
+## Screenshots
+
+Below are standard visual layouts and dashboards generated by this template:
+
+* **Problems**: Triggers for processes and filesystems
+
+<img width="847" height="421" alt="problems" src="https://github.com/user-attachments/assets/e7109a08-f9a4-4d02-9b61-604c8d58d910" />
+
+* **System Performance**: Displays CPU usage, system load, memory and swap utilization.
+
+<img width="616" height="296" alt="cpuutil" src="https://github.com/user-attachments/assets/aeab6168-a44f-45c2-a973-b4fd0a8b1265" />
+<img width="671" height="296" alt="sysload" src="https://github.com/user-attachments/assets/5ef814dc-8286-4458-b2ea-fc89fb9c1948" />
+<img width="616" height="268" alt="memusage" src="https://github.com/user-attachments/assets/e404c22a-b214-4bd5-a6eb-ea6f815561ed" />
+<img width="616" height="268" alt="swapusage" src="https://github.com/user-attachments/assets/50414451-ee9a-4b0e-91a9-f1d7b5f55d34" />
+
+* **Block Devices**: Real-time visualization of disk utilization, queue length and IO rate per device.
+
+<img width="671" height="268" alt="diskutil" src="https://github.com/user-attachments/assets/0fd0e356-c5cd-4aec-84f1-6da081fa49ab" />
+<img width="671" height="282" alt="diskio" src="https://github.com/user-attachments/assets/62a0670a-5075-4a2a-ae05-f88b35fa84e8" />
+<img width="616" height="254" alt="diskthru" src="https://github.com/user-attachments/assets/a88a45c3-13cc-4c8e-b0aa-a561f4d879cd" />
+
+* **Network Interfaces**: Incoming/outgoing bandwidth utilization and packet rates.
+
+<img width="616" height="268" alt="nettraffic" src="https://github.com/user-attachments/assets/80b5948a-15ae-463d-9d73-9258713c5e09" />
+<img width="616" height="296" alt="netpackets" src="https://github.com/user-attachments/assets/b24107d2-f160-4857-83bb-8c37d1bdb676" />

--- a/Applications/Others/template_sap_host_agent/6.2/template_sap_host_agent.xml
+++ b/Applications/Others/template_sap_host_agent/6.2/template_sap_host_agent.xml
@@ -1,0 +1,1830 @@
+<zabbix_export>
+  <version>6.2</version>
+  <date>2026-07-17T06:34:41Z</date>
+  <template_groups>
+    <template_group>
+      <uuid>a571c0d144b14fd4a87a9d9b2aa9fcd6</uuid>
+      <name>Templates/Applications</name>
+    </template_group>
+  </template_groups>
+  <templates>
+    <template>
+      <uuid>bcecec7d7a494dd995c45768057d4b43</uuid>
+      <template>Template SAP Host Agent by Zabbix agent 2</template>
+      <name>Template SAP Host Agent by Zabbix agent 2</name>
+      <description>Version: 8-36e3d05</description>
+      <groups>
+        <group>
+          <name>Templates/Applications</name>
+        </group>
+      </groups>
+      <items>
+        <item>
+          <uuid>b38fcdb6eb464c80bde1461a031afbc7</uuid>
+          <name>Interrupts per second</name>
+          <key>sap.agent.cpu.intr["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a2d335b4eef247b7abb06e3f90b13cdd</uuid>
+          <name>Load average (1m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1bd363e79a18490482e98334435eea7c</uuid>
+          <name>Load average (5m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c70c2e2ace0f455c8a241951cbcdf877</uuid>
+          <name>Load average (15m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f0bbe4be7e974dd49a05ea9ee6c95752</uuid>
+          <name>Number of CPUs</name>
+          <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bb00db5dc9fa411a96ec27fc9777ec62</uuid>
+          <name>Context switches per second</name>
+          <key>sap.agent.cpu.switches["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>sps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5064eead91d042aca0643d8e4fe7a13d</uuid>
+          <name>CPU utilization</name>
+          <type>DEPENDENT</type>
+          <key>sap.agent.cpu.util</key>
+          <delay>0</delay>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <description>CPU utilization in %.</description>
+          <preprocessing>
+            <step>
+              <type>JAVASCRIPT</type>
+              <parameters>
+                <parameter>//Calculate utilization
+return (100 - value)</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <master_item>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          </master_item>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>9e4a461766774602b087971817a26853</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.util,5m)&gt;{$CPU.UTIL.CRIT}</expression>
+              <name>High CPU utilization (over {$CPU.UTIL.CRIT}% for 5m)</name>
+              <opdata>Current utilization: {ITEM.LASTVALUE1}</opdata>
+              <priority>WARNING</priority>
+              <description>CPU utilization is too high. The system might be slow to respond.</description>
+              <dependencies>
+                <dependency>
+                  <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>43fa692269324ff7895c0746d66d0ea3</uuid>
+          <name>CPU idle time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>d9cc089714a0457388558c7b803040ff</uuid>
+          <name>CPU iowait time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c9e264a4ea4d418abf4b9b745685c435</uuid>
+          <name>CPU steal time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1259e4d32fa2405b971b696ea1f6dae5</uuid>
+          <name>CPU system time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f39da36a50564dc19bc54e3302dc27f8</uuid>
+          <name>CPU user time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>7f7c090809b3426681d62a5d9f532306</uuid>
+          <name>Memory utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.mem.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]) / last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>377658ded81c4580b6c7d7105a0bf64c</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem.util,5m)&gt;{$MEMORY.UTIL.MAX}</expression>
+              <name>High memory utilization (&gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+              <priority>AVERAGE</priority>
+              <description>The system is running out of free memory.</description>
+              <dependencies>
+                <dependency>
+                  <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+                  <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>9252bce6c9294c2e88ccf7e0dbcf3bde</uuid>
+          <name>Available physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>731d63fd55084cdb8951fdc5422bfcff</uuid>
+          <name>Free physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bef0fbf41aa3469684d1b3d1d47afa8f</uuid>
+          <name>Total physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a7d1a71a1a7b46a293604a6b44b4c8fe</uuid>
+          <name>Total virtual memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","virt","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f1a2abfdc14e4c80a56a555dc017a882</uuid>
+          <name>Operating system name</name>
+          <key>sap.agent.os.name["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>e51be36494c2472ab68cac0d1af3cc4a</uuid>
+          <name>Operating system version</name>
+          <key>sap.agent.os.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>46a198c67ccd47d69d3ca5508623dacc</uuid>
+          <name>SAP agent ping</name>
+          <key>sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <valuemap>
+            <name>Service state</name>
+          </valuemap>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>5c4d2858a04347298a0420a894a0e98d</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])=0</expression>
+              <name>SAP agent is unreachable</name>
+              <priority>AVERAGE</priority>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>f1e3e6eca35f48fab00c9b69b4dd8131</uuid>
+          <name>Swap-in bytes per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>82d8c82d98cc4ea0ac7f422e6c5f286d</uuid>
+          <name>Swap-in pages per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>b3223cb8189d4f4681ff2eff291f39d6</uuid>
+          <name>Swap-out bytes per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5db104cbcec54da5b09843c262958f2e</uuid>
+          <name>Swap-out pages per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1d20e12ef81647feb041434698a798e9</uuid>
+          <name>Free swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f967228dd57d4645811381b25fd75b80</uuid>
+          <name>Total swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>ecdf4fecceb549458c041f5b7f2e257d</uuid>
+          <name>Used swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>9640358636f04b9a9e61ebb0c1d365cd</uuid>
+          <name>Swap utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.swap.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]) / last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>8875ea6208cc4776a08084d43a16bf0d</uuid>
+          <name>Version of SAP agent running</name>
+          <key>sap.agent.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <trends>0</trends>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+        </item>
+      </items>
+      <discovery_rules>
+        <discovery_rule>
+          <uuid>300062a6d59f4c3a9bbcbb1f022f82ee</uuid>
+          <name>CPU discovery</name>
+          <key>sap.agent.cpu.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of CPUs.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>48125cd76ccb4df086cca7608f4d06e2</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <preprocessing>
+                <step>
+                  <type>JAVASCRIPT</type>
+                  <parameters>
+                    <parameter>//Calculate utilization
+return (100 - value)</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>9361f5fef88d4372949ac069515b6e89</uuid>
+              <name>CPU {#CPU.ID} idle time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4af8b69ef96145898f77d873b3cba423</uuid>
+              <name>CPU {#CPU.ID} iowait time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5595b2dbfb9843f293770972ea1aaa0d</uuid>
+              <name>CPU {#CPU.ID} system time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>afccff22b07c437aa71320015b159405</uuid>
+              <name>CPU {#CPU.ID} user time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>ccf335d326f44658be124463890012b3</uuid>
+              <name>CPU {#CPU.ID} usage</name>
+              <type>STACKED</type>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>fa5c92dbff2b45df978b79c4095ac23b</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>846f9b13aeea41ac9ab6327674ead1d0</uuid>
+          <name>Block devices discovery</name>
+          <key>sap.agent.dev.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of block devices.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>d8e6cb5e31d34a67905c4a7aa40affaa</uuid>
+              <name>Device {#DEVNAME}: IO rate</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>!io/s</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4b36092e28b4483bb3d92261150cf212</uuid>
+              <name>Device {#DEVNAME}: Queue length</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ba34c528fc644a688338588e7f5852d7</uuid>
+              <name>Device {#DEVNAME}: Service time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b53817901b0f4453982fa5d664c2d21a</uuid>
+              <name>Device {#DEVNAME}: Throughput</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ab4a897513a6413892d1a2bebc658b42</uuid>
+              <name>Device {#DEVNAME}: Utilization</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>f59bf6edb66c4a09a70c30ccb118f7dc</uuid>
+              <name>Device {#DEVNAME}: Wait time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>c16718f216654b08aa7c400c0219a64b</uuid>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"],15m) &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"}</expression>
+                  <name>{#DEVNAME}: Disk wait time is too high (wait &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"} ms for 15m)</name>
+                  <priority>WARNING</priority>
+                  <description>This trigger might indicate disk {#DEVNAME} saturation.</description>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>0939d82652154db7a27979c7379a5421</uuid>
+              <name>Device {#DEVNAME}: Disk IO rate</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63100</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>335087f8dfd047ddb3cc7f4e4d862fcd</uuid>
+              <name>Device {#DEVNAME}: Disk throughput</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>e2974723a6384fb0b2b29ed891dff025</uuid>
+              <name>Device {#DEVNAME}: Disk utilization and queue</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>bddd317b5a384816a695fb7053b48f49</uuid>
+          <name>Mounted filesystem discovery</name>
+          <key>sap.agent.fs.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of file systems of different types.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>b15be907c36440cab3225534a5d0ad1f</uuid>
+              <name>Filesystem {#FSNAME}: Free space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5d68aff2f769468eb057fcea2cfea511</uuid>
+              <name>Filesystem {#FSNAME}: Total space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>2b8f6969bd294a219ca05dddd11cdecb</uuid>
+              <name>Filesystem {#FSNAME}: Space utilization</name>
+              <type>CALCULATED</type>
+              <key>sap.agent.fs.util["{#FSNAME}"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <params>100*(last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])-last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]))/last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])</params>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>53a22cae29a943379436356c43811994</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>AVERAGE</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+            <trigger_prototype>
+              <uuid>e506eaddd3da4c9e94f69d0010e266e8</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>WARNING</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+              <dependencies>
+                <dependency>
+                  <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+                  <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+                </dependency>
+              </dependencies>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>f924384a8fb84b0ea22a3a92a792a31c</uuid>
+              <name>{#FSNAME}: Filesystem space usage</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>9bd171f82bdc4a488c8951cb9a88eb01</uuid>
+          <name>Network interface discovery</name>
+          <key>sap.agent.net.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of network interfaces.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>e4033b992d7c4a81a65fa2d680160722</uuid>
+              <name>Interface {#IFNAME}: Incoming traffic</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>96d6761c118a47edb252068a3b53f210</uuid>
+              <name>Interface {#IFNAME}: Incoming errors</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>faa96f2518ae4c5690e250580334fb47</uuid>
+              <name>Interface {#IFNAME}: Incoming packets</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>da877eba0133413f991b29118a793a6b</uuid>
+              <name>Interface {#IFNAME}: Outgoing traffic</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b6b00c9090ef4050ae1eac0809662e15</uuid>
+              <name>Interface {#IFNAME}: Outgoing errors</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ca5118209e5146f09d06353d2581e43e</uuid>
+              <name>Interface {#IFNAME}: Outgoing packets</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>a1c0eb431fc84e92996647173716fd1f</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}
+or min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}</expression>
+              <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+              <recovery_expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8
+and max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8</recovery_expression>
+              <name>Interface {#IFNAME}: High error rate (&gt;{$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)</name>
+              <opdata>errors in: {ITEM.LASTVALUE1}, errors out: {ITEM.LASTVALUE2}</opdata>
+              <priority>WARNING</priority>
+              <description>Recovers when below 80% of {$IF.ERRORS.WARN:"{#IFNAME}"} threshold</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>c5155ce8c4e14f7997e253f01944ece4</uuid>
+              <name>Interface {#IFNAME}: Network packets</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>F63100</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>4</sortorder>
+                  <color>A54F10</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>c779f37d42da4e5ca2f45fac5a35a045</uuid>
+              <name>Interface {#IFNAME}: Network traffic</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>BOLD_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>b18af0d372f34b13b4c43cc73b1edaa5</uuid>
+          <name>Process discovery</name>
+          <key>sap.agent.proc.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of instance processes.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>982ad677f38548c6af3b57efaa3944fc</uuid>
+              <name>Process {#PROCESS.DESC}: Get info</name>
+              <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              <history>0</history>
+              <trends>0</trends>
+              <value_type>TEXT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>825ff9efabbb409f909a42205d070805</uuid>
+              <name>Process {#PROCESS.DESC} pid</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.pid</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>5ba3199ecc3f4eea8994ec3ddb2fb71c</uuid>
+                  <expression>(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#1)&lt;&gt;last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#2))&gt;0</expression>
+                  <name>Process {#PROCESS.DESC} has been restarted</name>
+                  <priority>INFO</priority>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <uuid>c7bdd2e4cc8c470d8fa3a0a42bbcaced</uuid>
+              <name>Process {#PROCESS.DESC} start time</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","starttime"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <value_type>CHAR</value_type>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.starttime</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>83a838d9f126419a8ad25cef054c1b72</uuid>
+              <name>Process {#PROCESS.DESC} status</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <value_type>CHAR</value_type>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.textstatus</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>b2e718cdb5394437b59bbbef3a9646be</uuid>
+                  <expression>find(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"],,"regexp","^Running$")=0</expression>
+                  <name>Process {#PROCESS.DESC}: Unexpected status</name>
+                  <opdata>Current status: {ITEM.LASTVALUE1}</opdata>
+                  <priority>HIGH</priority>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+        </discovery_rule>
+      </discovery_rules>
+      <macros>
+        <macro>
+          <macro>{$CPU.UTIL.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$IF.ERRORS.WARN}</macro>
+          <value>2</value>
+        </macro>
+        <macro>
+          <macro>{$LOAD_AVG_PER_CPU.MAX.WARN}</macro>
+          <value>1.5</value>
+          <description>Load per CPU considered sustainable.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.AVAILABLE.MIN}</macro>
+          <value>20M</value>
+          <description>The warning threshold of the available memory.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.UTIL.MAX}</macro>
+          <value>90</value>
+          <description>The warning threshold of the memory utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.PASSWORD}</macro>
+          <type>SECRET_TEXT</type>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.URI}</macro>
+          <value>http://localhost:1128</value>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.USER}</macro>
+          <value>sapadm</value>
+        </macro>
+        <macro>
+          <macro>{$SWAP.PFREE.MIN.WARN}</macro>
+          <value>50</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.DEV.AWAIT.WARN}</macro>
+          <value>20</value>
+          <description>Disk average wait time (in ms) before the trigger would fire</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.CRIT}</macro>
+          <value>5G</value>
+          <description>The critical threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.WARN}</macro>
+          <value>10G</value>
+          <description>The warning threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.WARN}</macro>
+          <value>80</value>
+        </macro>
+      </macros>
+      <dashboards>
+        <dashboard>
+          <uuid>53e533040c1b4d83bea057509dd5b2cd</uuid>
+          <name>Block devices</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <width>8</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk utilization and queue</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <x>8</x>
+                  <width>8</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk IO rate</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <x>16</x>
+                  <width>8</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk throughput</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>72ca7e79acb54b968222424995eb35b4</uuid>
+          <name>Network interfaces</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Interface {#IFNAME}: Network traffic</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_PROTOTYPE</type>
+                  <x>12</x>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Interface {#IFNAME}: Network packets</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>903c4a9c190e44a49b3c8075e37795c7</uuid>
+          <name>System performance</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>GRAPH_CLASSIC</type>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>System load</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_CLASSIC</type>
+                  <x>12</x>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>CPU usage</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_CLASSIC</type>
+                  <y>5</y>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Memory usage</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>GRAPH_CLASSIC</type>
+                  <x>12</x>
+                  <y>5</y>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Swap usage</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+      </dashboards>
+      <valuemaps>
+        <valuemap>
+          <uuid>33feeafd9e2a4fe9950ee35198ccba02</uuid>
+          <name>Service state</name>
+          <mappings>
+            <mapping>
+              <value>0</value>
+              <newvalue>Down</newvalue>
+            </mapping>
+            <mapping>
+              <value>1</value>
+              <newvalue>Up</newvalue>
+            </mapping>
+          </mappings>
+        </valuemap>
+      </valuemaps>
+    </template>
+  </templates>
+  <triggers>
+    <trigger>
+      <uuid>0eb022f5eb694feb9b2da1ffd58312e4</uuid>
+      <expression>100 - max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.util,5m)&lt;{$SWAP.PFREE.MIN.WARN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])&gt;0</expression>
+      <name>High swap space usage (less than {$SWAP.PFREE.MIN.WARN}% free)</name>
+      <opdata>Free: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>WARNING</priority>
+      <description>This trigger is ignored, if there is no swap configured.</description>
+    </trigger>
+    <trigger>
+      <uuid>a9fea933fb46485aa18381402db46299</uuid>
+      <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+      <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+      <opdata>Available: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+    </trigger>
+    <trigger>
+      <uuid>bb1df76871fa447ba9c8cc7598275c2e</uuid>
+      <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+      <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+      <opdata>Load averages(1m 5m 15m): ({ITEM.LASTVALUE1} {ITEM.LASTVALUE3} {ITEM.LASTVALUE4}), # of CPUs: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+      <description>Per CPU load average is too high. Your system may be slow to respond.</description>
+    </trigger>
+  </triggers>
+  <graphs>
+    <graph>
+      <uuid>b30f986eac8345dea04d8351a6945459</uuid>
+      <name>CPU usage</name>
+      <type>STACKED</type>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>A54F10</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>FC6EA3</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>ff15c2bb38664127a34399fc05ed460a</uuid>
+      <name>CPU utilization</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>1e571d14c7c44bbcbfbb58d48969d487</uuid>
+      <name>Memory usage</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>BOLD_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>38242ed637884247ac7806847878e50d</uuid>
+      <name>Swap usage</name>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>F63131</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>b64e8d50de4b426a84a11e0e66208d5f</uuid>
+      <name>System load</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>F63100</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>A54F10</color>
+          <yaxisside>RIGHT</yaxisside>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+  </graphs>
+</zabbix_export>

--- a/Applications/Others/template_sap_host_agent/6.4/README.md
+++ b/Applications/Others/template_sap_host_agent/6.4/README.md
@@ -1,0 +1,187 @@
+# Template SAP Host Agent by Zabbix agent 2
+
+## Description
+
+This template is designed for monitoring **SAP Host Agent** performance and system status using **Zabbix Agent 2** with a native custom plugin. It discovers and monitors key host parameters collected via the SAP Host Agent, including CPU, Memory, Swap, Disk I/O, Filesystems, Network Interfaces, Instance processes and OS details.
+
+## Requirements
+
+To use this template, the following components are required:
+
+1. **Zabbix Agent 2** installed on the same host running the SAP Host Agent or on any other host that can reach it via the network.
+2. Native **SAP Host Agent** Zabbix plugin installed on the same host where Zabbix Agent 2 is running.
+3. **SAP Host Agent** must be active and configured with read access to its web service interface (typically running on port `1128` HTTP or `1129` HTTPS).
+
+## Installation
+
+1. **Install the Zabbix Agent 2 Plugin**:
+   - **Native Packages**: You can use pre-compiled packages for Debian/Ubuntu, SUSE (SLES) or Red Hat (RHEL/CentOS) ecosystems. Detailed instructions on adding repositories and installing these packages can be found on the [Documentation Website](https://docs.ravenlayer.com/plugins/zabbix-agent2-plugin-sapagent/).
+   - **Build from Source**: Alternatively, you can build the plugin directly from the source code available in the [GitHub Repository](https://github.com/RavenLayer/zabbix-agent2-plugin-sapagent/).
+
+2. **Import the Template**:
+   - Download the `template_sap_host_agent.xml` file.
+   - Import the XML file into your Zabbix server (**Configuration** -> **Templates** -> **Import**).
+
+3. **Configure Host Macros**:
+   - Link the template to your target host.
+   - Adjust the user macro values (e.g., `{$SAP.AGENT.URI}`, `{$SAP.AGENT.USER}` and `{$SAP.AGENT.PASSWORD}`) according to your target SAP Host Agent deployment.
+
+---
+
+## Macros
+
+| Name | Default Value | Description |
+| --- | --- | --- |
+| `{$SAP.AGENT.PASSWORD}` | | Password for SAP Host Agent basic authentication. |
+| `{$SAP.AGENT.URI}` | `http://localhost:1128` | URI of the SAP Host Agent API. |
+| `{$SAP.AGENT.USER}` | `sapadm` | Username for SAP Host Agent basic authentication. |
+| `{$CPU.UTIL.CRIT}` | `90` | Critical threshold for CPU utilization. |
+| `{$IF.ERRORS.WARN}` | `2` | Warning threshold for network interface errors. |
+| `{$LOAD_AVG_PER_CPU.MAX.WARN}` | `1.5` | Load per CPU considered sustainable. |
+| `{$MEMORY.AVAILABLE.MIN}` | `20M` | The warning threshold of the available memory. |
+| `{$MEMORY.UTIL.MAX}` | `90` | The warning threshold of the memory utilization. |
+| `{$SWAP.PFREE.MIN.WARN}` | `50` | Warning threshold for minimum percentage of free swap space. |
+| `{$VFS.DEV.AWAIT.WARN}` | `20` | Disk average wait time (in ms) before the trigger would fire |
+| `{$VFS.FS.FREE.MIN.CRIT}` | `5G` | The critical threshold of the filesystem utilization. |
+| `{$VFS.FS.FREE.MIN.WARN}` | `10G` | The warning threshold of the filesystem utilization. |
+| `{$VFS.FS.PUSED.MAX.CRIT}` | `90` | Critical threshold for filesystem utilization percentage. |
+| `{$VFS.FS.PUSED.MAX.WARN}` | `80` | Warning threshold for filesystem utilization percentage. |
+
+---
+
+## Items
+
+| Name | Type | Key |
+| --- | --- | --- |
+| Interrupts per second | Zabbix agent | `sap.agent.cpu.intr[<common_params>]` |
+| Load average (1m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg1]` |
+| Load average (5m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg5]` |
+| Load average (15m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg15]` |
+| Number of CPUs | Zabbix agent | `sap.agent.cpu.num[<common_params>]` |
+| Context switches per second | Zabbix agent | `sap.agent.cpu.switches[<common_params>]` |
+| CPU utilization | DEPENDENT | `sap.agent.cpu.util` |
+| CPU idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,idle]` |
+| CPU iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,iowait]` |
+| CPU steal time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,steal]` |
+| CPU system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,system]` |
+| CPU user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,user]` |
+| Memory utilization | CALCULATED | `sap.agent.mem.util` |
+| Available physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,available]` |
+| Free physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,free]` |
+| Total physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,size]` |
+| Total virtual memory | Zabbix agent | `sap.agent.mem[<common_params>,virt,size]` |
+| Operating system name | Zabbix agent | `sap.agent.os.name[<common_params>]` |
+| Operating system version | Zabbix agent | `sap.agent.os.version[<common_params>]` |
+| SAP agent ping | Zabbix agent | `sap.agent.ping[<common_params>]` |
+| Swap-in bytes per second | Zabbix agent | `sap.agent.swap.in[<common_params>,bytes]` |
+| Swap-in pages per second | Zabbix agent | `sap.agent.swap.in[<common_params>,pages]` |
+| Swap-out bytes per second | Zabbix agent | `sap.agent.swap.out[<common_params>,bytes]` |
+| Swap-out pages per second | Zabbix agent | `sap.agent.swap.out[<common_params>,pages]` |
+| Free swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,free]` |
+| Total swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,total]` |
+| Used swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,used]` |
+| Swap utilization | CALCULATED | `sap.agent.swap.util` |
+| Version of SAP agent running | Zabbix agent | `sap.agent.version[<common_params>]` |
+
+---
+
+## Discovery Rules
+
+### CPU discovery
+
+**Key**: `sap.agent.cpu.discovery[<common_params>]`  
+**Description**: Discovery of CPUs.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| CPU {#CPU.ID} utilization | DEPENDENT | `sap.agent.cpu.util["{#CPU.ID}]` |
+| CPU {#CPU.ID} idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},idle]` |
+| CPU {#CPU.ID} iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},iowait]` |
+| CPU {#CPU.ID} system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},system]` |
+| CPU {#CPU.ID} user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},user]` |
+
+### Block devices discovery
+
+**Key**: `sap.agent.dev.discovery[<common_params>]`  
+**Description**: Discovery of block devices.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Device {#DEVNAME}: IO rate | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},io]` |
+| Device {#DEVNAME}: Queue length | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},queue]` |
+| Device {#DEVNAME}: Service time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},svc]` |
+| Device {#DEVNAME}: Throughput | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},tput]` |
+| Device {#DEVNAME}: Utilization | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},util]` |
+| Device {#DEVNAME}: Wait time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},wait]` |
+
+### Mounted filesystem discovery
+
+**Key**: `sap.agent.fs.discovery[<common_params>]`  
+**Description**: Discovery of file systems of different types.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Filesystem {#FSNAME}: Free space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},free]` |
+| Filesystem {#FSNAME}: Total space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},total]` |
+| Filesystem {#FSNAME}: Space utilization | CALCULATED | `sap.agent.fs.util["{#FSNAME}]` |
+
+### Network interface discovery
+
+**Key**: `sap.agent.net.discovery[<common_params>]`  
+**Description**: Discovery of network interfaces.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Interface {#IFNAME}: Incoming traffic | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Incoming errors | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Incoming packets | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},packets]` |
+| Interface {#IFNAME}: Outgoing traffic | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Outgoing errors | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Outgoing packets | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},packets]` |
+
+### Process discovery
+
+**Key**: `sap.agent.proc.discovery[<common_params>]`  
+**Description**: Discovery of instance processes.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Process {#PROCESS.DESC}: Get info | Zabbix agent | `sap.agent.proc.get[<common_params>,{#INSTANCE.NAME},{#PROCESS.NAME}]` |
+| Process {#PROCESS.DESC} pid | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},pid]` |
+| Process {#PROCESS.DESC} start time | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},starttime]` |
+| Process {#PROCESS.DESC} status | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},status]` |
+
+### SAP Database discovery
+
+**Key**: `sap.agent.db.discovery[<common_params>]`  
+**Description**: Discovery of all SAP databases running on the host. Returns a JSON array containing database discovery macros (`{#DB.NAME}`, `{#DB.PROTOCOL}`, `{#DB.HOST}` and `{#DB.PORT}`).
+
+No pre-defined item prototypes are included in this template, but this rule can be used to configure custom monitoring for each discovered database.
+
+---
+
+## Screenshots
+
+Below are standard visual layouts and dashboards generated by this template:
+
+* **Problems**: Triggers for processes and filesystems
+
+<img width="847" height="421" alt="problems" src="https://github.com/user-attachments/assets/e7109a08-f9a4-4d02-9b61-604c8d58d910" />
+
+* **System Performance**: Displays CPU usage, system load, memory and swap utilization.
+
+<img width="616" height="296" alt="cpuutil" src="https://github.com/user-attachments/assets/aeab6168-a44f-45c2-a973-b4fd0a8b1265" />
+<img width="671" height="296" alt="sysload" src="https://github.com/user-attachments/assets/5ef814dc-8286-4458-b2ea-fc89fb9c1948" />
+<img width="616" height="268" alt="memusage" src="https://github.com/user-attachments/assets/e404c22a-b214-4bd5-a6eb-ea6f815561ed" />
+<img width="616" height="268" alt="swapusage" src="https://github.com/user-attachments/assets/50414451-ee9a-4b0e-91a9-f1d7b5f55d34" />
+
+* **Block Devices**: Real-time visualization of disk utilization, queue length and IO rate per device.
+
+<img width="671" height="268" alt="diskutil" src="https://github.com/user-attachments/assets/0fd0e356-c5cd-4aec-84f1-6da081fa49ab" />
+<img width="671" height="282" alt="diskio" src="https://github.com/user-attachments/assets/62a0670a-5075-4a2a-ae05-f88b35fa84e8" />
+<img width="616" height="254" alt="diskthru" src="https://github.com/user-attachments/assets/a88a45c3-13cc-4c8e-b0aa-a561f4d879cd" />
+
+* **Network Interfaces**: Incoming/outgoing bandwidth utilization and packet rates.
+
+<img width="616" height="268" alt="nettraffic" src="https://github.com/user-attachments/assets/80b5948a-15ae-463d-9d73-9258713c5e09" />
+<img width="616" height="296" alt="netpackets" src="https://github.com/user-attachments/assets/b24107d2-f160-4857-83bb-8c37d1bdb676" />

--- a/Applications/Others/template_sap_host_agent/6.4/template_sap_host_agent.xml
+++ b/Applications/Others/template_sap_host_agent/6.4/template_sap_host_agent.xml
@@ -1,0 +1,1829 @@
+<zabbix_export>
+  <version>6.4</version>
+  <template_groups>
+    <template_group>
+      <uuid>a571c0d144b14fd4a87a9d9b2aa9fcd6</uuid>
+      <name>Templates/Applications</name>
+    </template_group>
+  </template_groups>
+  <templates>
+    <template>
+      <uuid>bcecec7d7a494dd995c45768057d4b43</uuid>
+      <template>Template SAP Host Agent by Zabbix agent 2</template>
+      <name>Template SAP Host Agent by Zabbix agent 2</name>
+      <description>Version: 8-36e3d05</description>
+      <groups>
+        <group>
+          <name>Templates/Applications</name>
+        </group>
+      </groups>
+      <items>
+        <item>
+          <uuid>b38fcdb6eb464c80bde1461a031afbc7</uuid>
+          <name>Interrupts per second</name>
+          <key>sap.agent.cpu.intr["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a2d335b4eef247b7abb06e3f90b13cdd</uuid>
+          <name>Load average (1m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1bd363e79a18490482e98334435eea7c</uuid>
+          <name>Load average (5m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c70c2e2ace0f455c8a241951cbcdf877</uuid>
+          <name>Load average (15m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f0bbe4be7e974dd49a05ea9ee6c95752</uuid>
+          <name>Number of CPUs</name>
+          <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bb00db5dc9fa411a96ec27fc9777ec62</uuid>
+          <name>Context switches per second</name>
+          <key>sap.agent.cpu.switches["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>sps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5064eead91d042aca0643d8e4fe7a13d</uuid>
+          <name>CPU utilization</name>
+          <type>DEPENDENT</type>
+          <key>sap.agent.cpu.util</key>
+          <delay>0</delay>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <description>CPU utilization in %.</description>
+          <preprocessing>
+            <step>
+              <type>JAVASCRIPT</type>
+              <parameters>
+                <parameter>//Calculate utilization
+return (100 - value)</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <master_item>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          </master_item>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>9e4a461766774602b087971817a26853</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.util,5m)&gt;{$CPU.UTIL.CRIT}</expression>
+              <name>High CPU utilization (over {$CPU.UTIL.CRIT}% for 5m)</name>
+              <opdata>Current utilization: {ITEM.LASTVALUE1}</opdata>
+              <priority>WARNING</priority>
+              <description>CPU utilization is too high. The system might be slow to respond.</description>
+              <dependencies>
+                <dependency>
+                  <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>43fa692269324ff7895c0746d66d0ea3</uuid>
+          <name>CPU idle time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>d9cc089714a0457388558c7b803040ff</uuid>
+          <name>CPU iowait time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c9e264a4ea4d418abf4b9b745685c435</uuid>
+          <name>CPU steal time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1259e4d32fa2405b971b696ea1f6dae5</uuid>
+          <name>CPU system time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f39da36a50564dc19bc54e3302dc27f8</uuid>
+          <name>CPU user time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>7f7c090809b3426681d62a5d9f532306</uuid>
+          <name>Memory utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.mem.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]) / last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>377658ded81c4580b6c7d7105a0bf64c</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem.util,5m)&gt;{$MEMORY.UTIL.MAX}</expression>
+              <name>High memory utilization (&gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+              <priority>AVERAGE</priority>
+              <description>The system is running out of free memory.</description>
+              <dependencies>
+                <dependency>
+                  <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+                  <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>9252bce6c9294c2e88ccf7e0dbcf3bde</uuid>
+          <name>Available physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>731d63fd55084cdb8951fdc5422bfcff</uuid>
+          <name>Free physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bef0fbf41aa3469684d1b3d1d47afa8f</uuid>
+          <name>Total physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a7d1a71a1a7b46a293604a6b44b4c8fe</uuid>
+          <name>Total virtual memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","virt","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f1a2abfdc14e4c80a56a555dc017a882</uuid>
+          <name>Operating system name</name>
+          <key>sap.agent.os.name["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <value_type>CHAR</value_type>
+          <trends>0</trends>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>e51be36494c2472ab68cac0d1af3cc4a</uuid>
+          <name>Operating system version</name>
+          <key>sap.agent.os.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <value_type>CHAR</value_type>
+          <trends>0</trends>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>46a198c67ccd47d69d3ca5508623dacc</uuid>
+          <name>SAP agent ping</name>
+          <key>sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <valuemap>
+            <name>Service state</name>
+          </valuemap>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>5c4d2858a04347298a0420a894a0e98d</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])=0</expression>
+              <name>SAP agent is unreachable</name>
+              <priority>AVERAGE</priority>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>f1e3e6eca35f48fab00c9b69b4dd8131</uuid>
+          <name>Swap-in bytes per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>82d8c82d98cc4ea0ac7f422e6c5f286d</uuid>
+          <name>Swap-in pages per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>b3223cb8189d4f4681ff2eff291f39d6</uuid>
+          <name>Swap-out bytes per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5db104cbcec54da5b09843c262958f2e</uuid>
+          <name>Swap-out pages per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1d20e12ef81647feb041434698a798e9</uuid>
+          <name>Free swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f967228dd57d4645811381b25fd75b80</uuid>
+          <name>Total swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>ecdf4fecceb549458c041f5b7f2e257d</uuid>
+          <name>Used swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>9640358636f04b9a9e61ebb0c1d365cd</uuid>
+          <name>Swap utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.swap.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]) / last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>8875ea6208cc4776a08084d43a16bf0d</uuid>
+          <name>Version of SAP agent running</name>
+          <key>sap.agent.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>CHAR</value_type>
+          <trends>0</trends>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+        </item>
+      </items>
+      <discovery_rules>
+        <discovery_rule>
+          <uuid>300062a6d59f4c3a9bbcbb1f022f82ee</uuid>
+          <name>CPU discovery</name>
+          <key>sap.agent.cpu.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of CPUs.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>48125cd76ccb4df086cca7608f4d06e2</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <preprocessing>
+                <step>
+                  <type>JAVASCRIPT</type>
+                  <parameters>
+                    <parameter>//Calculate utilization
+return (100 - value)</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>9361f5fef88d4372949ac069515b6e89</uuid>
+              <name>CPU {#CPU.ID} idle time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4af8b69ef96145898f77d873b3cba423</uuid>
+              <name>CPU {#CPU.ID} iowait time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5595b2dbfb9843f293770972ea1aaa0d</uuid>
+              <name>CPU {#CPU.ID} system time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>afccff22b07c437aa71320015b159405</uuid>
+              <name>CPU {#CPU.ID} user time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>ccf335d326f44658be124463890012b3</uuid>
+              <name>CPU {#CPU.ID} usage</name>
+              <type>STACKED</type>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>fa5c92dbff2b45df978b79c4095ac23b</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>846f9b13aeea41ac9ab6327674ead1d0</uuid>
+          <name>Block devices discovery</name>
+          <key>sap.agent.dev.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of block devices.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>d8e6cb5e31d34a67905c4a7aa40affaa</uuid>
+              <name>Device {#DEVNAME}: IO rate</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>!io/s</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4b36092e28b4483bb3d92261150cf212</uuid>
+              <name>Device {#DEVNAME}: Queue length</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ba34c528fc644a688338588e7f5852d7</uuid>
+              <name>Device {#DEVNAME}: Service time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b53817901b0f4453982fa5d664c2d21a</uuid>
+              <name>Device {#DEVNAME}: Throughput</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ab4a897513a6413892d1a2bebc658b42</uuid>
+              <name>Device {#DEVNAME}: Utilization</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>f59bf6edb66c4a09a70c30ccb118f7dc</uuid>
+              <name>Device {#DEVNAME}: Wait time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>c16718f216654b08aa7c400c0219a64b</uuid>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"],15m) &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"}</expression>
+                  <name>{#DEVNAME}: Disk wait time is too high (wait &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"} ms for 15m)</name>
+                  <priority>WARNING</priority>
+                  <description>This trigger might indicate disk {#DEVNAME} saturation.</description>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>0939d82652154db7a27979c7379a5421</uuid>
+              <name>Device {#DEVNAME}: Disk IO rate</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63100</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>335087f8dfd047ddb3cc7f4e4d862fcd</uuid>
+              <name>Device {#DEVNAME}: Disk throughput</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>e2974723a6384fb0b2b29ed891dff025</uuid>
+              <name>Device {#DEVNAME}: Disk utilization and queue</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>bddd317b5a384816a695fb7053b48f49</uuid>
+          <name>Mounted filesystem discovery</name>
+          <key>sap.agent.fs.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of file systems of different types.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>b15be907c36440cab3225534a5d0ad1f</uuid>
+              <name>Filesystem {#FSNAME}: Free space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5d68aff2f769468eb057fcea2cfea511</uuid>
+              <name>Filesystem {#FSNAME}: Total space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>2b8f6969bd294a219ca05dddd11cdecb</uuid>
+              <name>Filesystem {#FSNAME}: Space utilization</name>
+              <type>CALCULATED</type>
+              <key>sap.agent.fs.util["{#FSNAME}"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <params>100*(last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])-last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]))/last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])</params>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>53a22cae29a943379436356c43811994</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>AVERAGE</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+            <trigger_prototype>
+              <uuid>e506eaddd3da4c9e94f69d0010e266e8</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>WARNING</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+              <dependencies>
+                <dependency>
+                  <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+                  <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+                </dependency>
+              </dependencies>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>f924384a8fb84b0ea22a3a92a792a31c</uuid>
+              <name>{#FSNAME}: Filesystem space usage</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>9bd171f82bdc4a488c8951cb9a88eb01</uuid>
+          <name>Network interface discovery</name>
+          <key>sap.agent.net.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of network interfaces.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>e4033b992d7c4a81a65fa2d680160722</uuid>
+              <name>Interface {#IFNAME}: Incoming traffic</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>96d6761c118a47edb252068a3b53f210</uuid>
+              <name>Interface {#IFNAME}: Incoming errors</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>faa96f2518ae4c5690e250580334fb47</uuid>
+              <name>Interface {#IFNAME}: Incoming packets</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>da877eba0133413f991b29118a793a6b</uuid>
+              <name>Interface {#IFNAME}: Outgoing traffic</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b6b00c9090ef4050ae1eac0809662e15</uuid>
+              <name>Interface {#IFNAME}: Outgoing errors</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ca5118209e5146f09d06353d2581e43e</uuid>
+              <name>Interface {#IFNAME}: Outgoing packets</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>a1c0eb431fc84e92996647173716fd1f</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}
+or min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}</expression>
+              <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+              <recovery_expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8
+and max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8</recovery_expression>
+              <name>Interface {#IFNAME}: High error rate (&gt;{$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)</name>
+              <opdata>errors in: {ITEM.LASTVALUE1}, errors out: {ITEM.LASTVALUE2}</opdata>
+              <priority>WARNING</priority>
+              <description>Recovers when below 80% of {$IF.ERRORS.WARN:"{#IFNAME}"} threshold</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>c5155ce8c4e14f7997e253f01944ece4</uuid>
+              <name>Interface {#IFNAME}: Network packets</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>F63100</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>4</sortorder>
+                  <color>A54F10</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>c779f37d42da4e5ca2f45fac5a35a045</uuid>
+              <name>Interface {#IFNAME}: Network traffic</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>BOLD_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>b18af0d372f34b13b4c43cc73b1edaa5</uuid>
+          <name>Process discovery</name>
+          <key>sap.agent.proc.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <description>Discovery of instance processes.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>982ad677f38548c6af3b57efaa3944fc</uuid>
+              <name>Process {#PROCESS.DESC}: Get info</name>
+              <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              <history>0</history>
+              <value_type>TEXT</value_type>
+              <trends>0</trends>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>825ff9efabbb409f909a42205d070805</uuid>
+              <name>Process {#PROCESS.DESC} pid</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.pid</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>5ba3199ecc3f4eea8994ec3ddb2fb71c</uuid>
+                  <expression>(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#1)&lt;&gt;last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#2))&gt;0</expression>
+                  <name>Process {#PROCESS.DESC} has been restarted</name>
+                  <priority>INFO</priority>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <uuid>c7bdd2e4cc8c470d8fa3a0a42bbcaced</uuid>
+              <name>Process {#PROCESS.DESC} start time</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","starttime"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <value_type>CHAR</value_type>
+              <trends>0</trends>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.starttime</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>83a838d9f126419a8ad25cef054c1b72</uuid>
+              <name>Process {#PROCESS.DESC} status</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <value_type>CHAR</value_type>
+              <trends>0</trends>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.textstatus</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>b2e718cdb5394437b59bbbef3a9646be</uuid>
+                  <expression>find(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"],,"regexp","^Running$")=0</expression>
+                  <name>Process {#PROCESS.DESC}: Unexpected status</name>
+                  <opdata>Current status: {ITEM.LASTVALUE1}</opdata>
+                  <priority>HIGH</priority>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+        </discovery_rule>
+      </discovery_rules>
+      <macros>
+        <macro>
+          <macro>{$CPU.UTIL.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$IF.ERRORS.WARN}</macro>
+          <value>2</value>
+        </macro>
+        <macro>
+          <macro>{$LOAD_AVG_PER_CPU.MAX.WARN}</macro>
+          <value>1.5</value>
+          <description>Load per CPU considered sustainable.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.AVAILABLE.MIN}</macro>
+          <value>20M</value>
+          <description>The warning threshold of the available memory.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.UTIL.MAX}</macro>
+          <value>90</value>
+          <description>The warning threshold of the memory utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.PASSWORD}</macro>
+          <type>SECRET_TEXT</type>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.URI}</macro>
+          <value>http://localhost:1128</value>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.USER}</macro>
+          <value>sapadm</value>
+        </macro>
+        <macro>
+          <macro>{$SWAP.PFREE.MIN.WARN}</macro>
+          <value>50</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.DEV.AWAIT.WARN}</macro>
+          <value>20</value>
+          <description>Disk average wait time (in ms) before the trigger would fire</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.CRIT}</macro>
+          <value>5G</value>
+          <description>The critical threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.WARN}</macro>
+          <value>10G</value>
+          <description>The warning threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.WARN}</macro>
+          <value>80</value>
+        </macro>
+      </macros>
+      <dashboards>
+        <dashboard>
+          <uuid>53e533040c1b4d83bea057509dd5b2cd</uuid>
+          <name>Block devices</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>graphprototype</type>
+                  <width>8</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk utilization and queue</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graphprototype</type>
+                  <x>8</x>
+                  <width>8</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk IO rate</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graphprototype</type>
+                  <x>16</x>
+                  <width>8</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk throughput</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>72ca7e79acb54b968222424995eb35b4</uuid>
+          <name>Network interfaces</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>graphprototype</type>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Interface {#IFNAME}: Network traffic</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graphprototype</type>
+                  <x>12</x>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Interface {#IFNAME}: Network packets</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>903c4a9c190e44a49b3c8075e37795c7</uuid>
+          <name>System performance</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>graph</type>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>System load</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graph</type>
+                  <y>5</y>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Memory usage</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graph</type>
+                  <x>12</x>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>CPU usage</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graph</type>
+                  <x>12</x>
+                  <y>5</y>
+                  <width>12</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Swap usage</name>
+                      </value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+      </dashboards>
+      <valuemaps>
+        <valuemap>
+          <uuid>33feeafd9e2a4fe9950ee35198ccba02</uuid>
+          <name>Service state</name>
+          <mappings>
+            <mapping>
+              <value>0</value>
+              <newvalue>Down</newvalue>
+            </mapping>
+            <mapping>
+              <value>1</value>
+              <newvalue>Up</newvalue>
+            </mapping>
+          </mappings>
+        </valuemap>
+      </valuemaps>
+    </template>
+  </templates>
+  <triggers>
+    <trigger>
+      <uuid>0eb022f5eb694feb9b2da1ffd58312e4</uuid>
+      <expression>100 - max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.util,5m)&lt;{$SWAP.PFREE.MIN.WARN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])&gt;0</expression>
+      <name>High swap space usage (less than {$SWAP.PFREE.MIN.WARN}% free)</name>
+      <opdata>Free: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>WARNING</priority>
+      <description>This trigger is ignored, if there is no swap configured.</description>
+    </trigger>
+    <trigger>
+      <uuid>a9fea933fb46485aa18381402db46299</uuid>
+      <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+      <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+      <opdata>Available: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+    </trigger>
+    <trigger>
+      <uuid>bb1df76871fa447ba9c8cc7598275c2e</uuid>
+      <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+      <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+      <opdata>Load averages(1m 5m 15m): ({ITEM.LASTVALUE1} {ITEM.LASTVALUE3} {ITEM.LASTVALUE4}), # of CPUs: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+      <description>Per CPU load average is too high. Your system may be slow to respond.</description>
+    </trigger>
+  </triggers>
+  <graphs>
+    <graph>
+      <uuid>b30f986eac8345dea04d8351a6945459</uuid>
+      <name>CPU usage</name>
+      <type>STACKED</type>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>A54F10</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>FC6EA3</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>ff15c2bb38664127a34399fc05ed460a</uuid>
+      <name>CPU utilization</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>1e571d14c7c44bbcbfbb58d48969d487</uuid>
+      <name>Memory usage</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>BOLD_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>38242ed637884247ac7806847878e50d</uuid>
+      <name>Swap usage</name>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>F63131</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>b64e8d50de4b426a84a11e0e66208d5f</uuid>
+      <name>System load</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>F63100</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>A54F10</color>
+          <yaxisside>RIGHT</yaxisside>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+  </graphs>
+</zabbix_export>

--- a/Applications/Others/template_sap_host_agent/7.0/README.md
+++ b/Applications/Others/template_sap_host_agent/7.0/README.md
@@ -1,0 +1,187 @@
+# Template SAP Host Agent by Zabbix agent 2
+
+## Description
+
+This template is designed for monitoring **SAP Host Agent** performance and system status using **Zabbix Agent 2** with a native custom plugin. It discovers and monitors key host parameters collected via the SAP Host Agent, including CPU, Memory, Swap, Disk I/O, Filesystems, Network Interfaces, Instance processes and OS details.
+
+## Requirements
+
+To use this template, the following components are required:
+
+1. **Zabbix Agent 2** installed on the same host running the SAP Host Agent or on any other host that can reach it via the network.
+2. Native **SAP Host Agent** Zabbix plugin installed on the same host where Zabbix Agent 2 is running.
+3. **SAP Host Agent** must be active and configured with read access to its web service interface (typically running on port `1128` HTTP or `1129` HTTPS).
+
+## Installation
+
+1. **Install the Zabbix Agent 2 Plugin**:
+   - **Native Packages**: You can use pre-compiled packages for Debian/Ubuntu, SUSE (SLES) or Red Hat (RHEL/CentOS) ecosystems. Detailed instructions on adding repositories and installing these packages can be found on the [Documentation Website](https://docs.ravenlayer.com/plugins/zabbix-agent2-plugin-sapagent/).
+   - **Build from Source**: Alternatively, you can build the plugin directly from the source code available in the [GitHub Repository](https://github.com/RavenLayer/zabbix-agent2-plugin-sapagent/).
+
+2. **Import the Template**:
+   - Download the `template_sap_host_agent.xml` file.
+   - Import the XML file into your Zabbix server (**Configuration** -> **Templates** -> **Import**).
+
+3. **Configure Host Macros**:
+   - Link the template to your target host.
+   - Adjust the user macro values (e.g., `{$SAP.AGENT.URI}`, `{$SAP.AGENT.USER}` and `{$SAP.AGENT.PASSWORD}`) according to your target SAP Host Agent deployment.
+
+---
+
+## Macros
+
+| Name | Default Value | Description |
+| --- | --- | --- |
+| `{$SAP.AGENT.PASSWORD}` | | Password for SAP Host Agent basic authentication. |
+| `{$SAP.AGENT.URI}` | `http://localhost:1128` | URI of the SAP Host Agent API. |
+| `{$SAP.AGENT.USER}` | `sapadm` | Username for SAP Host Agent basic authentication. |
+| `{$CPU.UTIL.CRIT}` | `90` | Critical threshold for CPU utilization. |
+| `{$IF.ERRORS.WARN}` | `2` | Warning threshold for network interface errors. |
+| `{$LOAD_AVG_PER_CPU.MAX.WARN}` | `1.5` | Load per CPU considered sustainable. |
+| `{$MEMORY.AVAILABLE.MIN}` | `20M` | The warning threshold of the available memory. |
+| `{$MEMORY.UTIL.MAX}` | `90` | The warning threshold of the memory utilization. |
+| `{$SWAP.PFREE.MIN.WARN}` | `50` | Warning threshold for minimum percentage of free swap space. |
+| `{$VFS.DEV.AWAIT.WARN}` | `20` | Disk average wait time (in ms) before the trigger would fire |
+| `{$VFS.FS.FREE.MIN.CRIT}` | `5G` | The critical threshold of the filesystem utilization. |
+| `{$VFS.FS.FREE.MIN.WARN}` | `10G` | The warning threshold of the filesystem utilization. |
+| `{$VFS.FS.PUSED.MAX.CRIT}` | `90` | Critical threshold for filesystem utilization percentage. |
+| `{$VFS.FS.PUSED.MAX.WARN}` | `80` | Warning threshold for filesystem utilization percentage. |
+
+---
+
+## Items
+
+| Name | Type | Key |
+| --- | --- | --- |
+| Interrupts per second | Zabbix agent | `sap.agent.cpu.intr[<common_params>]` |
+| Load average (1m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg1]` |
+| Load average (5m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg5]` |
+| Load average (15m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg15]` |
+| Number of CPUs | Zabbix agent | `sap.agent.cpu.num[<common_params>]` |
+| Context switches per second | Zabbix agent | `sap.agent.cpu.switches[<common_params>]` |
+| CPU utilization | DEPENDENT | `sap.agent.cpu.util` |
+| CPU idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,idle]` |
+| CPU iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,iowait]` |
+| CPU steal time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,steal]` |
+| CPU system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,system]` |
+| CPU user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,user]` |
+| Memory utilization | CALCULATED | `sap.agent.mem.util` |
+| Available physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,available]` |
+| Free physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,free]` |
+| Total physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,size]` |
+| Total virtual memory | Zabbix agent | `sap.agent.mem[<common_params>,virt,size]` |
+| Operating system name | Zabbix agent | `sap.agent.os.name[<common_params>]` |
+| Operating system version | Zabbix agent | `sap.agent.os.version[<common_params>]` |
+| SAP agent ping | Zabbix agent | `sap.agent.ping[<common_params>]` |
+| Swap-in bytes per second | Zabbix agent | `sap.agent.swap.in[<common_params>,bytes]` |
+| Swap-in pages per second | Zabbix agent | `sap.agent.swap.in[<common_params>,pages]` |
+| Swap-out bytes per second | Zabbix agent | `sap.agent.swap.out[<common_params>,bytes]` |
+| Swap-out pages per second | Zabbix agent | `sap.agent.swap.out[<common_params>,pages]` |
+| Free swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,free]` |
+| Total swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,total]` |
+| Used swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,used]` |
+| Swap utilization | CALCULATED | `sap.agent.swap.util` |
+| Version of SAP agent running | Zabbix agent | `sap.agent.version[<common_params>]` |
+
+---
+
+## Discovery Rules
+
+### CPU discovery
+
+**Key**: `sap.agent.cpu.discovery[<common_params>]`  
+**Description**: Discovery of CPUs.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| CPU {#CPU.ID} utilization | DEPENDENT | `sap.agent.cpu.util["{#CPU.ID}]` |
+| CPU {#CPU.ID} idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},idle]` |
+| CPU {#CPU.ID} iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},iowait]` |
+| CPU {#CPU.ID} system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},system]` |
+| CPU {#CPU.ID} user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},user]` |
+
+### Block devices discovery
+
+**Key**: `sap.agent.dev.discovery[<common_params>]`  
+**Description**: Discovery of block devices.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Device {#DEVNAME}: IO rate | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},io]` |
+| Device {#DEVNAME}: Queue length | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},queue]` |
+| Device {#DEVNAME}: Service time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},svc]` |
+| Device {#DEVNAME}: Throughput | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},tput]` |
+| Device {#DEVNAME}: Utilization | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},util]` |
+| Device {#DEVNAME}: Wait time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},wait]` |
+
+### Mounted filesystem discovery
+
+**Key**: `sap.agent.fs.discovery[<common_params>]`  
+**Description**: Discovery of file systems of different types.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Filesystem {#FSNAME}: Free space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},free]` |
+| Filesystem {#FSNAME}: Total space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},total]` |
+| Filesystem {#FSNAME}: Space utilization | CALCULATED | `sap.agent.fs.util["{#FSNAME}]` |
+
+### Network interface discovery
+
+**Key**: `sap.agent.net.discovery[<common_params>]`  
+**Description**: Discovery of network interfaces.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Interface {#IFNAME}: Incoming traffic | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Incoming errors | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Incoming packets | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},packets]` |
+| Interface {#IFNAME}: Outgoing traffic | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Outgoing errors | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Outgoing packets | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},packets]` |
+
+### Process discovery
+
+**Key**: `sap.agent.proc.discovery[<common_params>]`  
+**Description**: Discovery of instance processes.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Process {#PROCESS.DESC}: Get info | Zabbix agent | `sap.agent.proc.get[<common_params>,{#INSTANCE.NAME},{#PROCESS.NAME}]` |
+| Process {#PROCESS.DESC} pid | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},pid]` |
+| Process {#PROCESS.DESC} start time | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},starttime]` |
+| Process {#PROCESS.DESC} status | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},status]` |
+
+### SAP Database discovery
+
+**Key**: `sap.agent.db.discovery[<common_params>]`  
+**Description**: Discovery of all SAP databases running on the host. Returns a JSON array containing database discovery macros (`{#DB.NAME}`, `{#DB.PROTOCOL}`, `{#DB.HOST}` and `{#DB.PORT}`).
+
+No pre-defined item prototypes are included in this template, but this rule can be used to configure custom monitoring for each discovered database.
+
+---
+
+## Screenshots
+
+Below are standard visual layouts and dashboards generated by this template:
+
+* **Problems**: Triggers for processes and filesystems
+
+<img width="847" height="421" alt="problems" src="https://github.com/user-attachments/assets/e7109a08-f9a4-4d02-9b61-604c8d58d910" />
+
+* **System Performance**: Displays CPU usage, system load, memory and swap utilization.
+
+<img width="616" height="296" alt="cpuutil" src="https://github.com/user-attachments/assets/aeab6168-a44f-45c2-a973-b4fd0a8b1265" />
+<img width="671" height="296" alt="sysload" src="https://github.com/user-attachments/assets/5ef814dc-8286-4458-b2ea-fc89fb9c1948" />
+<img width="616" height="268" alt="memusage" src="https://github.com/user-attachments/assets/e404c22a-b214-4bd5-a6eb-ea6f815561ed" />
+<img width="616" height="268" alt="swapusage" src="https://github.com/user-attachments/assets/50414451-ee9a-4b0e-91a9-f1d7b5f55d34" />
+
+* **Block Devices**: Real-time visualization of disk utilization, queue length and IO rate per device.
+
+<img width="671" height="268" alt="diskutil" src="https://github.com/user-attachments/assets/0fd0e356-c5cd-4aec-84f1-6da081fa49ab" />
+<img width="671" height="282" alt="diskio" src="https://github.com/user-attachments/assets/62a0670a-5075-4a2a-ae05-f88b35fa84e8" />
+<img width="616" height="254" alt="diskthru" src="https://github.com/user-attachments/assets/a88a45c3-13cc-4c8e-b0aa-a561f4d879cd" />
+
+* **Network Interfaces**: Incoming/outgoing bandwidth utilization and packet rates.
+
+<img width="616" height="268" alt="nettraffic" src="https://github.com/user-attachments/assets/80b5948a-15ae-463d-9d73-9258713c5e09" />
+<img width="616" height="296" alt="netpackets" src="https://github.com/user-attachments/assets/b24107d2-f160-4857-83bb-8c37d1bdb676" />

--- a/Applications/Others/template_sap_host_agent/7.0/template_sap_host_agent.xml
+++ b/Applications/Others/template_sap_host_agent/7.0/template_sap_host_agent.xml
@@ -1,0 +1,1884 @@
+<zabbix_export>
+  <version>7.0</version>
+  <template_groups>
+    <template_group>
+      <uuid>a571c0d144b14fd4a87a9d9b2aa9fcd6</uuid>
+      <name>Templates/Applications</name>
+    </template_group>
+  </template_groups>
+  <templates>
+    <template>
+      <uuid>bcecec7d7a494dd995c45768057d4b43</uuid>
+      <template>Template SAP Host Agent by Zabbix agent 2</template>
+      <name>Template SAP Host Agent by Zabbix agent 2</name>
+      <description>Version: 8-36e3d05</description>
+      <groups>
+        <group>
+          <name>Templates/Applications</name>
+        </group>
+      </groups>
+      <items>
+        <item>
+          <uuid>b38fcdb6eb464c80bde1461a031afbc7</uuid>
+          <name>Interrupts per second</name>
+          <key>sap.agent.cpu.intr["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a2d335b4eef247b7abb06e3f90b13cdd</uuid>
+          <name>Load average (1m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1bd363e79a18490482e98334435eea7c</uuid>
+          <name>Load average (5m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c70c2e2ace0f455c8a241951cbcdf877</uuid>
+          <name>Load average (15m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f0bbe4be7e974dd49a05ea9ee6c95752</uuid>
+          <name>Number of CPUs</name>
+          <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bb00db5dc9fa411a96ec27fc9777ec62</uuid>
+          <name>Context switches per second</name>
+          <key>sap.agent.cpu.switches["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>sps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5064eead91d042aca0643d8e4fe7a13d</uuid>
+          <name>CPU utilization</name>
+          <type>DEPENDENT</type>
+          <key>sap.agent.cpu.util</key>
+          <delay>0</delay>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <description>CPU utilization in %.</description>
+          <preprocessing>
+            <step>
+              <type>JAVASCRIPT</type>
+              <parameters>
+                <parameter>//Calculate utilization
+return (100 - value)</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <master_item>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          </master_item>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>9e4a461766774602b087971817a26853</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.util,5m)&gt;{$CPU.UTIL.CRIT}</expression>
+              <name>High CPU utilization (over {$CPU.UTIL.CRIT}% for 5m)</name>
+              <opdata>Current utilization: {ITEM.LASTVALUE1}</opdata>
+              <priority>WARNING</priority>
+              <description>CPU utilization is too high. The system might be slow to respond.</description>
+              <dependencies>
+                <dependency>
+                  <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>43fa692269324ff7895c0746d66d0ea3</uuid>
+          <name>CPU idle time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>d9cc089714a0457388558c7b803040ff</uuid>
+          <name>CPU iowait time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c9e264a4ea4d418abf4b9b745685c435</uuid>
+          <name>CPU steal time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1259e4d32fa2405b971b696ea1f6dae5</uuid>
+          <name>CPU system time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f39da36a50564dc19bc54e3302dc27f8</uuid>
+          <name>CPU user time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>7f7c090809b3426681d62a5d9f532306</uuid>
+          <name>Memory utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.mem.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]) / last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>377658ded81c4580b6c7d7105a0bf64c</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem.util,5m)&gt;{$MEMORY.UTIL.MAX}</expression>
+              <name>High memory utilization (&gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+              <priority>AVERAGE</priority>
+              <description>The system is running out of free memory.</description>
+              <dependencies>
+                <dependency>
+                  <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+                  <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>9252bce6c9294c2e88ccf7e0dbcf3bde</uuid>
+          <name>Available physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>731d63fd55084cdb8951fdc5422bfcff</uuid>
+          <name>Free physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bef0fbf41aa3469684d1b3d1d47afa8f</uuid>
+          <name>Total physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a7d1a71a1a7b46a293604a6b44b4c8fe</uuid>
+          <name>Total virtual memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","virt","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f1a2abfdc14e4c80a56a555dc017a882</uuid>
+          <name>Operating system name</name>
+          <key>sap.agent.os.name["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <value_type>CHAR</value_type>
+          <trends>0</trends>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>e51be36494c2472ab68cac0d1af3cc4a</uuid>
+          <name>Operating system version</name>
+          <key>sap.agent.os.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <value_type>CHAR</value_type>
+          <trends>0</trends>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>46a198c67ccd47d69d3ca5508623dacc</uuid>
+          <name>SAP agent ping</name>
+          <key>sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <valuemap>
+            <name>Service state</name>
+          </valuemap>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>5c4d2858a04347298a0420a894a0e98d</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])=0</expression>
+              <name>SAP agent is unreachable</name>
+              <priority>AVERAGE</priority>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>f1e3e6eca35f48fab00c9b69b4dd8131</uuid>
+          <name>Swap-in bytes per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>82d8c82d98cc4ea0ac7f422e6c5f286d</uuid>
+          <name>Swap-in pages per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>b3223cb8189d4f4681ff2eff291f39d6</uuid>
+          <name>Swap-out bytes per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5db104cbcec54da5b09843c262958f2e</uuid>
+          <name>Swap-out pages per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1d20e12ef81647feb041434698a798e9</uuid>
+          <name>Free swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f967228dd57d4645811381b25fd75b80</uuid>
+          <name>Total swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>ecdf4fecceb549458c041f5b7f2e257d</uuid>
+          <name>Used swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>9640358636f04b9a9e61ebb0c1d365cd</uuid>
+          <name>Swap utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.swap.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]) / last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>8875ea6208cc4776a08084d43a16bf0d</uuid>
+          <name>Version of SAP agent running</name>
+          <key>sap.agent.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>CHAR</value_type>
+          <trends>0</trends>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+        </item>
+      </items>
+      <discovery_rules>
+        <discovery_rule>
+          <uuid>300062a6d59f4c3a9bbcbb1f022f82ee</uuid>
+          <name>CPU discovery</name>
+          <key>sap.agent.cpu.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of CPUs.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>48125cd76ccb4df086cca7608f4d06e2</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <preprocessing>
+                <step>
+                  <type>JAVASCRIPT</type>
+                  <parameters>
+                    <parameter>//Calculate utilization
+return (100 - value)</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>9361f5fef88d4372949ac069515b6e89</uuid>
+              <name>CPU {#CPU.ID} idle time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4af8b69ef96145898f77d873b3cba423</uuid>
+              <name>CPU {#CPU.ID} iowait time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5595b2dbfb9843f293770972ea1aaa0d</uuid>
+              <name>CPU {#CPU.ID} system time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>afccff22b07c437aa71320015b159405</uuid>
+              <name>CPU {#CPU.ID} user time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>ccf335d326f44658be124463890012b3</uuid>
+              <name>CPU {#CPU.ID} usage</name>
+              <type>STACKED</type>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>fa5c92dbff2b45df978b79c4095ac23b</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>846f9b13aeea41ac9ab6327674ead1d0</uuid>
+          <name>Block devices discovery</name>
+          <key>sap.agent.dev.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of block devices.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>d8e6cb5e31d34a67905c4a7aa40affaa</uuid>
+              <name>Device {#DEVNAME}: IO rate</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>!io/s</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4b36092e28b4483bb3d92261150cf212</uuid>
+              <name>Device {#DEVNAME}: Queue length</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ba34c528fc644a688338588e7f5852d7</uuid>
+              <name>Device {#DEVNAME}: Service time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b53817901b0f4453982fa5d664c2d21a</uuid>
+              <name>Device {#DEVNAME}: Throughput</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ab4a897513a6413892d1a2bebc658b42</uuid>
+              <name>Device {#DEVNAME}: Utilization</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>f59bf6edb66c4a09a70c30ccb118f7dc</uuid>
+              <name>Device {#DEVNAME}: Wait time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>c16718f216654b08aa7c400c0219a64b</uuid>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"],15m) &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"}</expression>
+                  <name>{#DEVNAME}: Disk wait time is too high (wait &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"} ms for 15m)</name>
+                  <priority>WARNING</priority>
+                  <description>This trigger might indicate disk {#DEVNAME} saturation.</description>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>0939d82652154db7a27979c7379a5421</uuid>
+              <name>Device {#DEVNAME}: Disk IO rate</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63100</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>335087f8dfd047ddb3cc7f4e4d862fcd</uuid>
+              <name>Device {#DEVNAME}: Disk throughput</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>e2974723a6384fb0b2b29ed891dff025</uuid>
+              <name>Device {#DEVNAME}: Disk utilization and queue</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>bddd317b5a384816a695fb7053b48f49</uuid>
+          <name>Mounted filesystem discovery</name>
+          <key>sap.agent.fs.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of file systems of different types.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>b15be907c36440cab3225534a5d0ad1f</uuid>
+              <name>Filesystem {#FSNAME}: Free space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5d68aff2f769468eb057fcea2cfea511</uuid>
+              <name>Filesystem {#FSNAME}: Total space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>2b8f6969bd294a219ca05dddd11cdecb</uuid>
+              <name>Filesystem {#FSNAME}: Space utilization</name>
+              <type>CALCULATED</type>
+              <key>sap.agent.fs.util["{#FSNAME}"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <params>100*(last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])-last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]))/last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])</params>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>53a22cae29a943379436356c43811994</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>AVERAGE</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+            <trigger_prototype>
+              <uuid>e506eaddd3da4c9e94f69d0010e266e8</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>WARNING</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+              <dependencies>
+                <dependency>
+                  <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+                  <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+                </dependency>
+              </dependencies>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>f924384a8fb84b0ea22a3a92a792a31c</uuid>
+              <name>{#FSNAME}: Filesystem space usage</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>9bd171f82bdc4a488c8951cb9a88eb01</uuid>
+          <name>Network interface discovery</name>
+          <key>sap.agent.net.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of network interfaces.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>e4033b992d7c4a81a65fa2d680160722</uuid>
+              <name>Interface {#IFNAME}: Incoming traffic</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>96d6761c118a47edb252068a3b53f210</uuid>
+              <name>Interface {#IFNAME}: Incoming errors</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>faa96f2518ae4c5690e250580334fb47</uuid>
+              <name>Interface {#IFNAME}: Incoming packets</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>da877eba0133413f991b29118a793a6b</uuid>
+              <name>Interface {#IFNAME}: Outgoing traffic</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b6b00c9090ef4050ae1eac0809662e15</uuid>
+              <name>Interface {#IFNAME}: Outgoing errors</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ca5118209e5146f09d06353d2581e43e</uuid>
+              <name>Interface {#IFNAME}: Outgoing packets</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>a1c0eb431fc84e92996647173716fd1f</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}
+or min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}</expression>
+              <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+              <recovery_expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8
+and max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8</recovery_expression>
+              <name>Interface {#IFNAME}: High error rate (&gt;{$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)</name>
+              <opdata>errors in: {ITEM.LASTVALUE1}, errors out: {ITEM.LASTVALUE2}</opdata>
+              <priority>WARNING</priority>
+              <description>Recovers when below 80% of {$IF.ERRORS.WARN:"{#IFNAME}"} threshold</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>c5155ce8c4e14f7997e253f01944ece4</uuid>
+              <name>Interface {#IFNAME}: Network packets</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>F63100</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>4</sortorder>
+                  <color>A54F10</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>c779f37d42da4e5ca2f45fac5a35a045</uuid>
+              <name>Interface {#IFNAME}: Network traffic</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>BOLD_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>b18af0d372f34b13b4c43cc73b1edaa5</uuid>
+          <name>Process discovery</name>
+          <key>sap.agent.proc.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of instance processes.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>982ad677f38548c6af3b57efaa3944fc</uuid>
+              <name>Process {#PROCESS.DESC}: Get info</name>
+              <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              <history>0</history>
+              <value_type>TEXT</value_type>
+              <trends>0</trends>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>825ff9efabbb409f909a42205d070805</uuid>
+              <name>Process {#PROCESS.DESC} pid</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <trends>0</trends>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.pid</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>5ba3199ecc3f4eea8994ec3ddb2fb71c</uuid>
+                  <expression>(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#1)&lt;&gt;last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#2))&gt;0</expression>
+                  <name>Process {#PROCESS.DESC} has been restarted</name>
+                  <priority>INFO</priority>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <uuid>c7bdd2e4cc8c470d8fa3a0a42bbcaced</uuid>
+              <name>Process {#PROCESS.DESC} start time</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","starttime"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <value_type>CHAR</value_type>
+              <trends>0</trends>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.starttime</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>83a838d9f126419a8ad25cef054c1b72</uuid>
+              <name>Process {#PROCESS.DESC} status</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"]</key>
+              <delay>0</delay>
+              <history>7d</history>
+              <value_type>CHAR</value_type>
+              <trends>0</trends>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.textstatus</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>b2e718cdb5394437b59bbbef3a9646be</uuid>
+                  <expression>find(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"],,"regexp","^Running$")=0</expression>
+                  <name>Process {#PROCESS.DESC}: Unexpected status</name>
+                  <opdata>Current status: {ITEM.LASTVALUE1}</opdata>
+                  <priority>HIGH</priority>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+        </discovery_rule>
+      </discovery_rules>
+      <macros>
+        <macro>
+          <macro>{$CPU.UTIL.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$IF.ERRORS.WARN}</macro>
+          <value>2</value>
+        </macro>
+        <macro>
+          <macro>{$LOAD_AVG_PER_CPU.MAX.WARN}</macro>
+          <value>1.5</value>
+          <description>Load per CPU considered sustainable.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.AVAILABLE.MIN}</macro>
+          <value>20M</value>
+          <description>The warning threshold of the available memory.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.UTIL.MAX}</macro>
+          <value>90</value>
+          <description>The warning threshold of the memory utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.PASSWORD}</macro>
+          <type>SECRET_TEXT</type>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.URI}</macro>
+          <value>http://localhost:1128</value>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.USER}</macro>
+          <value>sapadm</value>
+        </macro>
+        <macro>
+          <macro>{$SWAP.PFREE.MIN.WARN}</macro>
+          <value>50</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.DEV.AWAIT.WARN}</macro>
+          <value>20</value>
+          <description>Disk average wait time (in ms) before the trigger would fire</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.CRIT}</macro>
+          <value>5G</value>
+          <description>The critical threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.WARN}</macro>
+          <value>10G</value>
+          <description>The warning threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.WARN}</macro>
+          <value>80</value>
+        </macro>
+      </macros>
+      <dashboards>
+        <dashboard>
+          <uuid>53e533040c1b4d83bea057509dd5b2cd</uuid>
+          <name>Block devices</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>graphprototype</type>
+                  <width>24</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk utilization and queue</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKV</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graphprototype</type>
+                  <x>24</x>
+                  <width>24</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk IO rate</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKW</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graphprototype</type>
+                  <x>48</x>
+                  <width>24</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk throughput</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKX</value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>72ca7e79acb54b968222424995eb35b4</uuid>
+          <name>Network interfaces</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>graphprototype</type>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Interface {#IFNAME}: Network traffic</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKY</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graphprototype</type>
+                  <x>36</x>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Interface {#IFNAME}: Network packets</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKZ</value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>903c4a9c190e44a49b3c8075e37795c7</uuid>
+          <name>System performance</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>graph</type>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>System load</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAALA</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graph</type>
+                  <y>5</y>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Memory usage</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAALC</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graph</type>
+                  <x>36</x>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>CPU usage</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAALB</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graph</type>
+                  <x>36</x>
+                  <y>5</y>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Swap usage</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAALD</value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+      </dashboards>
+      <valuemaps>
+        <valuemap>
+          <uuid>33feeafd9e2a4fe9950ee35198ccba02</uuid>
+          <name>Service state</name>
+          <mappings>
+            <mapping>
+              <value>0</value>
+              <newvalue>Down</newvalue>
+            </mapping>
+            <mapping>
+              <value>1</value>
+              <newvalue>Up</newvalue>
+            </mapping>
+          </mappings>
+        </valuemap>
+      </valuemaps>
+    </template>
+  </templates>
+  <triggers>
+    <trigger>
+      <uuid>0eb022f5eb694feb9b2da1ffd58312e4</uuid>
+      <expression>100 - max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.util,5m)&lt;{$SWAP.PFREE.MIN.WARN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])&gt;0</expression>
+      <name>High swap space usage (less than {$SWAP.PFREE.MIN.WARN}% free)</name>
+      <opdata>Free: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>WARNING</priority>
+      <description>This trigger is ignored, if there is no swap configured.</description>
+    </trigger>
+    <trigger>
+      <uuid>a9fea933fb46485aa18381402db46299</uuid>
+      <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+      <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+      <opdata>Available: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+    </trigger>
+    <trigger>
+      <uuid>bb1df76871fa447ba9c8cc7598275c2e</uuid>
+      <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+      <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+      <opdata>Load averages(1m 5m 15m): ({ITEM.LASTVALUE1} {ITEM.LASTVALUE3} {ITEM.LASTVALUE4}), # of CPUs: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+      <description>Per CPU load average is too high. Your system may be slow to respond.</description>
+    </trigger>
+  </triggers>
+  <graphs>
+    <graph>
+      <uuid>b30f986eac8345dea04d8351a6945459</uuid>
+      <name>CPU usage</name>
+      <type>STACKED</type>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>A54F10</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>FC6EA3</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>ff15c2bb38664127a34399fc05ed460a</uuid>
+      <name>CPU utilization</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>1e571d14c7c44bbcbfbb58d48969d487</uuid>
+      <name>Memory usage</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>BOLD_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>38242ed637884247ac7806847878e50d</uuid>
+      <name>Swap usage</name>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>F63131</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>b64e8d50de4b426a84a11e0e66208d5f</uuid>
+      <name>System load</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>F63100</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>A54F10</color>
+          <yaxisside>RIGHT</yaxisside>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+  </graphs>
+</zabbix_export>

--- a/Applications/Others/template_sap_host_agent/7.2/README.md
+++ b/Applications/Others/template_sap_host_agent/7.2/README.md
@@ -1,0 +1,187 @@
+# Template SAP Host Agent by Zabbix agent 2
+
+## Description
+
+This template is designed for monitoring **SAP Host Agent** performance and system status using **Zabbix Agent 2** with a native custom plugin. It discovers and monitors key host parameters collected via the SAP Host Agent, including CPU, Memory, Swap, Disk I/O, Filesystems, Network Interfaces, Instance processes and OS details.
+
+## Requirements
+
+To use this template, the following components are required:
+
+1. **Zabbix Agent 2** installed on the same host running the SAP Host Agent or on any other host that can reach it via the network.
+2. Native **SAP Host Agent** Zabbix plugin installed on the same host where Zabbix Agent 2 is running.
+3. **SAP Host Agent** must be active and configured with read access to its web service interface (typically running on port `1128` HTTP or `1129` HTTPS).
+
+## Installation
+
+1. **Install the Zabbix Agent 2 Plugin**:
+   - **Native Packages**: You can use pre-compiled packages for Debian/Ubuntu, SUSE (SLES) or Red Hat (RHEL/CentOS) ecosystems. Detailed instructions on adding repositories and installing these packages can be found on the [Documentation Website](https://docs.ravenlayer.com/plugins/zabbix-agent2-plugin-sapagent/).
+   - **Build from Source**: Alternatively, you can build the plugin directly from the source code available in the [GitHub Repository](https://github.com/RavenLayer/zabbix-agent2-plugin-sapagent/).
+
+2. **Import the Template**:
+   - Download the `template_sap_host_agent.xml` file.
+   - Import the XML file into your Zabbix server (**Configuration** -> **Templates** -> **Import**).
+
+3. **Configure Host Macros**:
+   - Link the template to your target host.
+   - Adjust the user macro values (e.g., `{$SAP.AGENT.URI}`, `{$SAP.AGENT.USER}` and `{$SAP.AGENT.PASSWORD}`) according to your target SAP Host Agent deployment.
+
+---
+
+## Macros
+
+| Name | Default Value | Description |
+| --- | --- | --- |
+| `{$SAP.AGENT.PASSWORD}` | | Password for SAP Host Agent basic authentication. |
+| `{$SAP.AGENT.URI}` | `http://localhost:1128` | URI of the SAP Host Agent API. |
+| `{$SAP.AGENT.USER}` | `sapadm` | Username for SAP Host Agent basic authentication. |
+| `{$CPU.UTIL.CRIT}` | `90` | Critical threshold for CPU utilization. |
+| `{$IF.ERRORS.WARN}` | `2` | Warning threshold for network interface errors. |
+| `{$LOAD_AVG_PER_CPU.MAX.WARN}` | `1.5` | Load per CPU considered sustainable. |
+| `{$MEMORY.AVAILABLE.MIN}` | `20M` | The warning threshold of the available memory. |
+| `{$MEMORY.UTIL.MAX}` | `90` | The warning threshold of the memory utilization. |
+| `{$SWAP.PFREE.MIN.WARN}` | `50` | Warning threshold for minimum percentage of free swap space. |
+| `{$VFS.DEV.AWAIT.WARN}` | `20` | Disk average wait time (in ms) before the trigger would fire |
+| `{$VFS.FS.FREE.MIN.CRIT}` | `5G` | The critical threshold of the filesystem utilization. |
+| `{$VFS.FS.FREE.MIN.WARN}` | `10G` | The warning threshold of the filesystem utilization. |
+| `{$VFS.FS.PUSED.MAX.CRIT}` | `90` | Critical threshold for filesystem utilization percentage. |
+| `{$VFS.FS.PUSED.MAX.WARN}` | `80` | Warning threshold for filesystem utilization percentage. |
+
+---
+
+## Items
+
+| Name | Type | Key |
+| --- | --- | --- |
+| Interrupts per second | Zabbix agent | `sap.agent.cpu.intr[<common_params>]` |
+| Load average (1m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg1]` |
+| Load average (5m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg5]` |
+| Load average (15m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg15]` |
+| Number of CPUs | Zabbix agent | `sap.agent.cpu.num[<common_params>]` |
+| Context switches per second | Zabbix agent | `sap.agent.cpu.switches[<common_params>]` |
+| CPU utilization | DEPENDENT | `sap.agent.cpu.util` |
+| CPU idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,idle]` |
+| CPU iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,iowait]` |
+| CPU steal time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,steal]` |
+| CPU system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,system]` |
+| CPU user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,user]` |
+| Memory utilization | CALCULATED | `sap.agent.mem.util` |
+| Available physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,available]` |
+| Free physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,free]` |
+| Total physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,size]` |
+| Total virtual memory | Zabbix agent | `sap.agent.mem[<common_params>,virt,size]` |
+| Operating system name | Zabbix agent | `sap.agent.os.name[<common_params>]` |
+| Operating system version | Zabbix agent | `sap.agent.os.version[<common_params>]` |
+| SAP agent ping | Zabbix agent | `sap.agent.ping[<common_params>]` |
+| Swap-in bytes per second | Zabbix agent | `sap.agent.swap.in[<common_params>,bytes]` |
+| Swap-in pages per second | Zabbix agent | `sap.agent.swap.in[<common_params>,pages]` |
+| Swap-out bytes per second | Zabbix agent | `sap.agent.swap.out[<common_params>,bytes]` |
+| Swap-out pages per second | Zabbix agent | `sap.agent.swap.out[<common_params>,pages]` |
+| Free swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,free]` |
+| Total swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,total]` |
+| Used swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,used]` |
+| Swap utilization | CALCULATED | `sap.agent.swap.util` |
+| Version of SAP agent running | Zabbix agent | `sap.agent.version[<common_params>]` |
+
+---
+
+## Discovery Rules
+
+### CPU discovery
+
+**Key**: `sap.agent.cpu.discovery[<common_params>]`  
+**Description**: Discovery of CPUs.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| CPU {#CPU.ID} utilization | DEPENDENT | `sap.agent.cpu.util["{#CPU.ID}]` |
+| CPU {#CPU.ID} idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},idle]` |
+| CPU {#CPU.ID} iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},iowait]` |
+| CPU {#CPU.ID} system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},system]` |
+| CPU {#CPU.ID} user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},user]` |
+
+### Block devices discovery
+
+**Key**: `sap.agent.dev.discovery[<common_params>]`  
+**Description**: Discovery of block devices.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Device {#DEVNAME}: IO rate | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},io]` |
+| Device {#DEVNAME}: Queue length | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},queue]` |
+| Device {#DEVNAME}: Service time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},svc]` |
+| Device {#DEVNAME}: Throughput | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},tput]` |
+| Device {#DEVNAME}: Utilization | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},util]` |
+| Device {#DEVNAME}: Wait time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},wait]` |
+
+### Mounted filesystem discovery
+
+**Key**: `sap.agent.fs.discovery[<common_params>]`  
+**Description**: Discovery of file systems of different types.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Filesystem {#FSNAME}: Free space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},free]` |
+| Filesystem {#FSNAME}: Total space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},total]` |
+| Filesystem {#FSNAME}: Space utilization | CALCULATED | `sap.agent.fs.util["{#FSNAME}]` |
+
+### Network interface discovery
+
+**Key**: `sap.agent.net.discovery[<common_params>]`  
+**Description**: Discovery of network interfaces.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Interface {#IFNAME}: Incoming traffic | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Incoming errors | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Incoming packets | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},packets]` |
+| Interface {#IFNAME}: Outgoing traffic | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Outgoing errors | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Outgoing packets | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},packets]` |
+
+### Process discovery
+
+**Key**: `sap.agent.proc.discovery[<common_params>]`  
+**Description**: Discovery of instance processes.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Process {#PROCESS.DESC}: Get info | Zabbix agent | `sap.agent.proc.get[<common_params>,{#INSTANCE.NAME},{#PROCESS.NAME}]` |
+| Process {#PROCESS.DESC} pid | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},pid]` |
+| Process {#PROCESS.DESC} start time | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},starttime]` |
+| Process {#PROCESS.DESC} status | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},status]` |
+
+### SAP Database discovery
+
+**Key**: `sap.agent.db.discovery[<common_params>]`  
+**Description**: Discovery of all SAP databases running on the host. Returns a JSON array containing database discovery macros (`{#DB.NAME}`, `{#DB.PROTOCOL}`, `{#DB.HOST}` and `{#DB.PORT}`).
+
+No pre-defined item prototypes are included in this template, but this rule can be used to configure custom monitoring for each discovered database.
+
+---
+
+## Screenshots
+
+Below are standard visual layouts and dashboards generated by this template:
+
+* **Problems**: Triggers for processes and filesystems
+
+<img width="847" height="421" alt="problems" src="https://github.com/user-attachments/assets/e7109a08-f9a4-4d02-9b61-604c8d58d910" />
+
+* **System Performance**: Displays CPU usage, system load, memory and swap utilization.
+
+<img width="616" height="296" alt="cpuutil" src="https://github.com/user-attachments/assets/aeab6168-a44f-45c2-a973-b4fd0a8b1265" />
+<img width="671" height="296" alt="sysload" src="https://github.com/user-attachments/assets/5ef814dc-8286-4458-b2ea-fc89fb9c1948" />
+<img width="616" height="268" alt="memusage" src="https://github.com/user-attachments/assets/e404c22a-b214-4bd5-a6eb-ea6f815561ed" />
+<img width="616" height="268" alt="swapusage" src="https://github.com/user-attachments/assets/50414451-ee9a-4b0e-91a9-f1d7b5f55d34" />
+
+* **Block Devices**: Real-time visualization of disk utilization, queue length and IO rate per device.
+
+<img width="671" height="268" alt="diskutil" src="https://github.com/user-attachments/assets/0fd0e356-c5cd-4aec-84f1-6da081fa49ab" />
+<img width="671" height="282" alt="diskio" src="https://github.com/user-attachments/assets/62a0670a-5075-4a2a-ae05-f88b35fa84e8" />
+<img width="616" height="254" alt="diskthru" src="https://github.com/user-attachments/assets/a88a45c3-13cc-4c8e-b0aa-a561f4d879cd" />
+
+* **Network Interfaces**: Incoming/outgoing bandwidth utilization and packet rates.
+
+<img width="616" height="268" alt="nettraffic" src="https://github.com/user-attachments/assets/80b5948a-15ae-463d-9d73-9258713c5e09" />
+<img width="616" height="296" alt="netpackets" src="https://github.com/user-attachments/assets/b24107d2-f160-4857-83bb-8c37d1bdb676" />

--- a/Applications/Others/template_sap_host_agent/7.2/template_sap_host_agent.xml
+++ b/Applications/Others/template_sap_host_agent/7.2/template_sap_host_agent.xml
@@ -1,0 +1,1873 @@
+<zabbix_export>
+  <version>7.2</version>
+  <template_groups>
+    <template_group>
+      <uuid>a571c0d144b14fd4a87a9d9b2aa9fcd6</uuid>
+      <name>Templates/Applications</name>
+    </template_group>
+  </template_groups>
+  <templates>
+    <template>
+      <uuid>bcecec7d7a494dd995c45768057d4b43</uuid>
+      <template>Template SAP Host Agent by Zabbix agent 2</template>
+      <name>Template SAP Host Agent by Zabbix agent 2</name>
+      <description>Version: 8-36e3d05</description>
+      <groups>
+        <group>
+          <name>Templates/Applications</name>
+        </group>
+      </groups>
+      <items>
+        <item>
+          <uuid>b38fcdb6eb464c80bde1461a031afbc7</uuid>
+          <name>Interrupts per second</name>
+          <key>sap.agent.cpu.intr["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a2d335b4eef247b7abb06e3f90b13cdd</uuid>
+          <name>Load average (1m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1bd363e79a18490482e98334435eea7c</uuid>
+          <name>Load average (5m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c70c2e2ace0f455c8a241951cbcdf877</uuid>
+          <name>Load average (15m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f0bbe4be7e974dd49a05ea9ee6c95752</uuid>
+          <name>Number of CPUs</name>
+          <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bb00db5dc9fa411a96ec27fc9777ec62</uuid>
+          <name>Context switches per second</name>
+          <key>sap.agent.cpu.switches["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>sps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5064eead91d042aca0643d8e4fe7a13d</uuid>
+          <name>CPU utilization</name>
+          <type>DEPENDENT</type>
+          <key>sap.agent.cpu.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <description>CPU utilization in %.</description>
+          <preprocessing>
+            <step>
+              <type>JAVASCRIPT</type>
+              <parameters>
+                <parameter>//Calculate utilization
+return (100 - value)</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <master_item>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          </master_item>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>9e4a461766774602b087971817a26853</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.util,5m)&gt;{$CPU.UTIL.CRIT}</expression>
+              <name>High CPU utilization (over {$CPU.UTIL.CRIT}% for 5m)</name>
+              <opdata>Current utilization: {ITEM.LASTVALUE1}</opdata>
+              <priority>WARNING</priority>
+              <description>CPU utilization is too high. The system might be slow to respond.</description>
+              <dependencies>
+                <dependency>
+                  <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>43fa692269324ff7895c0746d66d0ea3</uuid>
+          <name>CPU idle time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>d9cc089714a0457388558c7b803040ff</uuid>
+          <name>CPU iowait time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c9e264a4ea4d418abf4b9b745685c435</uuid>
+          <name>CPU steal time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1259e4d32fa2405b971b696ea1f6dae5</uuid>
+          <name>CPU system time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f39da36a50564dc19bc54e3302dc27f8</uuid>
+          <name>CPU user time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>7f7c090809b3426681d62a5d9f532306</uuid>
+          <name>Memory utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.mem.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]) / last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>377658ded81c4580b6c7d7105a0bf64c</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem.util,5m)&gt;{$MEMORY.UTIL.MAX}</expression>
+              <name>High memory utilization (&gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+              <priority>AVERAGE</priority>
+              <description>The system is running out of free memory.</description>
+              <dependencies>
+                <dependency>
+                  <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+                  <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>9252bce6c9294c2e88ccf7e0dbcf3bde</uuid>
+          <name>Available physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>731d63fd55084cdb8951fdc5422bfcff</uuid>
+          <name>Free physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bef0fbf41aa3469684d1b3d1d47afa8f</uuid>
+          <name>Total physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a7d1a71a1a7b46a293604a6b44b4c8fe</uuid>
+          <name>Total virtual memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","virt","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f1a2abfdc14e4c80a56a555dc017a882</uuid>
+          <name>Operating system name</name>
+          <key>sap.agent.os.name["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>e51be36494c2472ab68cac0d1af3cc4a</uuid>
+          <name>Operating system version</name>
+          <key>sap.agent.os.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>46a198c67ccd47d69d3ca5508623dacc</uuid>
+          <name>SAP agent ping</name>
+          <key>sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <valuemap>
+            <name>Service state</name>
+          </valuemap>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>5c4d2858a04347298a0420a894a0e98d</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])=0</expression>
+              <name>SAP agent is unreachable</name>
+              <priority>AVERAGE</priority>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>f1e3e6eca35f48fab00c9b69b4dd8131</uuid>
+          <name>Swap-in bytes per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>82d8c82d98cc4ea0ac7f422e6c5f286d</uuid>
+          <name>Swap-in pages per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>b3223cb8189d4f4681ff2eff291f39d6</uuid>
+          <name>Swap-out bytes per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5db104cbcec54da5b09843c262958f2e</uuid>
+          <name>Swap-out pages per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1d20e12ef81647feb041434698a798e9</uuid>
+          <name>Free swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f967228dd57d4645811381b25fd75b80</uuid>
+          <name>Total swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>ecdf4fecceb549458c041f5b7f2e257d</uuid>
+          <name>Used swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>9640358636f04b9a9e61ebb0c1d365cd</uuid>
+          <name>Swap utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.swap.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]) / last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>8875ea6208cc4776a08084d43a16bf0d</uuid>
+          <name>Version of SAP agent running</name>
+          <key>sap.agent.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+        </item>
+      </items>
+      <discovery_rules>
+        <discovery_rule>
+          <uuid>300062a6d59f4c3a9bbcbb1f022f82ee</uuid>
+          <name>CPU discovery</name>
+          <key>sap.agent.cpu.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of CPUs.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>48125cd76ccb4df086cca7608f4d06e2</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <preprocessing>
+                <step>
+                  <type>JAVASCRIPT</type>
+                  <parameters>
+                    <parameter>//Calculate utilization
+return (100 - value)</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>9361f5fef88d4372949ac069515b6e89</uuid>
+              <name>CPU {#CPU.ID} idle time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4af8b69ef96145898f77d873b3cba423</uuid>
+              <name>CPU {#CPU.ID} iowait time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5595b2dbfb9843f293770972ea1aaa0d</uuid>
+              <name>CPU {#CPU.ID} system time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>afccff22b07c437aa71320015b159405</uuid>
+              <name>CPU {#CPU.ID} user time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>ccf335d326f44658be124463890012b3</uuid>
+              <name>CPU {#CPU.ID} usage</name>
+              <type>STACKED</type>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>fa5c92dbff2b45df978b79c4095ac23b</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>846f9b13aeea41ac9ab6327674ead1d0</uuid>
+          <name>Block devices discovery</name>
+          <key>sap.agent.dev.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of block devices.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>d8e6cb5e31d34a67905c4a7aa40affaa</uuid>
+              <name>Device {#DEVNAME}: IO rate</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>!io/s</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4b36092e28b4483bb3d92261150cf212</uuid>
+              <name>Device {#DEVNAME}: Queue length</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ba34c528fc644a688338588e7f5852d7</uuid>
+              <name>Device {#DEVNAME}: Service time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b53817901b0f4453982fa5d664c2d21a</uuid>
+              <name>Device {#DEVNAME}: Throughput</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ab4a897513a6413892d1a2bebc658b42</uuid>
+              <name>Device {#DEVNAME}: Utilization</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>f59bf6edb66c4a09a70c30ccb118f7dc</uuid>
+              <name>Device {#DEVNAME}: Wait time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>c16718f216654b08aa7c400c0219a64b</uuid>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"],15m) &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"}</expression>
+                  <name>{#DEVNAME}: Disk wait time is too high (wait &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"} ms for 15m)</name>
+                  <priority>WARNING</priority>
+                  <description>This trigger might indicate disk {#DEVNAME} saturation.</description>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>0939d82652154db7a27979c7379a5421</uuid>
+              <name>Device {#DEVNAME}: Disk IO rate</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63100</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>335087f8dfd047ddb3cc7f4e4d862fcd</uuid>
+              <name>Device {#DEVNAME}: Disk throughput</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>e2974723a6384fb0b2b29ed891dff025</uuid>
+              <name>Device {#DEVNAME}: Disk utilization and queue</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>bddd317b5a384816a695fb7053b48f49</uuid>
+          <name>Mounted filesystem discovery</name>
+          <key>sap.agent.fs.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of file systems of different types.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>b15be907c36440cab3225534a5d0ad1f</uuid>
+              <name>Filesystem {#FSNAME}: Free space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5d68aff2f769468eb057fcea2cfea511</uuid>
+              <name>Filesystem {#FSNAME}: Total space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>2b8f6969bd294a219ca05dddd11cdecb</uuid>
+              <name>Filesystem {#FSNAME}: Space utilization</name>
+              <type>CALCULATED</type>
+              <key>sap.agent.fs.util["{#FSNAME}"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <params>100*(last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])-last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]))/last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])</params>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>53a22cae29a943379436356c43811994</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>AVERAGE</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+            <trigger_prototype>
+              <uuid>e506eaddd3da4c9e94f69d0010e266e8</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>WARNING</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+              <dependencies>
+                <dependency>
+                  <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+                  <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+                </dependency>
+              </dependencies>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>f924384a8fb84b0ea22a3a92a792a31c</uuid>
+              <name>{#FSNAME}: Filesystem space usage</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>9bd171f82bdc4a488c8951cb9a88eb01</uuid>
+          <name>Network interface discovery</name>
+          <key>sap.agent.net.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of network interfaces.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>e4033b992d7c4a81a65fa2d680160722</uuid>
+              <name>Interface {#IFNAME}: Incoming traffic</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>96d6761c118a47edb252068a3b53f210</uuid>
+              <name>Interface {#IFNAME}: Incoming errors</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>faa96f2518ae4c5690e250580334fb47</uuid>
+              <name>Interface {#IFNAME}: Incoming packets</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>da877eba0133413f991b29118a793a6b</uuid>
+              <name>Interface {#IFNAME}: Outgoing traffic</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b6b00c9090ef4050ae1eac0809662e15</uuid>
+              <name>Interface {#IFNAME}: Outgoing errors</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ca5118209e5146f09d06353d2581e43e</uuid>
+              <name>Interface {#IFNAME}: Outgoing packets</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>a1c0eb431fc84e92996647173716fd1f</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}
+or min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}</expression>
+              <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+              <recovery_expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8
+and max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8</recovery_expression>
+              <name>Interface {#IFNAME}: High error rate (&gt;{$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)</name>
+              <opdata>errors in: {ITEM.LASTVALUE1}, errors out: {ITEM.LASTVALUE2}</opdata>
+              <priority>WARNING</priority>
+              <description>Recovers when below 80% of {$IF.ERRORS.WARN:"{#IFNAME}"} threshold</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>c5155ce8c4e14f7997e253f01944ece4</uuid>
+              <name>Interface {#IFNAME}: Network packets</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>F63100</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>4</sortorder>
+                  <color>A54F10</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>c779f37d42da4e5ca2f45fac5a35a045</uuid>
+              <name>Interface {#IFNAME}: Network traffic</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>BOLD_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>b18af0d372f34b13b4c43cc73b1edaa5</uuid>
+          <name>Process discovery</name>
+          <key>sap.agent.proc.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of instance processes.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>982ad677f38548c6af3b57efaa3944fc</uuid>
+              <name>Process {#PROCESS.DESC}: Get info</name>
+              <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              <history>0</history>
+              <value_type>TEXT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>825ff9efabbb409f909a42205d070805</uuid>
+              <name>Process {#PROCESS.DESC} pid</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"]</key>
+              <history>7d</history>
+              <trends>0</trends>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.pid</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>5ba3199ecc3f4eea8994ec3ddb2fb71c</uuid>
+                  <expression>(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#1)&lt;&gt;last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#2))&gt;0</expression>
+                  <name>Process {#PROCESS.DESC} has been restarted</name>
+                  <priority>INFO</priority>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <uuid>c7bdd2e4cc8c470d8fa3a0a42bbcaced</uuid>
+              <name>Process {#PROCESS.DESC} start time</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","starttime"]</key>
+              <history>7d</history>
+              <value_type>CHAR</value_type>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.starttime</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>83a838d9f126419a8ad25cef054c1b72</uuid>
+              <name>Process {#PROCESS.DESC} status</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"]</key>
+              <history>7d</history>
+              <value_type>CHAR</value_type>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.textstatus</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>b2e718cdb5394437b59bbbef3a9646be</uuid>
+                  <expression>find(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"],,"regexp","^Running$")=0</expression>
+                  <name>Process {#PROCESS.DESC}: Unexpected status</name>
+                  <opdata>Current status: {ITEM.LASTVALUE1}</opdata>
+                  <priority>HIGH</priority>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+        </discovery_rule>
+      </discovery_rules>
+      <macros>
+        <macro>
+          <macro>{$CPU.UTIL.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$IF.ERRORS.WARN}</macro>
+          <value>2</value>
+        </macro>
+        <macro>
+          <macro>{$LOAD_AVG_PER_CPU.MAX.WARN}</macro>
+          <value>1.5</value>
+          <description>Load per CPU considered sustainable.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.AVAILABLE.MIN}</macro>
+          <value>20M</value>
+          <description>The warning threshold of the available memory.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.UTIL.MAX}</macro>
+          <value>90</value>
+          <description>The warning threshold of the memory utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.PASSWORD}</macro>
+          <type>SECRET_TEXT</type>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.URI}</macro>
+          <value>http://localhost:1128</value>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.USER}</macro>
+          <value>sapadm</value>
+        </macro>
+        <macro>
+          <macro>{$SWAP.PFREE.MIN.WARN}</macro>
+          <value>50</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.DEV.AWAIT.WARN}</macro>
+          <value>20</value>
+          <description>Disk average wait time (in ms) before the trigger would fire</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.CRIT}</macro>
+          <value>5G</value>
+          <description>The critical threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.WARN}</macro>
+          <value>10G</value>
+          <description>The warning threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.WARN}</macro>
+          <value>80</value>
+        </macro>
+      </macros>
+      <dashboards>
+        <dashboard>
+          <uuid>53e533040c1b4d83bea057509dd5b2cd</uuid>
+          <name>Block devices</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>graphprototype</type>
+                  <width>24</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk utilization and queue</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKV</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graphprototype</type>
+                  <x>24</x>
+                  <width>24</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk IO rate</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKW</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graphprototype</type>
+                  <x>48</x>
+                  <width>24</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk throughput</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKX</value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>72ca7e79acb54b968222424995eb35b4</uuid>
+          <name>Network interfaces</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>graphprototype</type>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Interface {#IFNAME}: Network traffic</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKY</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graphprototype</type>
+                  <x>36</x>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Interface {#IFNAME}: Network packets</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKZ</value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>903c4a9c190e44a49b3c8075e37795c7</uuid>
+          <name>System performance</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>graph</type>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>System load</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAALA</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graph</type>
+                  <y>5</y>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Memory usage</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAALC</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graph</type>
+                  <x>36</x>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>CPU usage</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAALB</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graph</type>
+                  <x>36</x>
+                  <y>5</y>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Swap usage</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAALD</value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+      </dashboards>
+      <valuemaps>
+        <valuemap>
+          <uuid>33feeafd9e2a4fe9950ee35198ccba02</uuid>
+          <name>Service state</name>
+          <mappings>
+            <mapping>
+              <value>0</value>
+              <newvalue>Down</newvalue>
+            </mapping>
+            <mapping>
+              <value>1</value>
+              <newvalue>Up</newvalue>
+            </mapping>
+          </mappings>
+        </valuemap>
+      </valuemaps>
+    </template>
+  </templates>
+  <triggers>
+    <trigger>
+      <uuid>0eb022f5eb694feb9b2da1ffd58312e4</uuid>
+      <expression>100 - max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.util,5m)&lt;{$SWAP.PFREE.MIN.WARN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])&gt;0</expression>
+      <name>High swap space usage (less than {$SWAP.PFREE.MIN.WARN}% free)</name>
+      <opdata>Free: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>WARNING</priority>
+      <description>This trigger is ignored, if there is no swap configured.</description>
+    </trigger>
+    <trigger>
+      <uuid>a9fea933fb46485aa18381402db46299</uuid>
+      <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+      <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+      <opdata>Available: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+    </trigger>
+    <trigger>
+      <uuid>bb1df76871fa447ba9c8cc7598275c2e</uuid>
+      <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+      <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+      <opdata>Load averages(1m 5m 15m): ({ITEM.LASTVALUE1} {ITEM.LASTVALUE3} {ITEM.LASTVALUE4}), # of CPUs: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+      <description>Per CPU load average is too high. Your system may be slow to respond.</description>
+    </trigger>
+  </triggers>
+  <graphs>
+    <graph>
+      <uuid>b30f986eac8345dea04d8351a6945459</uuid>
+      <name>CPU usage</name>
+      <type>STACKED</type>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>A54F10</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>FC6EA3</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>ff15c2bb38664127a34399fc05ed460a</uuid>
+      <name>CPU utilization</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>1e571d14c7c44bbcbfbb58d48969d487</uuid>
+      <name>Memory usage</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>BOLD_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>38242ed637884247ac7806847878e50d</uuid>
+      <name>Swap usage</name>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>F63131</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>b64e8d50de4b426a84a11e0e66208d5f</uuid>
+      <name>System load</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>F63100</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>A54F10</color>
+          <yaxisside>RIGHT</yaxisside>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+  </graphs>
+</zabbix_export>

--- a/Applications/Others/template_sap_host_agent/7.4/README.md
+++ b/Applications/Others/template_sap_host_agent/7.4/README.md
@@ -1,0 +1,187 @@
+# Template SAP Host Agent by Zabbix agent 2
+
+## Description
+
+This template is designed for monitoring **SAP Host Agent** performance and system status using **Zabbix Agent 2** with a native custom plugin. It discovers and monitors key host parameters collected via the SAP Host Agent, including CPU, Memory, Swap, Disk I/O, Filesystems, Network Interfaces, Instance processes and OS details.
+
+## Requirements
+
+To use this template, the following components are required:
+
+1. **Zabbix Agent 2** installed on the same host running the SAP Host Agent or on any other host that can reach it via the network.
+2. Native **SAP Host Agent** Zabbix plugin installed on the same host where Zabbix Agent 2 is running.
+3. **SAP Host Agent** must be active and configured with read access to its web service interface (typically running on port `1128` HTTP or `1129` HTTPS).
+
+## Installation
+
+1. **Install the Zabbix Agent 2 Plugin**:
+   - **Native Packages**: You can use pre-compiled packages for Debian/Ubuntu, SUSE (SLES) or Red Hat (RHEL/CentOS) ecosystems. Detailed instructions on adding repositories and installing these packages can be found on the [Documentation Website](https://docs.ravenlayer.com/plugins/zabbix-agent2-plugin-sapagent/).
+   - **Build from Source**: Alternatively, you can build the plugin directly from the source code available in the [GitHub Repository](https://github.com/RavenLayer/zabbix-agent2-plugin-sapagent/).
+
+2. **Import the Template**:
+   - Download the `template_sap_host_agent.xml` file.
+   - Import the XML file into your Zabbix server (**Configuration** -> **Templates** -> **Import**).
+
+3. **Configure Host Macros**:
+   - Link the template to your target host.
+   - Adjust the user macro values (e.g., `{$SAP.AGENT.URI}`, `{$SAP.AGENT.USER}` and `{$SAP.AGENT.PASSWORD}`) according to your target SAP Host Agent deployment.
+
+---
+
+## Macros
+
+| Name | Default Value | Description |
+| --- | --- | --- |
+| `{$SAP.AGENT.PASSWORD}` | | Password for SAP Host Agent basic authentication. |
+| `{$SAP.AGENT.URI}` | `http://localhost:1128` | URI of the SAP Host Agent API. |
+| `{$SAP.AGENT.USER}` | `sapadm` | Username for SAP Host Agent basic authentication. |
+| `{$CPU.UTIL.CRIT}` | `90` | Critical threshold for CPU utilization. |
+| `{$IF.ERRORS.WARN}` | `2` | Warning threshold for network interface errors. |
+| `{$LOAD_AVG_PER_CPU.MAX.WARN}` | `1.5` | Load per CPU considered sustainable. |
+| `{$MEMORY.AVAILABLE.MIN}` | `20M` | The warning threshold of the available memory. |
+| `{$MEMORY.UTIL.MAX}` | `90` | The warning threshold of the memory utilization. |
+| `{$SWAP.PFREE.MIN.WARN}` | `50` | Warning threshold for minimum percentage of free swap space. |
+| `{$VFS.DEV.AWAIT.WARN}` | `20` | Disk average wait time (in ms) before the trigger would fire |
+| `{$VFS.FS.FREE.MIN.CRIT}` | `5G` | The critical threshold of the filesystem utilization. |
+| `{$VFS.FS.FREE.MIN.WARN}` | `10G` | The warning threshold of the filesystem utilization. |
+| `{$VFS.FS.PUSED.MAX.CRIT}` | `90` | Critical threshold for filesystem utilization percentage. |
+| `{$VFS.FS.PUSED.MAX.WARN}` | `80` | Warning threshold for filesystem utilization percentage. |
+
+---
+
+## Items
+
+| Name | Type | Key |
+| --- | --- | --- |
+| Interrupts per second | Zabbix agent | `sap.agent.cpu.intr[<common_params>]` |
+| Load average (1m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg1]` |
+| Load average (5m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg5]` |
+| Load average (15m avg) | Zabbix agent | `sap.agent.cpu.load[<common_params>,avg15]` |
+| Number of CPUs | Zabbix agent | `sap.agent.cpu.num[<common_params>]` |
+| Context switches per second | Zabbix agent | `sap.agent.cpu.switches[<common_params>]` |
+| CPU utilization | DEPENDENT | `sap.agent.cpu.util` |
+| CPU idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,idle]` |
+| CPU iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,iowait]` |
+| CPU steal time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,steal]` |
+| CPU system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,system]` |
+| CPU user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,all,user]` |
+| Memory utilization | CALCULATED | `sap.agent.mem.util` |
+| Available physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,available]` |
+| Free physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,free]` |
+| Total physical memory | Zabbix agent | `sap.agent.mem[<common_params>,phy,size]` |
+| Total virtual memory | Zabbix agent | `sap.agent.mem[<common_params>,virt,size]` |
+| Operating system name | Zabbix agent | `sap.agent.os.name[<common_params>]` |
+| Operating system version | Zabbix agent | `sap.agent.os.version[<common_params>]` |
+| SAP agent ping | Zabbix agent | `sap.agent.ping[<common_params>]` |
+| Swap-in bytes per second | Zabbix agent | `sap.agent.swap.in[<common_params>,bytes]` |
+| Swap-in pages per second | Zabbix agent | `sap.agent.swap.in[<common_params>,pages]` |
+| Swap-out bytes per second | Zabbix agent | `sap.agent.swap.out[<common_params>,bytes]` |
+| Swap-out pages per second | Zabbix agent | `sap.agent.swap.out[<common_params>,pages]` |
+| Free swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,free]` |
+| Total swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,total]` |
+| Used swap space | Zabbix agent | `sap.agent.swap.size[<common_params>,used]` |
+| Swap utilization | CALCULATED | `sap.agent.swap.util` |
+| Version of SAP agent running | Zabbix agent | `sap.agent.version[<common_params>]` |
+
+---
+
+## Discovery Rules
+
+### CPU discovery
+
+**Key**: `sap.agent.cpu.discovery[<common_params>]`  
+**Description**: Discovery of CPUs.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| CPU {#CPU.ID} utilization | DEPENDENT | `sap.agent.cpu.util["{#CPU.ID}]` |
+| CPU {#CPU.ID} idle time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},idle]` |
+| CPU {#CPU.ID} iowait time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},iowait]` |
+| CPU {#CPU.ID} system time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},system]` |
+| CPU {#CPU.ID} user time | Zabbix agent | `sap.agent.cpu.util[<common_params>,{#CPU.ID},user]` |
+
+### Block devices discovery
+
+**Key**: `sap.agent.dev.discovery[<common_params>]`  
+**Description**: Discovery of block devices.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Device {#DEVNAME}: IO rate | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},io]` |
+| Device {#DEVNAME}: Queue length | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},queue]` |
+| Device {#DEVNAME}: Service time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},svc]` |
+| Device {#DEVNAME}: Throughput | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},tput]` |
+| Device {#DEVNAME}: Utilization | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},util]` |
+| Device {#DEVNAME}: Wait time | Zabbix agent | `sap.agent.dev[<common_params>,{#DEVNAME},wait]` |
+
+### Mounted filesystem discovery
+
+**Key**: `sap.agent.fs.discovery[<common_params>]`  
+**Description**: Discovery of file systems of different types.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Filesystem {#FSNAME}: Free space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},free]` |
+| Filesystem {#FSNAME}: Total space | Zabbix agent | `sap.agent.fs.size[<common_params>,{#FSNAME},total]` |
+| Filesystem {#FSNAME}: Space utilization | CALCULATED | `sap.agent.fs.util["{#FSNAME}]` |
+
+### Network interface discovery
+
+**Key**: `sap.agent.net.discovery[<common_params>]`  
+**Description**: Discovery of network interfaces.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Interface {#IFNAME}: Incoming traffic | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Incoming errors | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Incoming packets | Zabbix agent | `sap.agent.net.in[<common_params>,{#IFNAME},packets]` |
+| Interface {#IFNAME}: Outgoing traffic | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},bytes]` |
+| Interface {#IFNAME}: Outgoing errors | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},errors]` |
+| Interface {#IFNAME}: Outgoing packets | Zabbix agent | `sap.agent.net.out[<common_params>,{#IFNAME},packets]` |
+
+### Process discovery
+
+**Key**: `sap.agent.proc.discovery[<common_params>]`  
+**Description**: Discovery of instance processes.
+
+| Item Prototype Name | Type | Key |
+| --- | --- | --- |
+| Process {#PROCESS.DESC}: Get info | Zabbix agent | `sap.agent.proc.get[<common_params>,{#INSTANCE.NAME},{#PROCESS.NAME}]` |
+| Process {#PROCESS.DESC} pid | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},pid]` |
+| Process {#PROCESS.DESC} start time | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},starttime]` |
+| Process {#PROCESS.DESC} status | DEPENDENT | `sap.agent.proc["{#INSTANCE.NAME},{#PROCESS.NAME},status]` |
+
+### SAP Database discovery
+
+**Key**: `sap.agent.db.discovery[<common_params>]`  
+**Description**: Discovery of all SAP databases running on the host. Returns a JSON array containing database discovery macros (`{#DB.NAME}`, `{#DB.PROTOCOL}`, `{#DB.HOST}` and `{#DB.PORT}`).
+
+No pre-defined item prototypes are included in this template, but this rule can be used to configure custom monitoring for each discovered database.
+
+---
+
+## Screenshots
+
+Below are standard visual layouts and dashboards generated by this template:
+
+* **Problems**: Triggers for processes and filesystems
+
+<img width="847" height="421" alt="problems" src="https://github.com/user-attachments/assets/e7109a08-f9a4-4d02-9b61-604c8d58d910" />
+
+* **System Performance**: Displays CPU usage, system load, memory and swap utilization.
+
+<img width="616" height="296" alt="cpuutil" src="https://github.com/user-attachments/assets/aeab6168-a44f-45c2-a973-b4fd0a8b1265" />
+<img width="671" height="296" alt="sysload" src="https://github.com/user-attachments/assets/5ef814dc-8286-4458-b2ea-fc89fb9c1948" />
+<img width="616" height="268" alt="memusage" src="https://github.com/user-attachments/assets/e404c22a-b214-4bd5-a6eb-ea6f815561ed" />
+<img width="616" height="268" alt="swapusage" src="https://github.com/user-attachments/assets/50414451-ee9a-4b0e-91a9-f1d7b5f55d34" />
+
+* **Block Devices**: Real-time visualization of disk utilization, queue length and IO rate per device.
+
+<img width="671" height="268" alt="diskutil" src="https://github.com/user-attachments/assets/0fd0e356-c5cd-4aec-84f1-6da081fa49ab" />
+<img width="671" height="282" alt="diskio" src="https://github.com/user-attachments/assets/62a0670a-5075-4a2a-ae05-f88b35fa84e8" />
+<img width="616" height="254" alt="diskthru" src="https://github.com/user-attachments/assets/a88a45c3-13cc-4c8e-b0aa-a561f4d879cd" />
+
+* **Network Interfaces**: Incoming/outgoing bandwidth utilization and packet rates.
+
+<img width="616" height="268" alt="nettraffic" src="https://github.com/user-attachments/assets/80b5948a-15ae-463d-9d73-9258713c5e09" />
+<img width="616" height="296" alt="netpackets" src="https://github.com/user-attachments/assets/b24107d2-f160-4857-83bb-8c37d1bdb676" />

--- a/Applications/Others/template_sap_host_agent/7.4/template_sap_host_agent.xml
+++ b/Applications/Others/template_sap_host_agent/7.4/template_sap_host_agent.xml
@@ -1,0 +1,1873 @@
+<zabbix_export>
+  <version>7.4</version>
+  <template_groups>
+    <template_group>
+      <uuid>a571c0d144b14fd4a87a9d9b2aa9fcd6</uuid>
+      <name>Templates/Applications</name>
+    </template_group>
+  </template_groups>
+  <templates>
+    <template>
+      <uuid>bcecec7d7a494dd995c45768057d4b43</uuid>
+      <template>Template SAP Host Agent by Zabbix agent 2</template>
+      <name>Template SAP Host Agent by Zabbix agent 2</name>
+      <description>Version: 8-36e3d05</description>
+      <groups>
+        <group>
+          <name>Templates/Applications</name>
+        </group>
+      </groups>
+      <items>
+        <item>
+          <uuid>b38fcdb6eb464c80bde1461a031afbc7</uuid>
+          <name>Interrupts per second</name>
+          <key>sap.agent.cpu.intr["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a2d335b4eef247b7abb06e3f90b13cdd</uuid>
+          <name>Load average (1m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1bd363e79a18490482e98334435eea7c</uuid>
+          <name>Load average (5m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c70c2e2ace0f455c8a241951cbcdf877</uuid>
+          <name>Load average (15m avg)</name>
+          <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f0bbe4be7e974dd49a05ea9ee6c95752</uuid>
+          <name>Number of CPUs</name>
+          <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bb00db5dc9fa411a96ec27fc9777ec62</uuid>
+          <name>Context switches per second</name>
+          <key>sap.agent.cpu.switches["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>sps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5064eead91d042aca0643d8e4fe7a13d</uuid>
+          <name>CPU utilization</name>
+          <type>DEPENDENT</type>
+          <key>sap.agent.cpu.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <description>CPU utilization in %.</description>
+          <preprocessing>
+            <step>
+              <type>JAVASCRIPT</type>
+              <parameters>
+                <parameter>//Calculate utilization
+return (100 - value)</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <master_item>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          </master_item>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>9e4a461766774602b087971817a26853</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.util,5m)&gt;{$CPU.UTIL.CRIT}</expression>
+              <name>High CPU utilization (over {$CPU.UTIL.CRIT}% for 5m)</name>
+              <opdata>Current utilization: {ITEM.LASTVALUE1}</opdata>
+              <priority>WARNING</priority>
+              <description>CPU utilization is too high. The system might be slow to respond.</description>
+              <dependencies>
+                <dependency>
+                  <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>43fa692269324ff7895c0746d66d0ea3</uuid>
+          <name>CPU idle time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","idle"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>d9cc089714a0457388558c7b803040ff</uuid>
+          <name>CPU iowait time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>c9e264a4ea4d418abf4b9b745685c435</uuid>
+          <name>CPU steal time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1259e4d32fa2405b971b696ea1f6dae5</uuid>
+          <name>CPU system time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f39da36a50564dc19bc54e3302dc27f8</uuid>
+          <name>CPU user time</name>
+          <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>CPU</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>7f7c090809b3426681d62a5d9f532306</uuid>
+          <name>Memory utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.mem.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]) / last(//sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>377658ded81c4580b6c7d7105a0bf64c</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem.util,5m)&gt;{$MEMORY.UTIL.MAX}</expression>
+              <name>High memory utilization (&gt;{$MEMORY.UTIL.MAX}% for 5m)</name>
+              <priority>AVERAGE</priority>
+              <description>The system is running out of free memory.</description>
+              <dependencies>
+                <dependency>
+                  <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+                  <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+                </dependency>
+              </dependencies>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>9252bce6c9294c2e88ccf7e0dbcf3bde</uuid>
+          <name>Available physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>731d63fd55084cdb8951fdc5422bfcff</uuid>
+          <name>Free physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>bef0fbf41aa3469684d1b3d1d47afa8f</uuid>
+          <name>Total physical memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>a7d1a71a1a7b46a293604a6b44b4c8fe</uuid>
+          <name>Total virtual memory</name>
+          <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","virt","size"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f1a2abfdc14e4c80a56a555dc017a882</uuid>
+          <name>Operating system name</name>
+          <key>sap.agent.os.name["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>e51be36494c2472ab68cac0d1af3cc4a</uuid>
+          <name>Operating system version</name>
+          <key>sap.agent.os.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1d</delay>
+          <history>7d</history>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Operating system</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>46a198c67ccd47d69d3ca5508623dacc</uuid>
+          <name>SAP agent ping</name>
+          <key>sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <valuemap>
+            <name>Service state</name>
+          </valuemap>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+          <triggers>
+            <trigger>
+              <uuid>5c4d2858a04347298a0420a894a0e98d</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.ping["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])=0</expression>
+              <name>SAP agent is unreachable</name>
+              <priority>AVERAGE</priority>
+            </trigger>
+          </triggers>
+        </item>
+        <item>
+          <uuid>f1e3e6eca35f48fab00c9b69b4dd8131</uuid>
+          <name>Swap-in bytes per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>82d8c82d98cc4ea0ac7f422e6c5f286d</uuid>
+          <name>Swap-in pages per second</name>
+          <key>sap.agent.swap.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>b3223cb8189d4f4681ff2eff291f39d6</uuid>
+          <name>Swap-out bytes per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","bytes"]</key>
+          <history>7d</history>
+          <units>Bps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>5db104cbcec54da5b09843c262958f2e</uuid>
+          <name>Swap-out pages per second</name>
+          <key>sap.agent.swap.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","pages"]</key>
+          <history>7d</history>
+          <units>pps</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>1d20e12ef81647feb041434698a798e9</uuid>
+          <name>Free swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>f967228dd57d4645811381b25fd75b80</uuid>
+          <name>Total swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>ecdf4fecceb549458c041f5b7f2e257d</uuid>
+          <name>Used swap space</name>
+          <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          <history>7d</history>
+          <units>B</units>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>9640358636f04b9a9e61ebb0c1d365cd</uuid>
+          <name>Swap utilization</name>
+          <type>CALCULATED</type>
+          <key>sap.agent.swap.util</key>
+          <history>7d</history>
+          <value_type>FLOAT</value_type>
+          <units>%</units>
+          <params>(1 - last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","free"]) / last(//sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])) * 100</params>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Memory</value>
+            </tag>
+          </tags>
+        </item>
+        <item>
+          <uuid>8875ea6208cc4776a08084d43a16bf0d</uuid>
+          <name>Version of SAP agent running</name>
+          <key>sap.agent.version["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <history>7d</history>
+          <value_type>CHAR</value_type>
+          <preprocessing>
+            <step>
+              <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+              <parameters>
+                <parameter>1d</parameter>
+              </parameters>
+            </step>
+          </preprocessing>
+          <tags>
+            <tag>
+              <tag>Application</tag>
+              <value>Monitoring agent</value>
+            </tag>
+          </tags>
+        </item>
+      </items>
+      <discovery_rules>
+        <discovery_rule>
+          <uuid>300062a6d59f4c3a9bbcbb1f022f82ee</uuid>
+          <name>CPU discovery</name>
+          <key>sap.agent.cpu.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of CPUs.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>48125cd76ccb4df086cca7608f4d06e2</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <preprocessing>
+                <step>
+                  <type>JAVASCRIPT</type>
+                  <parameters>
+                    <parameter>//Calculate utilization
+return (100 - value)</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>9361f5fef88d4372949ac069515b6e89</uuid>
+              <name>CPU {#CPU.ID} idle time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","idle"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4af8b69ef96145898f77d873b3cba423</uuid>
+              <name>CPU {#CPU.ID} iowait time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5595b2dbfb9843f293770972ea1aaa0d</uuid>
+              <name>CPU {#CPU.ID} system time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>afccff22b07c437aa71320015b159405</uuid>
+              <name>CPU {#CPU.ID} user time</name>
+              <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>CPU {#CPU.ID}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>ccf335d326f44658be124463890012b3</uuid>
+              <name>CPU {#CPU.ID} usage</name>
+              <type>STACKED</type>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","user"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","system"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#CPU.ID}","iowait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>fa5c92dbff2b45df978b79c4095ac23b</uuid>
+              <name>CPU {#CPU.ID} utilization</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <ymax_type_1>FIXED</ymax_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.cpu.util["{#CPU.ID}"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>846f9b13aeea41ac9ab6327674ead1d0</uuid>
+          <name>Block devices discovery</name>
+          <key>sap.agent.dev.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of block devices.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>d8e6cb5e31d34a67905c4a7aa40affaa</uuid>
+              <name>Device {#DEVNAME}: IO rate</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>!io/s</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>4b36092e28b4483bb3d92261150cf212</uuid>
+              <name>Device {#DEVNAME}: Queue length</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ba34c528fc644a688338588e7f5852d7</uuid>
+              <name>Device {#DEVNAME}: Service time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b53817901b0f4453982fa5d664c2d21a</uuid>
+              <name>Device {#DEVNAME}: Throughput</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ab4a897513a6413892d1a2bebc658b42</uuid>
+              <name>Device {#DEVNAME}: Utilization</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>f59bf6edb66c4a09a70c30ccb118f7dc</uuid>
+              <name>Device {#DEVNAME}: Wait time</name>
+              <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>s</units>
+              <preprocessing>
+                <step>
+                  <type>MULTIPLIER</type>
+                  <parameters>
+                    <parameter>0.001</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Block devices</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Disk {#DEVNAME}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>c16718f216654b08aa7c400c0219a64b</uuid>
+                  <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"],15m) &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"}</expression>
+                  <name>{#DEVNAME}: Disk wait time is too high (wait &gt; {$VFS.DEV.AWAIT.WARN:"{#DEVNAME}"} ms for 15m)</name>
+                  <priority>WARNING</priority>
+                  <description>This trigger might indicate disk {#DEVNAME} saturation.</description>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>0939d82652154db7a27979c7379a5421</uuid>
+              <name>Device {#DEVNAME}: Disk IO rate</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","io"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63100</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","svc"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","wait"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>335087f8dfd047ddb3cc7f4e4d862fcd</uuid>
+              <name>Device {#DEVNAME}: Disk throughput</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","tput"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>e2974723a6384fb0b2b29ed891dff025</uuid>
+              <name>Device {#DEVNAME}: Disk utilization and queue</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <yaxisside>RIGHT</yaxisside>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","queue"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.dev["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#DEVNAME}","util"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>bddd317b5a384816a695fb7053b48f49</uuid>
+          <name>Mounted filesystem discovery</name>
+          <key>sap.agent.fs.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of file systems of different types.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>b15be907c36440cab3225534a5d0ad1f</uuid>
+              <name>Filesystem {#FSNAME}: Free space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>5d68aff2f769468eb057fcea2cfea511</uuid>
+              <name>Filesystem {#FSNAME}: Total space</name>
+              <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+              <history>7d</history>
+              <units>B</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>2b8f6969bd294a219ca05dddd11cdecb</uuid>
+              <name>Filesystem {#FSNAME}: Space utilization</name>
+              <type>CALCULATED</type>
+              <key>sap.agent.fs.util["{#FSNAME}"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>%</units>
+              <params>100*(last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])-last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]))/last(//sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"])</params>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystems</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Filesystem {#FSNAME}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>53a22cae29a943379436356c43811994</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>AVERAGE</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+            <trigger_prototype>
+              <uuid>e506eaddd3da4c9e94f69d0010e266e8</uuid>
+              <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+              <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%)</name>
+              <opdata>Space free: {ITEM.LASTVALUE2} ({ITEM.LASTVALUE1})</opdata>
+              <priority>WARNING</priority>
+              <description>Two conditions should match: First, space utilization should be above {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}.
+ Second condition should be one of the following:
+ - The disk free space is less than {$VFS.FS.FREE.MIN.WARN:"{#FSNAME}"}.
+ - The disk will be full in less than 24 hours.</description>
+              <manual_close>YES</manual_close>
+              <dependencies>
+                <dependency>
+                  <name>{#FSNAME}: Filesystem space is low (used &gt; {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%)</name>
+                  <expression>last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"])&gt;{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"} and
+(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"])&lt;{$VFS.FS.FREE.MIN.CRIT:"{#FSNAME}"} or timeleft(/Template SAP Host Agent by Zabbix agent 2/sap.agent.fs.util["{#FSNAME}"],1h,100)&lt;1d)</expression>
+                </dependency>
+              </dependencies>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>f924384a8fb84b0ea22a3a92a792a31c</uuid>
+              <name>{#FSNAME}: Filesystem space usage</name>
+              <ymin_type_1>FIXED</ymin_type_1>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","total"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>F63131</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.fs.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#FSNAME}","free"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>9bd171f82bdc4a488c8951cb9a88eb01</uuid>
+          <name>Network interface discovery</name>
+          <key>sap.agent.net.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of network interfaces.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>e4033b992d7c4a81a65fa2d680160722</uuid>
+              <name>Interface {#IFNAME}: Incoming traffic</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>96d6761c118a47edb252068a3b53f210</uuid>
+              <name>Interface {#IFNAME}: Incoming errors</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>faa96f2518ae4c5690e250580334fb47</uuid>
+              <name>Interface {#IFNAME}: Incoming packets</name>
+              <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>da877eba0133413f991b29118a793a6b</uuid>
+              <name>Interface {#IFNAME}: Outgoing traffic</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <units>bps</units>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>b6b00c9090ef4050ae1eac0809662e15</uuid>
+              <name>Interface {#IFNAME}: Outgoing errors</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>ca5118209e5146f09d06353d2581e43e</uuid>
+              <name>Interface {#IFNAME}: Outgoing packets</name>
+              <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+              <history>7d</history>
+              <value_type>FLOAT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Interface {#IFNAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Network interfaces</value>
+                </tag>
+              </tags>
+            </item_prototype>
+          </item_prototypes>
+          <trigger_prototypes>
+            <trigger_prototype>
+              <uuid>a1c0eb431fc84e92996647173716fd1f</uuid>
+              <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}
+or min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&gt;{$IF.ERRORS.WARN:"{#IFNAME}"}</expression>
+              <recovery_mode>RECOVERY_EXPRESSION</recovery_mode>
+              <recovery_expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8
+and max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"],5m)&lt;{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8</recovery_expression>
+              <name>Interface {#IFNAME}: High error rate (&gt;{$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)</name>
+              <opdata>errors in: {ITEM.LASTVALUE1}, errors out: {ITEM.LASTVALUE2}</opdata>
+              <priority>WARNING</priority>
+              <description>Recovers when below 80% of {$IF.ERRORS.WARN:"{#IFNAME}"} threshold</description>
+              <manual_close>YES</manual_close>
+            </trigger_prototype>
+          </trigger_prototypes>
+          <graph_prototypes>
+            <graph_prototype>
+              <uuid>c5155ce8c4e14f7997e253f01944ece4</uuid>
+              <name>Interface {#IFNAME}: Network packets</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","packets"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>3</sortorder>
+                  <color>F63100</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>4</sortorder>
+                  <color>A54F10</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","errors"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+            <graph_prototype>
+              <uuid>c779f37d42da4e5ca2f45fac5a35a045</uuid>
+              <name>Interface {#IFNAME}: Network traffic</name>
+              <graph_items>
+                <graph_item>
+                  <sortorder>1</sortorder>
+                  <drawtype>GRADIENT_LINE</drawtype>
+                  <color>1A7C11</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.in["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+                <graph_item>
+                  <sortorder>2</sortorder>
+                  <drawtype>BOLD_LINE</drawtype>
+                  <color>2774A4</color>
+                  <item>
+                    <host>Template SAP Host Agent by Zabbix agent 2</host>
+                    <key>sap.agent.net.out["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#IFNAME}","bytes"]</key>
+                  </item>
+                </graph_item>
+              </graph_items>
+            </graph_prototype>
+          </graph_prototypes>
+        </discovery_rule>
+        <discovery_rule>
+          <uuid>b18af0d372f34b13b4c43cc73b1edaa5</uuid>
+          <name>Process discovery</name>
+          <key>sap.agent.proc.discovery["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          <delay>1h</delay>
+          <lifetime>30d</lifetime>
+          <enabled_lifetime_type>DISABLE_NEVER</enabled_lifetime_type>
+          <description>Discovery of instance processes.</description>
+          <item_prototypes>
+            <item_prototype>
+              <uuid>982ad677f38548c6af3b57efaa3944fc</uuid>
+              <name>Process {#PROCESS.DESC}: Get info</name>
+              <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              <history>0</history>
+              <value_type>TEXT</value_type>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>825ff9efabbb409f909a42205d070805</uuid>
+              <name>Process {#PROCESS.DESC} pid</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"]</key>
+              <history>7d</history>
+              <trends>0</trends>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.pid</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>5ba3199ecc3f4eea8994ec3ddb2fb71c</uuid>
+                  <expression>(last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#1)&lt;&gt;last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","pid"],#2))&gt;0</expression>
+                  <name>Process {#PROCESS.DESC} has been restarted</name>
+                  <priority>INFO</priority>
+                  <manual_close>YES</manual_close>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+            <item_prototype>
+              <uuid>c7bdd2e4cc8c470d8fa3a0a42bbcaced</uuid>
+              <name>Process {#PROCESS.DESC} start time</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","starttime"]</key>
+              <history>7d</history>
+              <value_type>CHAR</value_type>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.starttime</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+            </item_prototype>
+            <item_prototype>
+              <uuid>83a838d9f126419a8ad25cef054c1b72</uuid>
+              <name>Process {#PROCESS.DESC} status</name>
+              <type>DEPENDENT</type>
+              <key>sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"]</key>
+              <history>7d</history>
+              <value_type>CHAR</value_type>
+              <preprocessing>
+                <step>
+                  <type>JSONPATH</type>
+                  <parameters>
+                    <parameter>$.textstatus</parameter>
+                  </parameters>
+                </step>
+                <step>
+                  <type>DISCARD_UNCHANGED_HEARTBEAT</type>
+                  <parameters>
+                    <parameter>1h</parameter>
+                  </parameters>
+                </step>
+              </preprocessing>
+              <master_item>
+                <key>sap.agent.proc.get["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","{#INSTANCE.NAME}","{#PROCESS.NAME}"]</key>
+              </master_item>
+              <tags>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Instance {#INSTANCE.NAME}</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Processes</value>
+                </tag>
+                <tag>
+                  <tag>Application</tag>
+                  <value>Process {#PROCESS.DESC}</value>
+                </tag>
+              </tags>
+              <trigger_prototypes>
+                <trigger_prototype>
+                  <uuid>b2e718cdb5394437b59bbbef3a9646be</uuid>
+                  <expression>find(/Template SAP Host Agent by Zabbix agent 2/sap.agent.proc["{#INSTANCE.NAME}","{#PROCESS.NAME}","status"],,"regexp","^Running$")=0</expression>
+                  <name>Process {#PROCESS.DESC}: Unexpected status</name>
+                  <opdata>Current status: {ITEM.LASTVALUE1}</opdata>
+                  <priority>HIGH</priority>
+                </trigger_prototype>
+              </trigger_prototypes>
+            </item_prototype>
+          </item_prototypes>
+        </discovery_rule>
+      </discovery_rules>
+      <macros>
+        <macro>
+          <macro>{$CPU.UTIL.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$IF.ERRORS.WARN}</macro>
+          <value>2</value>
+        </macro>
+        <macro>
+          <macro>{$LOAD_AVG_PER_CPU.MAX.WARN}</macro>
+          <value>1.5</value>
+          <description>Load per CPU considered sustainable.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.AVAILABLE.MIN}</macro>
+          <value>20M</value>
+          <description>The warning threshold of the available memory.</description>
+        </macro>
+        <macro>
+          <macro>{$MEMORY.UTIL.MAX}</macro>
+          <value>90</value>
+          <description>The warning threshold of the memory utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.PASSWORD}</macro>
+          <type>SECRET_TEXT</type>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.URI}</macro>
+          <value>http://localhost:1128</value>
+        </macro>
+        <macro>
+          <macro>{$SAP.AGENT.USER}</macro>
+          <value>sapadm</value>
+        </macro>
+        <macro>
+          <macro>{$SWAP.PFREE.MIN.WARN}</macro>
+          <value>50</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.DEV.AWAIT.WARN}</macro>
+          <value>20</value>
+          <description>Disk average wait time (in ms) before the trigger would fire</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.CRIT}</macro>
+          <value>5G</value>
+          <description>The critical threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.FREE.MIN.WARN}</macro>
+          <value>10G</value>
+          <description>The warning threshold of the filesystem utilization.</description>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.CRIT}</macro>
+          <value>90</value>
+        </macro>
+        <macro>
+          <macro>{$VFS.FS.PUSED.MAX.WARN}</macro>
+          <value>80</value>
+        </macro>
+      </macros>
+      <dashboards>
+        <dashboard>
+          <uuid>53e533040c1b4d83bea057509dd5b2cd</uuid>
+          <name>Block devices</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>graphprototype</type>
+                  <width>24</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk utilization and queue</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKV</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graphprototype</type>
+                  <x>24</x>
+                  <width>24</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk IO rate</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKW</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graphprototype</type>
+                  <x>48</x>
+                  <width>24</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Device {#DEVNAME}: Disk throughput</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKX</value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>72ca7e79acb54b968222424995eb35b4</uuid>
+          <name>Network interfaces</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>graphprototype</type>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Interface {#IFNAME}: Network traffic</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKY</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graphprototype</type>
+                  <x>36</x>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>INTEGER</type>
+                      <name>columns</name>
+                      <value>1</value>
+                    </field>
+                    <field>
+                      <type>GRAPH_PROTOTYPE</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Interface {#IFNAME}: Network packets</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAAKZ</value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+        <dashboard>
+          <uuid>903c4a9c190e44a49b3c8075e37795c7</uuid>
+          <name>System performance</name>
+          <pages>
+            <page>
+              <widgets>
+                <widget>
+                  <type>graph</type>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>System load</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAALA</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graph</type>
+                  <y>5</y>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Memory usage</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAALC</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graph</type>
+                  <x>36</x>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>CPU usage</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAALB</value>
+                    </field>
+                  </fields>
+                </widget>
+                <widget>
+                  <type>graph</type>
+                  <x>36</x>
+                  <y>5</y>
+                  <width>36</width>
+                  <height>5</height>
+                  <fields>
+                    <field>
+                      <type>GRAPH</type>
+                      <name>graphid</name>
+                      <value>
+                        <host>Template SAP Host Agent by Zabbix agent 2</host>
+                        <name>Swap usage</name>
+                      </value>
+                    </field>
+                    <field>
+                      <type>STRING</type>
+                      <name>reference</name>
+                      <value>AAALD</value>
+                    </field>
+                  </fields>
+                </widget>
+              </widgets>
+            </page>
+          </pages>
+        </dashboard>
+      </dashboards>
+      <valuemaps>
+        <valuemap>
+          <uuid>33feeafd9e2a4fe9950ee35198ccba02</uuid>
+          <name>Service state</name>
+          <mappings>
+            <mapping>
+              <value>0</value>
+              <newvalue>Down</newvalue>
+            </mapping>
+            <mapping>
+              <value>1</value>
+              <newvalue>Up</newvalue>
+            </mapping>
+          </mappings>
+        </valuemap>
+      </valuemaps>
+    </template>
+  </templates>
+  <triggers>
+    <trigger>
+      <uuid>0eb022f5eb694feb9b2da1ffd58312e4</uuid>
+      <expression>100 - max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.util,5m)&lt;{$SWAP.PFREE.MIN.WARN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"])&gt;0</expression>
+      <name>High swap space usage (less than {$SWAP.PFREE.MIN.WARN}% free)</name>
+      <opdata>Free: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>WARNING</priority>
+      <description>This trigger is ignored, if there is no swap configured.</description>
+    </trigger>
+    <trigger>
+      <uuid>a9fea933fb46485aa18381402db46299</uuid>
+      <expression>max(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"],5m)&lt;{$MEMORY.AVAILABLE.MIN} and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"])&gt;0</expression>
+      <name>Lack of available memory (&lt;{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})</name>
+      <opdata>Available: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+    </trigger>
+    <trigger>
+      <uuid>bb1df76871fa447ba9c8cc7598275c2e</uuid>
+      <expression>min(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"],5m)/last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"])&gt;{$LOAD_AVG_PER_CPU.MAX.WARN}
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"])&gt;0
+and last(/Template SAP Host Agent by Zabbix agent 2/sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"])&gt;0</expression>
+      <name>Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)</name>
+      <opdata>Load averages(1m 5m 15m): ({ITEM.LASTVALUE1} {ITEM.LASTVALUE3} {ITEM.LASTVALUE4}), # of CPUs: {ITEM.LASTVALUE2}</opdata>
+      <priority>AVERAGE</priority>
+      <description>Per CPU load average is too high. Your system may be slow to respond.</description>
+    </trigger>
+  </triggers>
+  <graphs>
+    <graph>
+      <uuid>b30f986eac8345dea04d8351a6945459</uuid>
+      <name>CPU usage</name>
+      <type>STACKED</type>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","system"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","user"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>A54F10</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","iowait"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>FC6EA3</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","all","steal"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>ff15c2bb38664127a34399fc05ed460a</uuid>
+      <name>CPU utilization</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <ymax_type_1>FIXED</ymax_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.util</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>1e571d14c7c44bbcbfbb58d48969d487</uuid>
+      <name>Memory usage</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <drawtype>BOLD_LINE</drawtype>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","size"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <drawtype>GRADIENT_LINE</drawtype>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.mem["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","phy","available"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>38242ed637884247ac7806847878e50d</uuid>
+      <name>Swap usage</name>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>F63131</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","used"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.swap.size["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","total"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+    <graph>
+      <uuid>b64e8d50de4b426a84a11e0e66208d5f</uuid>
+      <name>System load</name>
+      <ymin_type_1>FIXED</ymin_type_1>
+      <graph_items>
+        <graph_item>
+          <sortorder>1</sortorder>
+          <color>1A7C11</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg1"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>2</sortorder>
+          <color>2774A4</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg5"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>3</sortorder>
+          <color>F63100</color>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.load["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}","avg15"]</key>
+          </item>
+        </graph_item>
+        <graph_item>
+          <sortorder>4</sortorder>
+          <color>A54F10</color>
+          <yaxisside>RIGHT</yaxisside>
+          <item>
+            <host>Template SAP Host Agent by Zabbix agent 2</host>
+            <key>sap.agent.cpu.num["{$SAP.AGENT.URI}","{$SAP.AGENT.USER}","{$SAP.AGENT.PASSWORD}"]</key>
+          </item>
+        </graph_item>
+      </graph_items>
+    </graph>
+  </graphs>
+</zabbix_export>

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ This repository is dedicated to templates that are created and maintained by Zab
         * [OKTA AD Agent Healthcheck](Applications/Others/template_okta_ad_agent_status)
         * [OpenVPN](Applications/Others/template_openvpn_for_thevpncompany)
         * [SAP Availability Linux](Applications/Others/template_sap_process)
+        * [SAP Host Agent](Applications/Others/template_sap_host_agent)
         * [App TACACS Service](Applications/Others/template_tacacs_service)
         * [App WireGuard](Applications/Others/template_wireguard_vpn)
         * [App Zookeeper](Applications/Others/template_zabbix_zookeper)


### PR DESCRIPTION
Currently, the official [Zabbix SAP Integration](https://www.zabbix.com/integrations/sap) page lists three projects but two of them are missing required scripts and external files, making them unusable. This has led to multiple community issues from users looking for a working solution: https://github.com/zabbix/community-templates/issues/146 https://github.com/zabbix/community-templates/issues/187 https://github.com/zabbix/community-templates/issues/619

This PR introduces a new SAP template to help address this gap in the Zabbix monitoring ecosystem.

I have included template versions from 5.0 onwards. If the maintainers feel that supporting all of these older versions is unnecessary, I am happy to drop them and only keep the recent ones.

I have also updated the main README.md file to link this new template for better discoverability.