### PR TITLE
Fix Synology service graph rendering with zero users

### DIFF
--- a/Storage_Devices/Synology/template_synology_diskstation_snmpv3/7.4/template_synology_diskstation_snmpv3.yaml
+++ b/Storage_Devices/Synology/template_synology_diskstation_snmpv3/7.4/template_synology_diskstation_snmpv3.yaml
@@ -1098,14 +1098,6 @@ zabbix_export:
             - uuid: 2d68532bbb1745bb8a21e0b967f38f36
               name: 'Service: {#SNMPVALUE} Users'
               show_triggers: 'NO'
-              ymin_type_1: ITEM
-              ymin_item_1:
-                host: 'Synology DiskStation by SNMP'
-                key: 'synologyService.serviceTable.serviceEntry.serviceUsers.[{#SNMPINDEX}]'
-              ymax_type_1: ITEM
-              ymax_item_1:
-                host: 'Synology DiskStation by SNMP'
-                key: 'synologyService.serviceTable.serviceEntry.serviceUsers.[{#SNMPINDEX}]'
               graph_items:
                 - color: 0000EE
                   calc_fnc: ALL


### PR DESCRIPTION
## Summary

- remove item-derived minimum and maximum axes from the Synology service-user graph prototype
- allow Zabbix automatic scaling to handle services with zero connected users
- preserve the graph UUID, discovery rule, item prototype, and graph item

## Validation

- the expected graph prototype block occurs exactly once in the pinned 7.4 template
- the replacement removes only the item-derived axis configuration
- the resulting template retains automatic graph scaling

Fixes #662