### PR TITLE
Add OPNsense firmware and WireGuard monitoring

### DIFF
--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -106,7 +106,7 @@ on the firewall.
 | Used Memory | `opns.memory.used` | Dependent | – | Used memory in bytes. |
 | ARC Memory | `opns.memory.arc` | Dependent | – | ZFS ARC memory usage in bytes. |
 | Memory utilization in % | `opns.memory.util` | Calculated | – | Percentage of used memory relative to total memory. |
-| Licensed until | `opns.product.licenseuntil` | Dependent | – | OPNsense Business Edition license expiry (Unix timestamp). Returns `no license` if not present. |
+| Licensed until | `opns.product.licenseuntil` | Dependent | – | OPNsense Business Edition license expiry (Unix timestamp). Returns `0` if not present. |
 
 ### Firewall Items
 

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -247,9 +247,9 @@ items and discovery rules.
 
 | Name | Severity | Description |
 |------|----------|-------------|
-| Gateway {#GWSTATUSNAME} Packet loss | **Average** | Packet loss > `{$OPNS.GW.MIN.PACKET.LOSS}` % for 5 min. |
-| Gateway {#GWSTATUSNAME} High packet loss | **High** | Packet loss > `{$OPNS.GW.HIGH.PACKET.LOSS}` % for 5 min. |
-| Gateway {#GWSTATUSNAME} is down | **Disaster** | Packet loss > 99% for 5 min. |
+| Gateway {#GWSTATUSNAME} Packet loss | **Average** | Packet loss > `{$OPNS.GW.MIN.PACKET.LOSS}` % for 5 min. Ignores the `9999` sentinel used when monitoring is disabled. |
+| Gateway {#GWSTATUSNAME} High packet loss | **High** | Packet loss > `{$OPNS.GW.HIGH.PACKET.LOSS}` % for 5 min. Ignores the `9999` sentinel used when monitoring is disabled. |
+| Gateway {#GWSTATUSNAME} is down | **Disaster** | Packet loss > 99% for 5 min. Ignores the `9999` sentinel used when monitoring is disabled. |
 | Gateway Monitoring on {#GWSTATUSNAME} is disabled | **Average** | All monitoring values return 9999 – gateway monitoring is not enabled in OPNsense. |
 
 ---

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -4,8 +4,8 @@
 
 This template monitors OPNsense firewalls via the built-in REST API using HTTP JSON agent requests.
 It collects data about system resources (CPU, memory, disk, uptime), firewall states and actions,
-gateway health, network interfaces, CARP high-availability status, and UPS status via NUT
-(Network UPS Tools).
+gateway health, network interfaces, CARP high-availability status, WireGuard peers, and UPS status
+via NUT (Network UPS Tools).
 
 The template uses OPNsense API key/secret authentication and requires no agent installation
 on the firewall.
@@ -27,6 +27,7 @@ on the firewall.
   - `core/firmware`
   - `nut/diagnostics`
   - `ipsec/sessions/searchPhase(1|2)` 
+  - `wireguard/service/show`
   
 ### Permissions
 
@@ -40,6 +41,7 @@ on the firewall.
 | page-system-gateways                   | System: Gateways                          |
 | page-system-login-logout               | Lobby: Dashboard                          |
 | page-status-ipsec | Status: IPsec |
+| page-wireguard-diagnostics | VPN: WireGuard: Status |
 
 
 
@@ -69,6 +71,7 @@ on the firewall.
    - Enable the item `RAW UPS` on the host if a UPS is connected and managed by NUT on OPNsense
    - See the [UPS Monitoring](#ups-monitoring-nut) section below for details
 
+
 > **Note:** The Zabbix server/proxy must trust the OPNsense TLS certificate, or Zabbix must be
 > configured to skip certificate verification for HTTP agent items.
 
@@ -93,6 +96,10 @@ on the firewall.
 | `{$OPNS.NUT.BAT.LOW}` | `30` | Battery charge (%) below which a warning is triggered. |
 | `{$OPNS.NUT.BAT.RUNTIME}` | `600` | Remaining battery runtime (seconds) below which an alert is triggered. |
 | `{$OPNS.NUT.HIGH.LOAD}` | `80` | UPS load (%) above which a warning is triggered. |
+| `{$OPNS.WG.INSTANCE.MATCHES}` | `.+` | Regex filter for WireGuard instances to discover. |
+| `{$OPNS.WG.INSTANCE.NOT_MATCHES}` | `^$` | Regex filter for WireGuard instances to exclude from discovery. |
+| `{$OPNS.WG.PEER.MATCHES}` | `.+` | Regex filter for WireGuard peers to discover. |
+| `{$OPNS.WG.PEER.NOT_MATCHES}` | `^$` | Regex filter for WireGuard peers to exclude from discovery. |
 
 ## Items Collected
 
@@ -170,6 +177,7 @@ items and discovery rules.
 | RAW Carp Interfaces | `opns.raw.interfaces.carp` | 1m | `/api/diagnostics/interface/get_vip_status` |
 | RAW Product Info | `opns.raw.product.info` | 30m | `/api/core/firmware/info` |
 | RAW UPS | `opns.ups.raw` | 5m | `/api/nut/diagnostics/upsstatus` *(disabled by default)* |
+| RAW WireGuard | `opns.wireguard.raw` | 1m | `/api/wireguard/service/show` |
 
 ## Triggers
 
@@ -193,6 +201,13 @@ items and discovery rules.
 | High Load on UPS Battery | **Average** | UPS load exceeds `{$OPNS.NUT.HIGH.LOAD}` % (default: 80%). |
 | Battery charge is below {$OPNS.NUT.BAT.LOW} | **Warning** | Battery charge is below `{$OPNS.NUT.BAT.LOW}` % (default: 30%). |
 | Remaining battery runtime is low | **High** | Estimated runtime is below `{$OPNS.NUT.BAT.RUNTIME}` seconds (default: 600s / 10 min). |
+
+### WireGuard Triggers
+
+| Name | Severity | Description |
+|------|----------|-------------|
+| WireGuard instance {#WG.INSTANCE} is down | **High** | Instance status has not been `up` for 5 minutes. |
+| WireGuard peer {#WG.NAME} is not online | **High** | Peer status has not been `online` for 5 minutes. OPNsense marks peers online when the latest handshake is not older than 300 seconds. |
 
 ## Discovery Rules
 
@@ -342,6 +357,63 @@ items and discovery rules.
 | …blocked packets OUTv4 | `opns.interface.fw.packets.blockout.v4[{#OPNS.INTERFACE.DEVICE}]` | – |
 | …passed packets INv4 | `opns.interface.fw.packets.passin.v4[{#OPNS.INTERFACE.DEVICE}]` | – |
 | …passed packets OUTv4 | `opns.interface.fw.packets.passout.v4[{#OPNS.INTERFACE.DEVICE}]` | – |
+
+---
+
+### 6. WireGuard Instance Discovery
+
+| Property | Value |
+|----------|-------|
+| Key | `opns.wireguard.instance.discovery` |
+| Type | Dependent (master: `opns.wireguard.raw`) |
+| LLD Macros | `{#WG.IF}` → `$.if`, `{#WG.INSTANCE}` → `$.name` |
+| Filters | `{#WG.INSTANCE}` configurable via `{$OPNS.WG.INSTANCE.MATCHES}` and `{$OPNS.WG.INSTANCE.NOT_MATCHES}` |
+| Keep lost resources | 1h |
+
+**Item Prototypes:**
+
+| Name | Key | Unit | Description |
+|------|-----|------|-------------|
+| WireGuard instance {#WG.INSTANCE}: status | `opns.wireguard.instance.status[{#WG.IF}]` | – | Interface status reported by OPNsense (`up` or `down`). |
+| WireGuard instance {#WG.INSTANCE}: listen port | `opns.wireguard.instance.listen_port[{#WG.IF}]` | – | WireGuard listen port. |
+| WireGuard instance {#WG.INSTANCE}: public key | `opns.wireguard.instance.public_key[{#WG.IF}]` | – | Instance public key. |
+
+**Trigger Prototypes:**
+
+| Name | Severity | Description |
+|------|----------|-------------|
+| WireGuard instance {#WG.INSTANCE} is down | **High** | Instance status has not been `up` for 5 minutes. |
+
+---
+
+### 7. WireGuard Peer Discovery
+
+| Property | Value |
+|----------|-------|
+| Key | `opns.wireguard.peer.discovery` |
+| Type | Dependent (master: `opns.wireguard.raw`) |
+| LLD Macros | `{#WG.PUBKEY}` → `$.public_key`, `{#WG.NAME}` → `$.name`, `{#WG.IF}` → `$.if`, `{#WG.IFNAME}` → `$.ifname` |
+| Filters | `{#WG.NAME}` configurable via `{$OPNS.WG.PEER.MATCHES}` and `{$OPNS.WG.PEER.NOT_MATCHES}`; `{#WG.IFNAME}` configurable via `{$OPNS.WG.INSTANCE.MATCHES}` and `{$OPNS.WG.INSTANCE.NOT_MATCHES}` |
+| Keep lost resources | 1h |
+
+**Item Prototypes:**
+
+| Name | Key | Unit | Description |
+|------|-----|------|-------------|
+| WireGuard peer {#WG.NAME}: status | `opns.wireguard.peer.status["{#WG.PUBKEY}"]` | – | Peer status reported by OPNsense (`online`, `stale`, or `offline`). |
+| WireGuard peer {#WG.NAME}: latest handshake | `opns.wireguard.peer.latest_handshake["{#WG.PUBKEY}"]` | unixtime | Latest WireGuard handshake timestamp. Returns `0` if no handshake exists. |
+| WireGuard peer {#WG.NAME}: latest handshake age | `opns.wireguard.peer.latest_handshake_age["{#WG.PUBKEY}"]` | s | Age of the latest handshake in seconds. Returns `0` if no handshake exists. |
+| WireGuard peer {#WG.NAME}: endpoint | `opns.wireguard.peer.endpoint["{#WG.PUBKEY}"]` | – | Current peer endpoint. |
+| WireGuard peer {#WG.NAME}: bytes received | `opns.wireguard.peer.transfer_rx["{#WG.PUBKEY}"]` | B | Total bytes received from the peer. |
+| WireGuard peer {#WG.NAME}: bytes received per second | `opns.wireguard.peer.transfer_rx.rate["{#WG.PUBKEY}"]` | Bps | Receive rate calculated from total received bytes. |
+| WireGuard peer {#WG.NAME}: bytes sent | `opns.wireguard.peer.transfer_tx["{#WG.PUBKEY}"]` | B | Total bytes sent to the peer. |
+| WireGuard peer {#WG.NAME}: bytes sent per second | `opns.wireguard.peer.transfer_tx.rate["{#WG.PUBKEY}"]` | Bps | Send rate calculated from total sent bytes. |
+
+**Trigger Prototypes:**
+
+| Name | Severity | Description |
+|------|----------|-------------|
+| WireGuard peer {#WG.NAME} is not online | **High** | Peer status has not been `online` for 5 minutes. |
 
 ## UPS Monitoring (NUT)
 

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -114,6 +114,11 @@ on the firewall.
 | ARC Memory | `opns.memory.arc` | Dependent | – | ZFS ARC memory usage in bytes. |
 | Memory utilization in % | `opns.memory.util` | Calculated | – | Percentage of used memory relative to total memory. |
 | Licensed until | `opns.product.licenseuntil` | Dependent | – | OPNsense Business Edition license expiry (Unix timestamp). Returns `0` if not present. |
+| Firmware update status | `opns.firmware.update.status` | Dependent | – | Firmware update status (`none`, `update`, `upgrade`, or `error`). |
+| Firmware update status message | `opns.firmware.update.status_msg` | Dependent | – | Human-readable firmware update status message. |
+| Firmware update count | `opns.firmware.update.count` | Dependent | – | Number of available firmware package or set updates. |
+| Firmware update packages | `opns.firmware.update.packages` | Dependent | – | List of available package or set updates. |
+| Firmware update requires reboot | `opns.firmware.update.reboot` | Dependent | – | Returns `1` when the available firmware update requires a reboot. |
 
 ### Firewall Items
 
@@ -176,6 +181,7 @@ items and discovery rules.
 | RAW Interfaces | `opns.raw.interfaces.stat` | 1m | `/api/diagnostics/traffic/_interface` |
 | RAW Carp Interfaces | `opns.raw.interfaces.carp` | 1m | `/api/diagnostics/interface/get_vip_status` |
 | RAW Product Info | `opns.raw.product.info` | 30m | `/api/core/firmware/info` |
+| RAW Firmware Status | `opns.raw.firmware.status` | 1d | `/api/core/firmware/status` *(POST; runs update probe before fetching status)* |
 | RAW UPS | `opns.ups.raw` | 5m | `/api/nut/diagnostics/upsstatus` *(disabled by default)* |
 | RAW WireGuard | `opns.wireguard.raw` | 1m | `/api/wireguard/service/show` |
 
@@ -189,6 +195,8 @@ items and discovery rules.
 | CPU load is high | **Warning** | CPU load exceeds `{$OPNS.CPU.LOAD.MAX}` for 5 minutes. |
 | Memory utilization is high | **Average** | Memory utilization exceeds `{$OPNS.MEMORY.UTIL.MAX}` % for 5 minutes. |
 | OPNSense Business License expires soon | **Average** | License expires in less than `{$OPNS.LICENSE.EXPIRY.WARN}` days. Only relevant for Business Edition. |
+| OPNsense firmware updates are available | **Info** | Firmware update status is `update` or `upgrade` and at least one update is available. |
+| OPNsense firmware update check failed | **Warning** | Firmware update check returned `error`. |
 | State table usage is high | **Warning** | State table utilization exceeds `{$OPNS.STATE.TABLE.UTIL.MAX}` % for the last 3 values. |
 | {HOST.NAME} has been restarted | **Info** | System uptime is less than 600 seconds (10 minutes). |
 

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -869,23 +869,23 @@ zabbix_export:
                   value: '{#GWSTATUSNAME}'
               trigger_prototypes:
                 - uuid: c19ef9f23a4748a0a91bd86b9cc91e83
-                  expression: 'min(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>{$OPNS.GW.HIGH.PACKET.LOSS}'
+                  expression: 'min(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>{$OPNS.GW.HIGH.PACKET.LOSS} and max(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)<=100'
                   name: 'Gateway {#GWSTATUSNAME} High packet loss'
                   priority: HIGH
                   dependencies:
                     - name: 'Gateway {#GWSTATUSNAME} is down'
-                      expression: 'min(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>99'
+                      expression: 'min(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>99 and max(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)<=100'
                 - uuid: 89f05eea06224a15bfe33977b378e846
-                  expression: 'min(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>99'
+                  expression: 'min(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>99 and max(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)<=100'
                   name: 'Gateway {#GWSTATUSNAME} is down'
                   priority: DISASTER
                 - uuid: 24002d47a9b24b058efa290ccb377335
-                  expression: 'min(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>{$OPNS.GW.MIN.PACKET.LOSS}'
+                  expression: 'min(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>{$OPNS.GW.MIN.PACKET.LOSS} and max(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)<=100'
                   name: 'Gateway {#GWSTATUSNAME} Packet loss'
                   priority: AVERAGE
                   dependencies:
                     - name: 'Gateway {#GWSTATUSNAME} High packet loss'
-                      expression: 'min(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>{$OPNS.GW.HIGH.PACKET.LOSS}'
+                      expression: 'min(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>{$OPNS.GW.HIGH.PACKET.LOSS} and max(/OPNsense by HTTP-JSON/opns.gw.status.loss[{#GWSTATUSNAME}],5m)<=100'
             - uuid: 958e45fe885c46cca12c5a427d93e54f
               name: 'Gateway Status {#GWSTATUSNAME}'
               type: DEPENDENT

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -298,13 +298,19 @@ zabbix_export:
               parameters:
                 - $.product.product_license.valid_to
               error_handler: CUSTOM_VALUE
-              error_handler_params: 'no license'
+              error_handler_params: '0'
             - type: JAVASCRIPT
               parameters:
                 - |
                   function convertDateToUnixTimestamp(input) {
+                      if (input === '0' || input === '' || input === null) {
+                          return 0;
+                      }
                       const date = new Date(input);
                       const unixTimestamp = Math.floor(date.getTime() / 1000);
+                      if (isNaN(unixTimestamp)) {
+                          return 0;
+                      }
                       return unixTimestamp;
                   }
                   
@@ -313,7 +319,7 @@ zabbix_export:
             key: opns.raw.product.info
           triggers:
             - uuid: 740c029a6e7a49cb8eedc53e759eb6bb
-              expression: '(last(/OPNsense by HTTP-JSON/opns.product.licenseuntil) - now()) / 86400 < {$OPNS.LICENSE.EXPIRY.WARN}'
+              expression: 'last(/OPNsense by HTTP-JSON/opns.product.licenseuntil)>0 and (last(/OPNsense by HTTP-JSON/opns.product.licenseuntil) - now()) / 86400 < {$OPNS.LICENSE.EXPIRY.WARN}'
               name: 'OPNSense Business License expires soon'
               event_name: 'OPNSense Business License expires soon (less than {$OPNS.LICENSE.EXPIRY.WARN} days)'
               priority: AVERAGE

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -341,6 +341,117 @@ zabbix_export:
               name: 'OPNSense Business License expires soon'
               event_name: 'OPNSense Business License expires soon (less than {$OPNS.LICENSE.EXPIRY.WARN} days)'
               priority: AVERAGE
+        - uuid: 6ebbcee115654039a5735c835bbdaa78
+          name: 'Firmware update count'
+          type: DEPENDENT
+          key: opns.firmware.update.count
+          history: 30d
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  if (data.status !== 'update' && data.status !== 'upgrade') {
+                      return 0;
+                  }
+                  if (data.all_packages) {
+                      return Object.keys(data.all_packages).length;
+                  }
+                  if (data.all_sets) {
+                      return Object.keys(data.all_sets).length;
+                  }
+                  return 0;
+          master_item:
+            key: opns.raw.firmware.status
+          tags:
+            - tag: component
+              value: firmware
+        - uuid: daba216c1e654377982db23dfad0b0a0
+          name: 'Firmware update packages'
+          type: DEPENDENT
+          key: opns.firmware.update.packages
+          history: 30d
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  var packages = data.all_packages || data.all_sets || {};
+                  var result = [];
+                  Object.keys(packages).sort().forEach(function (name) {
+                      var pkg = packages[name];
+                      result.push(pkg.name + ': ' + pkg.old + ' -> ' + pkg.new + ' (' + pkg.reason + ')');
+                  });
+                  return result.join('\n');
+          master_item:
+            key: opns.raw.firmware.status
+          tags:
+            - tag: component
+              value: firmware
+        - uuid: c38e9bd38f2749839673580d91239005
+          name: 'Firmware update requires reboot'
+          type: DEPENDENT
+          key: opns.firmware.update.reboot
+          history: 30d
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.status_reboot
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+          master_item:
+            key: opns.raw.firmware.status
+          tags:
+            - tag: component
+              value: firmware
+        - uuid: ec1dbbdb46a1445f9c5595ab24a76083
+          name: 'Firmware update status'
+          type: DEPENDENT
+          key: opns.firmware.update.status
+          history: 30d
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.status
+          master_item:
+            key: opns.raw.firmware.status
+          tags:
+            - tag: component
+              value: firmware
+          triggers:
+            - uuid: 6003bfd5a8f44a6d9a04f08de932fef1
+              expression: 'find(/OPNsense by HTTP-JSON/opns.firmware.update.status,#1,"regexp","^(update|upgrade)$")=1 and last(/OPNsense by HTTP-JSON/opns.firmware.update.count)>0'
+              name: 'OPNsense firmware updates are available'
+              event_name: 'OPNsense firmware updates are available ({ITEM.LASTVALUE})'
+              opdata: 'Updates: {ITEM.LASTVALUE2}'
+              priority: INFO
+              description: 'A firmware update or major upgrade is available.'
+            - uuid: a5755520c5e2491cb9b44cd9d1f438af
+              expression: 'find(/OPNsense by HTTP-JSON/opns.firmware.update.status,#1,"eq","error")=1'
+              name: 'OPNsense firmware update check failed'
+              opdata: '{ITEM.LASTVALUE}'
+              priority: WARNING
+              description: 'The OPNsense firmware update check returned an error.'
+        - uuid: 68ad33be2ee3422c8b711a243a860ca5
+          name: 'Firmware update status message'
+          type: DEPENDENT
+          key: opns.firmware.update.status_msg
+          history: 30d
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.status_msg
+          master_item:
+            key: opns.raw.firmware.status
+          tags:
+            - tag: component
+              value: firmware
         - uuid: 164f961df24a445aa57872068e5a1f99
           name: 'RAW Disk'
           type: HTTP_AGENT
@@ -535,6 +646,21 @@ zabbix_export:
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
           url: 'https://{HOST.IP}:{$OPNS.PORT}/api/core/firmware/info'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: d50283b96ba64d769fbd744e9a71f327
+          name: 'RAW Firmware Status'
+          type: HTTP_AGENT
+          key: opns.raw.firmware.status
+          delay: 1d
+          history: 7d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          request_method: POST
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/core/firmware/status'
           tags:
             - tag: component
               value: raw

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -237,6 +237,24 @@ zabbix_export:
           tags:
             - tag: component
               value: raw
+        - uuid: 7945ce5b7e174b9e8f6ea6da6dd64060
+          name: 'RAW WireGuard'
+          type: HTTP_AGENT
+          key: opns.wireguard.raw
+          delay: 1m
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/wireguard/service/show'
+          tags:
+            - tag: component
+              value: raw
         - uuid: f8800baa079b46f485a049ee02d61b57
           name: 'ARC Memory'
           type: DEPENDENT
@@ -1343,6 +1361,293 @@ zabbix_export:
               path: $.device
             - lld_macro: '{#OPNS.INTERFACE.NAME}'
               path: $.name
+        - uuid: 36c000378e754ccb9475fa047160fd8f
+          name: 'WireGuard Instance Discovery'
+          type: DEPENDENT
+          key: opns.wireguard.instance.discovery
+          filter:
+            conditions:
+              - macro: '{#WG.INSTANCE}'
+                value: '{$OPNS.WG.INSTANCE.MATCHES}'
+              - macro: '{#WG.INSTANCE}'
+                value: '{$OPNS.WG.INSTANCE.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+          lifetime: 1h
+          item_prototypes:
+            - uuid: 5946da75329d435b93d24a25ed70d5ff
+              name: 'WireGuard instance {#WG.INSTANCE}: status'
+              type: DEPENDENT
+              key: 'opns.wireguard.instance.status[{#WG.IF}]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.if == "{#WG.IF}")].status.first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.INSTANCE}'
+                - tag: interface
+                  value: '{#WG.IF}'
+              trigger_prototypes:
+                - uuid: 290408665fab4886ab6d4ef2c35bda65
+                  expression: 'find(/OPNsense by HTTP-JSON/opns.wireguard.instance.status[{#WG.IF}],5m,"eq","up")=0'
+                  name: 'WireGuard instance {#WG.INSTANCE} is down'
+                  priority: HIGH
+            - uuid: 9b6b1a92c9384e8ea4d3302fb701f494
+              name: 'WireGuard instance {#WG.INSTANCE}: listen port'
+              type: DEPENDENT
+              key: 'opns.wireguard.instance.listen_port[{#WG.IF}]'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.if == "{#WG.IF}")].["listen-port"].first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.INSTANCE}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: 5a01a56577a74926a311bbdcff64543f
+              name: 'WireGuard instance {#WG.INSTANCE}: public key'
+              type: DEPENDENT
+              key: 'opns.wireguard.instance.public_key[{#WG.IF}]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.if == "{#WG.IF}")].["public-key"].first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.INSTANCE}'
+                - tag: interface
+                  value: '{#WG.IF}'
+          master_item:
+            key: opns.wireguard.raw
+          lld_macro_paths:
+            - lld_macro: '{#WG.IF}'
+              path: $.if
+            - lld_macro: '{#WG.INSTANCE}'
+              path: $.name
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var rows = JSON.parse(value);
+                  var instances = [];
+                  for (var i = 0; i < rows.length; i++) {
+                      if (rows[i].type === 'interface') {
+                          if (rows[i].name === '') {
+                              rows[i].name = rows[i].if;
+                          }
+                          instances.push(rows[i]);
+                      }
+                  }
+                  return JSON.stringify(instances);
+        - uuid: 3f23060d61274c6d9beb2087f259bd54
+          name: 'WireGuard Peer Discovery'
+          type: DEPENDENT
+          key: opns.wireguard.peer.discovery
+          filter:
+            conditions:
+              - macro: '{#WG.NAME}'
+                value: '{$OPNS.WG.PEER.MATCHES}'
+              - macro: '{#WG.NAME}'
+                value: '{$OPNS.WG.PEER.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#WG.IFNAME}'
+                value: '{$OPNS.WG.INSTANCE.MATCHES}'
+              - macro: '{#WG.IFNAME}'
+                value: '{$OPNS.WG.INSTANCE.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+          lifetime: 1h
+          item_prototypes:
+            - uuid: 7397099101c74754bc0d639b37b8bbc9
+              name: 'WireGuard peer {#WG.NAME}: status'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.status["{#WG.PUBKEY}"]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["peer-status"].first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+              trigger_prototypes:
+                - uuid: bbb8926ace0b483fa7d397703e47d4d2
+                  expression: 'find(/OPNsense by HTTP-JSON/opns.wireguard.peer.status["{#WG.PUBKEY}"],5m,"eq","online")=0'
+                  name: 'WireGuard peer {#WG.NAME} is not online'
+                  priority: HIGH
+                  description: 'WireGuard peer status is stale or offline. OPNsense marks peers online when the latest handshake is not older than 300 seconds.'
+            - uuid: c373db13af244a14b21d582905d4dfa4
+              name: 'WireGuard peer {#WG.NAME}: latest handshake age'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.latest_handshake_age["{#WG.PUBKEY}"]'
+              units: s
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["latest-handshake-age"].first()'
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      if (value === null || value === '' || value === 'null') {
+                          return 0;
+                      }
+                      return value;
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: 5c886d9ab9bf4569acd058a1f060d306
+              name: 'WireGuard peer {#WG.NAME}: latest handshake'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.latest_handshake["{#WG.PUBKEY}"]'
+              units: unixtime
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["latest-handshake"].first()'
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      if (value === null || value === '' || value === 'null') {
+                          return 0;
+                      }
+                      return value;
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: d1c0192b3c194c73be8cb62a8635de5e
+              name: 'WireGuard peer {#WG.NAME}: endpoint'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.endpoint["{#WG.PUBKEY}"]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].endpoint.first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: e58a63a78b5249f0b579dd0cbd82c0f3
+              name: 'WireGuard peer {#WG.NAME}: bytes received'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.transfer_rx["{#WG.PUBKEY}"]'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["transfer-rx"].first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: 4fa44cf6d91b4d7595bedb07cdfe480a
+              name: 'WireGuard peer {#WG.NAME}: bytes received per second'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.transfer_rx.rate["{#WG.PUBKEY}"]'
+              value_type: FLOAT
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["transfer-rx"].first()'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: e74a5d5c709a4ff7932195f5a7d1728b
+              name: 'WireGuard peer {#WG.NAME}: bytes sent'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.transfer_tx["{#WG.PUBKEY}"]'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["transfer-tx"].first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: df146ef2cc8b4ea59da11b0516befbfe
+              name: 'WireGuard peer {#WG.NAME}: bytes sent per second'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.transfer_tx.rate["{#WG.PUBKEY}"]'
+              value_type: FLOAT
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["transfer-tx"].first()'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+          master_item:
+            key: opns.wireguard.raw
+          lld_macro_paths:
+            - lld_macro: '{#WG.IF}'
+              path: $.if
+            - lld_macro: '{#WG.IFNAME}'
+              path: $.ifname
+            - lld_macro: '{#WG.NAME}'
+              path: $.name
+            - lld_macro: '{#WG.PUBKEY}'
+              path: $.public_key
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var rows = JSON.parse(value);
+                  var peers = [];
+                  for (var i = 0; i < rows.length; i++) {
+                      if (rows[i].type === 'peer') {
+                          rows[i].public_key = rows[i]['public-key'];
+                          if (rows[i].ifname === '' || rows[i].ifname === null) {
+                              rows[i].ifname = rows[i].if;
+                          }
+                          if (rows[i].name === '') {
+                              rows[i].name = rows[i]['public-key'];
+                          }
+                          peers.push(rows[i]);
+                      }
+                  }
+                  return JSON.stringify(peers);
         - uuid: e53f5f66e0db470b9e1b6bd32384d070
           name: 'IPsec Phase1 Discovery'
           type: DEPENDENT
@@ -1726,6 +2031,18 @@ zabbix_export:
         - macro: '{$OPNS.PORT}'
           value: '443'
           description: 'HTTPS API Port'
+        - macro: '{$OPNS.WG.INSTANCE.MATCHES}'
+          value: .+
+          description: 'Regex filter for WireGuard instance discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$OPNS.WG.INSTANCE.NOT_MATCHES}'
+          value: ^$
+          description: 'Regex filter for excluding WireGuard instances from discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$OPNS.WG.PEER.MATCHES}'
+          value: .+
+          description: 'Regex filter for WireGuard peer discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$OPNS.WG.PEER.NOT_MATCHES}'
+          value: ^$
+          description: 'Regex filter for excluding WireGuard peers from discovery. Can be overridden on the host or linked template level.'
       dashboards:
         - uuid: 7a4b378cb31c4d6fb3c4c69731653336
           name: 'OPNsense Info'


### PR DESCRIPTION
- Add OPNsense firmware update monitoring via `/api/core/firmware/status`
- Collect update status, status message, update count, package list, and reboot requirement
- Add triggers for available firmware updates and failed update checks
- Add WireGuard monitoring via `/api/wireguard/service/show`
- Discover WireGuard instances and peers with regex include/exclude macros
- Add WireGuard instance and peer status, handshake, endpoint, and transfer metrics
- Ignore disabled gateway monitoring sentinel values in gateway loss/down triggers
- Keep missing or invalid license expiry values numeric to avoid unsupported item errors
- Update README with new items, triggers, permissions, macros, and discovery details
