### PR TITLE
Add APC AP7822 SNMP template

### DIFF
--- a/Power_(UPS)/APC/template_apc_ap7822_snmp/7.0/README.md
+++ b/Power_(UPS)/APC/template_apc_ap7822_snmp/7.0/README.md
@@ -1,0 +1,128 @@
+# APC AP7822 by SNMP
+
+## Overview
+
+This template monitors an **APC AP7822 Metered Rack PDU** through SNMP.
+
+It uses numeric OIDs from **APC PowerNet-MIB v4.6.0**, so PowerNet-MIB does not
+need to be installed on the Zabbix server or proxy.
+
+The template contains:
+
+- 36 items
+- 11 triggers
+- 8 value maps
+- Device inventory and capability information
+- Total, Bank 1, and Bank 2 current monitoring
+- Load-state monitoring based on thresholds configured on the PDU
+- Bank low-load, near-overload, and overload thresholds
+- Active power, apparent power, and power factor
+- Power-supply status and alarm monitoring
+- SNMP availability monitoring
+
+## Requirements
+
+- Zabbix 7.0
+- An SNMP interface configured on the Zabbix host
+- SNMP enabled on the APC AP7822
+- Network access from the Zabbix server or proxy to UDP port 161 on the PDU
+
+The template was tested with:
+
+| Component | Version |
+|---|---|
+| Zabbix | 7.0.28 |
+| Device | APC AP7822 |
+| Application firmware | v3.9.3 |
+| AOS firmware | v3.9.4 |
+| SNMP | SNMPv2c |
+
+Other AP7xxx models may expose a similar OID tree, but this template has only
+been validated against the AP7822.
+
+## Installation
+
+1. Import `template_apc_ap7822_snmp.yaml` in **Data collection → Templates → Import**.
+2. Create a host for the PDU or edit an existing host.
+3. Add an SNMP interface using the PDU IP address.
+4. Configure the SNMP version and credentials on the host interface.
+5. Link the **APC AP7822 by SNMP** template to the host.
+
+No MIB installation or external script is required.
+
+## Macros
+
+| Macro | Default | Description |
+|---|---:|---|
+| `{$APC.SNMP.TIMEOUT}` | `5m` | Time window used by the SNMP availability trigger. |
+
+## Collected metrics
+
+### Inventory
+
+- PDU name
+- Hardware revision
+- Firmware revision
+- Manufacturing date
+- Model
+- Serial number
+- Device current rating
+- Number of outlets, phases, and banks
+- Breaker rating
+- Controlled and monitored outlet counts
+- Device, outlet-layout, and display orientation
+
+### Electrical measurements
+
+- Total current
+- Bank 1 current
+- Bank 2 current
+- Total, Bank 1, and Bank 2 load state
+- Bank low-load threshold
+- Bank near-overload threshold
+- Bank overload threshold
+- Configured nominal line-to-line voltage
+- Active power
+- Apparent power
+- Power factor
+
+The current OIDs return tenths of an ampere. The template applies a `0.1`
+multiplier during preprocessing.
+
+The nominal voltage item is the configured voltage used by the PDU for power
+calculation. It is not a real-time input-voltage measurement.
+
+### Health and availability
+
+- SNMP agent availability
+- Power supply 1 status
+- Power supply 2 status
+- General power-supply alarm
+
+## Triggers
+
+| Trigger condition | Severity |
+|---|---|
+| SNMP data collection unavailable for `{$APC.SNMP.TIMEOUT}` | Warning |
+| Total, Bank 1, or Bank 2 load is low | Information |
+| Total, Bank 1, or Bank 2 load is near overload | Warning |
+| Total, Bank 1, or Bank 2 load is overloaded | High |
+| PDU reports a power-supply alarm | High |
+
+Load triggers use the state reported by the PDU. Thresholds should be configured
+on the APC device according to the electrical design and operating requirements
+of the installation.
+
+## Known limitations
+
+- The AP7822 has 16 physical outlets but reports `0` controlled outlets and `0`
+  outlet-level monitored outlets through the legacy `rPDU` MIB tree.
+- Per-outlet switching, state, and current monitoring are therefore not included.
+- The template is specific to the legacy APC `rPDU` tree under
+  `.1.3.6.1.4.1.318.1.1.12`; it is not intended for newer devices that use
+  the `rPDU2` tree.
+- Only SNMP polling is included. SNMP trap processing is not configured.
+
+## Author
+
+Mustafa Volkan Vurulkan ([@vurulkan](https://github.com/vurulkan))

--- a/Power_(UPS)/APC/template_apc_ap7822_snmp/7.0/template_apc_ap7822_snmp.yaml
+++ b/Power_(UPS)/APC/template_apc_ap7822_snmp/7.0/template_apc_ap7822_snmp.yaml
@@ -1,0 +1,851 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+  - uuid: 2e7a82e8d83e445a89e4565dfe221043
+    name: Templates/Power
+  templates:
+  - uuid: 74f6b39a9e25496fb109b35f36a3b7a5
+    template: APC AP7822 by SNMP
+    name: APC AP7822 by SNMP
+    description: 'Template for monitoring the APC AP7822 Metered Rack PDU via SNMP.
+
+
+      The template uses numeric OIDs from APC PowerNet-MIB v4.6.0, so the MIB does not need to be installed on the Zabbix
+      server or proxy. It provides device inventory, total and bank current measurements, load states, bank thresholds, active
+      and apparent power, power factor, power-supply status, and SNMP availability monitoring.
+
+
+      Tested with Zabbix 7.0.28 and APC AP7822 application firmware v3.9.3 / AOS v3.9.4 using SNMPv2c.
+
+
+      The AP7822 exposes 16 outlets but reports zero controlled outlets and zero outlet-level monitored outlets; therefore,
+      per-outlet switching and current items are intentionally not included.
+
+
+      Author: Mustafa Volkan Vurulkan (@vurulkan)'
+    vendor:
+      name: APC
+      version: 7.0-1
+    groups:
+    - name: Templates/Power
+    items:
+    - uuid: b6d61d737ef8484db0e7d8a3be9b3527
+      name: SNMP agent availability
+      type: INTERNAL
+      key: zabbix[host,snmp,available]
+      description: Availability state of SNMP polling for the host.
+      valuemap:
+        name: Zabbix host availability
+      tags:
+      - tag: component
+        value: health
+      - tag: device
+        value: pdu
+      triggers:
+      - uuid: d29a97630c444b2da42c4cdf5b6c6d00
+        expression: max(/APC AP7822 by SNMP/zabbix[host,snmp,available],{$APC.SNMP.TIMEOUT})=0
+        name: 'APC AP7822: No SNMP data collection'
+        opdata: 'Current state: {ITEM.LASTVALUE1}'
+        priority: WARNING
+        description: SNMP polling is unavailable. Check reachability, the host SNMP interface, community/security settings
+          and UDP/161.
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: 4f9caff30f9e4ab698bf895a2d80be01
+      name: PDU name
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.1.0]
+      key: apc.rpdu.name
+      delay: 1h
+      value_type: CHAR
+      trends: '0'
+      description: PowerNet-MIB::rPDUIdentName
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: be52e61e876247979c8bcc110785ed62
+      name: Hardware revision
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.2.0]
+      key: apc.rpdu.hw.rev
+      delay: 1h
+      value_type: CHAR
+      trends: '0'
+      description: PowerNet-MIB::rPDUIdentHardwareRev
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 325f4e0f55024ae8a457302e5fb87797
+      name: Firmware revision
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.3.0]
+      key: apc.rpdu.fw.rev
+      delay: 1h
+      value_type: CHAR
+      trends: '0'
+      description: PowerNet-MIB::rPDUIdentFirmwareRev
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 60904f390bfe46f2b51efcb0d35a23b4
+      name: Date of manufacture
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.4.0]
+      key: apc.rpdu.manufacture.date
+      delay: 1h
+      value_type: CHAR
+      trends: '0'
+      description: PowerNet-MIB::rPDUIdentDateOfManufacture
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 9254de84a2d24588a70a1f4d37020475
+      name: Model
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.5.0]
+      key: apc.rpdu.model
+      delay: 1h
+      value_type: CHAR
+      trends: '0'
+      description: PowerNet-MIB::rPDUIdentModelNumber
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 9d1e7228a6344d7a837b1235e0895355
+      name: Serial number
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.6.0]
+      key: apc.rpdu.serial
+      delay: 1h
+      value_type: CHAR
+      trends: '0'
+      description: PowerNet-MIB::rPDUIdentSerialNumber
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 42a8c53889744f2daaf1ab3175db50ab
+      name: Device current rating
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.7.0]
+      key: apc.rpdu.rating.current
+      delay: 1h
+      units: A
+      description: PowerNet-MIB::rPDUIdentDeviceRating
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 49641d63e6394e95af65ea37aeaec238
+      name: Outlet count
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.8.0]
+      key: apc.rpdu.outlets.total
+      delay: 1h
+      description: PowerNet-MIB::rPDUIdentDeviceNumOutlets
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 30ac807f96e245b48f3a42a20c6af183
+      name: Phase count
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.9.0]
+      key: apc.rpdu.phases.total
+      delay: 1h
+      description: PowerNet-MIB::rPDUIdentDeviceNumPhases
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 3bae96612b754263ba5e741bb0ad26aa
+      name: Breaker/bank count
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.10.0]
+      key: apc.rpdu.breakers.total
+      delay: 1h
+      description: PowerNet-MIB::rPDUIdentDeviceNumBreakers
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 8c519ab294a1465e8044a6d71092ab9f
+      name: Breaker current rating
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.11.0]
+      key: apc.rpdu.breaker.rating
+      delay: 1h
+      units: A
+      description: PowerNet-MIB::rPDUIdentDeviceBreakerRating
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 28978761dd6944c1baa89ba94f6fbdf7
+      name: Controlled outlet count
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.3.1.3.0]
+      key: apc.rpdu.outlets.controlled
+      delay: 1h
+      description: PowerNet-MIB::rPDUOutletDevNumCntrlOutlets.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: cb0e589a71f248a296a49da340e4dcc7
+      name: Monitored outlet count
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.3.1.5.0]
+      key: apc.rpdu.outlets.monitored
+      delay: 1h
+      description: PowerNet-MIB::rPDUOutletDevMonitoredOutlets.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 53511a0323db4bc691b03735bb0ed310
+      name: Device orientation
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.12.0]
+      key: apc.rpdu.orientation
+      delay: 1h
+      description: PowerNet-MIB::rPDUIdentDeviceOrientation
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      valuemap:
+        name: APC PDU orientation
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 02546cd94b48401089413525df1f8cd7
+      name: Outlet layout
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.13.0]
+      key: apc.rpdu.outlet.layout
+      delay: 1h
+      description: PowerNet-MIB::rPDUIdentDeviceOutletLayout
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      valuemap:
+        name: APC PDU outlet layout
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: cf6a76f8d1ac4a76b603cbc4997e7fa3
+      name: Display orientation
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.14.0]
+      key: apc.rpdu.display.orientation
+      delay: 1h
+      description: PowerNet-MIB::rPDUIdentDeviceDisplayOrientation
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      valuemap:
+        name: APC PDU display orientation
+      tags:
+      - tag: component
+        value: inventory
+      - tag: device
+        value: pdu
+    - uuid: 46083d578c9f4cbf813e8f1bcbae6f4a
+      name: Nominal line-to-line voltage
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.15.0]
+      key: apc.rpdu.voltage.nominal
+      delay: 1m
+      units: V
+      description: PowerNet-MIB::rPDUIdentDeviceLinetoLineVoltage. This is the configured nominal voltage used by the PDU
+        for power calculations.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 6h
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: 60e7aa0c46464ae6b9500de0686b34a4
+      name: Active power
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.16.0]
+      key: apc.rpdu.power.active
+      delay: 1m
+      units: W
+      description: PowerNet-MIB::rPDUIdentDevicePowerWatts.
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: c513de00008c4f0db9afed0486f3f261
+      name: Power factor
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.17.0]
+      key: apc.rpdu.power.factor
+      delay: 1m
+      value_type: FLOAT
+      description: PowerNet-MIB::rPDUIdentDevicePowerFactor. The raw value is in thousandths; 1000 equals 1.000.
+      preprocessing:
+      - type: MULTIPLIER
+        parameters:
+        - '0.001'
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: 9f3ca3e3e684479c937650de27f7bcc1
+      name: Apparent power
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.1.18.0]
+      key: apc.rpdu.power.apparent
+      delay: 1m
+      units: VA
+      description: PowerNet-MIB::rPDUIdentDevicePowerVA.
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: 8cb4914299014081898719a265293432
+      name: Total current
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.2.3.1.1.2.1]
+      key: apc.rpdu.load.current[total]
+      delay: 1m
+      value_type: FLOAT
+      units: A
+      description: PowerNet-MIB::rPDULoadStatusLoad, status-table index 1. The raw value is measured in tenths of an ampere.
+      preprocessing:
+      - type: MULTIPLIER
+        parameters:
+        - '0.1'
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: 211cf4d1b4034c70b121d41fe07da7c7
+      name: Total load state
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.2.3.1.1.3.1]
+      key: apc.rpdu.load.state[total]
+      delay: 1m
+      description: PowerNet-MIB::rPDULoadStatusLoadState, status-table index 1.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      valuemap:
+        name: APC PDU load state
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+      triggers:
+      - uuid: 973657ccb21d46eaa1663ff11e0c40ec
+        expression: last(/APC AP7822 by SNMP/apc.rpdu.load.state[total])=2
+        name: 'APC AP7822: Total load is low'
+        priority: INFO
+        description: Total current is below the low-load threshold configured on the PDU.
+        tags:
+        - tag: scope
+          value: performance
+        opdata: 'State: {ITEM.LASTVALUE1}'
+      - uuid: f9345f6bdb4e4c74aed22d27613a80be
+        expression: last(/APC AP7822 by SNMP/apc.rpdu.load.state[total])=3
+        name: 'APC AP7822: Total load is near overload'
+        priority: WARNING
+        description: Total current has reached the near-overload state reported by the PDU.
+        tags:
+        - tag: scope
+          value: performance
+        opdata: 'State: {ITEM.LASTVALUE1}'
+      - uuid: 9fc71c2a23074b3a96ca425599f76f33
+        expression: last(/APC AP7822 by SNMP/apc.rpdu.load.state[total])=4
+        name: 'APC AP7822: Total load is overloaded'
+        priority: HIGH
+        description: Total current has reached the overload state reported by the PDU.
+        tags:
+        - tag: scope
+          value: performance
+        opdata: 'State: {ITEM.LASTVALUE1}'
+    - uuid: c74b86b547ce4816a5bb55114645c620
+      name: Bank 1 current
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.2.3.1.1.2.2]
+      key: apc.rpdu.load.current[bank1]
+      delay: 1m
+      value_type: FLOAT
+      units: A
+      description: PowerNet-MIB::rPDULoadStatusLoad, status-table index 2. The raw value is measured in tenths of an ampere.
+      preprocessing:
+      - type: MULTIPLIER
+        parameters:
+        - '0.1'
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: 1aa66bf3898e4bdb8a84da05861c714f
+      name: Bank 1 load state
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.2.3.1.1.3.2]
+      key: apc.rpdu.load.state[bank1]
+      delay: 1m
+      description: PowerNet-MIB::rPDULoadStatusLoadState, status-table index 2.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      valuemap:
+        name: APC PDU load state
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+      triggers:
+      - uuid: befd9da2ffe44633a88b8292ef687358
+        expression: last(/APC AP7822 by SNMP/apc.rpdu.load.state[bank1])=2
+        name: 'APC AP7822: Bank 1 load is low'
+        priority: INFO
+        description: Bank 1 current is below the low-load threshold configured on the PDU.
+        tags:
+        - tag: scope
+          value: performance
+        opdata: 'State: {ITEM.LASTVALUE1}'
+      - uuid: ffbfbebf01064a9f9dceb8d7f84a7c39
+        expression: last(/APC AP7822 by SNMP/apc.rpdu.load.state[bank1])=3
+        name: 'APC AP7822: Bank 1 load is near overload'
+        priority: WARNING
+        description: Bank 1 current has reached the near-overload state reported by the PDU.
+        tags:
+        - tag: scope
+          value: performance
+        opdata: 'State: {ITEM.LASTVALUE1}'
+      - uuid: 3859f98e555a4c779b54b174001e28fb
+        expression: last(/APC AP7822 by SNMP/apc.rpdu.load.state[bank1])=4
+        name: 'APC AP7822: Bank 1 load is overloaded'
+        priority: HIGH
+        description: Bank 1 current has reached the overload state reported by the PDU.
+        tags:
+        - tag: scope
+          value: performance
+        opdata: 'State: {ITEM.LASTVALUE1}'
+    - uuid: 1f7bc150e945410e8ac5d84ee3698ed8
+      name: Bank 1 low-load threshold
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.2.4.1.1.2.1]
+      key: apc.rpdu.load.threshold[bank1,low]
+      delay: 15m
+      units: A
+      description: PowerNet-MIB legacy rPDULoadBankConfig threshold table, row 1. Rows 1 and 2 represent Bank 1 and Bank 2
+        on the AP7822.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: 57f9bfa2c8c745a19411d9075480f7ef
+      name: Bank 1 near-overload threshold
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.2.4.1.1.3.1]
+      key: apc.rpdu.load.threshold[bank1,near]
+      delay: 15m
+      units: A
+      description: PowerNet-MIB legacy rPDULoadBankConfig threshold table, row 1. Rows 1 and 2 represent Bank 1 and Bank 2
+        on the AP7822.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: 60ae8c20c865402abbc22997ea29976b
+      name: Bank 1 overload threshold
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.2.4.1.1.4.1]
+      key: apc.rpdu.load.threshold[bank1,overload]
+      delay: 15m
+      units: A
+      description: PowerNet-MIB legacy rPDULoadBankConfig threshold table, row 1. Rows 1 and 2 represent Bank 1 and Bank 2
+        on the AP7822.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: fb497174ee034333a7977f454dbd20c9
+      name: Bank 2 current
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.2.3.1.1.2.3]
+      key: apc.rpdu.load.current[bank2]
+      delay: 1m
+      value_type: FLOAT
+      units: A
+      description: PowerNet-MIB::rPDULoadStatusLoad, status-table index 3. The raw value is measured in tenths of an ampere.
+      preprocessing:
+      - type: MULTIPLIER
+        parameters:
+        - '0.1'
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: 9ba3ab9e90ca4b9fba56e1bed845f6b9
+      name: Bank 2 load state
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.2.3.1.1.3.3]
+      key: apc.rpdu.load.state[bank2]
+      delay: 1m
+      description: PowerNet-MIB::rPDULoadStatusLoadState, status-table index 3.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      valuemap:
+        name: APC PDU load state
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+      triggers:
+      - uuid: a6b7b9e38b5845c99d0f7c967470001d
+        expression: last(/APC AP7822 by SNMP/apc.rpdu.load.state[bank2])=2
+        name: 'APC AP7822: Bank 2 load is low'
+        priority: INFO
+        description: Bank 2 current is below the low-load threshold configured on the PDU.
+        tags:
+        - tag: scope
+          value: performance
+        opdata: 'State: {ITEM.LASTVALUE1}'
+      - uuid: c2c69279700047f381970353b84062d4
+        expression: last(/APC AP7822 by SNMP/apc.rpdu.load.state[bank2])=3
+        name: 'APC AP7822: Bank 2 load is near overload'
+        priority: WARNING
+        description: Bank 2 current has reached the near-overload state reported by the PDU.
+        tags:
+        - tag: scope
+          value: performance
+        opdata: 'State: {ITEM.LASTVALUE1}'
+      - uuid: 63a8643da1574dd2bc620acc845bb1c5
+        expression: last(/APC AP7822 by SNMP/apc.rpdu.load.state[bank2])=4
+        name: 'APC AP7822: Bank 2 load is overloaded'
+        priority: HIGH
+        description: Bank 2 current has reached the overload state reported by the PDU.
+        tags:
+        - tag: scope
+          value: performance
+        opdata: 'State: {ITEM.LASTVALUE1}'
+    - uuid: 945409038ca34baf87392b2f0091e70c
+      name: Bank 2 low-load threshold
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.2.4.1.1.2.2]
+      key: apc.rpdu.load.threshold[bank2,low]
+      delay: 15m
+      units: A
+      description: PowerNet-MIB legacy rPDULoadBankConfig threshold table, row 2. Rows 1 and 2 represent Bank 1 and Bank 2
+        on the AP7822.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: ada18208ed7141adb5f9b593ad1158b6
+      name: Bank 2 near-overload threshold
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.2.4.1.1.3.2]
+      key: apc.rpdu.load.threshold[bank2,near]
+      delay: 15m
+      units: A
+      description: PowerNet-MIB legacy rPDULoadBankConfig threshold table, row 2. Rows 1 and 2 represent Bank 1 and Bank 2
+        on the AP7822.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: 8d6f99170b8348b5a3711b4745bc885d
+      name: Bank 2 overload threshold
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.2.4.1.1.4.2]
+      key: apc.rpdu.load.threshold[bank2,overload]
+      delay: 15m
+      units: A
+      description: PowerNet-MIB legacy rPDULoadBankConfig threshold table, row 2. Rows 1 and 2 represent Bank 1 and Bank 2
+        on the AP7822.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 12h
+      tags:
+      - tag: component
+        value: power
+      - tag: device
+        value: pdu
+    - uuid: 4218865f797747a4918f1f20752262e3
+      name: Power supply 1 status
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.4.1.1.0]
+      key: apc.rpdu.power.supply1.status
+      delay: 5m
+      description: PowerNet-MIB::rPDUPowerSupply1Status.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      valuemap:
+        name: APC PDU power supply 1 status
+      tags:
+      - tag: component
+        value: health
+      - tag: device
+        value: pdu
+    - uuid: ca4cec5a7f7340d7af2b9d4adc9dff9a
+      name: Power supply 2 status
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.4.1.2.0]
+      key: apc.rpdu.power.supply2.status
+      delay: 5m
+      description: PowerNet-MIB::rPDUPowerSupply2Status. Metered Rack PDUs normally report the second supply as not present.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      valuemap:
+        name: APC PDU power supply 2 status
+      tags:
+      - tag: component
+        value: health
+      - tag: device
+        value: pdu
+    - uuid: ab12dace9ed74b739876834cf7b72209
+      name: Power supply alarm
+      type: SNMP_AGENT
+      snmp_oid: get[1.3.6.1.4.1.318.1.1.12.4.1.3.0]
+      key: apc.rpdu.power.supply.alarm
+      delay: 5m
+      description: PowerNet-MIB::rPDUPowerSupplyAlarm.
+      preprocessing:
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      valuemap:
+        name: APC PDU power supply alarm
+      tags:
+      - tag: component
+        value: health
+      - tag: device
+        value: pdu
+      triggers:
+      - uuid: 8d0a2fbf78134ee6a0b461495fdf584d
+        expression: last(/APC AP7822 by SNMP/apc.rpdu.power.supply.alarm)<>1
+        name: 'APC AP7822: Power supply alarm'
+        opdata: 'State: {ITEM.LASTVALUE1}'
+        priority: HIGH
+        description: The Rack PDU reports a power-supply failure.
+        tags:
+        - tag: scope
+          value: availability
+    tags:
+    - tag: class
+      value: power
+    - tag: target
+      value: pdu
+    - tag: vendor
+      value: apc
+    - tag: model
+      value: ap7822
+    macros:
+    - macro: '{$APC.SNMP.TIMEOUT}'
+      value: 5m
+      description: Time window used by the SNMP availability trigger.
+    valuemaps:
+    - uuid: ccf7aba5286c404b8c2e346af92b38f7
+      name: Zabbix host availability
+      mappings:
+      - value: '0'
+        newvalue: not available
+      - value: '1'
+        newvalue: available
+      - value: '2'
+        newvalue: unknown
+    - uuid: fec11873513f473c99e12394db3d6b60
+      name: APC PDU load state
+      mappings:
+      - value: '1'
+        newvalue: Normal
+      - value: '2'
+        newvalue: Low load
+      - value: '3'
+        newvalue: Near overload
+      - value: '4'
+        newvalue: Overload
+    - uuid: 87a62744ac5e4ed499e1c3dddb85ce5c
+      name: APC PDU orientation
+      mappings:
+      - value: '1'
+        newvalue: Horizontal
+      - value: '2'
+        newvalue: Vertical
+    - uuid: 1c68a27a1f9f4bd89cddc6c1cac5e881
+      name: APC PDU display orientation
+      mappings:
+      - value: '1'
+        newvalue: Normal
+      - value: '2'
+        newvalue: Reversed
+    - uuid: a759cfd37ad54084a10e86c07af26113
+      name: APC PDU outlet layout
+      mappings:
+      - value: '1'
+        newvalue: Phase-to-neutral sequential
+      - value: '2'
+        newvalue: Phase-to-phase sequential
+      - value: '3'
+        newvalue: Mixed phase-to-neutral / phase-to-phase
+      - value: '4'
+        newvalue: Phase-to-phase grouped
+      - value: '5'
+        newvalue: Phase-to-neutral grouped
+      - value: '6'
+        newvalue: Mixed grouped layout
+      - value: '7'
+        newvalue: Phase-to-phase double grouped
+      - value: '8'
+        newvalue: Phase-to-neutral double grouped
+      - value: '9'
+        newvalue: Not applicable
+    - uuid: b8ba56f4039b4a2b82ec8df47aefb746
+      name: APC PDU power supply 1 status
+      mappings:
+      - value: '1'
+        newvalue: OK
+      - value: '2'
+        newvalue: Failed
+    - uuid: d1748199618d4cf4abb03d5bb5427b22
+      name: APC PDU power supply 2 status
+      mappings:
+      - value: '1'
+        newvalue: OK
+      - value: '2'
+        newvalue: Failed
+      - value: '3'
+        newvalue: Not present
+    - uuid: 46f4b44102914b1689df3eae3079357a
+      name: APC PDU power supply alarm
+      mappings:
+      - value: '1'
+        newvalue: All available supplies OK
+      - value: '2'
+        newvalue: Power supply 1 failed
+      - value: '3'
+        newvalue: Power supply 2 failed
+      - value: '4'
+        newvalue: Both power supplies failed


### PR DESCRIPTION
## Overview

This PR adds a new SNMP template for the APC AP7822 Metered Rack PDU.

The template is based on APC PowerNet-MIB and has been tested with:

- APC AP7822
- AOS 3.9.4
- Application firmware 3.9.3
- Zabbix 7.0.28

## Features

- Device inventory
- Total current
- Bank 1 current
- Bank 2 current
- Load state monitoring
- Active power
- Apparent power
- Power factor
- Power supply monitoring
- SNMP availability trigger

The template intentionally does not include outlet-level monitoring because the tested AP7822 firmware reports zero monitored and zero controlled outlets through the legacy rPDU MIB tree.