### PR TITLE
Add Seagate Exos X 4005/4006 by HTTP template

### DIFF
--- a/Storage_Devices/Seagate/template_seagate_exos_x_4005_4006/7.0/README.md
+++ b/Storage_Devices/Seagate/template_seagate_exos_x_4005_4006/7.0/README.md
@@ -20,22 +20,38 @@ discovery, trigger prototypes, graph prototypes, template dashboards, value
 maps, and host macros. No external scripts or Zabbix Agent are required on the
 storage system.
 
-## Version 1.1.1
 
-Version 1.1.1 is a backward-compatible correction release for version 1.1.0.
+## Repository
 
-It adds independent optional API ports for the primary and secondary
-controllers:
+Current template source:
+
+[https://github.com/guicampos21/zabbix-templates/tree/main/templates/storage/template_seagate_exos_x_4005_4006/7.0](https://github.com/guicampos21/zabbix-templates/tree/main/templates/storage/template_seagate_exos_x_4005_4006/7.0)
+
+## Version 1.1.2
+
+Version 1.1.2 is a backward-compatible correction release for version 1.1.1.
+
+It changes the host-port down trigger from a static state check to a
+transition-aware alert:
+
+```text
+Up -> non-Up
+```
+
+A host port that is already disconnected when the template is linked or
+updated does not create a problem. This prevents unused FC/iSCSI ports from
+generating false alarms.
+
+After a monitored port transitions from `Up` to any non-Up state, the problem
+remains open until the port returns to `Up`.
+
+Version 1.1.1 controller-specific API port support remains unchanged:
 
 - `{$SEAGATE.API.PORT.PRIMARY}`
 - `{$SEAGATE.API.PORT.SECONDARY}`
 
-This supports NAT and port-forwarding designs where both controllers are
-accessed through the same public IP address or DNS name but use different
-external TCP ports.
-
-Existing hosts continue to work without changes. Both new macros are empty by
-default and inherit the existing `{$SEAGATE.API.PORT}` value.
+Existing API, NAT, collection, item, discovery, graph, dashboard, and UUID
+behavior is preserved.
 
 ## Requirements
 
@@ -150,7 +166,7 @@ and, if that endpoint fails:
 https://storage-nat.example.com:8002
 ```
 
-Version 1.1.1 allows the primary and secondary host values to be identical when
+Version 1.1.1 and later allow the primary and secondary host values to be identical when
 their resolved ports are different. This is required for controller-specific
 destination NAT.
 
@@ -342,6 +358,90 @@ sum(port_latency_us * port_IO_rate) / sum(port_IO_rate)
 `System latency: Source` identifies the method currently feeding the unified
 system-latency items.
 
+
+## Host-port down alert behavior
+
+### Purpose
+
+Storage arrays commonly have unused FC or iSCSI host ports. These ports are
+normally reported as `Disconnected`, even though no cable, switch path, or host
+connection is expected.
+
+Earlier template versions alerted whenever the current status was not `Up`.
+That behavior required contextual macros for every intentionally unused port.
+
+Version 1.1.2 distinguishes between:
+
+- a port that was already disconnected when monitoring started; and
+- a port that was operational and then lost its connection.
+
+### Problem condition
+
+The host-port problem opens only when all of the following are true:
+
+```text
+Current status is not Up
+Previous stored status was Up
+{$SEAGATE.PORT.DOWN.ENABLED:"{#PORT.ID}"} = 1
+```
+
+Conceptual transition:
+
+```text
+Up -> Warning
+Up -> Error
+Up -> Not present
+Up -> Unknown
+Up -> Disconnected
+```
+
+A port whose first observed state is `Disconnected` has no previous `Up`
+sample and therefore does not create a problem.
+
+### Persistent problem behavior
+
+The trigger uses a dedicated recovery expression:
+
+```text
+Current status = Up
+```
+
+This means that after a real `Up -> non-Up` transition:
+
+- the problem opens once;
+- repeated non-Up samples do not create duplicate events;
+- the problem remains open for minutes, days, or weeks while the port remains
+  non-Up; and
+- the problem closes only when the port returns to `Up`.
+
+The comparison with the previous sample is used only to detect the initial
+transition. It does not cause the open problem to disappear on later polling
+cycles.
+
+### Contextual overrides
+
+The existing contextual macro remains available:
+
+```text
+{$SEAGATE.PORT.DOWN.ENABLED:"A3"} = 0
+```
+
+Use it when a specific port must be completely excluded from host-port and SFP
+alerting, even if that port was previously connected.
+
+For normal unused ports, no per-port override is required in version 1.1.2.
+
+### Upgrade note
+
+Problems that were already open under the version 1.1.1 static-state trigger
+may remain visible after import because they were created before the new
+transition-aware logic.
+
+The trigger prototype now permits manual close. After confirming that the
+affected ports are intentionally unused, close those legacy problems once.
+They will not reopen unless the port later becomes `Up` and then transitions
+back to a non-Up state.
+
 ## Important macros
 
 | Macro | Default | Purpose |
@@ -358,7 +458,7 @@ system-latency items.
 | `{$SEAGATE.ALERTS.MODE}` | `auto` | Structured Alerts mode |
 | `{$SEAGATE.EVENTS.LAST}` | `100` | Number of recent events requested |
 | `{$SEAGATE.ENCLOSURE.EXPECTED}` | `1` | Expected total enclosure count |
-| `{$SEAGATE.PORT.DOWN.ENABLED}` | `1` | Host-port/SFP alert policy |
+| `{$SEAGATE.PORT.DOWN.ENABLED}` | `1` | Enable transition-aware host-port/SFP alerts; override by port context to completely ignore a port |
 | `{$SEAGATE.REDUNDANCY.REQUIRED}` | `1` | Require storage redundancy |
 | `{$SEAGATE.NTP.REQUIRED}` | `0` | Require NTP when set to 1 |
 
@@ -376,7 +476,7 @@ system-latency items.
 
 ### Primary works but the secondary endpoint is never attempted
 
-Version 1.1.1 recognizes the secondary endpoint when either the host or port
+Version 1.1.1 and later recognize the secondary endpoint when either the host or port
 differs.
 
 Confirm at least one condition is true:
@@ -437,6 +537,7 @@ MIT
 
 Guilherme Campos — `@guicampos21`
 
+
 ## Template dashboard
 
 The **Overview** template dashboard uses the Zabbix 72-column Full HD grid and
@@ -444,33 +545,65 @@ contains two pages:
 
 - **Overview**: API availability, system health, product, firmware,
   latency-source values, average and maximum system-latency graphs, and active
-  problems
+  problems.
 - **Components**: controller, disk, pool, volume, host-port, and disk
-  temperature graph prototypes
+  temperature graph prototypes.
 
 ## Validation
 
-The 1.1.1 bundle passed its supplied offline port-resolution and failover
-validation. The repository package also passed YAML, UUID, JavaScript,
-dashboard-reference, generated-inventory, and severity-policy checks:
+The supplied bundle includes an offline validation report covering:
 
-- Zabbix export version: `7.0`
-- Template version: `1.1.1`
-- UUID fields: `427`, with the complete 1.1.0 UUID set preserved
-- Script master items: `5`, all passing JavaScript syntax, proxy, port
-  resolution, same-host/different-port failover, and active-endpoint checks
-- Dashboard: `1` dashboard, `2` pages, and `14` widgets
-- Heartbeats: `76` occurrences of `30m`, `64` occurrences of `1h`, and no
-  remaining `1d` heartbeat
-- Trigger severities: `51` High, `11` Average, `35` Warning, `7` Information,
-  and no Disaster triggers
-- SHA-256: `1030c9b9e4810d528b1f196ca7fd438cd1c280000cd2a82f9e71242abccffc63`
+- YAML parsing
+- Zabbix export version
+- Vendor version
+- UUID uniqueness and UUIDv4 format
+- Object-count preservation
+- Current severity policy
+- Host-port trigger UUID preservation
+- Transition-aware problem expression
+- Recovery expression
+- Manual-close support
+- JavaScript syntax for all Script master items
+- Heartbeat policy
+- Static state-machine scenarios
 
-This offline result does not claim a live import or controller failover test.
-The final validation is an import into Zabbix 7.0+ and a controlled test of both
-configured management endpoints.
+The final repository package preserves the 1.1.1 storage tags and passed the
+repository checks with:
+
+- `427` unique UUIDv4 identifiers
+- `78` fixed items, `14` discovery rules, and `192` item prototypes
+- `24` fixed triggers and `80` trigger prototypes
+- `2` fixed graphs and `19` graph prototypes
+- `51` High, `11` Average, `35` Warning, `7` Information, and no Disaster
+  triggers
+- SHA-256: `13a678cf46f939cc58fe5e8ede8b7e1e19ed3b21ffb033a13adeac7598b38c25`
+
+Offline validation does not replace an import into Zabbix 7.0+ and a controlled
+live test.
+
+Recommended live validation:
+
+1. Import version 1.1.2 over version 1.1.1.
+2. Confirm an unused port already in `Disconnected` state does not open a new
+   problem.
+3. Connect a test port and confirm it reaches `Up`.
+4. Disconnect the same port and confirm the problem opens.
+5. Leave the port disconnected through multiple polling and heartbeat cycles
+   and confirm the problem remains open.
+6. Reconnect the port and confirm the problem closes.
+7. Manually close any legacy unused-port problems created by version 1.1.1.
 
 ## Release history
+
+### 1.1.2
+
+- Changed the host-port down trigger to detect `Up -> non-Up` transitions.
+- Prevented ports that are already disconnected from generating false alarms.
+- Added a recovery expression so a real port-down event remains open until the
+  port returns to `Up`.
+- Enabled manual close for one-time cleanup of legacy unused-port problems.
+- Preserved the contextual host-port/SFP alert macro.
+- Preserved all existing UUIDs and monitoring objects.
 
 ### 1.1.1
 
@@ -483,10 +616,8 @@ configured management endpoints.
 
 - Adopted the upstream-compatible directory and filename convention.
 - Added a Full HD template dashboard with Overview and Components pages.
-- Added optional HTTP proxy support to every Script master item.
-- Changed the default least-privilege API username to `zbx_monitor`.
-- Aligned template tags and resource trigger severities with Zabbix guidance.
-- Added author and MIT license metadata.
+- Added optional HTTP proxy support.
+- Published the normalized Seagate Exos X 4005/4006 monitoring package.
 
 ### 1.0.7
 
@@ -508,7 +639,7 @@ configured management endpoints.
 <!-- BEGIN GENERATED MONITORING INVENTORY -->
 ## Complete monitoring inventory
 
-Complete inventory generated from the Zabbix 7.0 YAML export, version 1.1.1.
+Complete inventory generated from the Zabbix 7.0 YAML export, version 1.1.2.
 It includes fixed objects and low-level discovery (LLD) prototypes.
 
 > [!NOTE]

--- a/Storage_Devices/Seagate/template_seagate_exos_x_4005_4006/7.0/README.md
+++ b/Storage_Devices/Seagate/template_seagate_exos_x_4005_4006/7.0/README.md
@@ -10,95 +10,270 @@ Indium controller modules and the following enclosure formats:
 - 2U24
 - 5U84
 
-The template was validated offline with real API responses from:
+It was validated offline with real API responses from:
 
 - Seagate Exos X 4005-family storage reporting product ID `4865`
 - Seagate Exos X 4006
 
 It uses native Zabbix features only: Script items, dependent items, low-level
-discovery, trigger prototypes, graph prototypes, value maps, and host macros.
-No external scripts or agents are required.
+discovery, trigger prototypes, graph prototypes, template dashboards, value
+maps, and host macros. No external scripts or Zabbix Agent are required on the
+storage system.
+
+## Version 1.1.1
+
+Version 1.1.1 is a backward-compatible correction release for version 1.1.0.
+
+It adds independent optional API ports for the primary and secondary
+controllers:
+
+- `{$SEAGATE.API.PORT.PRIMARY}`
+- `{$SEAGATE.API.PORT.SECONDARY}`
+
+This supports NAT and port-forwarding designs where both controllers are
+accessed through the same public IP address or DNS name but use different
+external TCP ports.
+
+Existing hosts continue to work without changes. Both new macros are empty by
+default and inherit the existing `{$SEAGATE.API.PORT}` value.
 
 ## Requirements
 
 - Zabbix 7.0 or newer
-- Network access from the Zabbix server or proxy to the storage management
-  controller over HTTP or HTTPS
+- Network access from the Zabbix server or proxy to the storage management API
 - A Seagate Exos account with Monitor/read-only permissions and Web/API access
-- The native Seagate JSON API enabled on the storage system
+- Native Seagate JSON API enabled
 
 > [!IMPORTANT]
-> Import and test the template on a non-critical host first. Although it was
-> validated against real API captures, a live import and several collection
-> cycles are the final compatibility test for your firmware and configuration.
+> Import and test the template on a non-critical host first. Offline YAML,
+> UUID, and JavaScript validation does not replace an actual Zabbix import and
+> a live collection/failover test against the target storage firmware.
 
 ## Installation
 
-1. Download
-   [`template_seagate_exos_x_4005_4006.yaml`](template_seagate_exos_x_4005_4006.yaml).
+1. Download `template_seagate_exos_x_4005_4006.yaml`.
 2. In Zabbix, open **Data collection > Templates**.
-3. Select **Import**, choose the downloaded YAML file, and complete the import.
-4. Create or select the host that represents the storage array.
-5. Link the **Seagate Exos Storage by HTTP** template to the host.
-6. Open the host's **Macros** tab and configure the required values:
+3. Select **Import** and choose the YAML file.
+4. Create or select the host representing the storage array.
+5. Link **Seagate Exos Storage by HTTP**.
+6. Configure the required host macros:
 
-   | Macro | Example | Description |
-   |---|---|---|
-   | `{$SEAGATE.API.HOST}` | `192.0.2.10` | Primary controller management IP address or hostname |
-   | `{$SEAGATE.API.USERNAME}` | `zbx_monitor` | Dedicated Monitor/read-only API user |
-   | `{$SEAGATE.API.PASSWORD}` | — | API password, stored as a secret-text macro |
+| Macro | Example | Description |
+|---|---|---|
+| `{$SEAGATE.API.HOST}` | `192.0.2.10` | Primary controller management IP address or hostname |
+| `{$SEAGATE.API.USERNAME}` | `zbx_monitor` | Monitor/read-only API user |
+| `{$SEAGATE.API.PASSWORD}` | — | API password stored as a secret-text macro |
 
-7. If necessary, override the connection defaults:
+Optional connection macros:
 
-   | Macro | Default | Description |
-   |---|---:|---|
-   | `{$SEAGATE.API.SCHEME}` | `https` | API scheme: `https` or `http` |
-   | `{$SEAGATE.API.PORT}` | `443` | Management API TCP port |
-   | `{$SEAGATE.API.HOST.SECONDARY}` | empty | Optional partner-controller management address |
-   | `{$SEAGATE.HTTP.PROXY}` | empty | Optional HTTP proxy, for example `http://proxy.example:8080` |
+| Macro | Default | Description |
+|---|---:|---|
+| `{$SEAGATE.API.SCHEME}` | `https` | API scheme: `https` or `http` |
+| `{$SEAGATE.API.PORT}` | `443` | Shared/default management API TCP port |
+| `{$SEAGATE.API.HOST.SECONDARY}` | empty | Optional partner-controller address |
+| `{$SEAGATE.API.PORT.PRIMARY}` | empty | Primary-controller port override; inherits the shared port |
+| `{$SEAGATE.API.PORT.SECONDARY}` | empty | Secondary-controller port override; inherits the shared port |
+| `{$SEAGATE.HTTP.PROXY}` | empty | Optional HTTP proxy used by all Script master items |
 
-The host does not require an Agent, SNMP, JMX, or IPMI interface for this
-template. Collection is performed by Zabbix Script items from the Zabbix server
-or the proxy monitoring the host.
+The Zabbix host does not require Agent, SNMP, JMX, or IPMI interfaces. All
+collection is performed by Script master items running on the Zabbix server or
+the proxy assigned to the host.
+
+## Controller-specific API ports
+
+The template resolves the API port independently for each controller.
+
+Primary controller:
+
+```text
+{$SEAGATE.API.PORT.PRIMARY}
+        or, when empty:
+{$SEAGATE.API.PORT}
+```
+
+Secondary controller:
+
+```text
+{$SEAGATE.API.PORT.SECONDARY}
+        or, when empty:
+{$SEAGATE.API.PORT}
+```
+
+The fallback to `{$SEAGATE.API.PORT}` preserves the behavior of version 1.1.0
+and earlier host configurations.
+
+### Use case 1: Standard direct management addresses
+
+Both controllers use HTTPS TCP/443 and have different management addresses.
+
+```text
+{$SEAGATE.API.HOST} = 192.0.2.10
+{$SEAGATE.API.HOST.SECONDARY} = 192.0.2.11
+{$SEAGATE.API.PORT} = 443
+{$SEAGATE.API.PORT.PRIMARY} =
+{$SEAGATE.API.PORT.SECONDARY} =
+```
+
+The collector tries:
+
+```text
+https://192.0.2.10:443
+```
+
+and, if the primary endpoint cannot be used:
+
+```text
+https://192.0.2.11:443
+```
+
+### Use case 2: Both controllers behind the same NAT address
+
+A NAT device publishes controller A on TCP/8001 and controller B on TCP/8002.
+
+```text
+{$SEAGATE.API.HOST} = storage-nat.example.com
+{$SEAGATE.API.HOST.SECONDARY} = storage-nat.example.com
+{$SEAGATE.API.PORT} = 443
+{$SEAGATE.API.PORT.PRIMARY} = 8001
+{$SEAGATE.API.PORT.SECONDARY} = 8002
+```
+
+The collector tries:
+
+```text
+https://storage-nat.example.com:8001
+```
+
+and, if that endpoint fails:
+
+```text
+https://storage-nat.example.com:8002
+```
+
+Version 1.1.1 allows the primary and secondary host values to be identical when
+their resolved ports are different. This is required for controller-specific
+destination NAT.
+
+Example NAT rules:
+
+```text
+Public-IP:8001 -> Controller-A-IP:443
+Public-IP:8002 -> Controller-B-IP:443
+```
+
+The Zabbix server or proxy must be able to reach both externally published
+ports. Firewall source restrictions and NAT session timeouts must permit the
+complete HTTPS API request.
+
+### Use case 3: One custom port shared by both controllers
+
+Both controllers listen or are published on TCP/8443.
+
+```text
+{$SEAGATE.API.HOST} = 192.0.2.10
+{$SEAGATE.API.HOST.SECONDARY} = 192.0.2.11
+{$SEAGATE.API.PORT} = 8443
+{$SEAGATE.API.PORT.PRIMARY} =
+{$SEAGATE.API.PORT.SECONDARY} =
+```
+
+Both controller-specific macros are empty, so both endpoints inherit TCP/8443.
+
+### Use case 4: Different addresses and different ports
+
+```text
+{$SEAGATE.API.HOST} = 198.51.100.10
+{$SEAGATE.API.HOST.SECONDARY} = 198.51.100.11
+{$SEAGATE.API.PORT} = 443
+{$SEAGATE.API.PORT.PRIMARY} = 8001
+{$SEAGATE.API.PORT.SECONDARY} = 8002
+```
+
+The template uses the exact host-and-port pair assigned to each controller.
+
+## Active management endpoint
+
+The `Active management endpoint` item stores the endpoint selected by the
+collector in `host:port` format.
+
+Examples:
+
+```text
+storage-nat.example.com:8001
+```
+
+After failover:
+
+```text
+storage-nat.example.com:8002
+```
+
+This makes controller and NAT-port failover visible in Zabbix and Grafana.
+
+## Backward compatibility
+
+No host macro changes are required for arrays already monitored with version
+1.1.0.
+
+When these macros remain empty:
+
+```text
+{$SEAGATE.API.PORT.PRIMARY} =
+{$SEAGATE.API.PORT.SECONDARY} =
+```
+
+the behavior remains:
+
+```text
+Primary:
+{$SEAGATE.API.HOST}:{$SEAGATE.API.PORT}
+
+Secondary:
+{$SEAGATE.API.HOST.SECONDARY}:{$SEAGATE.API.PORT}
+```
+
+All existing item, discovery-rule, trigger, graph, and value-map UUIDs are
+preserved. The template dashboard UUID published with version 1.1.0 is also
+preserved.
 
 ## Storage-side preparation
 
 Create a dedicated account in the Seagate management interface with the
-Monitor/read-only role, name it `zbx_monitor` when practical, and permit Web/API
-access. Confirm that the Zabbix server or proxy can reach the selected
-management address and port.
+Monitor/read-only role and Web/API access. Confirm that the Zabbix server or
+proxy can reach each configured host-and-port pair.
 
-The template authenticates with the Seagate API using
-`SHA-256(username + "_" + password)`, obtains a session key, runs read-only
-`show` commands, and logs out. Credentials are supplied through Zabbix macros;
-the password macro is defined as `SECRET_TEXT`.
+The template authenticates using:
 
-For dual-controller systems, set `{$SEAGATE.API.HOST.SECONDARY}` to enable
-login failover. The template tries the secondary address when the primary
-address cannot be used.
+```text
+SHA-256(username + "_" + password)
+```
+
+It obtains a session key, runs read-only `show` and supported `query` commands,
+and logs out. The password is supplied through the
+`{$SEAGATE.API.PASSWORD}` secret-text macro.
 
 ## First-run verification
 
-Allow two or three polling cycles after linking the template, then check
-**Monitoring > Latest data** for the host.
+Allow two or three polling cycles after linking or updating the template, then
+check **Monitoring > Latest data**.
 
-Verify the following:
+Verify:
 
-1. The `API availability raw` item is supported and reports an available API.
-2. The five Script master items collect data without method errors:
-   - API check
+1. `API availability raw` is supported.
+2. `API available` reports `Yes`.
+3. `Active management endpoint` shows the expected `host:port`.
+4. All five Script master items collect without method errors:
+   - API availability
    - Core data
    - Performance data
-   - Events and alerts
    - Inventory data
-3. Low-level discovery creates the expected controllers, disks, pools, volumes,
-   ports, enclosures, and other installed components.
-4. Unsupported firmware-specific fields do not affect required monitoring.
-5. Trigger thresholds and port policies match the storage configuration.
-6. `System latency: Source` identifies either the native 4006 metrics or the
-   4005/4865 host-port weighted fallback.
+   - Events and alerts
+5. Low-level discovery creates the expected controllers, disks, pools, volumes,
+   ports, enclosures, and hardware components.
+6. For NAT deployments, test TCP/8001 and TCP/8002 independently and confirm
+   failover to the secondary endpoint.
 
-The default collection schedule is:
+Default collection schedule:
 
 | Data set | Interval |
 |---|---:|
@@ -108,25 +283,16 @@ The default collection schedule is:
 | Events and alerts | 1 minute |
 | Inventory | 30 minutes |
 
-Intervals can be changed with the `{$SEAGATE.INTERVAL.*}` macros.
+Intervals can be changed using the `{$SEAGATE.INTERVAL.*}` macros.
 
 ## Dashboard data freshness
 
-Version 1.0.7 reduces stale-looking values in Grafana and NOC dashboards without
-storing every unchanged polling result.
+The default inventory interval is 30 minutes. Dashboard-facing unchanged
+values are periodically stored using preprocessing heartbeats so short Grafana
+time ranges can still retrieve recent text and inventory values.
 
-- The default `{$SEAGATE.INTERVAL.INVENTORY}` value is `30m`.
-- All preprocessing heartbeats that previously used `1d` now use `30m`.
-- The template contains 76 30-minute heartbeat steps and no remaining one-day
-  heartbeat.
-- Existing one-hour heartbeats remain unchanged.
-- Availability, core, performance, and event polling intervals remain
-  unchanged.
-
-This affects how frequently unchanged values are stored, not how frequently
-most operational data is collected. The shorter inventory master-item interval
-is necessary so dependent product and firmware values can store a sample every
-30 minutes.
+Grafana text panels must use the Zabbix data source **Text** query type for
+Character, Text, and Log items. Numeric items use **Metrics**.
 
 ## Monitored components
 
@@ -139,7 +305,7 @@ Low-level discovery covers:
 - Volumes
 - Storage tiers
 - Enclosures
-- Field-replaceable units (FRUs)
+- Field-replaceable units
 - Fans and power supplies
 - Sensors
 - SAS links
@@ -147,26 +313,134 @@ Low-level discovery covers:
 - Replication sets
 
 The template monitors health, capacity, utilization, performance, firmware,
-system read/write latency, error counters, the common event log, and structured
-active alerts when the storage model supports them.
+system read/write latency, error counters, the common Event Log, and structured
+active alerts when supported by the storage generation.
 
-The [complete monitoring inventory](#complete-monitoring-inventory) below lists
-every fixed item, discovery rule, item prototype, fixed trigger, trigger
-prototype, fixed graph, graph prototype, and dashboard widget, including Zabbix
-keys and severities.
+## System latency
 
-| Zabbix object | Fixed | LLD/prototype |
-|---|---:|---:|
-| Items | 78 | 192 |
-| Discovery rules | — | 14 |
-| Triggers | 24 | 80 |
-| Graphs | 2 | 19 |
-| Template dashboards | 1 dashboard / 2 pages / 14 widgets | — |
+### Exos X 4006
+
+The template queries native read-only Metrics Framework values:
+
+```text
+system.read-avg-response-time
+system.write-avg-response-time
+system.read-max-response-time
+system.write-max-response-time
+```
+
+### 4005 / 4865 fallback
+
+The tested 4005/4865 API does not expose the same Metrics Framework. The
+template derives host-facing average read and write latency from I/O-weighted
+host-port statistics:
+
+```text
+sum(port_latency_us * port_IO_rate) / sum(port_IO_rate)
+```
+
+`System latency: Source` identifies the method currently feeding the unified
+system-latency items.
+
+## Important macros
+
+| Macro | Default | Purpose |
+|---|---:|---|
+| `{$SEAGATE.API.HOST}` | empty | Primary management host |
+| `{$SEAGATE.API.HOST.SECONDARY}` | empty | Optional partner-controller host |
+| `{$SEAGATE.API.PORT}` | `443` | Shared/default API port |
+| `{$SEAGATE.API.PORT.PRIMARY}` | empty | Primary port override |
+| `{$SEAGATE.API.PORT.SECONDARY}` | empty | Secondary port override |
+| `{$SEAGATE.API.SCHEME}` | `https` | HTTP or HTTPS |
+| `{$SEAGATE.API.USERNAME}` | `zbx_monitor` | Read-only API username |
+| `{$SEAGATE.API.PASSWORD}` | secret | Read-only API password |
+| `{$SEAGATE.HTTP.PROXY}` | empty | Optional HTTP proxy |
+| `{$SEAGATE.ALERTS.MODE}` | `auto` | Structured Alerts mode |
+| `{$SEAGATE.EVENTS.LAST}` | `100` | Number of recent events requested |
+| `{$SEAGATE.ENCLOSURE.EXPECTED}` | `1` | Expected total enclosure count |
+| `{$SEAGATE.PORT.DOWN.ENABLED}` | `1` | Host-port/SFP alert policy |
+| `{$SEAGATE.REDUNDANCY.REQUIRED}` | `1` | Require storage redundancy |
+| `{$SEAGATE.NTP.REQUIRED}` | `0` | Require NTP when set to 1 |
+
+## Security notes
+
+- Use a dedicated Monitor/read-only storage account.
+- Keep `{$SEAGATE.API.PASSWORD}` as a secret-text host macro.
+- Limit firewall access to the Zabbix server or proxy source addresses.
+- For NAT deployments, do not expose the management API broadly to the
+  Internet.
+- Prefer a private network, VPN, or dedicated management path.
+- The template executes read-only API commands only.
+
+## Troubleshooting controller-specific ports
+
+### Primary works but the secondary endpoint is never attempted
+
+Version 1.1.1 recognizes the secondary endpoint when either the host or port
+differs.
+
+Confirm at least one condition is true:
+
+```text
+{$SEAGATE.API.HOST.SECONDARY} != {$SEAGATE.API.HOST}
+```
+
+or:
+
+```text
+{$SEAGATE.API.PORT.SECONDARY} != {$SEAGATE.API.PORT.PRIMARY}
+```
+
+### Both NAT ports fail
+
+From the Zabbix server or proxy, verify TCP/TLS reachability:
+
+```bash
+curl -kI https://storage-nat.example.com:8001/
+curl -kI https://storage-nat.example.com:8002/
+```
+
+An HTTP response from the root path can prove basic TCP/TLS reachability, but
+the final test must use the Seagate API login endpoint or the Zabbix Script
+item.
+
+Check:
+
+- Destination NAT rules
+- Firewall source restrictions
+- TCP port forwarding
+- TLS inspection or reverse-proxy behavior
+- Controller Web/API service status
+- Credentials
+- Zabbix Script item timeout
+
+### Existing direct-connected storage stopped collecting after import
+
+Confirm the new macros are empty or contain valid TCP ports:
+
+```text
+{$SEAGATE.API.PORT.PRIMARY} =
+{$SEAGATE.API.PORT.SECONDARY} =
+```
+
+Also confirm the shared port is still correct:
+
+```text
+{$SEAGATE.API.PORT} = 443
+```
+
+## License
+
+MIT
+
+## Author
+
+Guilherme Campos — `@guicampos21`
 
 ## Template dashboard
 
-The **Overview** template dashboard is designed for the Zabbix 72-column
-Full HD grid and contains two pages:
+The **Overview** template dashboard uses the Zabbix 72-column Full HD grid and
+contains two pages:
 
 - **Overview**: API availability, system health, product, firmware,
   latency-source values, average and maximum system-latency graphs, and active
@@ -174,276 +448,67 @@ Full HD grid and contains two pages:
 - **Components**: controller, disk, pool, volume, host-port, and disk
   temperature graph prototypes
 
-## Important configuration macros
-
-| Macro | Default | Purpose |
-|---|---:|---|
-| `{$SEAGATE.ALERTS.MODE}` | `auto` | Structured Alerts API mode: `auto`, `enabled`, or `disabled` |
-| `{$SEAGATE.EVENTS.LAST}` | `100` | Number of recent events requested; maximum 1000 |
-| `{$SEAGATE.DATA.TIMEOUT}` | `60s` | Script master-item timeout |
-| `{$SEAGATE.HTTP.PROXY}` | empty | Optional proxy applied to all HTTP API requests |
-| `{$SEAGATE.ENCLOSURE.EXPECTED}` | `1` | Expected total enclosure count, including the controller enclosure |
-| `{$SEAGATE.PORT.DOWN.ENABLED}` | `1` | Enable host-port and SFP alerts |
-| `{$SEAGATE.VOLUME.WRITEBACK.REQUIRED}` | `1` | Require write-back policy |
-| `{$SEAGATE.REDUNDANCY.REQUIRED}` | `1` | Alert when the system is not redundant |
-| `{$SEAGATE.NTP.REQUIRED}` | `0` | Require NTP when set to `1` |
-| `{$SEAGATE.CONTROLLER.CPU.WARN}` | `90` | Controller CPU warning threshold, in percent |
-| `{$SEAGATE.DISK.TEMP.WARN}` | `50` | Disk temperature warning threshold, in degrees Celsius |
-| `{$SEAGATE.DISK.TEMP.CRIT}` | `60` | Disk temperature critical threshold, in degrees Celsius |
-| `{$SEAGATE.SSD.LIFE.WARN}` | `10` | SSD remaining-life warning threshold, in percent |
-
-Capacity thresholds for disk groups, pools, and tiers are also exposed as
-template macros and can be overridden at host level.
-
-### Excluding intentionally unused ports
-
-Port and SFP alerts support macro contexts. To suppress down alerts for an
-intentionally unused port, create a host-level context macro such as:
-
-```text
-{$SEAGATE.PORT.DOWN.ENABLED:"A3"} = 0
-```
-
-Use the discovered port name shown in Zabbix as the context.
-
-### Enclosure and SAS expansion-port policy
-
-Set `{$SEAGATE.ENCLOSURE.EXPECTED}` to the total number of enclosures that
-should be visible:
-
-- `1`: controller enclosure only
-- `2`: controller enclosure and one expansion enclosure
-- `3`: controller enclosure and two expansion enclosures
-
-The template raises a High-severity problem when the discovered enclosure count
-is below this value.
-
-An external `Expansion Port Universal` SAS link is not considered failed only
-because its state is `Disconnected`; that state is valid for an unused expansion
-port or the last port in an enclosure chain. Health monitoring remains enabled
-for all SAS links, while abnormal internal or non-expansion SAS links continue
-to generate problems.
-
-## System latency
-
-Version 1.0.6 provides one unified system-latency view while selecting the
-collection method supported by the storage model.
-
-### Exos X 4006 native metrics
-
-On Exos X 4006, the template queries these read-only Metrics Framework values:
-
-- `system.read-avg-response-time`
-- `system.write-avg-response-time`
-- `system.read-max-response-time`
-- `system.write-max-response-time`
-
-The collector only runs `query metrics`; it does not call `start metrics` or
-`stop metrics`. Bare `N/A` tokens occasionally returned by the API are sanitized
-before the response is parsed as JSON.
-
-### 4005/4865 fallback
-
-The tested 4005/4865 API does not expose the Metrics Framework. For that system,
-the template derives the host-facing average read and write latency from
-`show host-port-statistics`.
-
-It derives the read and write I/O rate of each host port from its cumulative
-counters and calculates an I/O-weighted aggregate:
-
-```text
-sum(port_latency_us × port_IO_rate) / sum(port_IO_rate)
-```
-
-Comparison with native 4006 metrics over clean, aligned intervals produced:
-
-| Measurement | Read | Write |
-|---|---:|---:|
-| Mean absolute error | approximately 3.05% | approximately 18.16% |
-| Pearson correlation | approximately 0.9201 | approximately 0.9605 |
-
-`System latency: Source` shows which method currently feeds the unified items.
-
-### Items and graphs
-
-The system-latency items are:
-
-- `System: Read average response time`
-- `System: Write average response time`
-- `System: Read maximum response time` — native 4006 only
-- `System: Write maximum response time` — native 4006 only
-- `System latency: Source`
-
-All system-latency values are stored and displayed in microseconds. The template
-includes the `System latency` graph for average read/write time and the
-`System maximum latency (4006 native)` graph for native maximum values.
-
-Pool, disk-group, and host-port latency graphs remain available because they
-represent different layers of the storage I/O path.
-
-## Hardware and model compatibility
-
-| Scope | Supported target |
-|---|---|
-| Product family | Seagate Exos X |
-| Management/controller models | 4005 and 4006 |
-| Controller platforms | Gallium and Indium |
-| Enclosure formats | 2U12, 2U24, and 5U84 |
-
-| Feature | 4005/4865 | Exos X 4006 |
-|---|:---:|:---:|
-| Core system and hardware state | Validated | Validated |
-| Controllers and performance | Validated | Validated |
-| Disks and predictive counters | Validated | Validated |
-| Disk groups, pools, volumes, and tiers | Validated | Validated |
-| Enclosures, FRUs, fans, PSUs, and sensors | Validated | Validated |
-| SAS link and expander health | Validated | Validated |
-| Host ports and SFP data | Validated | Validated |
-| Unified system average latency | Weighted fallback | Native metrics |
-| System maximum latency | Not exposed by tested API | Native metrics |
-| Common Event Log | Validated | Validated |
-| Structured active Alerts | Not exposed by tested API | Validated |
-| Alert-condition history | Not exposed by tested API | Validated |
-| Replication commands | Validated; no active set available | Validated; no active set available |
-
-The template discovers components dynamically and addresses API fields by name,
-which makes it tolerant of model differences. Results can still vary with
-firmware releases and installed hardware.
-
-## Alert behavior
-
-- Controller and system firmware changes generate Information events.
-- Disk error triggers fire when a cumulative counter increases.
-- Block-based capacity values are converted to bytes using the reported block
-  size.
-- Existing component response-time values are converted from microseconds to
-  seconds where required; the unified system-latency items remain in
-  microseconds.
-- Persistent hardware problems use the current component health or status.
-- New Warning, Error, and Critical event IDs generate supplemental edge
-  notifications.
-- Structured active-alert counters are used on supported Exos X 4006 systems.
-
-Native syslog or SNMP event forwarding is still recommended when guaranteed
-delivery of every asynchronous storage event is required.
-
-## Troubleshooting
-
-### Authentication fails
-
-- Confirm the username and password at host macro level.
-- Confirm the account has Monitor/read-only and Web/API access.
-- Check that no unresolved macro is overriding the template value.
-- Test both controller addresses if a secondary endpoint is configured.
-
-The login endpoint is validated through a successful HTTP status,
-`response-type: Success`, and a non-empty session key. Unlike normal `show`
-commands, login does not need to return `return-code: 0`.
-
-### Script items are unsupported
-
-- Confirm that the Zabbix server or assigned proxy can resolve and reach the
-  controller address.
-- Check `{$SEAGATE.API.SCHEME}` and `{$SEAGATE.API.PORT}`.
-- Review the master item's error message and the API method-error items.
-- Increase `{$SEAGATE.DATA.TIMEOUT}` if the array answers slowly.
-
-### Expected hardware is not discovered
-
-- Wait for the relevant discovery interval.
-- Check the corresponding Script master item for API errors.
-- Confirm that the component is visible to the read-only storage account.
-- Compare the storage firmware and model with the validated systems above.
-
-## Intentional exclusions
-
-The template does not collect:
-
-- Full `audit-log`, because it was extremely large and truncated in testing
-- `workload`, which is mainly intended for tiering and capacity analysis
-- `metrics-list` continuously; the 4006 system-latency collector queries the
-  required metrics directly
-- `fan-modules`, which returned HTTP 400 on the tested 4006; `show fans` supplies
-  the required data
-- `host-phy-statistics`, which is SAS-host-specific and did not apply to the
-  tested configuration
-- `remote-systems`, which returned HTTP 400 on the tested 4006
-
 ## Validation
 
-Release 1.1.0 passed offline YAML, UUID format and uniqueness, heartbeat,
-HTTP-proxy, dashboard-reference, and severity-policy checks. The monitoring
-logic is already in production use; the upstream-compatible packaging and
-1.1.0 conformance changes were validated structurally.
+The 1.1.1 bundle passed its supplied offline port-resolution and failover
+validation. The repository package also passed YAML, UUID, JavaScript,
+dashboard-reference, generated-inventory, and severity-policy checks:
 
 - Zabbix export version: `7.0`
-- UUID fields: `427`, all correctly formatted and unique
-- Script master items: `5`, all passing JavaScript syntax and HTTP-proxy checks
-- Dashboard: `1` dashboard, `2` pages, and `14` widgets with valid references
-- Heartbeats: `76` occurrences of `30m` and no remaining `1d` heartbeat
-- Trigger policy: no Disaster triggers; degraded states use Average
-- SHA-256: `51daf147ad05a2835ae69ffd404945466f9e756a528c2165275b0409da6811fa`
+- Template version: `1.1.1`
+- UUID fields: `427`, with the complete 1.1.0 UUID set preserved
+- Script master items: `5`, all passing JavaScript syntax, proxy, port
+  resolution, same-host/different-port failover, and active-endpoint checks
+- Dashboard: `1` dashboard, `2` pages, and `14` widgets
+- Heartbeats: `76` occurrences of `30m`, `64` occurrences of `1h`, and no
+  remaining `1d` heartbeat
+- Trigger severities: `51` High, `11` Average, `35` Warning, `7` Information,
+  and no Disaster triggers
+- SHA-256: `1030c9b9e4810d528b1f196ca7fd438cd1c280000cd2a82f9e71242abccffc63`
 
-A separate clean-instance import was intentionally not executed for 1.1.0 at
-the maintainer's request.
-
-## Vendor documentation
-
-- [Seagate Exos X 4006 support](https://www.seagate.com/support/disk-arrays/exos-x-4006/)
-- [Seagate Exos X 4006 Series Storage Management Guide](https://www.seagate.com/content/dam/seagate/assets/support/disk-arrays/exos-x-4006-2u12/_shared/files/204468700-01-A_4006_SMG.pdf)
-
-## Version
-
-- Template version: `1.1.0`
-- Minimum Zabbix version: `7.0`
-- Export format: Zabbix `7.0`
-
-## Author and license
-
-- Author: [Guilherme Campos (@guicampos21)](https://github.com/guicampos21)
-- Maintainer/vendor: SentrixIT
-- License: [MIT](https://github.com/guicampos21/zabbix-templates/blob/main/LICENSE)
+This offline result does not claim a live import or controller failover test.
+The final validation is an import into Zabbix 7.0+ and a controlled test of both
+configured management endpoints.
 
 ## Release history
 
+### 1.1.1
+
+- Added optional primary and secondary controller API port macros.
+- Added same-host, different-port failover for NAT and port-forwarding.
+- Preserved `{$SEAGATE.API.PORT}` as the backward-compatible shared default.
+- Changed the active management endpoint value to `host:port`.
+
 ### 1.1.0
 
-- Reorganized the template into the upstream-compatible
-  `template_seagate_exos_x_4005_4006/7.0/` directory layout.
-- Renamed the import file to `template_seagate_exos_x_4005_4006.yaml`.
+- Adopted the upstream-compatible directory and filename convention.
 - Added a Full HD template dashboard with Overview and Components pages.
-- Added `{$SEAGATE.HTTP.PROXY}` to every Script master item.
+- Added optional HTTP proxy support to every Script master item.
 - Changed the default least-privilege API username to `zbx_monitor`.
-- Aligned template tags with the Zabbix storage classification.
-- Changed resource-level Disaster triggers to High and degraded-state triggers
-  from High to Average.
-- Added the author and MIT license metadata required for upstream submission.
+- Aligned template tags and resource trigger severities with Zabbix guidance.
+- Added author and MIT license metadata.
 
 ### 1.0.7
 
-- Changed the inventory interval and all former one-day preprocessing
-  heartbeats to `30m`, ensuring dashboard-facing unchanged values are stored at
-  least every 30 minutes.
-- Left one-hour heartbeats and core, performance, availability, and event
-  polling intervals unchanged.
+- Changed the inventory interval and former one-day preprocessing heartbeats to
+  `30m` so unchanged dashboard-facing values remain recent.
 
 ### 1.0.6
 
 - Added unified system read and write average latency.
 - Added native average and maximum system latency for Exos X 4006.
 - Added an I/O-weighted host-port fallback for the tested 4005/4865 API.
-- Added average and maximum system-latency graphs and source identification.
-- Corrected fixed graph placement in the Zabbix 7.0 export hierarchy.
+- Added the average and maximum system-latency graphs.
 
 ### 1.0.4
 
 - Refined disconnected expansion-port handling.
-- Added the expected-enclosure policy and related High-severity trigger.
+- Added the expected-enclosure policy and related trigger.
 
 <!-- BEGIN GENERATED MONITORING INVENTORY -->
 ## Complete monitoring inventory
 
-Complete inventory generated from the Zabbix 7.0 YAML export, version 1.1.0.
+Complete inventory generated from the Zabbix 7.0 YAML export, version 1.1.1.
 It includes fixed objects and low-level discovery (LLD) prototypes.
 
 > [!NOTE]

--- a/Storage_Devices/Seagate/template_seagate_exos_x_4005_4006/7.0/README.md
+++ b/Storage_Devices/Seagate/template_seagate_exos_x_4005_4006/7.0/README.md
@@ -1,0 +1,1283 @@
+# Zabbix Template for Seagate Exos X 4005/4006 Storage
+
+Zabbix 7.0+ template for monitoring Seagate Exos storage systems through the
+native JSON management API.
+
+The template is designed for Seagate Exos X 4005/4006 systems with Gallium or
+Indium controller modules and the following enclosure formats:
+
+- 2U12
+- 2U24
+- 5U84
+
+The template was validated offline with real API responses from:
+
+- Seagate Exos X 4005-family storage reporting product ID `4865`
+- Seagate Exos X 4006
+
+It uses native Zabbix features only: Script items, dependent items, low-level
+discovery, trigger prototypes, graph prototypes, value maps, and host macros.
+No external scripts or agents are required.
+
+## Requirements
+
+- Zabbix 7.0 or newer
+- Network access from the Zabbix server or proxy to the storage management
+  controller over HTTP or HTTPS
+- A Seagate Exos account with Monitor/read-only permissions and Web/API access
+- The native Seagate JSON API enabled on the storage system
+
+> [!IMPORTANT]
+> Import and test the template on a non-critical host first. Although it was
+> validated against real API captures, a live import and several collection
+> cycles are the final compatibility test for your firmware and configuration.
+
+## Installation
+
+1. Download
+   [`template_seagate_exos_x_4005_4006.yaml`](template_seagate_exos_x_4005_4006.yaml).
+2. In Zabbix, open **Data collection > Templates**.
+3. Select **Import**, choose the downloaded YAML file, and complete the import.
+4. Create or select the host that represents the storage array.
+5. Link the **Seagate Exos Storage by HTTP** template to the host.
+6. Open the host's **Macros** tab and configure the required values:
+
+   | Macro | Example | Description |
+   |---|---|---|
+   | `{$SEAGATE.API.HOST}` | `192.0.2.10` | Primary controller management IP address or hostname |
+   | `{$SEAGATE.API.USERNAME}` | `zbx_monitor` | Dedicated Monitor/read-only API user |
+   | `{$SEAGATE.API.PASSWORD}` | — | API password, stored as a secret-text macro |
+
+7. If necessary, override the connection defaults:
+
+   | Macro | Default | Description |
+   |---|---:|---|
+   | `{$SEAGATE.API.SCHEME}` | `https` | API scheme: `https` or `http` |
+   | `{$SEAGATE.API.PORT}` | `443` | Management API TCP port |
+   | `{$SEAGATE.API.HOST.SECONDARY}` | empty | Optional partner-controller management address |
+   | `{$SEAGATE.HTTP.PROXY}` | empty | Optional HTTP proxy, for example `http://proxy.example:8080` |
+
+The host does not require an Agent, SNMP, JMX, or IPMI interface for this
+template. Collection is performed by Zabbix Script items from the Zabbix server
+or the proxy monitoring the host.
+
+## Storage-side preparation
+
+Create a dedicated account in the Seagate management interface with the
+Monitor/read-only role, name it `zbx_monitor` when practical, and permit Web/API
+access. Confirm that the Zabbix server or proxy can reach the selected
+management address and port.
+
+The template authenticates with the Seagate API using
+`SHA-256(username + "_" + password)`, obtains a session key, runs read-only
+`show` commands, and logs out. Credentials are supplied through Zabbix macros;
+the password macro is defined as `SECRET_TEXT`.
+
+For dual-controller systems, set `{$SEAGATE.API.HOST.SECONDARY}` to enable
+login failover. The template tries the secondary address when the primary
+address cannot be used.
+
+## First-run verification
+
+Allow two or three polling cycles after linking the template, then check
+**Monitoring > Latest data** for the host.
+
+Verify the following:
+
+1. The `API availability raw` item is supported and reports an available API.
+2. The five Script master items collect data without method errors:
+   - API check
+   - Core data
+   - Performance data
+   - Events and alerts
+   - Inventory data
+3. Low-level discovery creates the expected controllers, disks, pools, volumes,
+   ports, enclosures, and other installed components.
+4. Unsupported firmware-specific fields do not affect required monitoring.
+5. Trigger thresholds and port policies match the storage configuration.
+6. `System latency: Source` identifies either the native 4006 metrics or the
+   4005/4865 host-port weighted fallback.
+
+The default collection schedule is:
+
+| Data set | Interval |
+|---|---:|
+| API availability | 1 minute |
+| Core system and hardware state | 2 minutes |
+| Performance | 1 minute |
+| Events and alerts | 1 minute |
+| Inventory | 30 minutes |
+
+Intervals can be changed with the `{$SEAGATE.INTERVAL.*}` macros.
+
+## Dashboard data freshness
+
+Version 1.0.7 reduces stale-looking values in Grafana and NOC dashboards without
+storing every unchanged polling result.
+
+- The default `{$SEAGATE.INTERVAL.INVENTORY}` value is `30m`.
+- All preprocessing heartbeats that previously used `1d` now use `30m`.
+- The template contains 76 30-minute heartbeat steps and no remaining one-day
+  heartbeat.
+- Existing one-hour heartbeats remain unchanged.
+- Availability, core, performance, and event polling intervals remain
+  unchanged.
+
+This affects how frequently unchanged values are stored, not how frequently
+most operational data is collected. The shorter inventory master-item interval
+is necessary so dependent product and firmware values can store a sample every
+30 minutes.
+
+## Monitored components
+
+Low-level discovery covers:
+
+- Controllers
+- Physical disks
+- Disk groups
+- Pools
+- Volumes
+- Storage tiers
+- Enclosures
+- Field-replaceable units (FRUs)
+- Fans and power supplies
+- Sensors
+- SAS links
+- FC, iSCSI, and SAS host ports
+- Replication sets
+
+The template monitors health, capacity, utilization, performance, firmware,
+system read/write latency, error counters, the common event log, and structured
+active alerts when the storage model supports them.
+
+The [complete monitoring inventory](#complete-monitoring-inventory) below lists
+every fixed item, discovery rule, item prototype, fixed trigger, trigger
+prototype, fixed graph, graph prototype, and dashboard widget, including Zabbix
+keys and severities.
+
+| Zabbix object | Fixed | LLD/prototype |
+|---|---:|---:|
+| Items | 78 | 192 |
+| Discovery rules | — | 14 |
+| Triggers | 24 | 80 |
+| Graphs | 2 | 19 |
+| Template dashboards | 1 dashboard / 2 pages / 14 widgets | — |
+
+## Template dashboard
+
+The **Overview** template dashboard is designed for the Zabbix 72-column
+Full HD grid and contains two pages:
+
+- **Overview**: API availability, system health, product, firmware,
+  latency-source values, average and maximum system-latency graphs, and active
+  problems
+- **Components**: controller, disk, pool, volume, host-port, and disk
+  temperature graph prototypes
+
+## Important configuration macros
+
+| Macro | Default | Purpose |
+|---|---:|---|
+| `{$SEAGATE.ALERTS.MODE}` | `auto` | Structured Alerts API mode: `auto`, `enabled`, or `disabled` |
+| `{$SEAGATE.EVENTS.LAST}` | `100` | Number of recent events requested; maximum 1000 |
+| `{$SEAGATE.DATA.TIMEOUT}` | `60s` | Script master-item timeout |
+| `{$SEAGATE.HTTP.PROXY}` | empty | Optional proxy applied to all HTTP API requests |
+| `{$SEAGATE.ENCLOSURE.EXPECTED}` | `1` | Expected total enclosure count, including the controller enclosure |
+| `{$SEAGATE.PORT.DOWN.ENABLED}` | `1` | Enable host-port and SFP alerts |
+| `{$SEAGATE.VOLUME.WRITEBACK.REQUIRED}` | `1` | Require write-back policy |
+| `{$SEAGATE.REDUNDANCY.REQUIRED}` | `1` | Alert when the system is not redundant |
+| `{$SEAGATE.NTP.REQUIRED}` | `0` | Require NTP when set to `1` |
+| `{$SEAGATE.CONTROLLER.CPU.WARN}` | `90` | Controller CPU warning threshold, in percent |
+| `{$SEAGATE.DISK.TEMP.WARN}` | `50` | Disk temperature warning threshold, in degrees Celsius |
+| `{$SEAGATE.DISK.TEMP.CRIT}` | `60` | Disk temperature critical threshold, in degrees Celsius |
+| `{$SEAGATE.SSD.LIFE.WARN}` | `10` | SSD remaining-life warning threshold, in percent |
+
+Capacity thresholds for disk groups, pools, and tiers are also exposed as
+template macros and can be overridden at host level.
+
+### Excluding intentionally unused ports
+
+Port and SFP alerts support macro contexts. To suppress down alerts for an
+intentionally unused port, create a host-level context macro such as:
+
+```text
+{$SEAGATE.PORT.DOWN.ENABLED:"A3"} = 0
+```
+
+Use the discovered port name shown in Zabbix as the context.
+
+### Enclosure and SAS expansion-port policy
+
+Set `{$SEAGATE.ENCLOSURE.EXPECTED}` to the total number of enclosures that
+should be visible:
+
+- `1`: controller enclosure only
+- `2`: controller enclosure and one expansion enclosure
+- `3`: controller enclosure and two expansion enclosures
+
+The template raises a High-severity problem when the discovered enclosure count
+is below this value.
+
+An external `Expansion Port Universal` SAS link is not considered failed only
+because its state is `Disconnected`; that state is valid for an unused expansion
+port or the last port in an enclosure chain. Health monitoring remains enabled
+for all SAS links, while abnormal internal or non-expansion SAS links continue
+to generate problems.
+
+## System latency
+
+Version 1.0.6 provides one unified system-latency view while selecting the
+collection method supported by the storage model.
+
+### Exos X 4006 native metrics
+
+On Exos X 4006, the template queries these read-only Metrics Framework values:
+
+- `system.read-avg-response-time`
+- `system.write-avg-response-time`
+- `system.read-max-response-time`
+- `system.write-max-response-time`
+
+The collector only runs `query metrics`; it does not call `start metrics` or
+`stop metrics`. Bare `N/A` tokens occasionally returned by the API are sanitized
+before the response is parsed as JSON.
+
+### 4005/4865 fallback
+
+The tested 4005/4865 API does not expose the Metrics Framework. For that system,
+the template derives the host-facing average read and write latency from
+`show host-port-statistics`.
+
+It derives the read and write I/O rate of each host port from its cumulative
+counters and calculates an I/O-weighted aggregate:
+
+```text
+sum(port_latency_us × port_IO_rate) / sum(port_IO_rate)
+```
+
+Comparison with native 4006 metrics over clean, aligned intervals produced:
+
+| Measurement | Read | Write |
+|---|---:|---:|
+| Mean absolute error | approximately 3.05% | approximately 18.16% |
+| Pearson correlation | approximately 0.9201 | approximately 0.9605 |
+
+`System latency: Source` shows which method currently feeds the unified items.
+
+### Items and graphs
+
+The system-latency items are:
+
+- `System: Read average response time`
+- `System: Write average response time`
+- `System: Read maximum response time` — native 4006 only
+- `System: Write maximum response time` — native 4006 only
+- `System latency: Source`
+
+All system-latency values are stored and displayed in microseconds. The template
+includes the `System latency` graph for average read/write time and the
+`System maximum latency (4006 native)` graph for native maximum values.
+
+Pool, disk-group, and host-port latency graphs remain available because they
+represent different layers of the storage I/O path.
+
+## Hardware and model compatibility
+
+| Scope | Supported target |
+|---|---|
+| Product family | Seagate Exos X |
+| Management/controller models | 4005 and 4006 |
+| Controller platforms | Gallium and Indium |
+| Enclosure formats | 2U12, 2U24, and 5U84 |
+
+| Feature | 4005/4865 | Exos X 4006 |
+|---|:---:|:---:|
+| Core system and hardware state | Validated | Validated |
+| Controllers and performance | Validated | Validated |
+| Disks and predictive counters | Validated | Validated |
+| Disk groups, pools, volumes, and tiers | Validated | Validated |
+| Enclosures, FRUs, fans, PSUs, and sensors | Validated | Validated |
+| SAS link and expander health | Validated | Validated |
+| Host ports and SFP data | Validated | Validated |
+| Unified system average latency | Weighted fallback | Native metrics |
+| System maximum latency | Not exposed by tested API | Native metrics |
+| Common Event Log | Validated | Validated |
+| Structured active Alerts | Not exposed by tested API | Validated |
+| Alert-condition history | Not exposed by tested API | Validated |
+| Replication commands | Validated; no active set available | Validated; no active set available |
+
+The template discovers components dynamically and addresses API fields by name,
+which makes it tolerant of model differences. Results can still vary with
+firmware releases and installed hardware.
+
+## Alert behavior
+
+- Controller and system firmware changes generate Information events.
+- Disk error triggers fire when a cumulative counter increases.
+- Block-based capacity values are converted to bytes using the reported block
+  size.
+- Existing component response-time values are converted from microseconds to
+  seconds where required; the unified system-latency items remain in
+  microseconds.
+- Persistent hardware problems use the current component health or status.
+- New Warning, Error, and Critical event IDs generate supplemental edge
+  notifications.
+- Structured active-alert counters are used on supported Exos X 4006 systems.
+
+Native syslog or SNMP event forwarding is still recommended when guaranteed
+delivery of every asynchronous storage event is required.
+
+## Troubleshooting
+
+### Authentication fails
+
+- Confirm the username and password at host macro level.
+- Confirm the account has Monitor/read-only and Web/API access.
+- Check that no unresolved macro is overriding the template value.
+- Test both controller addresses if a secondary endpoint is configured.
+
+The login endpoint is validated through a successful HTTP status,
+`response-type: Success`, and a non-empty session key. Unlike normal `show`
+commands, login does not need to return `return-code: 0`.
+
+### Script items are unsupported
+
+- Confirm that the Zabbix server or assigned proxy can resolve and reach the
+  controller address.
+- Check `{$SEAGATE.API.SCHEME}` and `{$SEAGATE.API.PORT}`.
+- Review the master item's error message and the API method-error items.
+- Increase `{$SEAGATE.DATA.TIMEOUT}` if the array answers slowly.
+
+### Expected hardware is not discovered
+
+- Wait for the relevant discovery interval.
+- Check the corresponding Script master item for API errors.
+- Confirm that the component is visible to the read-only storage account.
+- Compare the storage firmware and model with the validated systems above.
+
+## Intentional exclusions
+
+The template does not collect:
+
+- Full `audit-log`, because it was extremely large and truncated in testing
+- `workload`, which is mainly intended for tiering and capacity analysis
+- `metrics-list` continuously; the 4006 system-latency collector queries the
+  required metrics directly
+- `fan-modules`, which returned HTTP 400 on the tested 4006; `show fans` supplies
+  the required data
+- `host-phy-statistics`, which is SAS-host-specific and did not apply to the
+  tested configuration
+- `remote-systems`, which returned HTTP 400 on the tested 4006
+
+## Validation
+
+Release 1.1.0 passed offline YAML, UUID format and uniqueness, heartbeat,
+HTTP-proxy, dashboard-reference, and severity-policy checks. The monitoring
+logic is already in production use; the upstream-compatible packaging and
+1.1.0 conformance changes were validated structurally.
+
+- Zabbix export version: `7.0`
+- UUID fields: `427`, all correctly formatted and unique
+- Script master items: `5`, all passing JavaScript syntax and HTTP-proxy checks
+- Dashboard: `1` dashboard, `2` pages, and `14` widgets with valid references
+- Heartbeats: `76` occurrences of `30m` and no remaining `1d` heartbeat
+- Trigger policy: no Disaster triggers; degraded states use Average
+- SHA-256: `51daf147ad05a2835ae69ffd404945466f9e756a528c2165275b0409da6811fa`
+
+A separate clean-instance import was intentionally not executed for 1.1.0 at
+the maintainer's request.
+
+## Vendor documentation
+
+- [Seagate Exos X 4006 support](https://www.seagate.com/support/disk-arrays/exos-x-4006/)
+- [Seagate Exos X 4006 Series Storage Management Guide](https://www.seagate.com/content/dam/seagate/assets/support/disk-arrays/exos-x-4006-2u12/_shared/files/204468700-01-A_4006_SMG.pdf)
+
+## Version
+
+- Template version: `1.1.0`
+- Minimum Zabbix version: `7.0`
+- Export format: Zabbix `7.0`
+
+## Author and license
+
+- Author: [Guilherme Campos (@guicampos21)](https://github.com/guicampos21)
+- Maintainer/vendor: SentrixIT
+- License: [MIT](https://github.com/guicampos21/zabbix-templates/blob/main/LICENSE)
+
+## Release history
+
+### 1.1.0
+
+- Reorganized the template into the upstream-compatible
+  `template_seagate_exos_x_4005_4006/7.0/` directory layout.
+- Renamed the import file to `template_seagate_exos_x_4005_4006.yaml`.
+- Added a Full HD template dashboard with Overview and Components pages.
+- Added `{$SEAGATE.HTTP.PROXY}` to every Script master item.
+- Changed the default least-privilege API username to `zbx_monitor`.
+- Aligned template tags with the Zabbix storage classification.
+- Changed resource-level Disaster triggers to High and degraded-state triggers
+  from High to Average.
+- Added the author and MIT license metadata required for upstream submission.
+
+### 1.0.7
+
+- Changed the inventory interval and all former one-day preprocessing
+  heartbeats to `30m`, ensuring dashboard-facing unchanged values are stored at
+  least every 30 minutes.
+- Left one-hour heartbeats and core, performance, availability, and event
+  polling intervals unchanged.
+
+### 1.0.6
+
+- Added unified system read and write average latency.
+- Added native average and maximum system latency for Exos X 4006.
+- Added an I/O-weighted host-port fallback for the tested 4005/4865 API.
+- Added average and maximum system-latency graphs and source identification.
+- Corrected fixed graph placement in the Zabbix 7.0 export hierarchy.
+
+### 1.0.4
+
+- Refined disconnected expansion-port handling.
+- Added the expected-enclosure policy and related High-severity trigger.
+
+<!-- BEGIN GENERATED MONITORING INVENTORY -->
+## Complete monitoring inventory
+
+Complete inventory generated from the Zabbix 7.0 YAML export, version 1.1.0.
+It includes fixed objects and low-level discovery (LLD) prototypes.
+
+> [!NOTE]
+> Script master items and dependent/raw transport items are included because
+> they are part of the template, even when they primarily support collection.
+> Trigger source identifies the item prototype that owns the trigger in the
+> Zabbix export; an expression can reference additional items.
+
+### Inventory summary
+
+| Object | Count |
+|---|---:|
+| Fixed items | 78 |
+| Discovery rules | 14 |
+| Item prototypes | 192 |
+| Fixed triggers | 24 |
+| Trigger prototypes | 80 |
+| Fixed graphs | 2 |
+| Graph prototypes | 19 |
+| Template dashboards | 1 |
+| Dashboard pages | 2 |
+| Dashboard widgets | 14 |
+
+### Fixed items
+
+#### Alerts
+
+| Item | Key | Type | Value type |
+|---|---|---|---|
+| Active alert summary | `seagate.exos.alerts.summary` | `DEPENDENT` | `TEXT` |
+| Active warning alert count | `seagate.exos.alerts.active_warning` | `DEPENDENT` | `UNSIGNED` |
+| Active error alert count | `seagate.exos.alerts.active_error` | `DEPENDENT` | `UNSIGNED` |
+| Active critical alert count | `seagate.exos.alerts.active_critical` | `DEPENDENT` | `UNSIGNED` |
+
+#### Cache
+
+| Item | Key | Type | Value type |
+|---|---|---|---|
+| Controller A unwritable cache | `seagate.exos.cache.unwritable_a` | `DEPENDENT` | `UNSIGNED` |
+| Controller B unwritable cache | `seagate.exos.cache.unwritable_b` | `DEPENDENT` | `UNSIGNED` |
+
+#### Errors
+
+| Item | Key | Type | Value type |
+|---|---|---|---|
+| API error detail | `seagate.exos.api.error` | `DEPENDENT` | `TEXT` |
+| Core API method errors | `seagate.exos.core.errors` | `DEPENDENT` | `TEXT` |
+| Performance API method errors | `seagate.exos.performance.errors` | `DEPENDENT` | `TEXT` |
+| Inventory API method errors | `seagate.exos.inventory.errors` | `DEPENDENT` | `TEXT` |
+| Events API method errors | `seagate.exos.events.errors` | `DEPENDENT` | `TEXT` |
+
+#### Events
+
+| Item | Key | Type | Value type |
+|---|---|---|---|
+| Latest warning event ID | `seagate.exos.event.latest_warning.id` | `DEPENDENT` | `UNSIGNED` |
+| Latest warning event message | `seagate.exos.event.latest_warning.message` | `DEPENDENT` | `TEXT` |
+| Latest error event ID | `seagate.exos.event.latest_error.id` | `DEPENDENT` | `UNSIGNED` |
+| Latest error event message | `seagate.exos.event.latest_error.message` | `DEPENDENT` | `TEXT` |
+| Latest critical event ID | `seagate.exos.event.latest_critical.id` | `DEPENDENT` | `UNSIGNED` |
+| Latest critical event message | `seagate.exos.event.latest_critical.message` | `DEPENDENT` | `TEXT` |
+
+#### Health
+
+| Item | Key | Type | Value type |
+|---|---|---|---|
+| API available | `seagate.exos.api.available` | `DEPENDENT` | `UNSIGNED` |
+| API authentication failed | `seagate.exos.api.auth_failed` | `DEPENDENT` | `UNSIGNED` |
+| System health | `seagate.exos.system.health` | `DEPENDENT` | `UNSIGNED` |
+| System health reason | `seagate.exos.system.health_reason` | `DEPENDENT` | `TEXT` |
+| Redundancy state | `seagate.exos.system.redundant` | `DEPENDENT` | `UNSIGNED` |
+| Other management controller operational | `seagate.exos.system.other_mc_operational` | `DEPENDENT` | `UNSIGNED` |
+
+#### Inventory
+
+| Item | Key | Type | Value type |
+|---|---|---|---|
+| Active management endpoint | `seagate.exos.api.endpoint` | `DEPENDENT` | `CHAR` |
+| System name | `seagate.exos.system.name` | `DEPENDENT` | `CHAR` |
+| Product ID | `seagate.exos.system.product_id` | `DEPENDENT` | `CHAR` |
+| Product brand | `seagate.exos.system.product_brand` | `DEPENDENT` | `CHAR` |
+| SCSI product ID | `seagate.exos.system.scsi_product_id` | `DEPENDENT` | `CHAR` |
+| Platform type | `seagate.exos.system.platform` | `DEPENDENT` | `CHAR` |
+| System firmware bundle | `seagate.exos.system.bundle_version` | `DEPENDENT` | `CHAR` |
+| Structured Alerts API supported | `seagate.exos.alerts.supported` | `DEPENDENT` | `UNSIGNED` |
+
+#### Performance
+
+| Item | Key | Type | Value type |
+|---|---|---|---|
+| API response time | `seagate.exos.api.latency` | `DEPENDENT` | `UNSIGNED` |
+| System latency: Native metrics supported | `seagate.exos.system.latency.native_supported` | `DEPENDENT` | `UNSIGNED` |
+| System latency: Source | `seagate.exos.system.latency.source` | `DEPENDENT` | `CHAR` |
+| System latency: Native read average response time | `seagate.exos.system.latency.native.read_avg` | `DEPENDENT` | `FLOAT` |
+| System latency: Native write average response time | `seagate.exos.system.latency.native.write_avg` | `DEPENDENT` | `FLOAT` |
+| System: Read maximum response time | `seagate.exos.system.latency.read_max` | `DEPENDENT` | `FLOAT` |
+| System: Write maximum response time | `seagate.exos.system.latency.write_max` | `DEPENDENT` | `FLOAT` |
+| System latency: Host-port weighted read average response time | `seagate.exos.system.latency.fallback.read_avg` | `CALCULATED` | `FLOAT` |
+| System latency: Host-port weighted write average response time | `seagate.exos.system.latency.fallback.write_avg` | `CALCULATED` | `FLOAT` |
+| System: Read average response time | `seagate.exos.system.latency.read_avg` | `CALCULATED` | `FLOAT` |
+| System: Write average response time | `seagate.exos.system.latency.write_avg` | `CALCULATED` | `FLOAT` |
+
+#### Raw
+
+| Item | Key | Type | Value type |
+|---|---|---|---|
+| API availability raw | `seagate.exos.api.check` | `SCRIPT` | `TEXT` |
+| Get core data | `seagate.exos.get.core` | `SCRIPT` | `TEXT` |
+| Get performance data | `seagate.exos.get.performance` | `SCRIPT` | `TEXT` |
+| Get inventory data | `seagate.exos.get.inventory` | `SCRIPT` | `TEXT` |
+| Get events and alerts | `seagate.exos.get.events` | `SCRIPT` | `TEXT` |
+| Get system object | `seagate.exos.get.system` | `DEPENDENT` | `TEXT` |
+| Get redundancy object | `seagate.exos.get.redundancy` | `DEPENDENT` | `TEXT` |
+| Get FDE object | `seagate.exos.get.fde` | `DEPENDENT` | `TEXT` |
+| Get controllers | `seagate.exos.get.controllers` | `DEPENDENT` | `TEXT` |
+| Get disks | `seagate.exos.get.disks` | `DEPENDENT` | `TEXT` |
+| Get disk groups | `seagate.exos.get.diskgroups` | `DEPENDENT` | `TEXT` |
+| Get pools | `seagate.exos.get.pools` | `DEPENDENT` | `TEXT` |
+| Get volumes | `seagate.exos.get.volumes` | `DEPENDENT` | `TEXT` |
+| Get enclosures | `seagate.exos.get.enclosures` | `DEPENDENT` | `TEXT` |
+| Get FRUs | `seagate.exos.get.frus` | `DEPENDENT` | `TEXT` |
+| Get fans | `seagate.exos.get.fans` | `DEPENDENT` | `TEXT` |
+| Get power supplies | `seagate.exos.get.psus` | `DEPENDENT` | `TEXT` |
+| Get sensors | `seagate.exos.get.sensors` | `DEPENDENT` | `TEXT` |
+| Get SAS links | `seagate.exos.get.saslinks` | `DEPENDENT` | `TEXT` |
+| Get host ports | `seagate.exos.get.ports` | `DEPENDENT` | `TEXT` |
+| Get controller statistics | `seagate.exos.get.controllerstats` | `DEPENDENT` | `TEXT` |
+| Get disk statistics | `seagate.exos.get.diskstats` | `DEPENDENT` | `TEXT` |
+| Get disk group statistics | `seagate.exos.get.diskgroupstats` | `DEPENDENT` | `TEXT` |
+| Get pool statistics | `seagate.exos.get.poolstats` | `DEPENDENT` | `TEXT` |
+| Get volume statistics | `seagate.exos.get.volumestats` | `DEPENDENT` | `TEXT` |
+| Get host port statistics | `seagate.exos.get.portstats` | `DEPENDENT` | `TEXT` |
+| Get tier statistics | `seagate.exos.get.tierstats` | `DEPENDENT` | `TEXT` |
+| Get versions | `seagate.exos.get.versions` | `DEPENDENT` | `TEXT` |
+| Get tiers | `seagate.exos.get.tiers` | `DEPENDENT` | `TEXT` |
+| Get replication sets | `seagate.exos.get.replicationsets` | `DEPENDENT` | `TEXT` |
+| Get events | `seagate.exos.get.eventlist` | `DEPENDENT` | `TEXT` |
+| Get active alerts | `seagate.exos.get.alerts` | `DEPENDENT` | `TEXT` |
+
+#### SAS
+
+| Item | Key | Type | Value type |
+|---|---|---|---|
+| Unhealthy expander PHY count | `seagate.exos.expander.unhealthy` | `DEPENDENT` | `UNSIGNED` |
+
+#### Security
+
+| Item | Key | Type | Value type |
+|---|---|---|---|
+| FDE security status | `seagate.exos.system.fde_status` | `DEPENDENT` | `CHAR` |
+
+#### Storage
+
+| Item | Key | Type | Value type |
+|---|---|---|---|
+| Enclosure count | `seagate.exos.system.enclosure_count` | `DEPENDENT` | `UNSIGNED` |
+
+#### Time
+
+| Item | Key | Type | Value type |
+|---|---|---|---|
+| NTP enabled | `seagate.exos.system.ntp_enabled` | `DEPENDENT` | `UNSIGNED` |
+
+### Fixed triggers
+
+| Trigger | Severity | Source item |
+|---|---|---|
+| Seagate Exos Storage: Management API is unavailable | `HIGH` | API available |
+| Seagate Exos Storage: API authentication failed | `HIGH` | API authentication failed |
+| Seagate Exos Storage: Core API method errors | `WARNING` | Core API method errors |
+| Seagate Exos Storage: Performance API method errors | `WARNING` | Performance API method errors |
+| Seagate Exos Storage: Inventory API method errors | `WARNING` | Inventory API method errors |
+| Seagate Exos Storage: Events API method errors | `WARNING` | Events API method errors |
+| Seagate Exos Storage: Enclosure count is below expected | `HIGH` | Enclosure count |
+| Seagate Exos Storage: System health is degraded | `AVERAGE` | System health |
+| Seagate Exos Storage: System health is in fault state | `HIGH` | System health |
+| Seagate Exos Storage: System health is unknown | `WARNING` | System health |
+| Seagate Exos Storage: Storage redundancy is lost | `HIGH` | Redundancy state |
+| Seagate Exos Storage: Partner management controller is not operational | `WARNING` | Other management controller operational |
+| Seagate Exos Storage: FDE security state changed | `INFO` | FDE security status |
+| Seagate Exos Storage: NTP is not activated | `WARNING` | NTP enabled |
+| Seagate Exos Storage: Controller A has unwritable cache | `HIGH` | Controller A unwritable cache |
+| Seagate Exos Storage: Controller B has unwritable cache | `HIGH` | Controller B unwritable cache |
+| Seagate Exos Storage: One or more expander PHYs are unhealthy | `HIGH` | Unhealthy expander PHY count |
+| Seagate Exos Storage: System firmware bundle changed | `INFO` | System firmware bundle |
+| Seagate Exos Storage: New warning event detected | `WARNING` | Latest warning event ID |
+| Seagate Exos Storage: New error event detected | `HIGH` | Latest error event ID |
+| Seagate Exos Storage: New critical event detected | `HIGH` | Latest critical event ID |
+| Seagate Exos Storage: Active warning alert conditions | `WARNING` | Active warning alert count |
+| Seagate Exos Storage: Active error alert conditions | `HIGH` | Active error alert count |
+| Seagate Exos Storage: Active critical alert conditions | `HIGH` | Active critical alert count |
+
+### Fixed graphs
+
+| Graph | Item keys |
+|---|---|
+| System latency | `seagate.exos.system.latency.read_avg`<br>`seagate.exos.system.latency.write_avg` |
+| System maximum latency (4006 native) | `seagate.exos.system.latency.read_max`<br>`seagate.exos.system.latency.write_max` |
+
+### Template dashboards
+
+#### Overview
+
+##### Overview
+
+| Widget | Type | Referenced object |
+|---|---|---|
+| API availability | `item` | seagate.exos.api.available |
+| System health | `item` | seagate.exos.system.health |
+| Product | `item` | seagate.exos.system.product_id |
+| Firmware bundle | `item` | seagate.exos.system.bundle_version |
+| System latency source | `item` | seagate.exos.system.latency.source |
+| Average system latency | `graph` | System latency |
+| Maximum system latency | `graph` | System maximum latency (4006 native) |
+| Active problems | `problems` |  |
+
+##### Components
+
+| Widget | Type | Referenced object |
+|---|---|---|
+| Controller performance | `graphprototype` | Controller [{#CONTROLLER.ID}]: Performance |
+| Disk performance | `graphprototype` | Disk [{#LOCATION}]: Performance |
+| Pool performance | `graphprototype` | Pool [{#NAME}]: Performance |
+| Volume performance | `graphprototype` | Volume [{#NAME}]: Performance |
+| Host port performance | `graphprototype` | Host port [{#PORT.ID}]: Performance |
+| Disk temperature | `graphprototype` | Disk [{#LOCATION}]: Temperature |
+
+### Low-level discovery
+
+#### Controllers discovery
+
+- Discovery key: `seagate.exos.controllers.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 27
+- Trigger prototypes: 7
+- Graph prototypes: 2
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| Controller [{#CONTROLLER.ID}]: Get data | `seagate.exos.controller.get["{#CONTROLLER.ID}"]` | `DEPENDENT` | `TEXT` |
+| Controller [{#CONTROLLER.ID}]: Get statistics | `seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]` | `DEPENDENT` | `TEXT` |
+| Controller [{#CONTROLLER.ID}]: Health | `seagate.exos.controller.health["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Status | `seagate.exos.controller.status["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Serial number | `seagate.exos.controller.serial["{#CONTROLLER.ID}"]` | `DEPENDENT` | `CHAR` |
+| Controller [{#CONTROLLER.ID}]: Part number | `seagate.exos.controller.part["{#CONTROLLER.ID}"]` | `DEPENDENT` | `CHAR` |
+| Controller [{#CONTROLLER.ID}]: Hardware version | `seagate.exos.controller.hardware["{#CONTROLLER.ID}"]` | `DEPENDENT` | `CHAR` |
+| Controller [{#CONTROLLER.ID}]: IP address | `seagate.exos.controller.ip["{#CONTROLLER.ID}"]` | `DEPENDENT` | `CHAR` |
+| Controller [{#CONTROLLER.ID}]: Failover reason | `seagate.exos.controller.failover_reason["{#CONTROLLER.ID}"]` | `DEPENDENT` | `TEXT` |
+| Controller [{#CONTROLLER.ID}]: Firmware | `seagate.exos.controller.firmware["{#CONTROLLER.ID}"]` | `DEPENDENT` | `CHAR` |
+| Controller [{#CONTROLLER.ID}]: Failed over | `seagate.exos.controller.failed_over["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Cache memory | `seagate.exos.controller.cache_memory["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: System memory | `seagate.exos.controller.system_memory["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Host ports | `seagate.exos.controller.host_ports["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Drive channels | `seagate.exos.controller.drive_channels["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: CPU utilization | `seagate.exos.controller.cpu["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Write cache used | `seagate.exos.controller.write_cache_used["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: IOPS | `seagate.exos.controller.iops["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Throughput | `seagate.exos.controller.bps["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Reads | `seagate.exos.controller.reads["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Writes | `seagate.exos.controller.writes["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Read cache hits | `seagate.exos.controller.read_cache_hits["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Read cache misses | `seagate.exos.controller.read_cache_misses["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Write cache hits | `seagate.exos.controller.write_cache_hits["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Write cache misses | `seagate.exos.controller.write_cache_misses["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Forwarded commands | `seagate.exos.controller.forwarded["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Controller [{#CONTROLLER.ID}]: Power-on hours | `seagate.exos.controller.power_on_hours["{#CONTROLLER.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: Controller [{#CONTROLLER.ID}] health is degraded | `WARNING` | Controller [{#CONTROLLER.ID}]: Health |
+| Seagate Exos Storage: Controller [{#CONTROLLER.ID}] health is in fault state | `HIGH` | Controller [{#CONTROLLER.ID}]: Health |
+| Seagate Exos Storage: Controller [{#CONTROLLER.ID}] health is unknown | `WARNING` | Controller [{#CONTROLLER.ID}]: Health |
+| Seagate Exos Storage: Controller [{#CONTROLLER.ID}] is down | `HIGH` | Controller [{#CONTROLLER.ID}]: Status |
+| Seagate Exos Storage: Controller [{#CONTROLLER.ID}] firmware changed | `INFO` | Controller [{#CONTROLLER.ID}]: Firmware |
+| Seagate Exos Storage: Controller [{#CONTROLLER.ID}] is failed over | `HIGH` | Controller [{#CONTROLLER.ID}]: Failed over |
+| Seagate Exos Storage: Controller [{#CONTROLLER.ID}] CPU utilization is high | `WARNING` | Controller [{#CONTROLLER.ID}]: CPU utilization |
+
+##### Graph prototypes
+
+| Graph prototype | Item prototype keys |
+|---|---|
+| Controller [{#CONTROLLER.ID}]: Performance | `seagate.exos.controller.cpu["{#CONTROLLER.ID}"]`<br>`seagate.exos.controller.iops["{#CONTROLLER.ID}"]`<br>`seagate.exos.controller.bps["{#CONTROLLER.ID}"]` |
+| Controller [{#CONTROLLER.ID}]: Cache utilization | `seagate.exos.controller.write_cache_used["{#CONTROLLER.ID}"]` |
+
+#### Physical disks discovery
+
+- Discovery key: `seagate.exos.disks.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 32
+- Trigger prototypes: 17
+- Graph prototypes: 2
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| Disk [{#LOCATION}]: Get data | `seagate.exos.disk.get["{#DURABLE.ID}"]` | `DEPENDENT` | `TEXT` |
+| Disk [{#LOCATION}]: Get statistics | `seagate.exos.disk.stats.get["{#DURABLE.ID}"]` | `DEPENDENT` | `TEXT` |
+| Disk [{#LOCATION}]: Health | `seagate.exos.disk.health["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Status | `seagate.exos.disk.status["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Model | `seagate.exos.disk.model["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Disk [{#LOCATION}]: Serial number | `seagate.exos.disk.serial["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Disk [{#LOCATION}]: Firmware revision | `seagate.exos.disk.firmware["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Disk [{#LOCATION}]: Interface | `seagate.exos.disk.interface["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Disk [{#LOCATION}]: Architecture | `seagate.exos.disk.architecture["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Disk [{#LOCATION}]: Disk group | `seagate.exos.disk.disk_group["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Disk [{#LOCATION}]: Pool | `seagate.exos.disk.pool["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Disk [{#LOCATION}]: Storage tier | `seagate.exos.disk.tier["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Disk [{#LOCATION}]: FDE state | `seagate.exos.disk.fde["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Disk [{#LOCATION}]: Current job | `seagate.exos.disk.job["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Disk [{#LOCATION}]: Capacity | `seagate.exos.disk.capacity["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: SMART enabled | `seagate.exos.disk.smart["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Temperature | `seagate.exos.disk.temperature["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Temperature status | `seagate.exos.disk.temperature_status["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Power-on hours | `seagate.exos.disk.power_on_hours["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: SSD life remaining | `seagate.exos.disk.ssd_life["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Job progress | `seagate.exos.disk.job_progress["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: IOPS | `seagate.exos.disk.iops["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Throughput | `seagate.exos.disk.bps["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Queue depth | `seagate.exos.disk.queue_depth["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Reads | `seagate.exos.disk.reads["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Writes | `seagate.exos.disk.writes["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Media errors | `seagate.exos.disk.media_errors["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Non-media errors | `seagate.exos.disk.nonmedia_errors["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: I/O timeouts | `seagate.exos.disk.timeouts["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: No-response events | `seagate.exos.disk.no_response["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Bad blocks | `seagate.exos.disk.bad_blocks["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk [{#LOCATION}]: Block reassignments | `seagate.exos.disk.reassigns["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: Disk [{#LOCATION}] health is degraded | `AVERAGE` | Disk [{#LOCATION}]: Health |
+| Seagate Exos Storage: Disk [{#LOCATION}] health is in fault state | `HIGH` | Disk [{#LOCATION}]: Health |
+| Seagate Exos Storage: Disk [{#LOCATION}] health is unknown | `WARNING` | Disk [{#LOCATION}]: Health |
+| Seagate Exos Storage: Disk [{#LOCATION}] is not Up | `HIGH` | Disk [{#LOCATION}]: Status |
+| Seagate Exos Storage: Disk [{#LOCATION}] firmware changed | `INFO` | Disk [{#LOCATION}]: Firmware revision |
+| Seagate Exos Storage: Disk [{#LOCATION}] job state changed | `INFO` | Disk [{#LOCATION}]: Current job |
+| Seagate Exos Storage: SMART is disabled on disk [{#LOCATION}] | `WARNING` | Disk [{#LOCATION}]: SMART enabled |
+| Seagate Exos Storage: Disk [{#LOCATION}] temperature is high | `WARNING` | Disk [{#LOCATION}]: Temperature |
+| Seagate Exos Storage: Disk [{#LOCATION}] temperature is critical | `HIGH` | Disk [{#LOCATION}]: Temperature |
+| Seagate Exos Storage: Disk [{#LOCATION}] temperature status is abnormal | `HIGH` | Disk [{#LOCATION}]: Temperature status |
+| Seagate Exos Storage: Disk [{#LOCATION}] SSD life is low | `WARNING` | Disk [{#LOCATION}]: SSD life remaining |
+| Seagate Exos Storage: Disk [{#LOCATION}] media errors increased | `HIGH` | Disk [{#LOCATION}]: Media errors |
+| Seagate Exos Storage: Disk [{#LOCATION}] non-media errors increased | `WARNING` | Disk [{#LOCATION}]: Non-media errors |
+| Seagate Exos Storage: Disk [{#LOCATION}] i/o timeouts increased | `HIGH` | Disk [{#LOCATION}]: I/O timeouts |
+| Seagate Exos Storage: Disk [{#LOCATION}] no-response events increased | `HIGH` | Disk [{#LOCATION}]: No-response events |
+| Seagate Exos Storage: Disk [{#LOCATION}] bad blocks increased | `HIGH` | Disk [{#LOCATION}]: Bad blocks |
+| Seagate Exos Storage: Disk [{#LOCATION}] block reassignments increased | `WARNING` | Disk [{#LOCATION}]: Block reassignments |
+
+##### Graph prototypes
+
+| Graph prototype | Item prototype keys |
+|---|---|
+| Disk [{#LOCATION}]: Performance | `seagate.exos.disk.iops["{#DURABLE.ID}"]`<br>`seagate.exos.disk.bps["{#DURABLE.ID}"]` |
+| Disk [{#LOCATION}]: Temperature | `seagate.exos.disk.temperature["{#DURABLE.ID}"]` |
+
+#### Disk groups discovery
+
+- Discovery key: `seagate.exos.diskgroups.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 24
+- Trigger prototypes: 11
+- Graph prototypes: 3
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| Disk group [{#NAME}]: Get data | `seagate.exos.diskgroup.get["{#NAME}"]` | `DEPENDENT` | `TEXT` |
+| Disk group [{#NAME}]: Get statistics | `seagate.exos.diskgroup.stats.get["{#NAME}"]` | `DEPENDENT` | `TEXT` |
+| Disk group [{#NAME}]: Health | `seagate.exos.diskgroup.health["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk group [{#NAME}]: Status | `seagate.exos.diskgroup.status["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk group [{#NAME}]: Pool | `seagate.exos.diskgroup.pool["{#NAME}"]` | `DEPENDENT` | `CHAR` |
+| Disk group [{#NAME}]: RAID type | `seagate.exos.diskgroup.raid["{#NAME}"]` | `DEPENDENT` | `CHAR` |
+| Disk group [{#NAME}]: Owner | `seagate.exos.diskgroup.owner["{#NAME}"]` | `DEPENDENT` | `CHAR` |
+| Disk group [{#NAME}]: Preferred owner | `seagate.exos.diskgroup.preferred_owner["{#NAME}"]` | `DEPENDENT` | `CHAR` |
+| Disk group [{#NAME}]: Tier | `seagate.exos.diskgroup.tier["{#NAME}"]` | `DEPENDENT` | `CHAR` |
+| Disk group [{#NAME}]: Current job | `seagate.exos.diskgroup.job["{#NAME}"]` | `DEPENDENT` | `CHAR` |
+| Disk group [{#NAME}]: Owner numeric | `seagate.exos.diskgroup.owner_numeric["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk group [{#NAME}]: Preferred owner numeric | `seagate.exos.diskgroup.preferred_owner_numeric["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk group [{#NAME}]: Write-back enabled | `seagate.exos.diskgroup.writeback["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk group [{#NAME}]: Disk count | `seagate.exos.diskgroup.diskcount["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk group [{#NAME}]: Spare count | `seagate.exos.diskgroup.sparecount["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk group [{#NAME}]: Total capacity | `seagate.exos.diskgroup.total["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk group [{#NAME}]: Free capacity | `seagate.exos.diskgroup.free["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk group [{#NAME}]: Raw capacity | `seagate.exos.diskgroup.raw["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk group [{#NAME}]: Used capacity | `seagate.exos.diskgroup.used_pct["{#NAME}"]` | `DEPENDENT` | `FLOAT` |
+| Disk group [{#NAME}]: IOPS | `seagate.exos.diskgroup.iops["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk group [{#NAME}]: Throughput | `seagate.exos.diskgroup.bps["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Disk group [{#NAME}]: Response time | `seagate.exos.diskgroup.latency["{#NAME}"]` | `DEPENDENT` | `FLOAT` |
+| Disk group [{#NAME}]: Read response time | `seagate.exos.diskgroup.read_latency["{#NAME}"]` | `DEPENDENT` | `FLOAT` |
+| Disk group [{#NAME}]: Write response time | `seagate.exos.diskgroup.write_latency["{#NAME}"]` | `DEPENDENT` | `FLOAT` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: Disk group [{#NAME}] health is degraded | `AVERAGE` | Disk group [{#NAME}]: Health |
+| Seagate Exos Storage: Disk group [{#NAME}] health is in fault state | `HIGH` | Disk group [{#NAME}]: Health |
+| Seagate Exos Storage: Disk group [{#NAME}] health is unknown | `WARNING` | Disk group [{#NAME}]: Health |
+| Seagate Exos Storage: Disk group [{#NAME}] is degraded | `AVERAGE` | Disk group [{#NAME}]: Status |
+| Seagate Exos Storage: Disk group [{#NAME}] is critical or offline | `HIGH` | Disk group [{#NAME}]: Status |
+| Seagate Exos Storage: Disk group [{#NAME}] job state changed | `INFO` | Disk group [{#NAME}]: Current job |
+| Seagate Exos Storage: Disk group [{#NAME}] owner differs from preferred owner | `WARNING` | Disk group [{#NAME}]: Owner numeric |
+| Seagate Exos Storage: Disk group [{#NAME}] write-back is disabled | `HIGH` | Disk group [{#NAME}]: Write-back enabled |
+| Seagate Exos Storage: Disk group [{#NAME}] utilization is high | `WARNING` | Disk group [{#NAME}]: Used capacity |
+| Seagate Exos Storage: Disk group [{#NAME}] utilization is very high | `HIGH` | Disk group [{#NAME}]: Used capacity |
+| Seagate Exos Storage: Disk group [{#NAME}] utilization is critical | `HIGH` | Disk group [{#NAME}]: Used capacity |
+
+##### Graph prototypes
+
+| Graph prototype | Item prototype keys |
+|---|---|
+| Disk group [{#NAME}]: Performance | `seagate.exos.diskgroup.iops["{#NAME}"]`<br>`seagate.exos.diskgroup.bps["{#NAME}"]` |
+| Disk group [{#NAME}]: Response time | `seagate.exos.diskgroup.latency["{#NAME}"]`<br>`seagate.exos.diskgroup.read_latency["{#NAME}"]`<br>`seagate.exos.diskgroup.write_latency["{#NAME}"]` |
+| Disk group [{#NAME}]: Space utilization | `seagate.exos.diskgroup.used_pct["{#NAME}"]` |
+
+#### Pools discovery
+
+- Discovery key: `seagate.exos.pools.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 12
+- Trigger prototypes: 7
+- Graph prototypes: 3
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| Pool [{#NAME}]: Get data | `seagate.exos.pool.get["{#NAME}"]` | `DEPENDENT` | `TEXT` |
+| Pool [{#NAME}]: Get statistics | `seagate.exos.pool.stats.get["{#NAME}"]` | `DEPENDENT` | `TEXT` |
+| Pool [{#NAME}]: Health | `seagate.exos.pool.health["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Pool [{#NAME}]: Total capacity | `seagate.exos.pool.total["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Pool [{#NAME}]: Available capacity | `seagate.exos.pool.available["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Pool [{#NAME}]: Used capacity | `seagate.exos.pool.used_pct["{#NAME}"]` | `DEPENDENT` | `FLOAT` |
+| Pool [{#NAME}]: Overcommitted | `seagate.exos.pool.overcommitted["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Pool [{#NAME}]: IOPS | `seagate.exos.pool.iops["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Pool [{#NAME}]: Throughput | `seagate.exos.pool.bps["{#NAME}"]` | `DEPENDENT` | `UNSIGNED` |
+| Pool [{#NAME}]: Response time | `seagate.exos.pool.latency["{#NAME}"]` | `DEPENDENT` | `FLOAT` |
+| Pool [{#NAME}]: Read response time | `seagate.exos.pool.read_latency["{#NAME}"]` | `DEPENDENT` | `FLOAT` |
+| Pool [{#NAME}]: Write response time | `seagate.exos.pool.write_latency["{#NAME}"]` | `DEPENDENT` | `FLOAT` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: Pool [{#NAME}] health is degraded | `AVERAGE` | Pool [{#NAME}]: Health |
+| Seagate Exos Storage: Pool [{#NAME}] health is in fault state | `HIGH` | Pool [{#NAME}]: Health |
+| Seagate Exos Storage: Pool [{#NAME}] health is unknown | `WARNING` | Pool [{#NAME}]: Health |
+| Seagate Exos Storage: Pool [{#NAME}] utilization is high | `WARNING` | Pool [{#NAME}]: Used capacity |
+| Seagate Exos Storage: Pool [{#NAME}] utilization is very high | `HIGH` | Pool [{#NAME}]: Used capacity |
+| Seagate Exos Storage: Pool [{#NAME}] utilization is critical | `HIGH` | Pool [{#NAME}]: Used capacity |
+| Seagate Exos Storage: Pool [{#NAME}] is overcommitted | `HIGH` | Pool [{#NAME}]: Overcommitted |
+
+##### Graph prototypes
+
+| Graph prototype | Item prototype keys |
+|---|---|
+| Pool [{#NAME}]: Performance | `seagate.exos.pool.iops["{#NAME}"]`<br>`seagate.exos.pool.bps["{#NAME}"]` |
+| Pool [{#NAME}]: Response time | `seagate.exos.pool.latency["{#NAME}"]`<br>`seagate.exos.pool.read_latency["{#NAME}"]`<br>`seagate.exos.pool.write_latency["{#NAME}"]` |
+| Pool [{#NAME}]: Space utilization | `seagate.exos.pool.used_pct["{#NAME}"]` |
+
+#### Volumes discovery
+
+- Discovery key: `seagate.exos.volumes.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 21
+- Trigger prototypes: 6
+- Graph prototypes: 1
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| Volume [{#NAME}]: Get data | `seagate.exos.volume.get["{#DURABLE.ID}"]` | `DEPENDENT` | `TEXT` |
+| Volume [{#NAME}]: Get statistics | `seagate.exos.volume.stats.get["{#DURABLE.ID}"]` | `DEPENDENT` | `TEXT` |
+| Volume [{#NAME}]: Health | `seagate.exos.volume.health["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Volume [{#NAME}]: Pool | `seagate.exos.volume.pool["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Volume [{#NAME}]: Owner | `seagate.exos.volume.owner["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Volume [{#NAME}]: Preferred owner | `seagate.exos.volume.preferred_owner["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Volume [{#NAME}]: Write policy | `seagate.exos.volume.write_policy["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Volume [{#NAME}]: Cache optimization | `seagate.exos.volume.cache_optimization["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Volume [{#NAME}]: Read-ahead | `seagate.exos.volume.read_ahead["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Volume [{#NAME}]: Tier affinity | `seagate.exos.volume.tier_affinity["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Volume [{#NAME}]: Owner numeric | `seagate.exos.volume.owner_numeric["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Volume [{#NAME}]: Preferred owner numeric | `seagate.exos.volume.preferred_owner_numeric["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Volume [{#NAME}]: Write-back enabled | `seagate.exos.volume.writeback["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Volume [{#NAME}]: Operation progress | `seagate.exos.volume.progress["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Volume [{#NAME}]: Size | `seagate.exos.volume.size["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Volume [{#NAME}]: Allocated size | `seagate.exos.volume.allocated["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Volume [{#NAME}]: IOPS | `seagate.exos.volume.iops["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Volume [{#NAME}]: Throughput | `seagate.exos.volume.bps["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Volume [{#NAME}]: Reads | `seagate.exos.volume.reads["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Volume [{#NAME}]: Writes | `seagate.exos.volume.writes["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Volume [{#NAME}]: Write cache utilization | `seagate.exos.volume.write_cache_pct["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: Volume [{#NAME}] health is degraded | `WARNING` | Volume [{#NAME}]: Health |
+| Seagate Exos Storage: Volume [{#NAME}] health is in fault state | `HIGH` | Volume [{#NAME}]: Health |
+| Seagate Exos Storage: Volume [{#NAME}] health is unknown | `WARNING` | Volume [{#NAME}]: Health |
+| Seagate Exos Storage: Volume [{#NAME}] owner differs from preferred owner | `WARNING` | Volume [{#NAME}]: Owner numeric |
+| Seagate Exos Storage: Volume [{#NAME}] is not using write-back | `HIGH` | Volume [{#NAME}]: Write-back enabled |
+| Seagate Exos Storage: Volume [{#NAME}] operation is active | `INFO` | Volume [{#NAME}]: Operation progress |
+
+##### Graph prototypes
+
+| Graph prototype | Item prototype keys |
+|---|---|
+| Volume [{#NAME}]: Performance | `seagate.exos.volume.iops["{#DURABLE.ID}"]`<br>`seagate.exos.volume.bps["{#DURABLE.ID}"]` |
+
+#### Storage tiers discovery
+
+- Discovery key: `seagate.exos.tiers.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 16
+- Trigger prototypes: 2
+- Graph prototypes: 3
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| Tier [{#POOL}/{#TIER}]: Get data | `seagate.exos.tier.get["{#SERIAL}"]` | `DEPENDENT` | `TEXT` |
+| Tier [{#POOL}/{#TIER}]: Get statistics | `seagate.exos.tier.stats.get["{#SERIAL}"]` | `DEPENDENT` | `TEXT` |
+| Tier [{#POOL}/{#TIER}]: Disk count | `seagate.exos.tier.diskcount["{#SERIAL}"]` | `DEPENDENT` | `UNSIGNED` |
+| Tier [{#POOL}/{#TIER}]: Raw capacity | `seagate.exos.tier.raw["{#SERIAL}"]` | `DEPENDENT` | `UNSIGNED` |
+| Tier [{#POOL}/{#TIER}]: Total capacity | `seagate.exos.tier.total["{#SERIAL}"]` | `DEPENDENT` | `UNSIGNED` |
+| Tier [{#POOL}/{#TIER}]: Allocated capacity | `seagate.exos.tier.allocated["{#SERIAL}"]` | `DEPENDENT` | `UNSIGNED` |
+| Tier [{#POOL}/{#TIER}]: Available capacity | `seagate.exos.tier.available["{#SERIAL}"]` | `DEPENDENT` | `UNSIGNED` |
+| Tier [{#POOL}/{#TIER}]: Used capacity | `seagate.exos.tier.used_pct["{#SERIAL}"]` | `DEPENDENT` | `FLOAT` |
+| Tier [{#POOL}/{#TIER}]: IOPS | `seagate.exos.tier.iops["{#SERIAL}"]` | `DEPENDENT` | `UNSIGNED` |
+| Tier [{#POOL}/{#TIER}]: Throughput | `seagate.exos.tier.bps["{#SERIAL}"]` | `DEPENDENT` | `UNSIGNED` |
+| Tier [{#POOL}/{#TIER}]: Response time | `seagate.exos.tier.latency["{#SERIAL}"]` | `DEPENDENT` | `FLOAT` |
+| Tier [{#POOL}/{#TIER}]: Read response time | `seagate.exos.tier.read_latency["{#SERIAL}"]` | `DEPENDENT` | `FLOAT` |
+| Tier [{#POOL}/{#TIER}]: Write response time | `seagate.exos.tier.write_latency["{#SERIAL}"]` | `DEPENDENT` | `FLOAT` |
+| Tier [{#POOL}/{#TIER}]: Pages allocated per minute | `seagate.exos.tier.pages_alloc["{#SERIAL}"]` | `DEPENDENT` | `UNSIGNED` |
+| Tier [{#POOL}/{#TIER}]: Pages deallocated per minute | `seagate.exos.tier.pages_dealloc["{#SERIAL}"]` | `DEPENDENT` | `UNSIGNED` |
+| Tier [{#POOL}/{#TIER}]: Pages reclaimed | `seagate.exos.tier.pages_reclaimed["{#SERIAL}"]` | `DEPENDENT` | `UNSIGNED` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: Tier [{#POOL}/{#TIER}] utilization is high | `WARNING` | Tier [{#POOL}/{#TIER}]: Used capacity |
+| Seagate Exos Storage: Tier [{#POOL}/{#TIER}] utilization is critical | `HIGH` | Tier [{#POOL}/{#TIER}]: Used capacity |
+
+##### Graph prototypes
+
+| Graph prototype | Item prototype keys |
+|---|---|
+| Tier [{#POOL}/{#TIER}]: Performance | `seagate.exos.tier.iops["{#SERIAL}"]`<br>`seagate.exos.tier.bps["{#SERIAL}"]` |
+| Tier [{#POOL}/{#TIER}]: Response time | `seagate.exos.tier.latency["{#SERIAL}"]`<br>`seagate.exos.tier.read_latency["{#SERIAL}"]`<br>`seagate.exos.tier.write_latency["{#SERIAL}"]` |
+| Tier [{#POOL}/{#TIER}]: Space utilization | `seagate.exos.tier.used_pct["{#SERIAL}"]` |
+
+#### Enclosures discovery
+
+- Discovery key: `seagate.exos.enclosures.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 11
+- Trigger prototypes: 4
+- Graph prototypes: 1
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| Enclosure [{#ENCLOSURE.ID}]: Get data | `seagate.exos.enclosure.get["{#DURABLE.ID}"]` | `DEPENDENT` | `TEXT` |
+| Enclosure [{#ENCLOSURE.ID}]: Health | `seagate.exos.enclosure.health["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Enclosure [{#ENCLOSURE.ID}]: Status | `seagate.exos.enclosure.status["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Enclosure [{#ENCLOSURE.ID}]: Model | `seagate.exos.enclosure.model["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Enclosure [{#ENCLOSURE.ID}]: Serial number | `seagate.exos.enclosure.serial["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Enclosure [{#ENCLOSURE.ID}]: Type | `seagate.exos.enclosure.type["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Enclosure [{#ENCLOSURE.ID}]: Revision | `seagate.exos.enclosure.revision["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Enclosure [{#ENCLOSURE.ID}]: Disk count | `seagate.exos.enclosure.diskcount["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Enclosure [{#ENCLOSURE.ID}]: Power supply count | `seagate.exos.enclosure.psucount["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Enclosure [{#ENCLOSURE.ID}]: Cooling element count | `seagate.exos.enclosure.coolingcount["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Enclosure [{#ENCLOSURE.ID}]: Power consumption | `seagate.exos.enclosure.power["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: Enclosure [{#ENCLOSURE.ID}] health is degraded | `AVERAGE` | Enclosure [{#ENCLOSURE.ID}]: Health |
+| Seagate Exos Storage: Enclosure [{#ENCLOSURE.ID}] health is in fault state | `HIGH` | Enclosure [{#ENCLOSURE.ID}]: Health |
+| Seagate Exos Storage: Enclosure [{#ENCLOSURE.ID}] health is unknown | `WARNING` | Enclosure [{#ENCLOSURE.ID}]: Health |
+| Seagate Exos Storage: Enclosure [{#ENCLOSURE.ID}] status is abnormal | `HIGH` | Enclosure [{#ENCLOSURE.ID}]: Status |
+
+##### Graph prototypes
+
+| Graph prototype | Item prototype keys |
+|---|---|
+| Enclosure [{#ENCLOSURE.ID}]: Power consumption | `seagate.exos.enclosure.power["{#DURABLE.ID}"]` |
+
+#### FRUs discovery
+
+- Discovery key: `seagate.exos.frus.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 6
+- Trigger prototypes: 1
+- Graph prototypes: 0
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| FRU [{#NAME}/{#LOCATION}]: Get data | `seagate.exos.fru.get["{#LLD.ID}"]` | `DEPENDENT` | `TEXT` |
+| FRU [{#NAME}/{#LOCATION}]: Status | `seagate.exos.fru.status["{#LLD.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| FRU [{#NAME}/{#LOCATION}]: Part number | `seagate.exos.fru.part["{#LLD.ID}"]` | `DEPENDENT` | `CHAR` |
+| FRU [{#NAME}/{#LOCATION}]: Serial number | `seagate.exos.fru.serial["{#LLD.ID}"]` | `DEPENDENT` | `CHAR` |
+| FRU [{#NAME}/{#LOCATION}]: Revision | `seagate.exos.fru.revision["{#LLD.ID}"]` | `DEPENDENT` | `CHAR` |
+| FRU [{#NAME}/{#LOCATION}]: Description | `seagate.exos.fru.description["{#LLD.ID}"]` | `DEPENDENT` | `TEXT` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: FRU [{#NAME}/{#LOCATION}] status is abnormal | `HIGH` | FRU [{#NAME}/{#LOCATION}]: Status |
+
+##### Graph prototypes
+
+No graph prototypes.
+
+#### Fans discovery
+
+- Discovery key: `seagate.exos.fans.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 4
+- Trigger prototypes: 5
+- Graph prototypes: 1
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| Fan [{#NAME}/{#LOCATION}]: Get data | `seagate.exos.fan.get["{#DURABLE.ID}"]` | `DEPENDENT` | `TEXT` |
+| Fan [{#NAME}/{#LOCATION}]: Health | `seagate.exos.fan.health["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Fan [{#NAME}/{#LOCATION}]: Status | `seagate.exos.fan.status["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Fan [{#NAME}/{#LOCATION}]: Speed | `seagate.exos.fan.speed["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: Fan [{#NAME}/{#LOCATION}] health is degraded | `AVERAGE` | Fan [{#NAME}/{#LOCATION}]: Health |
+| Seagate Exos Storage: Fan [{#NAME}/{#LOCATION}] health is in fault state | `HIGH` | Fan [{#NAME}/{#LOCATION}]: Health |
+| Seagate Exos Storage: Fan [{#NAME}/{#LOCATION}] health is unknown | `WARNING` | Fan [{#NAME}/{#LOCATION}]: Health |
+| Seagate Exos Storage: Fan [{#NAME}/{#LOCATION}] is not Up | `HIGH` | Fan [{#NAME}/{#LOCATION}]: Status |
+| Seagate Exos Storage: Fan [{#NAME}/{#LOCATION}] speed is zero | `HIGH` | Fan [{#NAME}/{#LOCATION}]: Speed |
+
+##### Graph prototypes
+
+| Graph prototype | Item prototype keys |
+|---|---|
+| Fan [{#NAME}/{#LOCATION}]: Speed | `seagate.exos.fan.speed["{#DURABLE.ID}"]` |
+
+#### Power supplies discovery
+
+- Discovery key: `seagate.exos.psus.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 7
+- Trigger prototypes: 4
+- Graph prototypes: 0
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| Power supply [{#LOCATION}]: Get data | `seagate.exos.psu.get["{#DURABLE.ID}"]` | `DEPENDENT` | `TEXT` |
+| Power supply [{#LOCATION}]: Health | `seagate.exos.psu.health["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Power supply [{#LOCATION}]: Status | `seagate.exos.psu.status["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Power supply [{#LOCATION}]: Part number | `seagate.exos.psu.part["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Power supply [{#LOCATION}]: Serial number | `seagate.exos.psu.serial["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Power supply [{#LOCATION}]: Firmware | `seagate.exos.psu.firmware["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Power supply [{#LOCATION}]: Model | `seagate.exos.psu.model["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: Power supply [{#LOCATION}] health is degraded | `AVERAGE` | Power supply [{#LOCATION}]: Health |
+| Seagate Exos Storage: Power supply [{#LOCATION}] health is in fault state | `HIGH` | Power supply [{#LOCATION}]: Health |
+| Seagate Exos Storage: Power supply [{#LOCATION}] health is unknown | `WARNING` | Power supply [{#LOCATION}]: Health |
+| Seagate Exos Storage: Power supply [{#LOCATION}] status is abnormal | `HIGH` | Power supply [{#LOCATION}]: Status |
+
+##### Graph prototypes
+
+No graph prototypes.
+
+#### Sensors discovery
+
+- Discovery key: `seagate.exos.sensors.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 4
+- Trigger prototypes: 2
+- Graph prototypes: 0
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| Sensor [{#NAME}]: Get data | `seagate.exos.sensor.get["{#DURABLE.ID}"]` | `DEPENDENT` | `TEXT` |
+| Sensor [{#NAME}]: Status | `seagate.exos.sensor.status["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Sensor [{#NAME}]: Value | `seagate.exos.sensor.value["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Sensor [{#NAME}]: Type | `seagate.exos.sensor.type["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: Sensor [{#NAME}] reports Warning | `WARNING` | Sensor [{#NAME}]: Status |
+| Seagate Exos Storage: Sensor [{#NAME}] reports Critical or Unrecoverable | `HIGH` | Sensor [{#NAME}]: Status |
+
+##### Graph prototypes
+
+No graph prototypes.
+
+#### SAS links discovery
+
+- Discovery key: `seagate.exos.saslinks.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 3
+- Trigger prototypes: 4
+- Graph prototypes: 0
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| SAS link [{#NAME}]: Get data | `seagate.exos.saslink.get["{#DURABLE.ID}"]` | `DEPENDENT` | `TEXT` |
+| SAS link [{#NAME}]: Health | `seagate.exos.saslink.health["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| SAS link [{#NAME}]: Status | `seagate.exos.saslink.status["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: SAS link [{#NAME}] health is degraded | `AVERAGE` | SAS link [{#NAME}]: Health |
+| Seagate Exos Storage: SAS link [{#NAME}] health is in fault state | `HIGH` | SAS link [{#NAME}]: Health |
+| Seagate Exos Storage: SAS link [{#NAME}] health is unknown | `WARNING` | SAS link [{#NAME}]: Health |
+| Seagate Exos Storage: SAS link [{#NAME}] status is abnormal | `HIGH` | SAS link [{#NAME}]: Status |
+
+##### Graph prototypes
+
+No graph prototypes.
+
+#### Host ports discovery
+
+- Discovery key: `seagate.exos.ports.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 22
+- Trigger prototypes: 7
+- Graph prototypes: 3
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| Host port [{#PORT.ID}]: Get data | `seagate.exos.port.get["{#DURABLE.ID}"]` | `DEPENDENT` | `TEXT` |
+| Host port [{#PORT.ID}]: Get statistics | `seagate.exos.port.stats.get["{#DURABLE.ID}"]` | `DEPENDENT` | `TEXT` |
+| Host port [{#PORT.ID}]: Health | `seagate.exos.port.health["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Host port [{#PORT.ID}]: Status | `seagate.exos.port.status["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Host port [{#PORT.ID}]: Port type | `seagate.exos.port.type["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Host port [{#PORT.ID}]: IP address | `seagate.exos.port.ip["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Host port [{#PORT.ID}]: MAC address | `seagate.exos.port.mac["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Host port [{#PORT.ID}]: SFP vendor | `seagate.exos.port.sfp_vendor["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Host port [{#PORT.ID}]: SFP part number | `seagate.exos.port.sfp_part["{#DURABLE.ID}"]` | `DEPENDENT` | `CHAR` |
+| Host port [{#PORT.ID}]: Actual speed | `seagate.exos.port.speed["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Host port [{#PORT.ID}]: SFP present | `seagate.exos.port.sfp_present["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Host port [{#PORT.ID}]: SFP status | `seagate.exos.port.sfp_status["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Host port [{#PORT.ID}]: IOPS | `seagate.exos.port.iops["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Host port [{#PORT.ID}]: Throughput | `seagate.exos.port.bps["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Host port [{#PORT.ID}]: Queue depth | `seagate.exos.port.queue_depth["{#DURABLE.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Host port [{#PORT.ID}]: Read I/O rate | `seagate.exos.port.read_iops_derived["{#DURABLE.ID}"]` | `DEPENDENT` | `FLOAT` |
+| Host port [{#PORT.ID}]: Write I/O rate | `seagate.exos.port.write_iops_derived["{#DURABLE.ID}"]` | `DEPENDENT` | `FLOAT` |
+| Host port [{#PORT.ID}]: Read latency weighted contribution | `seagate.exos.port.read_latency_weighted["{#DURABLE.ID}"]` | `CALCULATED` | `FLOAT` |
+| Host port [{#PORT.ID}]: Write latency weighted contribution | `seagate.exos.port.write_latency_weighted["{#DURABLE.ID}"]` | `CALCULATED` | `FLOAT` |
+| Host port [{#PORT.ID}]: Response time | `seagate.exos.port.latency["{#DURABLE.ID}"]` | `DEPENDENT` | `FLOAT` |
+| Host port [{#PORT.ID}]: Read response time | `seagate.exos.port.read_latency["{#DURABLE.ID}"]` | `DEPENDENT` | `FLOAT` |
+| Host port [{#PORT.ID}]: Write response time | `seagate.exos.port.write_latency["{#DURABLE.ID}"]` | `DEPENDENT` | `FLOAT` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: Host port [{#PORT.ID}] health is degraded | `AVERAGE` | Host port [{#PORT.ID}]: Health |
+| Seagate Exos Storage: Host port [{#PORT.ID}] health is in fault state | `HIGH` | Host port [{#PORT.ID}]: Health |
+| Seagate Exos Storage: Host port [{#PORT.ID}] health is unknown | `WARNING` | Host port [{#PORT.ID}]: Health |
+| Seagate Exos Storage: Host port [{#PORT.ID}] is down | `HIGH` | Host port [{#PORT.ID}]: Status |
+| Seagate Exos Storage: Host port [{#PORT.ID}] negotiated speed changed | `WARNING` | Host port [{#PORT.ID}]: Actual speed |
+| Seagate Exos Storage: SFP removed from host port [{#PORT.ID}] | `HIGH` | Host port [{#PORT.ID}]: SFP present |
+| Seagate Exos Storage: SFP status is abnormal on host port [{#PORT.ID}] | `HIGH` | Host port [{#PORT.ID}]: SFP status |
+
+##### Graph prototypes
+
+| Graph prototype | Item prototype keys |
+|---|---|
+| Host port [{#PORT.ID}]: Performance | `seagate.exos.port.iops["{#DURABLE.ID}"]`<br>`seagate.exos.port.bps["{#DURABLE.ID}"]` |
+| Host port [{#PORT.ID}]: Response time | `seagate.exos.port.latency["{#DURABLE.ID}"]`<br>`seagate.exos.port.read_latency["{#DURABLE.ID}"]`<br>`seagate.exos.port.write_latency["{#DURABLE.ID}"]` |
+| Host port [{#PORT.ID}]: Queue depth | `seagate.exos.port.queue_depth["{#DURABLE.ID}"]` |
+
+#### Replication sets discovery
+
+- Discovery key: `seagate.exos.replications.discovery`
+- Discovery type: `DEPENDENT`
+- Item prototypes: 3
+- Trigger prototypes: 3
+- Graph prototypes: 0
+
+##### Item prototypes
+
+| Item prototype | Key | Type | Value type |
+|---|---|---|---|
+| Replication set [{#NAME}]: Get data | `seagate.exos.replication.get["{#LLD.ID}"]` | `DEPENDENT` | `TEXT` |
+| Replication set [{#NAME}]: Health | `seagate.exos.replication.health["{#LLD.ID}"]` | `DEPENDENT` | `UNSIGNED` |
+| Replication set [{#NAME}]: Status | `seagate.exos.replication.status["{#LLD.ID}"]` | `DEPENDENT` | `CHAR` |
+
+##### Trigger prototypes
+
+| Trigger prototype | Severity | Source item prototype |
+|---|---|---|
+| Seagate Exos Storage: Replication set [{#NAME}] health is degraded | `AVERAGE` | Replication set [{#NAME}]: Health |
+| Seagate Exos Storage: Replication set [{#NAME}] health is in fault state | `HIGH` | Replication set [{#NAME}]: Health |
+| Seagate Exos Storage: Replication set [{#NAME}] health is unknown | `WARNING` | Replication set [{#NAME}]: Health |
+
+##### Graph prototypes
+
+No graph prototypes.
+<!-- END GENERATED MONITORING INVENTORY -->

--- a/Storage_Devices/Seagate/template_seagate_exos_x_4005_4006/7.0/template_seagate_exos_x_4005_4006.yaml
+++ b/Storage_Devices/Seagate/template_seagate_exos_x_4005_4006/7.0/template_seagate_exos_x_4005_4006.yaml
@@ -1,0 +1,7549 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+  - uuid: 7c2cb727f85b492d88cd56e17127c64d
+    name: Templates/SAN
+  templates:
+  - uuid: c4cd0958f0e942f3a69173b3812c36aa
+    template: Seagate Exos Storage by HTTP
+    name: Seagate Exos Storage by HTTP
+    description: |-
+      HTTP/HTTPS monitoring template for Seagate Exos X 4005 and 4006 storage arrays with Gallium or Indium controllers in 2U12, 2U24, and 5U84 enclosures. Validated against a Seagate 4005-family array reporting product ID 4865 and an Exos X 4006 array.
+
+      The template uses Zabbix Script master items, dependent items, low-level discovery, trigger prototypes, graph prototypes, template dashboards, macros, and value maps. Authentication uses SHA-256(username + "_" + password), obtains a sessionKey, and executes only read-only show or query commands.
+
+      Configure {$SEAGATE.API.HOST}, {$SEAGATE.API.PORT}, {$SEAGATE.API.USERNAME}, and secret {$SEAGATE.API.PASSWORD}. {$SEAGATE.API.PORT} defaults to 443. Optionally configure {$SEAGATE.API.HOST.SECONDARY} and {$SEAGATE.HTTP.PROXY}. Review context macros for intentionally unused host ports and intentionally write-through volumes.
+
+      Structured Alerts are auto-enabled for the tested 4006 identity. The tested 4005/4865 is monitored through component state plus the common Event Log. For guaranteed delivery of every asynchronous event, also configure the array native syslog or SNMP event forwarding.
+
+      Author: Guilherme Campos (@guicampos21)
+      License: MIT
+    vendor:
+      name: SentrixIT
+      version: 1.1.0
+    groups:
+    - name: Templates/SAN
+    items:
+    - uuid: a9c44b03920244c6b4d524962f817a8f
+      name: API availability raw
+      type: SCRIPT
+      key: seagate.exos.api.check
+      delay: '{$SEAGATE.INTERVAL.AVAILABILITY}'
+      history: '0'
+      value_type: TEXT
+      trends: '0'
+      description: Checks authentication and a read-only show system request.
+      params: |
+        function validate(p) {
+            ['scheme','host','username','password'].forEach(function (f) {
+                if (typeof p[f] === 'undefined' || p[f] === '') throw 'Required parameter is not set: ' + f;
+            });
+            if (p.scheme !== 'https' && p.scheme !== 'http') throw 'Unsupported API scheme: ' + p.scheme;
+            if (typeof p.port === 'undefined' || p.port === '') p.port = '443';
+            if (!/^\d+$/.test(String(p.port)) || Number(p.port) < 1 || Number(p.port) > 65535)
+                throw 'Invalid API TCP port: ' + p.port;
+        }
+        function baseUrl(p, host) { return p.scheme + '://' + host + ':' + String(p.port) + '/'; }
+        function finalStatus(o) {
+            if (!o || !o.status || !o.status.length) return null;
+            return o.status[o.status.length - 1];
+        }
+        function loginAt(p, host) {
+            var r = new HttpRequest(), body, o, st, http;
+            if (p.http_proxy) r.setProxy(p.http_proxy);
+            r.addHeader('datatype: json');
+            body = r.get(baseUrl(p,host) + 'api/login/' + sha256(p.username + '_' + p.password));
+            http = r.getStatus();
+            if (http === 401 || http === 403) throw 'AUTH: Login HTTP ' + http + ' at ' + host;
+            if (http < 200 || http >= 300) throw 'CONNECT: Login HTTP ' + http + ' at ' + host;
+            try { o = JSON.parse(body); } catch(e) { throw 'AUTH: Invalid login JSON at ' + host; }
+            st = finalStatus(o);
+            if (!st || String(st['response-type'] || '').toLowerCase() !== 'success' || !o.status[0].response)
+                throw 'AUTH: Authentication failed at ' + host + ': ' + (st ? st.response : 'missing status');
+            r.addHeader('sessionKey: ' + o.status[0].response);
+            return {request:r, host:host, base:baseUrl(p,host)};
+        }
+        function connect(p) {
+            try { return loginAt(p,p.host); }
+            catch(e1) {
+                if (p.secondary && p.secondary !== p.host) {
+                    try { return loginAt(p,p.secondary); }
+                    catch(e2) { throw String(e1) + '; secondary: ' + String(e2); }
+                }
+                throw e1;
+            }
+        }
+        function fetchApi(c, apiPath, label, errors, optional) {
+            var body, o, st, http;
+            try { body = c.request.get(c.base + 'api/' + apiPath); http = c.request.getStatus(); }
+            catch(e) { if (!optional) errors.push(label + ': ' + e); return null; }
+            if (http < 200 || http >= 300) { if (!optional) errors.push(label + ': HTTP ' + http); return null; }
+            try { o = JSON.parse(body); } catch(e2) { if (!optional) errors.push(label + ': invalid JSON'); return null; }
+            st = finalStatus(o);
+            if (!st || Number(st['return-code']) !== 0) {
+                if (!optional) errors.push(label + ': API RC ' + (st ? st['return-code'] : 'missing') + ' ' + (st ? st.response : ''));
+                return null;
+            }
+            return o;
+        }
+        function first(a) { return (a && a.length) ? a[0] : {}; }
+        function array(o,k) { return (o && o[k] && Array.isArray(o[k])) ? o[k] : []; }
+        function logout(c) {
+            if (!c) return;
+            try { c.request.get(c.base + 'api/exit'); } catch(e) {}
+        }
+        function supportsAlerts(sys,mode) {
+            if (mode === 'disabled') return false;
+            if (mode === 'enabled') return true;
+            var b = String(sys['product-brand'] || '').toLowerCase(), s = String(sys['scsi-product-id'] || '');
+            return b.indexOf('exos') >= 0 || s === '4006';
+        }
+
+        var p = JSON.parse(value), out = {available:0,auth_failed:0,endpoint:'',system_http:0,api_rc:-1,latency_ms:0,error:''}, start = Date.now();
+        try {
+            validate(p);
+            var c = connect(p), body, o, st;
+            out.endpoint = c.host;
+            body = c.request.get(c.base + 'api/show/system');
+            out.system_http = c.request.getStatus();
+            if (out.system_http < 200 || out.system_http >= 300) throw 'show system HTTP ' + out.system_http;
+            o = JSON.parse(body); st = finalStatus(o); out.api_rc = st ? Number(st['return-code']) : -1;
+            if (!st || out.api_rc !== 0) throw 'show system API error: ' + (st ? st.response : 'missing status');
+            out.available = 1;
+        } catch(e) {
+            out.error = String(e);
+            if (out.error.indexOf('AUTH:') >= 0) out.auth_failed = 1;
+        }
+        if (typeof c !== 'undefined' && c) logout(c);
+        out.latency_ms = Date.now() - start;
+        return JSON.stringify(out);
+      timeout: '{$SEAGATE.DATA.TIMEOUT}'
+      parameters:
+      - name: alerts_mode
+        value: '{$SEAGATE.ALERTS.MODE}'
+      - name: events_last
+        value: '{$SEAGATE.EVENTS.LAST}'
+      - name: host
+        value: '{$SEAGATE.API.HOST}'
+      - name: http_proxy
+        value: '{$SEAGATE.HTTP.PROXY}'
+      - name: password
+        value: '{$SEAGATE.API.PASSWORD}'
+      - name: port
+        value: '{$SEAGATE.API.PORT}'
+      - name: scheme
+        value: '{$SEAGATE.API.SCHEME}'
+      - name: secondary
+        value: '{$SEAGATE.API.HOST.SECONDARY}'
+      - name: username
+        value: '{$SEAGATE.API.USERNAME}'
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 32a7cc53410f4ef6b5f34f7434b8a587
+      name: Get core data
+      type: SCRIPT
+      key: seagate.exos.get.core
+      delay: '{$SEAGATE.INTERVAL.CORE}'
+      history: '0'
+      value_type: TEXT
+      trends: '0'
+      description: Read-only core hardware and health data.
+      params: |
+        function validate(p) {
+            ['scheme','host','username','password'].forEach(function (f) {
+                if (typeof p[f] === 'undefined' || p[f] === '') throw 'Required parameter is not set: ' + f;
+            });
+            if (p.scheme !== 'https' && p.scheme !== 'http') throw 'Unsupported API scheme: ' + p.scheme;
+            if (typeof p.port === 'undefined' || p.port === '') p.port = '443';
+            if (!/^\d+$/.test(String(p.port)) || Number(p.port) < 1 || Number(p.port) > 65535)
+                throw 'Invalid API TCP port: ' + p.port;
+        }
+        function baseUrl(p, host) { return p.scheme + '://' + host + ':' + String(p.port) + '/'; }
+        function finalStatus(o) {
+            if (!o || !o.status || !o.status.length) return null;
+            return o.status[o.status.length - 1];
+        }
+        function loginAt(p, host) {
+            var r = new HttpRequest(), body, o, st, http;
+            if (p.http_proxy) r.setProxy(p.http_proxy);
+            r.addHeader('datatype: json');
+            body = r.get(baseUrl(p,host) + 'api/login/' + sha256(p.username + '_' + p.password));
+            http = r.getStatus();
+            if (http === 401 || http === 403) throw 'AUTH: Login HTTP ' + http + ' at ' + host;
+            if (http < 200 || http >= 300) throw 'CONNECT: Login HTTP ' + http + ' at ' + host;
+            try { o = JSON.parse(body); } catch(e) { throw 'AUTH: Invalid login JSON at ' + host; }
+            st = finalStatus(o);
+            if (!st || String(st['response-type'] || '').toLowerCase() !== 'success' || !o.status[0].response)
+                throw 'AUTH: Authentication failed at ' + host + ': ' + (st ? st.response : 'missing status');
+            r.addHeader('sessionKey: ' + o.status[0].response);
+            return {request:r, host:host, base:baseUrl(p,host)};
+        }
+        function connect(p) {
+            try { return loginAt(p,p.host); }
+            catch(e1) {
+                if (p.secondary && p.secondary !== p.host) {
+                    try { return loginAt(p,p.secondary); }
+                    catch(e2) { throw String(e1) + '; secondary: ' + String(e2); }
+                }
+                throw e1;
+            }
+        }
+        function fetchApi(c, apiPath, label, errors, optional) {
+            var body, o, st, http;
+            try { body = c.request.get(c.base + 'api/' + apiPath); http = c.request.getStatus(); }
+            catch(e) { if (!optional) errors.push(label + ': ' + e); return null; }
+            if (http < 200 || http >= 300) { if (!optional) errors.push(label + ': HTTP ' + http); return null; }
+            try { o = JSON.parse(body); } catch(e2) { if (!optional) errors.push(label + ': invalid JSON'); return null; }
+            st = finalStatus(o);
+            if (!st || Number(st['return-code']) !== 0) {
+                if (!optional) errors.push(label + ': API RC ' + (st ? st['return-code'] : 'missing') + ' ' + (st ? st.response : ''));
+                return null;
+            }
+            return o;
+        }
+        function first(a) { return (a && a.length) ? a[0] : {}; }
+        function array(o,k) { return (o && o[k] && Array.isArray(o[k])) ? o[k] : []; }
+        function logout(c) {
+            if (!c) return;
+            try { c.request.get(c.base + 'api/exit'); } catch(e) {}
+        }
+        function supportsAlerts(sys,mode) {
+            if (mode === 'disabled') return false;
+            if (mode === 'enabled') return true;
+            var b = String(sys['product-brand'] || '').toLowerCase(), s = String(sys['scsi-product-id'] || '');
+            return b.indexOf('exos') >= 0 || s === '4006';
+        }
+
+        var p = JSON.parse(value), data = {errors:''}, errors = [], o, i, detail, phy = [], bad = 0;
+        try {
+            validate(p); var c = connect(p); data.endpoint = c.host;
+            o=fetchApi(c,'show/system','system',errors,false); data.system=o?first(o.system):{};
+            o=fetchApi(c,'show/redundancy-mode','redundancy-mode',errors,false); data.redundancy=o?first(o.redundancy):{};
+            o=fetchApi(c,'show/fde-state','fde-state',errors,false); data.fde=o?first(o['fde-state']):{};
+            o=fetchApi(c,'show/controllers','controllers',errors,false); data.controllers=o?array(o,'controllers'):[];
+            o=fetchApi(c,'show/disks','disks',errors,false); data.disks=o?array(o,'drives'):[];
+            o=fetchApi(c,'show/disk-groups','disk-groups',errors,false); data['disk-groups']=o?array(o,'disk-groups'):[];
+            o=fetchApi(c,'show/pools','pools',errors,false); data.pools=o?array(o,'pools'):[];
+            o=fetchApi(c,'show/volumes','volumes',errors,false); data.volumes=o?array(o,'volumes'):[];
+            o=fetchApi(c,'show/enclosures','enclosures',errors,false); data.enclosures=o?array(o,'enclosures'):[];
+            o=fetchApi(c,'show/frus','frus',errors,false); data.frus=o?array(o,'enclosure-fru'):[];
+            for(i=0;i<data.frus.length;i++) data.frus[i]['lld-id']=String(data.frus[i]['enclosure-id'])+'_'+String(data.frus[i].name)+'_'+String(data.frus[i]['fru-location'])+'_'+String(data.frus[i]['serial-number']);
+            o=fetchApi(c,'show/fans','fans',errors,false); data.fans=o?array(o,'fan'):[];
+            o=fetchApi(c,'show/power-supplies','power-supplies',errors,false); data['power-supplies']=o?array(o,'power-supplies'):[];
+            o=fetchApi(c,'show/sensor-status','sensor-status',errors,false); data.sensors=o?array(o,'sensors'):[];
+            o=fetchApi(c,'show/sas-link-health','sas-link-health',errors,false); data['sas-links']=o?array(o,'expander-ports'):[];
+            o=fetchApi(c,'show/expander-status','expander-status',errors,false);
+            if(o){ for(var k in o){ if(k.indexOf('sas-status-controller')===0 && Array.isArray(o[k])) phy=phy.concat(o[k]); } }
+            for(i=0;i<phy.length;i++) { if(Number(phy[i]['elem-status-numeric'])!==1 && Number(phy[i]['elem-status-numeric'])!==5) bad++; }
+            data['expander-summary']={total:phy.length,unhealthy:bad};
+            o=fetchApi(c,'show/ports','ports',errors,false); data.ports=o?array(o,'port'):[];
+            for(i=0;i<data.ports.length;i++) {
+                detail=(data.ports[i]['iscsi-port']&&data.ports[i]['iscsi-port'][0]) || (data.ports[i]['fc-port']&&data.ports[i]['fc-port'][0]) || {};
+                for(var dk in detail) if(typeof data.ports[i][dk]==='undefined') data.ports[i][dk]=detail[dk];
+            }
+            o=fetchApi(c,'show/unwritable-cache','unwritable-cache',errors,false); data['unwritable-cache']=o?first(o['unwritable-cache']):{};
+            o=fetchApi(c,'show/ntp-status','ntp-status',errors,false); data.ntp=o?first(o['ntp-status']):{};
+        } catch(e) { errors.push(String(e)); }
+        if (typeof c !== 'undefined' && c) logout(c);
+        data.errors=errors.join('; '); return JSON.stringify(data);
+      timeout: '{$SEAGATE.DATA.TIMEOUT}'
+      parameters:
+      - name: alerts_mode
+        value: '{$SEAGATE.ALERTS.MODE}'
+      - name: events_last
+        value: '{$SEAGATE.EVENTS.LAST}'
+      - name: host
+        value: '{$SEAGATE.API.HOST}'
+      - name: http_proxy
+        value: '{$SEAGATE.HTTP.PROXY}'
+      - name: password
+        value: '{$SEAGATE.API.PASSWORD}'
+      - name: port
+        value: '{$SEAGATE.API.PORT}'
+      - name: scheme
+        value: '{$SEAGATE.API.SCHEME}'
+      - name: secondary
+        value: '{$SEAGATE.API.HOST.SECONDARY}'
+      - name: username
+        value: '{$SEAGATE.API.USERNAME}'
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 58d44d44c65a4858b694ba50252b7d40
+      name: Get performance data
+      type: SCRIPT
+      key: seagate.exos.get.performance
+      delay: '{$SEAGATE.INTERVAL.PERFORMANCE}'
+      history: '0'
+      value_type: TEXT
+      trends: '0'
+      description: Read-only performance statistics. On Exos X 4006, the collector also queries native system read/write average
+        and maximum response-time metrics. On 4005/4865, the Metrics Framework is unsupported and system average latency is
+        derived from I/O-weighted host-port statistics.
+      params: |
+        function validate(p) {
+            ['scheme','host','username','password'].forEach(function (f) {
+                if (typeof p[f] === 'undefined' || p[f] === '') throw 'Required parameter is not set: ' + f;
+            });
+            if (p.scheme !== 'https' && p.scheme !== 'http') throw 'Unsupported API scheme: ' + p.scheme;
+            if (typeof p.port === 'undefined' || p.port === '') p.port = '443';
+            if (!/^\d+$/.test(String(p.port)) || Number(p.port) < 1 || Number(p.port) > 65535)
+                throw 'Invalid API TCP port: ' + p.port;
+        }
+        function baseUrl(p, host) { return p.scheme + '://' + host + ':' + String(p.port) + '/'; }
+        function finalStatus(o) {
+            if (!o || !o.status || !o.status.length) return null;
+            return o.status[o.status.length - 1];
+        }
+        function loginAt(p, host) {
+            var r = new HttpRequest(), body, o, st, http;
+            if (p.http_proxy) r.setProxy(p.http_proxy);
+            r.addHeader('datatype: json');
+            body = r.get(baseUrl(p,host) + 'api/login/' + sha256(p.username + '_' + p.password));
+            http = r.getStatus();
+            if (http === 401 || http === 403) throw 'AUTH: Login HTTP ' + http + ' at ' + host;
+            if (http < 200 || http >= 300) throw 'CONNECT: Login HTTP ' + http + ' at ' + host;
+            try { o = JSON.parse(body); } catch(e) { throw 'AUTH: Invalid login JSON at ' + host; }
+            st = finalStatus(o);
+            if (!st || String(st['response-type'] || '').toLowerCase() !== 'success' || !o.status[0].response)
+                throw 'AUTH: Authentication failed at ' + host + ': ' + (st ? st.response : 'missing status');
+            r.addHeader('sessionKey: ' + o.status[0].response);
+            return {request:r, host:host, base:baseUrl(p,host)};
+        }
+        function connect(p) {
+            try { return loginAt(p,p.host); }
+            catch(e1) {
+                if (p.secondary && p.secondary !== p.host) {
+                    try { return loginAt(p,p.secondary); }
+                    catch(e2) { throw String(e1) + '; secondary: ' + String(e2); }
+                }
+                throw e1;
+            }
+        }
+        function fetchApi(c, apiPath, label, errors, optional) {
+            var body, o, st, http;
+            try { body = c.request.get(c.base + 'api/' + apiPath); http = c.request.getStatus(); }
+            catch(e) { if (!optional) errors.push(label + ': ' + e); return null; }
+            if (http < 200 || http >= 300) { if (!optional) errors.push(label + ': HTTP ' + http); return null; }
+            try { o = JSON.parse(body); } catch(e2) { if (!optional) errors.push(label + ': invalid JSON'); return null; }
+            st = finalStatus(o);
+            if (!st || Number(st['return-code']) !== 0) {
+                if (!optional) errors.push(label + ': API RC ' + (st ? st['return-code'] : 'missing') + ' ' + (st ? st.response : ''));
+                return null;
+            }
+            return o;
+        }
+        function first(a) { return (a && a.length) ? a[0] : {}; }
+        function array(o,k) { return (o && o[k] && Array.isArray(o[k])) ? o[k] : []; }
+        function fetchRawOptional(c, apiPath) {
+            var body, http;
+            try {
+                body = c.request.get(c.base + 'api/' + apiPath);
+                http = c.request.getStatus();
+            } catch (e) {
+                return null;
+            }
+            if (http < 200 || http >= 300) return null;
+            return body;
+        }
+        function parseMetricsBody(body) {
+            var clean;
+            if (!body) return null;
+            clean = String(body).replace(/:\s*N\/A(\s*[,}])/g, ':null$1');
+            try { return JSON.parse(clean); } catch (e) { return null; }
+        }
+        function latestMetricRow(o) {
+            var rows, best = null, bestTs = 0, i, ts;
+            if (!o || !o['metrics-query'] || !Array.isArray(o['metrics-query'])) return null;
+            rows = o['metrics-query'];
+            for (i = 0; i < rows.length; i++) {
+                ts = Number(rows[i]['time-stamp-numeric'] || 0);
+                if (ts > bestTs) {
+                    bestTs = ts;
+                    best = rows[i];
+                }
+            }
+            return best;
+        }
+        function logout(c) {
+            if (!c) return;
+            try { c.request.get(c.base + 'api/exit'); } catch(e) {}
+        }
+        function supportsAlerts(sys,mode) {
+            if (mode === 'disabled') return false;
+            if (mode === 'enabled') return true;
+            var b = String(sys['product-brand'] || '').toLowerCase(), s = String(sys['scsi-product-id'] || '');
+            return b.indexOf('exos') >= 0 || s === '4006';
+        }
+
+        function flattenReset(a){ for(var i=0;i<a.length;i++){ var r=(a[i]['resettable-statistics']&&a[i]['resettable-statistics'][0])||{}; for(var k in r) if(typeof a[i][k]==='undefined') a[i][k]=r[k]; } return a; }
+        var p=JSON.parse(value), data={errors:''}, errors=[], o, a, i, mraw, mo, mst, mr;
+        data['system-latency-native'] = {
+            supported: 0,
+            source: 'Host Port Weighted Aggregate',
+            read_avg_us: 0,
+            write_avg_us: 0
+        };
+        try {
+            validate(p); var c=connect(p); data.endpoint=c.host;
+            o=fetchApi(c,'show/controller-statistics','controller-statistics',errors,false); a=o?array(o,'controller-statistics'):[]; for(i=0;i<a.length;i++) if(a[i]['durable-id']) a[i]['durable-id']=String(a[i]['durable-id']).toLowerCase(); data['controller-statistics']=a;
+            o=fetchApi(c,'show/disk-statistics','disk-statistics',errors,false); data['disk-statistics']=o?array(o,'disk-statistics'):[];
+            o=fetchApi(c,'show/disk-group-statistics','disk-group-statistics',errors,false); data['disk-group-statistics']=o?array(o,'disk-group-statistics'):[];
+            o=fetchApi(c,'show/pool-statistics','pool-statistics',errors,false); data['pool-statistics']=o?flattenReset(array(o,'pool-statistics')):[];
+            o=fetchApi(c,'show/volume-statistics','volume-statistics',errors,false); data['volume-statistics']=o?array(o,'volume-statistics'):[];
+            o=fetchApi(c,'show/host-port-statistics','host-port-statistics',errors,false); data['host-port-statistics']=o?array(o,'host-port-statistics'):[];
+            mraw=fetchRawOptional(c,'query/metrics/count/10/system.read-avg-response-time,system.write-avg-response-time,system.read-max-response-time,system.write-max-response-time');
+            mo=parseMetricsBody(mraw);
+            mst=finalStatus(mo);
+            mr=latestMetricRow(mo);
+            if (mo && mst && Number(mst['return-code']) === 0 && mr) {
+                data['system-latency-native'] = {
+                    supported: 1,
+                    source: 'Native Metrics Framework',
+                    read_avg_us: Number(mr['01'] || 0),
+                    write_avg_us: Number(mr['02'] || 0)
+                };
+                if (mr['03'] !== null && typeof mr['03'] !== 'undefined')
+                    data['system-latency-native'].read_max_us = Number(mr['03']);
+                if (mr['04'] !== null && typeof mr['04'] !== 'undefined')
+                    data['system-latency-native'].write_max_us = Number(mr['04']);
+            }
+            o=fetchApi(c,'show/tier-statistics/tier/all','tier-statistics',errors,false); data['tier-statistics']=o?flattenReset(array(o,'tier-statistics')):[];
+        } catch(e) { errors.push(String(e)); }
+        if (typeof c !== 'undefined' && c) logout(c);
+        data.errors=errors.join('; '); return JSON.stringify(data);
+      timeout: '{$SEAGATE.DATA.TIMEOUT}'
+      parameters:
+      - name: alerts_mode
+        value: '{$SEAGATE.ALERTS.MODE}'
+      - name: events_last
+        value: '{$SEAGATE.EVENTS.LAST}'
+      - name: host
+        value: '{$SEAGATE.API.HOST}'
+      - name: http_proxy
+        value: '{$SEAGATE.HTTP.PROXY}'
+      - name: password
+        value: '{$SEAGATE.API.PASSWORD}'
+      - name: port
+        value: '{$SEAGATE.API.PORT}'
+      - name: scheme
+        value: '{$SEAGATE.API.SCHEME}'
+      - name: secondary
+        value: '{$SEAGATE.API.HOST.SECONDARY}'
+      - name: username
+        value: '{$SEAGATE.API.USERNAME}'
+      tags:
+      - tag: component
+        value: raw
+    - uuid: bd042a9106c848cca476272c61f97cff
+      name: Get inventory data
+      type: SCRIPT
+      key: seagate.exos.get.inventory
+      delay: '{$SEAGATE.INTERVAL.INVENTORY}'
+      history: '0'
+      value_type: TEXT
+      trends: '0'
+      description: Read-only inventory, versions, tiers and replication data.
+      params: |
+        function validate(p) {
+            ['scheme','host','username','password'].forEach(function (f) {
+                if (typeof p[f] === 'undefined' || p[f] === '') throw 'Required parameter is not set: ' + f;
+            });
+            if (p.scheme !== 'https' && p.scheme !== 'http') throw 'Unsupported API scheme: ' + p.scheme;
+            if (typeof p.port === 'undefined' || p.port === '') p.port = '443';
+            if (!/^\d+$/.test(String(p.port)) || Number(p.port) < 1 || Number(p.port) > 65535)
+                throw 'Invalid API TCP port: ' + p.port;
+        }
+        function baseUrl(p, host) { return p.scheme + '://' + host + ':' + String(p.port) + '/'; }
+        function finalStatus(o) {
+            if (!o || !o.status || !o.status.length) return null;
+            return o.status[o.status.length - 1];
+        }
+        function loginAt(p, host) {
+            var r = new HttpRequest(), body, o, st, http;
+            if (p.http_proxy) r.setProxy(p.http_proxy);
+            r.addHeader('datatype: json');
+            body = r.get(baseUrl(p,host) + 'api/login/' + sha256(p.username + '_' + p.password));
+            http = r.getStatus();
+            if (http === 401 || http === 403) throw 'AUTH: Login HTTP ' + http + ' at ' + host;
+            if (http < 200 || http >= 300) throw 'CONNECT: Login HTTP ' + http + ' at ' + host;
+            try { o = JSON.parse(body); } catch(e) { throw 'AUTH: Invalid login JSON at ' + host; }
+            st = finalStatus(o);
+            if (!st || String(st['response-type'] || '').toLowerCase() !== 'success' || !o.status[0].response)
+                throw 'AUTH: Authentication failed at ' + host + ': ' + (st ? st.response : 'missing status');
+            r.addHeader('sessionKey: ' + o.status[0].response);
+            return {request:r, host:host, base:baseUrl(p,host)};
+        }
+        function connect(p) {
+            try { return loginAt(p,p.host); }
+            catch(e1) {
+                if (p.secondary && p.secondary !== p.host) {
+                    try { return loginAt(p,p.secondary); }
+                    catch(e2) { throw String(e1) + '; secondary: ' + String(e2); }
+                }
+                throw e1;
+            }
+        }
+        function fetchApi(c, apiPath, label, errors, optional) {
+            var body, o, st, http;
+            try { body = c.request.get(c.base + 'api/' + apiPath); http = c.request.getStatus(); }
+            catch(e) { if (!optional) errors.push(label + ': ' + e); return null; }
+            if (http < 200 || http >= 300) { if (!optional) errors.push(label + ': HTTP ' + http); return null; }
+            try { o = JSON.parse(body); } catch(e2) { if (!optional) errors.push(label + ': invalid JSON'); return null; }
+            st = finalStatus(o);
+            if (!st || Number(st['return-code']) !== 0) {
+                if (!optional) errors.push(label + ': API RC ' + (st ? st['return-code'] : 'missing') + ' ' + (st ? st.response : ''));
+                return null;
+            }
+            return o;
+        }
+        function first(a) { return (a && a.length) ? a[0] : {}; }
+        function array(o,k) { return (o && o[k] && Array.isArray(o[k])) ? o[k] : []; }
+        function logout(c) {
+            if (!c) return;
+            try { c.request.get(c.base + 'api/exit'); } catch(e) {}
+        }
+        function supportsAlerts(sys,mode) {
+            if (mode === 'disabled') return false;
+            if (mode === 'enabled') return true;
+            var b = String(sys['product-brand'] || '').toLowerCase(), s = String(sys['scsi-product-id'] || '');
+            return b.indexOf('exos') >= 0 || s === '4006';
+        }
+
+        var p=JSON.parse(value), data={errors:''}, errors=[], o, sys={}, ah=false, pools=[], tiers=[], pmap={}, i;
+        try {
+            validate(p); var c=connect(p); data.endpoint=c.host;
+            o=fetchApi(c,'show/system','system',errors,false); sys=o?first(o.system):{}; data.system=sys;
+            o=fetchApi(c,'show/versions','versions',errors,false); data.versions=o?array(o,'versions'):[];
+            o=fetchApi(c,'show/pools','pools',errors,false); pools=o?array(o,'pools'):[]; for(i=0;i<pools.length;i++)pmap[String(pools[i].name)]=Number(pools[i].blocksize||512);
+            o=fetchApi(c,'show/tiers/tier/all','tiers',errors,false); tiers=o?array(o,'tiers'):[]; for(i=0;i<tiers.length;i++) tiers[i].blocksize=pmap[String(tiers[i].pool)]||512; data.tiers=tiers;
+            o=fetchApi(c,'show/protocols','protocols',errors,false); data.protocols=o||{};
+            o=fetchApi(c,'show/peer-connections','peer-connections',errors,true); data['peer-connections']=o?(array(o,'peer-connection').length?array(o,'peer-connection'):array(o,'peer-connections')):[];
+            o=fetchApi(c,'show/replication-sets','replication-sets',errors,false); data['replication-sets']=o?array(o,'cs-replication-set'):[];
+            for(i=0;i<data['replication-sets'].length;i++) data['replication-sets'][i]['lld-id']=String(data['replication-sets'][i]['durable-id']||data['replication-sets'][i].name||data['replication-sets'][i]['serial-number']||i);
+            o=fetchApi(c,'show/replication-snapshot-history','replication-history',errors,false); data['replication-history']=o?array(o,'replication-snapshot-history'):[];
+            ah=supportsAlerts(sys,String(p.alerts_mode||'auto').toLowerCase()); data['alerts-supported']=ah?1:0;
+            if(ah){ o=fetchApi(c,'show/alert-condition-history','alert-condition-history',errors,true); data['alert-condition-history']=o?array(o,'conditions'):[]; } else data['alert-condition-history']=[];
+        } catch(e) { errors.push(String(e)); }
+        if (typeof c !== 'undefined' && c) logout(c);
+        data.errors=errors.join('; '); return JSON.stringify(data);
+      timeout: '{$SEAGATE.DATA.TIMEOUT}'
+      parameters:
+      - name: alerts_mode
+        value: '{$SEAGATE.ALERTS.MODE}'
+      - name: events_last
+        value: '{$SEAGATE.EVENTS.LAST}'
+      - name: host
+        value: '{$SEAGATE.API.HOST}'
+      - name: http_proxy
+        value: '{$SEAGATE.HTTP.PROXY}'
+      - name: password
+        value: '{$SEAGATE.API.PASSWORD}'
+      - name: port
+        value: '{$SEAGATE.API.PORT}'
+      - name: scheme
+        value: '{$SEAGATE.API.SCHEME}'
+      - name: secondary
+        value: '{$SEAGATE.API.HOST.SECONDARY}'
+      - name: username
+        value: '{$SEAGATE.API.USERNAME}'
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 6fd40c6440a94cd08d3ff2688581b104
+      name: Get events and alerts
+      type: SCRIPT
+      key: seagate.exos.get.events
+      delay: '{$SEAGATE.INTERVAL.EVENTS}'
+      history: '0'
+      value_type: TEXT
+      trends: '0'
+      description: Bounded event window and structured active alerts when supported.
+      params: |
+        function validate(p) {
+            ['scheme','host','username','password'].forEach(function (f) {
+                if (typeof p[f] === 'undefined' || p[f] === '') throw 'Required parameter is not set: ' + f;
+            });
+            if (p.scheme !== 'https' && p.scheme !== 'http') throw 'Unsupported API scheme: ' + p.scheme;
+            if (typeof p.port === 'undefined' || p.port === '') p.port = '443';
+            if (!/^\d+$/.test(String(p.port)) || Number(p.port) < 1 || Number(p.port) > 65535)
+                throw 'Invalid API TCP port: ' + p.port;
+        }
+        function baseUrl(p, host) { return p.scheme + '://' + host + ':' + String(p.port) + '/'; }
+        function finalStatus(o) {
+            if (!o || !o.status || !o.status.length) return null;
+            return o.status[o.status.length - 1];
+        }
+        function loginAt(p, host) {
+            var r = new HttpRequest(), body, o, st, http;
+            if (p.http_proxy) r.setProxy(p.http_proxy);
+            r.addHeader('datatype: json');
+            body = r.get(baseUrl(p,host) + 'api/login/' + sha256(p.username + '_' + p.password));
+            http = r.getStatus();
+            if (http === 401 || http === 403) throw 'AUTH: Login HTTP ' + http + ' at ' + host;
+            if (http < 200 || http >= 300) throw 'CONNECT: Login HTTP ' + http + ' at ' + host;
+            try { o = JSON.parse(body); } catch(e) { throw 'AUTH: Invalid login JSON at ' + host; }
+            st = finalStatus(o);
+            if (!st || String(st['response-type'] || '').toLowerCase() !== 'success' || !o.status[0].response)
+                throw 'AUTH: Authentication failed at ' + host + ': ' + (st ? st.response : 'missing status');
+            r.addHeader('sessionKey: ' + o.status[0].response);
+            return {request:r, host:host, base:baseUrl(p,host)};
+        }
+        function connect(p) {
+            try { return loginAt(p,p.host); }
+            catch(e1) {
+                if (p.secondary && p.secondary !== p.host) {
+                    try { return loginAt(p,p.secondary); }
+                    catch(e2) { throw String(e1) + '; secondary: ' + String(e2); }
+                }
+                throw e1;
+            }
+        }
+        function fetchApi(c, apiPath, label, errors, optional) {
+            var body, o, st, http;
+            try { body = c.request.get(c.base + 'api/' + apiPath); http = c.request.getStatus(); }
+            catch(e) { if (!optional) errors.push(label + ': ' + e); return null; }
+            if (http < 200 || http >= 300) { if (!optional) errors.push(label + ': HTTP ' + http); return null; }
+            try { o = JSON.parse(body); } catch(e2) { if (!optional) errors.push(label + ': invalid JSON'); return null; }
+            st = finalStatus(o);
+            if (!st || Number(st['return-code']) !== 0) {
+                if (!optional) errors.push(label + ': API RC ' + (st ? st['return-code'] : 'missing') + ' ' + (st ? st.response : ''));
+                return null;
+            }
+            return o;
+        }
+        function first(a) { return (a && a.length) ? a[0] : {}; }
+        function array(o,k) { return (o && o[k] && Array.isArray(o[k])) ? o[k] : []; }
+        function logout(c) {
+            if (!c) return;
+            try { c.request.get(c.base + 'api/exit'); } catch(e) {}
+        }
+        function supportsAlerts(sys,mode) {
+            if (mode === 'disabled') return false;
+            if (mode === 'enabled') return true;
+            var b = String(sys['product-brand'] || '').toLowerCase(), s = String(sys['scsi-product-id'] || '');
+            return b.indexOf('exos') >= 0 || s === '4006';
+        }
+
+        var p=JSON.parse(value), data={errors:''}, errors=[], o, ev=[], al=[], sys={}, ah=false, i, e;
+        function latestBySeverity(events,sev){ var best={}; for(var j=0;j<events.length;j++){ var x=events[j]; if(Number(x['severity-numeric'])===sev && Number(x['event-id']||0)>Number(best['event-id']||0)) best=x; } return best; }
+        try {
+            validate(p); var c=connect(p); data.endpoint=c.host;
+            o=fetchApi(c,'show/system','system',errors,false); sys=o?first(o.system):{};
+            var n=parseInt(p.events_last,10); if(!n||n<1)n=100; if(n>1000)n=1000;
+            o=fetchApi(c,'show/events/last/'+n+'/detail','events',errors,false); ev=o?array(o,'events'):[]; data.events=ev;
+            data['latest-warning']=latestBySeverity(ev,1); data['latest-error']=latestBySeverity(ev,2); data['latest-critical']=latestBySeverity(ev,3);
+            ah=supportsAlerts(sys,String(p.alerts_mode||'auto').toLowerCase()); data['alerts-supported']=ah?1:0;
+            if(ah){o=fetchApi(c,'show/alerts','alerts',errors,true); al=o?array(o,'alerts'):[];} data.alerts=al;
+            var counts={warning:0,error:0,critical:0}, summaries=[];
+            for(i=0;i<al.length;i++){
+                e=al[i]; if(Number(e['resolved-numeric'])===0){var sev=Number(e['severity-numeric']);
+                    if(sev===1)counts.warning++; if(sev===2)counts.error++; if(sev===3)counts.critical++;
+                    if(sev>=1&&sev<=3&&summaries.length<10)summaries.push('['+String(e.severity||sev)+'] '+String(e.component||'')+': '+String(e.reason||e.description||''));
+                }
+            }
+            data['active-alert-warning-count']=counts.warning; data['active-alert-error-count']=counts.error; data['active-alert-critical-count']=counts.critical; data['active-alert-summary']=summaries.join(' | ');
+        } catch(e) { errors.push(String(e)); }
+        if (typeof c !== 'undefined' && c) logout(c);
+        data.errors=errors.join('; '); return JSON.stringify(data);
+      timeout: '{$SEAGATE.DATA.TIMEOUT}'
+      parameters:
+      - name: alerts_mode
+        value: '{$SEAGATE.ALERTS.MODE}'
+      - name: events_last
+        value: '{$SEAGATE.EVENTS.LAST}'
+      - name: host
+        value: '{$SEAGATE.API.HOST}'
+      - name: http_proxy
+        value: '{$SEAGATE.HTTP.PROXY}'
+      - name: password
+        value: '{$SEAGATE.API.PASSWORD}'
+      - name: port
+        value: '{$SEAGATE.API.PORT}'
+      - name: scheme
+        value: '{$SEAGATE.API.SCHEME}'
+      - name: secondary
+        value: '{$SEAGATE.API.HOST.SECONDARY}'
+      - name: username
+        value: '{$SEAGATE.API.USERNAME}'
+      tags:
+      - tag: component
+        value: raw
+    - uuid: f86118e17aee4c59af79f879fae96f96
+      name: API available
+      type: DEPENDENT
+      key: seagate.exos.api.available
+      delay: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.available
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      valuemap:
+        name: Yes/No
+      master_item:
+        key: seagate.exos.api.check
+      tags:
+      - tag: component
+        value: health
+      triggers:
+      - uuid: 5ce1e37d70264021a82777627fee3da4
+        expression: max(/Seagate Exos Storage by HTTP/seagate.exos.api.available,5m)=0
+        name: 'Seagate Exos Storage: Management API is unavailable'
+        priority: HIGH
+        description: No successful authentication and show system request for five minutes.
+        dependencies:
+        - name: 'Seagate Exos Storage: API authentication failed'
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.api.auth_failed)=1
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: d5a0b35447954e7e844f6811520a081f
+      name: API authentication failed
+      type: DEPENDENT
+      key: seagate.exos.api.auth_failed
+      delay: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.auth_failed
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      valuemap:
+        name: Yes/No
+      master_item:
+        key: seagate.exos.api.check
+      tags:
+      - tag: component
+        value: health
+      triggers:
+      - uuid: 574948d9789f451284d7e483a8034282
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.api.auth_failed)=1
+        name: 'Seagate Exos Storage: API authentication failed'
+        priority: HIGH
+        description: The storage rejected the configured API credentials.
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: 1b2f9b646e2e4c7a9e76ace05c3a9141
+      name: Active management endpoint
+      type: DEPENDENT
+      key: seagate.exos.api.endpoint
+      delay: '0'
+      value_type: CHAR
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.endpoint
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.api.check
+      tags:
+      - tag: component
+        value: inventory
+      description: Management endpoint currently used by the API collector. An unchanged value is stored at least every 30
+        minutes for dashboards.
+    - uuid: a92e6bbf81ac4235936212c08c22927a
+      name: API response time
+      type: DEPENDENT
+      key: seagate.exos.api.latency
+      delay: '0'
+      units: ms
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.latency_ms
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.api.check
+      tags:
+      - tag: component
+        value: performance
+    - uuid: c87b18fb31cf4caaa489422995fe9567
+      name: API error detail
+      type: DEPENDENT
+      key: seagate.exos.api.error
+      delay: '0'
+      value_type: TEXT
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.error
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      master_item:
+        key: seagate.exos.api.check
+      tags:
+      - tag: component
+        value: errors
+    - uuid: 4fd91b7223df43fd92359e8249fb0158
+      name: Core API method errors
+      type: DEPENDENT
+      key: seagate.exos.core.errors
+      delay: '0'
+      value_type: TEXT
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.errors
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: errors
+      triggers:
+      - uuid: 4b11307e9ba64194b22ef710fe5e9f18
+        expression: length(last(/Seagate Exos Storage by HTTP/seagate.exos.core.errors))>0
+        name: 'Seagate Exos Storage: Core API method errors'
+        priority: WARNING
+        description: One or more read-only API methods failed.
+        dependencies:
+        - name: 'Seagate Exos Storage: Management API is unavailable'
+          expression: max(/Seagate Exos Storage by HTTP/seagate.exos.api.available,5m)=0
+        - name: 'Seagate Exos Storage: API authentication failed'
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.api.auth_failed)=1
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: 109ceeca211c4a08bc49722661148da9
+      name: Performance API method errors
+      type: DEPENDENT
+      key: seagate.exos.performance.errors
+      delay: '0'
+      value_type: TEXT
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.errors
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: errors
+      triggers:
+      - uuid: d2c286c3a6c743b5850d795836a77a5d
+        expression: length(last(/Seagate Exos Storage by HTTP/seagate.exos.performance.errors))>0
+        name: 'Seagate Exos Storage: Performance API method errors'
+        priority: WARNING
+        description: One or more read-only API methods failed.
+        dependencies:
+        - name: 'Seagate Exos Storage: Management API is unavailable'
+          expression: max(/Seagate Exos Storage by HTTP/seagate.exos.api.available,5m)=0
+        - name: 'Seagate Exos Storage: API authentication failed'
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.api.auth_failed)=1
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: f1dcda18f47f45fa8675f72780d61bd7
+      name: 'System latency: Native metrics supported'
+      type: DEPENDENT
+      key: seagate.exos.system.latency.native_supported
+      delay: '0'
+      history: 7d
+      trends: '0'
+      description: 1 when the native Exos Metrics Framework returned valid system latency data; 0 when the host-port weighted
+        fallback is used.
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['system-latency-native'].supported
+        error_handler: CUSTOM_VALUE
+        error_handler_params: '0'
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: performance
+      - tag: component
+        value: internal
+    - uuid: 34ba0ae0dcf247e7b4fe7ccbd7fbcf01
+      name: 'System latency: Source'
+      type: DEPENDENT
+      key: seagate.exos.system.latency.source
+      delay: '0'
+      history: 31d
+      value_type: CHAR
+      trends: '0'
+      description: Source used for the unified system latency items. Exos X 4006 uses the native Metrics Framework; 4005/4865
+        uses an I/O-weighted aggregate of host-port response times. An unchanged value is stored at least every 30 minutes.
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['system-latency-native'].source
+        error_handler: CUSTOM_VALUE
+        error_handler_params: Host Port Weighted Aggregate
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: performance
+    - uuid: c34a8b6ec217467c9249f29b761e81ab
+      name: 'System latency: Native read average response time'
+      type: DEPENDENT
+      key: seagate.exos.system.latency.native.read_avg
+      delay: '0'
+      history: 7d
+      value_type: FLOAT
+      trends: '0'
+      units: '!µs'
+      description: Native system read average response time from the Exos X 4006 Metrics Framework. Internal source for the
+        unified system latency item.
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['system-latency-native'].read_avg_us
+        error_handler: CUSTOM_VALUE
+        error_handler_params: '0'
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: performance
+      - tag: component
+        value: internal
+    - uuid: afed354f29d042258798529b5e3dc512
+      name: 'System latency: Native write average response time'
+      type: DEPENDENT
+      key: seagate.exos.system.latency.native.write_avg
+      delay: '0'
+      history: 7d
+      value_type: FLOAT
+      trends: '0'
+      units: '!µs'
+      description: Native system write average response time from the Exos X 4006 Metrics Framework. Internal source for the
+        unified system latency item.
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['system-latency-native'].write_avg_us
+        error_handler: CUSTOM_VALUE
+        error_handler_params: '0'
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: performance
+      - tag: component
+        value: internal
+    - uuid: bda9acd7f2e74ca78048f77183a06cf5
+      name: 'System: Read maximum response time'
+      type: DEPENDENT
+      key: seagate.exos.system.latency.read_max
+      delay: '0'
+      value_type: FLOAT
+      units: '!µs'
+      description: Native system maximum read response time. Available on Exos X 4006 via the Metrics Framework; no equivalent
+        maximum-latency metric was found for the tested 4005/4865 API.
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['system-latency-native'].read_max_us
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: performance
+    - uuid: b2c2c701daee433d97a2e8c796cb2e88
+      name: 'System: Write maximum response time'
+      type: DEPENDENT
+      key: seagate.exos.system.latency.write_max
+      delay: '0'
+      value_type: FLOAT
+      units: '!µs'
+      description: Native system maximum write response time. Available on Exos X 4006 via the Metrics Framework; no equivalent
+        maximum-latency metric was found for the tested 4005/4865 API.
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['system-latency-native'].write_max_us
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: performance
+    - uuid: 0608b46557b040f69107a5728a0b2479
+      name: 'System latency: Host-port weighted read average response time'
+      type: CALCULATED
+      key: seagate.exos.system.latency.fallback.read_avg
+      delay: '{$SEAGATE.INTERVAL.PERFORMANCE}'
+      value_type: FLOAT
+      units: '!µs'
+      params: sum(last_foreach(//seagate.exos.port.read_latency_weighted[*]))/max(sum(last_foreach(//seagate.exos.port.read_iops_derived[*])),1)
+      description: 4005/4865 system read latency fallback. It aggregates host-port average read response times using the derived
+        read I/O rate of each port as weight.
+      tags:
+      - tag: component
+        value: performance
+      - tag: component
+        value: calculation
+    - uuid: 2341b1971dc547edbaa1bf699e6eb055
+      name: 'System latency: Host-port weighted write average response time'
+      type: CALCULATED
+      key: seagate.exos.system.latency.fallback.write_avg
+      delay: '{$SEAGATE.INTERVAL.PERFORMANCE}'
+      value_type: FLOAT
+      units: '!µs'
+      params: sum(last_foreach(//seagate.exos.port.write_latency_weighted[*]))/max(sum(last_foreach(//seagate.exos.port.write_iops_derived[*])),1)
+      description: 4005/4865 system write latency fallback. It aggregates host-port average write response times using the
+        derived write I/O rate of each port as weight.
+      tags:
+      - tag: component
+        value: performance
+      - tag: component
+        value: calculation
+    - uuid: 1fc82adc30664ba880bcc7bc1b39241e
+      name: 'System: Read average response time'
+      type: CALCULATED
+      key: seagate.exos.system.latency.read_avg
+      delay: '{$SEAGATE.INTERVAL.PERFORMANCE}'
+      value_type: FLOAT
+      units: '!µs'
+      params: last(//seagate.exos.system.latency.native_supported)*last(//seagate.exos.system.latency.native.read_avg)+(1-last(//seagate.exos.system.latency.native_supported))*last(//seagate.exos.system.latency.fallback.read_avg)
+      description: Unified system read average response time. Uses the native Exos X 4006 system metric when available, otherwise
+        the 4005/4865 host-port weighted fallback.
+      tags:
+      - tag: component
+        value: performance
+    - uuid: d5649cd8e1ab4dd3a3727d4664a3dce5
+      name: 'System: Write average response time'
+      type: CALCULATED
+      key: seagate.exos.system.latency.write_avg
+      delay: '{$SEAGATE.INTERVAL.PERFORMANCE}'
+      value_type: FLOAT
+      units: '!µs'
+      params: last(//seagate.exos.system.latency.native_supported)*last(//seagate.exos.system.latency.native.write_avg)+(1-last(//seagate.exos.system.latency.native_supported))*last(//seagate.exos.system.latency.fallback.write_avg)
+      description: Unified system write average response time. Uses the native Exos X 4006 system metric when available, otherwise
+        the 4005/4865 host-port weighted fallback.
+      tags:
+      - tag: component
+        value: performance
+    - uuid: c05ba2259e3140f4b63eb35d9e9277b7
+      name: Inventory API method errors
+      type: DEPENDENT
+      key: seagate.exos.inventory.errors
+      delay: '0'
+      value_type: TEXT
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.errors
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      master_item:
+        key: seagate.exos.get.inventory
+      tags:
+      - tag: component
+        value: errors
+      triggers:
+      - uuid: ae50b9d8569740c595f6ee101880a9fd
+        expression: length(last(/Seagate Exos Storage by HTTP/seagate.exos.inventory.errors))>0
+        name: 'Seagate Exos Storage: Inventory API method errors'
+        priority: WARNING
+        description: One or more read-only API methods failed.
+        dependencies:
+        - name: 'Seagate Exos Storage: Management API is unavailable'
+          expression: max(/Seagate Exos Storage by HTTP/seagate.exos.api.available,5m)=0
+        - name: 'Seagate Exos Storage: API authentication failed'
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.api.auth_failed)=1
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: 362cee904cc442d8aba9801f61218bd6
+      name: Events API method errors
+      type: DEPENDENT
+      key: seagate.exos.events.errors
+      delay: '0'
+      value_type: TEXT
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.errors
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: errors
+      triggers:
+      - uuid: 2aadae57738a460aa6c2263f73b5500b
+        expression: length(last(/Seagate Exos Storage by HTTP/seagate.exos.events.errors))>0
+        name: 'Seagate Exos Storage: Events API method errors'
+        priority: WARNING
+        description: One or more read-only API methods failed.
+        dependencies:
+        - name: 'Seagate Exos Storage: Management API is unavailable'
+          expression: max(/Seagate Exos Storage by HTTP/seagate.exos.api.available,5m)=0
+        - name: 'Seagate Exos Storage: API authentication failed'
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.api.auth_failed)=1
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: fea6e73e4575413cafde3864dee9a6c2
+      name: Get system object
+      type: DEPENDENT
+      key: seagate.exos.get.system
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.system
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 4a278291120048899aede6797c39d22d
+      name: Get redundancy object
+      type: DEPENDENT
+      key: seagate.exos.get.redundancy
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.redundancy
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 605b5f63b010429cb77ce275c7121b2b
+      name: Get FDE object
+      type: DEPENDENT
+      key: seagate.exos.get.fde
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.fde
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: a9804553639046629c311bc598abd049
+      name: Get controllers
+      type: DEPENDENT
+      key: seagate.exos.get.controllers
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.controllers
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: c97d3acea5ff4d61bec2d115b8a43618
+      name: Get disks
+      type: DEPENDENT
+      key: seagate.exos.get.disks
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.disks
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 66ecbbcf33764f009b03da4a83d080f9
+      name: Get disk groups
+      type: DEPENDENT
+      key: seagate.exos.get.diskgroups
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['disk-groups']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 558d9f9ee34340669561b3f92efceee2
+      name: Get pools
+      type: DEPENDENT
+      key: seagate.exos.get.pools
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.pools
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: a4fd61eccdf44cca88f21e86a2931a35
+      name: Get volumes
+      type: DEPENDENT
+      key: seagate.exos.get.volumes
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.volumes
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: adc2c1f7c1b34f3fb64b7e578ab202d1
+      name: Get enclosures
+      type: DEPENDENT
+      key: seagate.exos.get.enclosures
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.enclosures
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 651cab442781473d97d2b976296d1038
+      name: Get FRUs
+      type: DEPENDENT
+      key: seagate.exos.get.frus
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.frus
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 0c92ca8c41774463b6459fac4a136810
+      name: Get fans
+      type: DEPENDENT
+      key: seagate.exos.get.fans
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.fans
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: c8c0ea6402d94bbb86cf2193d00160d8
+      name: Get power supplies
+      type: DEPENDENT
+      key: seagate.exos.get.psus
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['power-supplies']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 926085fab38f4a719dd9630fc9dab9df
+      name: Get sensors
+      type: DEPENDENT
+      key: seagate.exos.get.sensors
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.sensors
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 73e709552b6d4b528d88d80e86d27bda
+      name: Get SAS links
+      type: DEPENDENT
+      key: seagate.exos.get.saslinks
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['sas-links']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 1e2c2c3c82814486a84e0d51d558dfd7
+      name: Get host ports
+      type: DEPENDENT
+      key: seagate.exos.get.ports
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.ports
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 5689f7aacaee4a128abd71d48c6cd0a4
+      name: Get controller statistics
+      type: DEPENDENT
+      key: seagate.exos.get.controllerstats
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['controller-statistics']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 782e025183264b7cb46651d3d9ccf023
+      name: Get disk statistics
+      type: DEPENDENT
+      key: seagate.exos.get.diskstats
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['disk-statistics']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 27e6db59321f4550b4d5dd4373edbd32
+      name: Get disk group statistics
+      type: DEPENDENT
+      key: seagate.exos.get.diskgroupstats
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['disk-group-statistics']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 0704765871344e32b73446c72f1e4f28
+      name: Get pool statistics
+      type: DEPENDENT
+      key: seagate.exos.get.poolstats
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['pool-statistics']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 6777f6f9ad864f4b8f585e357e0fccf6
+      name: Get volume statistics
+      type: DEPENDENT
+      key: seagate.exos.get.volumestats
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['volume-statistics']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 5180dc0bfe804241875acd30d941518a
+      name: Get host port statistics
+      type: DEPENDENT
+      key: seagate.exos.get.portstats
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['host-port-statistics']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 15f75dcdc9444ce5b5c881ff54f5296b
+      name: Get tier statistics
+      type: DEPENDENT
+      key: seagate.exos.get.tierstats
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['tier-statistics']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.performance
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 146d291f06fe49b2a1a5c19f506667b9
+      name: Get versions
+      type: DEPENDENT
+      key: seagate.exos.get.versions
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.versions
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.inventory
+      tags:
+      - tag: component
+        value: raw
+    - uuid: ace970411c1b492e937951da204fd7bb
+      name: Get tiers
+      type: DEPENDENT
+      key: seagate.exos.get.tiers
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.tiers
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.inventory
+      tags:
+      - tag: component
+        value: raw
+    - uuid: a27a776d17234721800d2a1628fa1c5c
+      name: Get replication sets
+      type: DEPENDENT
+      key: seagate.exos.get.replicationsets
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['replication-sets']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.inventory
+      tags:
+      - tag: component
+        value: raw
+    - uuid: f79e780533fe4d1380cb7e917264bf16
+      name: Get events
+      type: DEPENDENT
+      key: seagate.exos.get.eventlist
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.events
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: raw
+    - uuid: a0bbb42190064d25882a8fabaf3886d1
+      name: Get active alerts
+      type: DEPENDENT
+      key: seagate.exos.get.alerts
+      delay: '0'
+      value_type: TEXT
+      history: '0'
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.alerts
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: raw
+    - uuid: 458bad6cb322404dae5777209a870b14
+      name: System name
+      type: DEPENDENT
+      key: seagate.exos.system.name
+      delay: '0'
+      value_type: CHAR
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['system-name']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.system
+      tags:
+      - tag: component
+        value: inventory
+    - uuid: 16d1535abf6143bb95ada946507d625d
+      name: Product ID
+      type: DEPENDENT
+      key: seagate.exos.system.product_id
+      delay: '0'
+      value_type: CHAR
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['product-id']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.system
+      tags:
+      - tag: component
+        value: inventory
+      description: Storage product identifier. An unchanged value is stored at least every 30 minutes for dashboards.
+    - uuid: 89519478171e4b20a5bc35d252dada6d
+      name: Product brand
+      type: DEPENDENT
+      key: seagate.exos.system.product_brand
+      delay: '0'
+      value_type: CHAR
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['product-brand']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.system
+      tags:
+      - tag: component
+        value: inventory
+    - uuid: 6ad68508f70f42758fdfd6fc3573e92b
+      name: SCSI product ID
+      type: DEPENDENT
+      key: seagate.exos.system.scsi_product_id
+      delay: '0'
+      value_type: CHAR
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['scsi-product-id']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.system
+      tags:
+      - tag: component
+        value: inventory
+    - uuid: 01cd3abb52824b189a1ba9e6ace61ff0
+      name: Platform type
+      type: DEPENDENT
+      key: seagate.exos.system.platform
+      delay: '0'
+      value_type: CHAR
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['platform-type']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.system
+      tags:
+      - tag: component
+        value: inventory
+    - uuid: a80ffda61f564b11ac7fcfb830e56c3c
+      name: Enclosure count
+      type: DEPENDENT
+      key: seagate.exos.system.enclosure_count
+      delay: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['enclosure-count']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      master_item:
+        key: seagate.exos.get.system
+      tags:
+      - tag: component
+        value: storage
+      triggers:
+      - uuid: a49ffa597fd34d959106c57e2951c49d
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.system.enclosure_count)<{$SEAGATE.ENCLOSURE.EXPECTED}
+        name: 'Seagate Exos Storage: Enclosure count is below expected'
+        event_name: 'Seagate Exos Storage: Enclosure count is below expected (current {ITEM.LASTVALUE1}, expected {$SEAGATE.ENCLOSURE.EXPECTED})'
+        priority: HIGH
+        description: The storage reports fewer enclosures than expected. Set {$SEAGATE.ENCLOSURE.EXPECTED} to the controller
+          enclosure plus all expansion enclosures that should normally be present. Default is 1.
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: a3246de71e684d229fc7214c811f65a0
+      name: System health
+      type: DEPENDENT
+      key: seagate.exos.system.health
+      delay: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['health-numeric']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      valuemap:
+        name: Health
+      master_item:
+        key: seagate.exos.get.system
+      tags:
+      - tag: component
+        value: health
+      triggers:
+      - uuid: 7f2f35fa3ec744f38fa9d70dc7cb601c
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.system.health)=1
+        name: 'Seagate Exos Storage: System health is degraded'
+        priority: AVERAGE
+        description: The storage reports degraded system health.
+        tags:
+        - tag: scope
+          value: availability
+      - uuid: 10c6e1f9aead46eb8eed4647683961b5
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.system.health)=2
+        name: 'Seagate Exos Storage: System health is in fault state'
+        priority: HIGH
+        description: The storage reports a system fault.
+        tags:
+        - tag: scope
+          value: availability
+      - uuid: 7d2e381d410b414588c80594e76e5d73
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.system.health)=3
+        name: 'Seagate Exos Storage: System health is unknown'
+        priority: WARNING
+        description: The storage cannot determine overall health.
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: 8e290505011c4306b6f0ba8c38651a1e
+      name: System health reason
+      type: DEPENDENT
+      key: seagate.exos.system.health_reason
+      delay: '0'
+      value_type: TEXT
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['health-reason']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      master_item:
+        key: seagate.exos.get.system
+      tags:
+      - tag: component
+        value: health
+    - uuid: 6b1f89a3f22141f38341038c59fdaff6
+      name: Redundancy state
+      type: DEPENDENT
+      key: seagate.exos.system.redundant
+      delay: '0'
+      preprocessing:
+      - type: JAVASCRIPT
+        parameters:
+        - var o=JSON.parse(value); return String(o['redundancy-status']||'').toLowerCase()==='redundant'?1:0;
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      valuemap:
+        name: Yes/No
+      master_item:
+        key: seagate.exos.get.redundancy
+      tags:
+      - tag: component
+        value: health
+      triggers:
+      - uuid: c85bdb8b5155467183b957cd8d2f4256
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.system.redundant)=0 and {$SEAGATE.REDUNDANCY.REQUIRED}=1
+        name: 'Seagate Exos Storage: Storage redundancy is lost'
+        priority: HIGH
+        description: The array is not in Redundant state.
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: d25355d9cadf41aba6016341ec0c66a8
+      name: Other management controller operational
+      type: DEPENDENT
+      key: seagate.exos.system.other_mc_operational
+      delay: '0'
+      preprocessing:
+      - type: JAVASCRIPT
+        parameters:
+        - var o=JSON.parse(value); return String(o['other-MC-status']||'').toLowerCase()==='operational'?1:0;
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      valuemap:
+        name: Yes/No
+      master_item:
+        key: seagate.exos.get.redundancy
+      tags:
+      - tag: component
+        value: health
+      triggers:
+      - uuid: cadd480cacbf4edfbe5c38bda44ed934
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.system.other_mc_operational)=0
+        name: 'Seagate Exos Storage: Partner management controller is not operational'
+        priority: WARNING
+        description: The partner management controller is not Operational.
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: b9d105b771e14dbd9f234fb69a9448b8
+      name: FDE security status
+      type: DEPENDENT
+      key: seagate.exos.system.fde_status
+      delay: '0'
+      value_type: CHAR
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['fde-security-status']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.fde
+      tags:
+      - tag: component
+        value: security
+      triggers:
+      - uuid: 5535df76711a4643895b4975d1450f47
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.system.fde_status,#1)<>last(/Seagate Exos Storage by HTTP/seagate.exos.system.fde_status,#2)
+        name: 'Seagate Exos Storage: FDE security state changed'
+        priority: INFO
+        description: The system FDE security state changed.
+        manual_close: 'YES'
+        tags:
+        - tag: scope
+          value: notice
+      description: Full Disk Encryption security status. An unchanged value is stored at least every 30 minutes for dashboards.
+    - uuid: dba4aaca506b470d9eb554786aeca0c1
+      name: NTP enabled
+      type: DEPENDENT
+      key: seagate.exos.system.ntp_enabled
+      delay: '0'
+      preprocessing:
+      - type: JAVASCRIPT
+        parameters:
+        - var o=JSON.parse(value).ntp||{}; return String(o['ntp-status']||'').toLowerCase()==='activated'?1:0;
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      valuemap:
+        name: Yes/No
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: time
+      triggers:
+      - uuid: 92a82e9788ab42539c99cc689b4d8ebd
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.system.ntp_enabled)=0 and {$SEAGATE.NTP.REQUIRED}=1
+        name: 'Seagate Exos Storage: NTP is not activated'
+        priority: WARNING
+        description: NTP is required by macro but is not activated.
+        tags:
+        - tag: scope
+          value: notice
+    - uuid: 43f5bb9165354274ba172a239c3fe749
+      name: Controller A unwritable cache
+      type: DEPENDENT
+      key: seagate.exos.cache.unwritable_a
+      delay: '0'
+      units: '%'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['unwritable-cache']['unwritable-a-percentage']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: cache
+      triggers:
+      - uuid: 13f35eaafea74121a1e065570cc30a61
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.cache.unwritable_a)>0
+        name: 'Seagate Exos Storage: Controller A has unwritable cache'
+        priority: HIGH
+        description: Unwritable cache is present on controller A.
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: 8c8b045c9ad3412286d6d48412418dcf
+      name: Controller B unwritable cache
+      type: DEPENDENT
+      key: seagate.exos.cache.unwritable_b
+      delay: '0'
+      units: '%'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['unwritable-cache']['unwritable-b-percentage']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: cache
+      triggers:
+      - uuid: a43f216ae995483b94389d9347c7fa34
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.cache.unwritable_b)>0
+        name: 'Seagate Exos Storage: Controller B has unwritable cache'
+        priority: HIGH
+        description: Unwritable cache is present on controller B.
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: 11b1da3a45cc43798381758ef20cc1ed
+      name: Unhealthy expander PHY count
+      type: DEPENDENT
+      key: seagate.exos.expander.unhealthy
+      delay: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['expander-summary'].unhealthy
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      master_item:
+        key: seagate.exos.get.core
+      tags:
+      - tag: component
+        value: sas
+      triggers:
+      - uuid: d9907109788b45f3be4d144ce0cbb9c1
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.expander.unhealthy)>0
+        name: 'Seagate Exos Storage: One or more expander PHYs are unhealthy'
+        priority: HIGH
+        description: At least one expander PHY is neither healthy nor an intentionally unused PHY.
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: f4c2f5035e304a92b2d2f06e4904c4e9
+      name: System firmware bundle
+      type: DEPENDENT
+      key: seagate.exos.system.bundle_version
+      delay: '0'
+      value_type: CHAR
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $.versions[0]['bundle-version']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.inventory
+      tags:
+      - tag: component
+        value: inventory
+      triggers:
+      - uuid: 25395b0aa19d49c2b97b98d5164488b2
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.system.bundle_version,#1)<>last(/Seagate Exos Storage
+          by HTTP/seagate.exos.system.bundle_version,#2)
+        name: 'Seagate Exos Storage: System firmware bundle changed'
+        priority: INFO
+        description: The storage system firmware bundle version changed.
+        manual_close: 'YES'
+        tags:
+        - tag: scope
+          value: notice
+      description: Storage firmware bundle version. An unchanged value is stored at least every 30 minutes for dashboards.
+    - uuid: 681eff4286af4344a1ddd6b6e9cc0ed9
+      name: Latest warning event ID
+      type: DEPENDENT
+      key: seagate.exos.event.latest_warning.id
+      delay: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['latest-warning']['event-id']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: events
+      triggers:
+      - uuid: 99bd65a502f442a9af41d33cf1126f75
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_warning.id,#1)<>last(/Seagate Exos Storage
+          by HTTP/seagate.exos.event.latest_warning.id,#2) and length(last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_warning.message))>0
+        name: 'Seagate Exos Storage: New warning event detected'
+        priority: WARNING
+        event_name: 'Seagate Exos Storage: New warning event {ITEM.LASTVALUE1}: {ITEM.LASTVALUE2}'
+        description: A new Seagate warning event ID was observed. This is supplemental to persistent component-state triggers.
+        tags:
+        - tag: scope
+          value: notice
+    - uuid: c1db0238f2034d67a752e6d2a8f62706
+      name: Latest warning event message
+      type: DEPENDENT
+      key: seagate.exos.event.latest_warning.message
+      delay: '0'
+      value_type: TEXT
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['latest-warning'].message
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: events
+    - uuid: 5aa89df0f931426fab3e479bff5de4e2
+      name: Latest error event ID
+      type: DEPENDENT
+      key: seagate.exos.event.latest_error.id
+      delay: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['latest-error']['event-id']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: events
+      triggers:
+      - uuid: b98adb3aaf4140a58116ab15bb3b1319
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_error.id,#1)<>last(/Seagate Exos Storage
+          by HTTP/seagate.exos.event.latest_error.id,#2) and length(last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_error.message))>0
+        name: 'Seagate Exos Storage: New error event detected'
+        priority: HIGH
+        event_name: 'Seagate Exos Storage: New error event {ITEM.LASTVALUE1}: {ITEM.LASTVALUE2}'
+        description: A new Seagate error event ID was observed. This is supplemental to persistent component-state triggers.
+        tags:
+        - tag: scope
+          value: notice
+    - uuid: 6c995c8359f94e89a12fdf108719f2a3
+      name: Latest error event message
+      type: DEPENDENT
+      key: seagate.exos.event.latest_error.message
+      delay: '0'
+      value_type: TEXT
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['latest-error'].message
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: events
+    - uuid: a4b5fca929ac433a872b246b710d2f0b
+      name: Latest critical event ID
+      type: DEPENDENT
+      key: seagate.exos.event.latest_critical.id
+      delay: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['latest-critical']['event-id']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: events
+      triggers:
+      - uuid: 697c09d9c5d5412baeeb9082bbecd3f1
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_critical.id,#1)<>last(/Seagate Exos Storage
+          by HTTP/seagate.exos.event.latest_critical.id,#2) and length(last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_critical.message))>0
+        name: 'Seagate Exos Storage: New critical event detected'
+        priority: HIGH
+        event_name: 'Seagate Exos Storage: New critical event {ITEM.LASTVALUE1}: {ITEM.LASTVALUE2}'
+        description: A new Seagate critical event ID was observed. This is supplemental to persistent component-state triggers.
+        tags:
+        - tag: scope
+          value: notice
+    - uuid: 1078d6590f614ffcb125660475ddc9c1
+      name: Latest critical event message
+      type: DEPENDENT
+      key: seagate.exos.event.latest_critical.message
+      delay: '0'
+      value_type: TEXT
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['latest-critical'].message
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: events
+    - uuid: 45dbfeb87403489cadf917c3461350f7
+      name: Structured Alerts API supported
+      type: DEPENDENT
+      key: seagate.exos.alerts.supported
+      delay: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['alerts-supported']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 30m
+      valuemap:
+        name: Yes/No
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: inventory
+    - uuid: b5e5b2fd7f6d42adbab508d8f9b6e30d
+      name: Active alert summary
+      type: DEPENDENT
+      key: seagate.exos.alerts.summary
+      delay: '0'
+      value_type: TEXT
+      trends: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['active-alert-summary']
+        error_handler: DISCARD_VALUE
+      - type: DISCARD_UNCHANGED_HEARTBEAT
+        parameters:
+        - 1h
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: alerts
+    - uuid: d2b2861386a94570b010e1c2c0466793
+      name: Active warning alert count
+      type: DEPENDENT
+      key: seagate.exos.alerts.active_warning
+      delay: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['active-alert-warning-count']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: alerts
+      triggers:
+      - uuid: 6c505c2deffc4488ab56fb918a4350e4
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.alerts.active_warning)>0 and length(last(/Seagate Exos
+          Storage by HTTP/seagate.exos.alerts.summary))>=0
+        name: 'Seagate Exos Storage: Active warning alert conditions'
+        priority: WARNING
+        event_name: 'Seagate Exos Storage: {ITEM.LASTVALUE1} active warning alert(s): {ITEM.LASTVALUE2}'
+        description: One or more unresolved structured alert conditions are active on a supported Exos X system.
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: 202b5f0c1914473891d13746e1913959
+      name: Active error alert count
+      type: DEPENDENT
+      key: seagate.exos.alerts.active_error
+      delay: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['active-alert-error-count']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: alerts
+      triggers:
+      - uuid: 1555f477104f458eb3a8c0d51a07e107
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.alerts.active_error)>0 and length(last(/Seagate Exos Storage
+          by HTTP/seagate.exos.alerts.summary))>=0
+        name: 'Seagate Exos Storage: Active error alert conditions'
+        priority: HIGH
+        event_name: 'Seagate Exos Storage: {ITEM.LASTVALUE1} active error alert(s): {ITEM.LASTVALUE2}'
+        description: One or more unresolved structured alert conditions are active on a supported Exos X system.
+        tags:
+        - tag: scope
+          value: availability
+    - uuid: 17c326ef9bdf494a896836e338366708
+      name: Active critical alert count
+      type: DEPENDENT
+      key: seagate.exos.alerts.active_critical
+      delay: '0'
+      preprocessing:
+      - type: JSONPATH
+        parameters:
+        - $['active-alert-critical-count']
+        error_handler: DISCARD_VALUE
+      master_item:
+        key: seagate.exos.get.events
+      tags:
+      - tag: component
+        value: alerts
+      triggers:
+      - uuid: f9e2b88d018742c9bffcf8b54680f9a8
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.alerts.active_critical)>0 and length(last(/Seagate Exos
+          Storage by HTTP/seagate.exos.alerts.summary))>=0
+        name: 'Seagate Exos Storage: Active critical alert conditions'
+        priority: HIGH
+        event_name: 'Seagate Exos Storage: {ITEM.LASTVALUE1} active critical alert(s): {ITEM.LASTVALUE2}'
+        description: One or more unresolved structured alert conditions are active on a supported Exos X system.
+        tags:
+        - tag: scope
+          value: availability
+    discovery_rules:
+    - uuid: 86b66f7305374fc3ac9cfb2a06505350
+      name: Controllers discovery
+      type: DEPENDENT
+      key: seagate.exos.controllers.discovery
+      delay: '0'
+      description: Discovers storage controllers.
+      item_prototypes:
+      - uuid: c710ac6a945f42ccb0a8fd77590e84b0
+        name: 'Controller [{#CONTROLLER.ID}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['controller-id'] == "{#CONTROLLER.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.controllers
+        tags:
+        - tag: component
+          value: raw
+      - uuid: db29aad71f4742debfc82a900a2d3bef
+        name: 'Controller [{#CONTROLLER.ID}]: Get statistics'
+        type: DEPENDENT
+        key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var a=JSON.parse(value), id=String('{#CONTROLLER.ID}').toLowerCase(); for(var i=0;i<a.length;i++) if(String(a[i]['durable-id']).toLowerCase()==='controller_'+id)
+            return JSON.stringify(a[i]); throw 'Controller statistics not found';
+        master_item:
+          key: seagate.exos.get.controllerstats
+        tags:
+        - tag: component
+          value: raw
+      - uuid: b19fba78b67c4af6ba3a238c95602032
+        name: 'Controller [{#CONTROLLER.ID}]: Health'
+        type: DEPENDENT
+        key: seagate.exos.controller.health["{#CONTROLLER.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['health-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Health
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+        trigger_prototypes:
+        - uuid: 7a74a0b3f1434e699e031597b8ebb3d3
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.controller.health["{#CONTROLLER.ID}"])=1
+          name: 'Seagate Exos Storage: Controller [{#CONTROLLER.ID}] health is degraded'
+          priority: WARNING
+          description: The component reports degraded health.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 19f2dc2bd59848aea6190b678ed4e83b
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.controller.health["{#CONTROLLER.ID}"])=2
+          name: 'Seagate Exos Storage: Controller [{#CONTROLLER.ID}] health is in fault state'
+          priority: HIGH
+          description: The component reports a fault.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 52db79b7cccf4795a27732999ebf9fab
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.controller.health["{#CONTROLLER.ID}"])=3
+          name: 'Seagate Exos Storage: Controller [{#CONTROLLER.ID}] health is unknown'
+          priority: WARNING
+          description: The component health is unknown.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: c6c1be92568d43fa990d048839760213
+        name: 'Controller [{#CONTROLLER.ID}]: Status'
+        type: DEPENDENT
+        key: seagate.exos.controller.status["{#CONTROLLER.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['status-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Controller status
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+        trigger_prototypes:
+        - uuid: 035f624594bc4707806aa1283cdec71e
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.controller.status["{#CONTROLLER.ID}"])=1
+          name: 'Seagate Exos Storage: Controller [{#CONTROLLER.ID}] is down'
+          priority: HIGH
+          description: Controller status is Down.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: e03fade58b2f4ed79410deda824efb1e
+        name: 'Controller [{#CONTROLLER.ID}]: Serial number'
+        type: DEPENDENT
+        key: seagate.exos.controller.serial["{#CONTROLLER.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['serial-number']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+      - uuid: c35cbf48eee3410fbd25d8d591386664
+        name: 'Controller [{#CONTROLLER.ID}]: Part number'
+        type: DEPENDENT
+        key: seagate.exos.controller.part["{#CONTROLLER.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['part-number']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+      - uuid: 3f8afb5beb844d948ae294cc3a5ac139
+        name: 'Controller [{#CONTROLLER.ID}]: Hardware version'
+        type: DEPENDENT
+        key: seagate.exos.controller.hardware["{#CONTROLLER.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['hardware-version']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+      - uuid: b7a8908665b544558f86e0c58b455b45
+        name: 'Controller [{#CONTROLLER.ID}]: IP address'
+        type: DEPENDENT
+        key: seagate.exos.controller.ip["{#CONTROLLER.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['ip-address']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+      - uuid: 31f582fe6f1b473c9ea563a13901b228
+        name: 'Controller [{#CONTROLLER.ID}]: Failover reason'
+        type: DEPENDENT
+        key: seagate.exos.controller.failover_reason["{#CONTROLLER.ID}"]
+        delay: '0'
+        value_type: TEXT
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['fail-over-reason']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+      - uuid: f0d1b6e66ec449dd950a786dfeade504
+        name: 'Controller [{#CONTROLLER.ID}]: Firmware'
+        type: DEPENDENT
+        key: seagate.exos.controller.firmware["{#CONTROLLER.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['sc-fw']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+        trigger_prototypes:
+        - uuid: c18eb3215dc248dc8696dbca40ee8f72
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.controller.firmware["{#CONTROLLER.ID}"],#1)<>last(/Seagate
+            Exos Storage by HTTP/seagate.exos.controller.firmware["{#CONTROLLER.ID}"],#2)
+          name: 'Seagate Exos Storage: Controller [{#CONTROLLER.ID}] firmware changed'
+          priority: INFO
+          description: The controller firmware version changed.
+          manual_close: 'YES'
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: 4f22821e1b294f6095db0ee977b95dff
+        name: 'Controller [{#CONTROLLER.ID}]: Failed over'
+        type: DEPENDENT
+        key: seagate.exos.controller.failed_over["{#CONTROLLER.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['failed-over-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Yes/No
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+        trigger_prototypes:
+        - uuid: 4f67d576aa2c45ceb5d43ed1dfcd476b
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.controller.failed_over["{#CONTROLLER.ID}"])=1
+          name: 'Seagate Exos Storage: Controller [{#CONTROLLER.ID}] is failed over'
+          priority: HIGH
+          description: Controller failover is active.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: f7222f851c754ec987f07877ddd07802
+        name: 'Controller [{#CONTROLLER.ID}]: Cache memory'
+        type: DEPENDENT
+        key: seagate.exos.controller.cache_memory["{#CONTROLLER.ID}"]
+        delay: '0'
+        units: MB
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['cache-memory-size']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+      - uuid: 8872f5865b90481d80f08b7f43d53edc
+        name: 'Controller [{#CONTROLLER.ID}]: System memory'
+        type: DEPENDENT
+        key: seagate.exos.controller.system_memory["{#CONTROLLER.ID}"]
+        delay: '0'
+        units: MB
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['system-memory-size']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+      - uuid: e717daaef371449caf3f7e584a0fa1bb
+        name: 'Controller [{#CONTROLLER.ID}]: Host ports'
+        type: DEPENDENT
+        key: seagate.exos.controller.host_ports["{#CONTROLLER.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['host-ports']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+      - uuid: 5563b18ec63642279b1ffbff76a48d8a
+        name: 'Controller [{#CONTROLLER.ID}]: Drive channels'
+        type: DEPENDENT
+        key: seagate.exos.controller.drive_channels["{#CONTROLLER.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['drive-channels']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.controller.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: controller
+      - uuid: e7c5bbc4629843c5a483589fc000bce1
+        name: 'Controller [{#CONTROLLER.ID}]: CPU utilization'
+        type: DEPENDENT
+        key: seagate.exos.controller.cpu["{#CONTROLLER.ID}"]
+        delay: '0'
+        units: '%'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['cpu-load']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: performance
+        trigger_prototypes:
+        - uuid: 671d50b153614a93869d12fa64d8c06a
+          expression: avg(/Seagate Exos Storage by HTTP/seagate.exos.controller.cpu["{#CONTROLLER.ID}"],5m)>{$SEAGATE.CONTROLLER.CPU.WARN}
+          name: 'Seagate Exos Storage: Controller [{#CONTROLLER.ID}] CPU utilization is high'
+          priority: WARNING
+          description: Controller CPU utilization exceeded the configured threshold.
+          tags:
+          - tag: scope
+            value: performance
+      - uuid: 243e06c10c5f46f8ae8c115ff2d0c6c2
+        name: 'Controller [{#CONTROLLER.ID}]: Write cache used'
+        type: DEPENDENT
+        key: seagate.exos.controller.write_cache_used["{#CONTROLLER.ID}"]
+        delay: '0'
+        units: '%'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['write-cache-used']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 9d145348b783473eae6af40305cc076f
+        name: 'Controller [{#CONTROLLER.ID}]: IOPS'
+        type: DEPENDENT
+        key: seagate.exos.controller.iops["{#CONTROLLER.ID}"]
+        delay: '0'
+        units: '!iops'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['iops']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 7fb5a53953dc4f27a4c5de3df8e0f23f
+        name: 'Controller [{#CONTROLLER.ID}]: Throughput'
+        type: DEPENDENT
+        key: seagate.exos.controller.bps["{#CONTROLLER.ID}"]
+        delay: '0'
+        units: Bps
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['bytes-per-second-numeric']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 4276cdc0f7c84b5692d09cfebbe4a203
+        name: 'Controller [{#CONTROLLER.ID}]: Reads'
+        type: DEPENDENT
+        key: seagate.exos.controller.reads["{#CONTROLLER.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-reads']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 3bbd1b1e36d64db8844e7a2fbeb1af81
+        name: 'Controller [{#CONTROLLER.ID}]: Writes'
+        type: DEPENDENT
+        key: seagate.exos.controller.writes["{#CONTROLLER.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-writes']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 2892fd64a4664069988f616bc33529a6
+        name: 'Controller [{#CONTROLLER.ID}]: Read cache hits'
+        type: DEPENDENT
+        key: seagate.exos.controller.read_cache_hits["{#CONTROLLER.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['read-cache-hits']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: c3788f3b93144d5c9a79715bfe8c3df4
+        name: 'Controller [{#CONTROLLER.ID}]: Read cache misses'
+        type: DEPENDENT
+        key: seagate.exos.controller.read_cache_misses["{#CONTROLLER.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['read-cache-misses']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 589e765ae7ea43d8ba44a50cfee89b0e
+        name: 'Controller [{#CONTROLLER.ID}]: Write cache hits'
+        type: DEPENDENT
+        key: seagate.exos.controller.write_cache_hits["{#CONTROLLER.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['write-cache-hits']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 43bff8e2595340909998cba8b23f0e74
+        name: 'Controller [{#CONTROLLER.ID}]: Write cache misses'
+        type: DEPENDENT
+        key: seagate.exos.controller.write_cache_misses["{#CONTROLLER.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['write-cache-misses']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 98fbbea28e5c4ba68709a29744478047
+        name: 'Controller [{#CONTROLLER.ID}]: Forwarded commands'
+        type: DEPENDENT
+        key: seagate.exos.controller.forwarded["{#CONTROLLER.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['num-forwarded-cmds']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 03d629751cf446fba95a12ecd96c9a5e
+        name: 'Controller [{#CONTROLLER.ID}]: Power-on hours'
+        type: DEPENDENT
+        key: seagate.exos.controller.power_on_hours["{#CONTROLLER.ID}"]
+        delay: '0'
+        units: h
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['total-power-on-hours']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.controller.stats.get["{#CONTROLLER.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      master_item:
+        key: seagate.exos.get.controllers
+      lld_macro_paths:
+      - lld_macro: '{#CONTROLLER.ID}'
+        path: $['controller-id']
+      - lld_macro: '{#SERIAL}'
+        path: $['serial-number']
+      graph_prototypes:
+      - uuid: 834a80fc02904e689fb5aca7f87e388e
+        name: 'Controller [{#CONTROLLER.ID}]: Performance'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.controller.cpu["{#CONTROLLER.ID}"]
+        - color: F63100
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.controller.iops["{#CONTROLLER.ID}"]
+          sortorder: '1'
+        - color: 00611C
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.controller.bps["{#CONTROLLER.ID}"]
+          sortorder: '2'
+          yaxisside: RIGHT
+      - uuid: 53cf00b3e33b4a55bef0f2f97c9548f3
+        name: 'Controller [{#CONTROLLER.ID}]: Cache utilization'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.controller.write_cache_used["{#CONTROLLER.ID}"]
+    - uuid: 620c55c7d18648e1b9b0a9662a6574f9
+      name: Physical disks discovery
+      type: DEPENDENT
+      key: seagate.exos.disks.discovery
+      delay: '0'
+      description: Discovers physical disks.
+      item_prototypes:
+      - uuid: f7858918b5e64b948705fccc7b6a3cd5
+        name: 'Disk [{#LOCATION}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['durable-id'] == "{#DURABLE.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.disks
+        tags:
+        - tag: component
+          value: raw
+      - uuid: d599132ba7ef464b9f714639eac4ccc9
+        name: 'Disk [{#LOCATION}]: Get statistics'
+        type: DEPENDENT
+        key: seagate.exos.disk.stats.get["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['durable-id'] == "{#DURABLE.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.diskstats
+        tags:
+        - tag: component
+          value: raw
+      - uuid: 14b04f4e4e1442af891d80667c81faac
+        name: 'Disk [{#LOCATION}]: Health'
+        type: DEPENDENT
+        key: seagate.exos.disk.health["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['health-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Health
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+        trigger_prototypes:
+        - uuid: bada6392093b42d0b7f6f13c53355821
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.health["{#DURABLE.ID}"])=1
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] health is degraded'
+          priority: AVERAGE
+          description: The component reports degraded health.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 18dcaf6db41149178f4b475447b094e8
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.health["{#DURABLE.ID}"])=2
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] health is in fault state'
+          priority: HIGH
+          description: The component reports a fault.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 02c5456762204c1387164dfbc93d171a
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.health["{#DURABLE.ID}"])=3
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] health is unknown'
+          priority: WARNING
+          description: The component health is unknown.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 969a03563cea4c15ae9977188e182164
+        name: 'Disk [{#LOCATION}]: Status'
+        type: DEPENDENT
+        key: seagate.exos.disk.status["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return String(o.status||'').toLowerCase()==='up'?0:1;
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Disk status
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+        trigger_prototypes:
+        - uuid: f423de52e1374a3c9ce13d98c4e79839
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.status["{#DURABLE.ID}"])=1
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] is not Up'
+          priority: HIGH
+          description: The physical disk is not in Up state.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: f8fd8a4ad665476d8f79a0a029ed602e
+        name: 'Disk [{#LOCATION}]: Model'
+        type: DEPENDENT
+        key: seagate.exos.disk.model["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['model']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+      - uuid: 528337961fea44a887c15ffba53a5f90
+        name: 'Disk [{#LOCATION}]: Serial number'
+        type: DEPENDENT
+        key: seagate.exos.disk.serial["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['serial-number']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+      - uuid: 7f0bc35f1a3140cba8ef33a0c057a522
+        name: 'Disk [{#LOCATION}]: Firmware revision'
+        type: DEPENDENT
+        key: seagate.exos.disk.firmware["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['revision']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+        trigger_prototypes:
+        - uuid: 3e4d32ae53594dd99b230247fb210ec5
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.firmware["{#DURABLE.ID}"],#1)<>last(/Seagate Exos
+            Storage by HTTP/seagate.exos.disk.firmware["{#DURABLE.ID}"],#2)
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] firmware changed'
+          priority: INFO
+          description: The disk firmware revision changed.
+          manual_close: 'YES'
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: 5dc6dbdc6678465fa566a7cc1527528e
+        name: 'Disk [{#LOCATION}]: Interface'
+        type: DEPENDENT
+        key: seagate.exos.disk.interface["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['interface']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+      - uuid: 0e2a5ee021de4c5c9e5c91fb8b990306
+        name: 'Disk [{#LOCATION}]: Architecture'
+        type: DEPENDENT
+        key: seagate.exos.disk.architecture["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['architecture']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+      - uuid: 8aa5f27b8e0e49ee977a15fa43008ea8
+        name: 'Disk [{#LOCATION}]: Disk group'
+        type: DEPENDENT
+        key: seagate.exos.disk.disk_group["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['disk-group']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+      - uuid: 05d0480451784d92ab0c705c801a2c97
+        name: 'Disk [{#LOCATION}]: Pool'
+        type: DEPENDENT
+        key: seagate.exos.disk.pool["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['storage-pool-name']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+      - uuid: aa121f8682e0481b80bc36d13aaedb1b
+        name: 'Disk [{#LOCATION}]: Storage tier'
+        type: DEPENDENT
+        key: seagate.exos.disk.tier["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['storage-tier']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+      - uuid: f74bf794ff3d4c94b292ed8a636325c3
+        name: 'Disk [{#LOCATION}]: FDE state'
+        type: DEPENDENT
+        key: seagate.exos.disk.fde["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['fde-state']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+      - uuid: c2e6a44ca4824b23a1e3e2d2a01d04e3
+        name: 'Disk [{#LOCATION}]: Current job'
+        type: DEPENDENT
+        key: seagate.exos.disk.job["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['job-running']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+        trigger_prototypes:
+        - uuid: 3a72651b21e9457b81596537aa5ff776
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.job["{#DURABLE.ID}"],#1)<>last(/Seagate Exos Storage
+            by HTTP/seagate.exos.disk.job["{#DURABLE.ID}"],#2)
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] job state changed'
+          priority: INFO
+          description: A disk background job started, stopped, or changed.
+          manual_close: 'YES'
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: 40b07ec4b1b74f259ab0d0ff251cbd17
+        name: 'Disk [{#LOCATION}]: Capacity'
+        type: DEPENDENT
+        key: seagate.exos.disk.capacity["{#DURABLE.ID}"]
+        delay: '0'
+        units: B
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['size-numeric']||o.blocks||0)*Number(o.blocksize||512);
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+      - uuid: 4682a8c08e544a6b9886e907a22ccf48
+        name: 'Disk [{#LOCATION}]: SMART enabled'
+        type: DEPENDENT
+        key: seagate.exos.disk.smart["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['smart-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        valuemap:
+          name: SMART state
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+        trigger_prototypes:
+        - uuid: 0ec52000da274842b66b060978f8126c
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.smart["{#DURABLE.ID}"])=2
+          name: 'Seagate Exos Storage: SMART is disabled on disk [{#LOCATION}]'
+          priority: WARNING
+          description: SMART monitoring is disabled on this disk.
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: dabcf0c243774e0788ee08ea19f18b9d
+        name: 'Disk [{#LOCATION}]: Temperature'
+        type: DEPENDENT
+        key: seagate.exos.disk.temperature["{#DURABLE.ID}"]
+        delay: '0'
+        units: C
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['temperature-numeric']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: temperature
+        trigger_prototypes:
+        - uuid: 4cefe65cfdcf4de483283634d2971689
+          expression: avg(/Seagate Exos Storage by HTTP/seagate.exos.disk.temperature["{#DURABLE.ID}"],5m)>{$SEAGATE.DISK.TEMP.WARN}
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] temperature is high'
+          priority: WARNING
+          description: Disk temperature exceeded the warning threshold.
+          tags:
+          - tag: scope
+            value: performance
+          dependencies:
+          - name: 'Seagate Exos Storage: Disk [{#LOCATION}] temperature is critical'
+            expression: avg(/Seagate Exos Storage by HTTP/seagate.exos.disk.temperature["{#DURABLE.ID}"],5m)>{$SEAGATE.DISK.TEMP.CRIT}
+        - uuid: 39afc89d68ae49478e3d8075e2027c7f
+          expression: avg(/Seagate Exos Storage by HTTP/seagate.exos.disk.temperature["{#DURABLE.ID}"],5m)>{$SEAGATE.DISK.TEMP.CRIT}
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] temperature is critical'
+          priority: HIGH
+          description: Disk temperature exceeded the critical threshold.
+          tags:
+          - tag: scope
+            value: performance
+      - uuid: 4b48cb982b9c4b12be00bf629a71fa2e
+        name: 'Disk [{#LOCATION}]: Temperature status'
+        type: DEPENDENT
+        key: seagate.exos.disk.temperature_status["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['temperature-status-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Disk temperature status
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: temperature
+        trigger_prototypes:
+        - uuid: 87e4614807054229be788170d3fda03a
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.temperature_status["{#DURABLE.ID}"])<>1
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] temperature status is abnormal'
+          priority: HIGH
+          description: The storage firmware reports an abnormal disk temperature state.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: db7a8180f67f4534b10e77d7a4b03a5d
+        name: 'Disk [{#LOCATION}]: Power-on hours'
+        type: DEPENDENT
+        key: seagate.exos.disk.power_on_hours["{#DURABLE.ID}"]
+        delay: '0'
+        units: h
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['power-on-hours']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+      - uuid: df3d4afc36a14cf4bf0255f8d7b5047f
+        name: 'Disk [{#LOCATION}]: SSD life remaining'
+        type: DEPENDENT
+        key: seagate.exos.disk.ssd_life["{#DURABLE.ID}"]
+        delay: '0'
+        units: '%'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['ssd-life-left-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+        trigger_prototypes:
+        - uuid: 63313472f4894290b40b5604c70d3f55
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.ssd_life["{#DURABLE.ID}"])<{$SEAGATE.SSD.LIFE.WARN}
+            and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.ssd_life["{#DURABLE.ID}"])<>255
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] SSD life is low'
+          priority: WARNING
+          description: SSD remaining life is below the configured threshold.
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: ee21a7752a7f4acc9e8794ffc85bb4d1
+        name: 'Disk [{#LOCATION}]: Job progress'
+        type: DEPENDENT
+        key: seagate.exos.disk.job_progress["{#DURABLE.ID}"]
+        delay: '0'
+        units: '%'
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value),s=String(o['current-job-completion']||'0'); return parseFloat(s)||0;
+        master_item:
+          key: seagate.exos.disk.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+      - uuid: 7a23b8ab038e435bbc3fe45a27c7395a
+        name: 'Disk [{#LOCATION}]: IOPS'
+        type: DEPENDENT
+        key: seagate.exos.disk.iops["{#DURABLE.ID}"]
+        delay: '0'
+        units: '!iops'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['iops']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.disk.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 2f458d37b6b949ec919107d06c76bde9
+        name: 'Disk [{#LOCATION}]: Throughput'
+        type: DEPENDENT
+        key: seagate.exos.disk.bps["{#DURABLE.ID}"]
+        delay: '0'
+        units: Bps
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['bytes-per-second-numeric']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.disk.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 4c8394cb46f145d798f5a6b2c27f48fe
+        name: 'Disk [{#LOCATION}]: Queue depth'
+        type: DEPENDENT
+        key: seagate.exos.disk.queue_depth["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['queue-depth']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.disk.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: ae00fd7dbde34fddb0899fbf6ac28304
+        name: 'Disk [{#LOCATION}]: Reads'
+        type: DEPENDENT
+        key: seagate.exos.disk.reads["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-reads']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.disk.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 1b54f0b04b2a48dea2ed5f5c3fa01bc0
+        name: 'Disk [{#LOCATION}]: Writes'
+        type: DEPENDENT
+        key: seagate.exos.disk.writes["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-writes']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.disk.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: fbd1c1e6d163459a88d54f986d2d6ac8
+        name: 'Disk [{#LOCATION}]: Media errors'
+        type: DEPENDENT
+        key: seagate.exos.disk.media_errors["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-media-errors-1']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.disk.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+        trigger_prototypes:
+        - uuid: 0f94148c71934b09a521b643645a137a
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.media_errors["{#DURABLE.ID}"])>last(/Seagate Exos
+            Storage by HTTP/seagate.exos.disk.media_errors["{#DURABLE.ID}"],#2) and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.media_errors["{#DURABLE.ID}"])>0
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] media errors increased'
+          priority: HIGH
+          description: The cumulative media errors counter increased.
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: 9c2bdfcb0750424fa1ee1f9ee9a56131
+        name: 'Disk [{#LOCATION}]: Non-media errors'
+        type: DEPENDENT
+        key: seagate.exos.disk.nonmedia_errors["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-nonmedia-errors-1']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.disk.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+        trigger_prototypes:
+        - uuid: 6dc7abe022994f68b85b7a182bf25c75
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.nonmedia_errors["{#DURABLE.ID}"])>last(/Seagate
+            Exos Storage by HTTP/seagate.exos.disk.nonmedia_errors["{#DURABLE.ID}"],#2) and last(/Seagate Exos Storage by
+            HTTP/seagate.exos.disk.nonmedia_errors["{#DURABLE.ID}"])>0
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] non-media errors increased'
+          priority: WARNING
+          description: The cumulative non-media errors counter increased.
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: b1433802d10f421fb95914a857c9eb5e
+        name: 'Disk [{#LOCATION}]: I/O timeouts'
+        type: DEPENDENT
+        key: seagate.exos.disk.timeouts["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['io-timeout-count-1']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.disk.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+        trigger_prototypes:
+        - uuid: d6e6ce3fb5614b74b54b723b491259fe
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.timeouts["{#DURABLE.ID}"])>last(/Seagate Exos Storage
+            by HTTP/seagate.exos.disk.timeouts["{#DURABLE.ID}"],#2) and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.timeouts["{#DURABLE.ID}"])>0
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] i/o timeouts increased'
+          priority: HIGH
+          description: The cumulative i/o timeouts counter increased.
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: 69708fe191764c129850c3f174473b2c
+        name: 'Disk [{#LOCATION}]: No-response events'
+        type: DEPENDENT
+        key: seagate.exos.disk.no_response["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['no-response-count-1']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.disk.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+        trigger_prototypes:
+        - uuid: 088aa5aaf5a641ebbc001fdaa554668e
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.no_response["{#DURABLE.ID}"])>last(/Seagate Exos
+            Storage by HTTP/seagate.exos.disk.no_response["{#DURABLE.ID}"],#2) and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.no_response["{#DURABLE.ID}"])>0
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] no-response events increased'
+          priority: HIGH
+          description: The cumulative no-response events counter increased.
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: 926ff910db6a4482bd3184f1ef14adfd
+        name: 'Disk [{#LOCATION}]: Bad blocks'
+        type: DEPENDENT
+        key: seagate.exos.disk.bad_blocks["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-bad-blocks-1']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.disk.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+        trigger_prototypes:
+        - uuid: 7f8e8e831f03400a9b54cf85450c35b3
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.bad_blocks["{#DURABLE.ID}"])>last(/Seagate Exos
+            Storage by HTTP/seagate.exos.disk.bad_blocks["{#DURABLE.ID}"],#2) and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.bad_blocks["{#DURABLE.ID}"])>0
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] bad blocks increased'
+          priority: HIGH
+          description: The cumulative bad blocks counter increased.
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: b84f8c0cac254c7fa5677244e0a32475
+        name: 'Disk [{#LOCATION}]: Block reassignments'
+        type: DEPENDENT
+        key: seagate.exos.disk.reassigns["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-block-reassigns-1']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.disk.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: disk
+        trigger_prototypes:
+        - uuid: 1e6a2dfda6cb48e0bd824b926f3c95c2
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.reassigns["{#DURABLE.ID}"])>last(/Seagate Exos
+            Storage by HTTP/seagate.exos.disk.reassigns["{#DURABLE.ID}"],#2) and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.reassigns["{#DURABLE.ID}"])>0
+          name: 'Seagate Exos Storage: Disk [{#LOCATION}] block reassignments increased'
+          priority: WARNING
+          description: The cumulative block reassignments counter increased.
+          tags:
+          - tag: scope
+            value: notice
+      master_item:
+        key: seagate.exos.get.disks
+      lld_macro_paths:
+      - lld_macro: '{#DURABLE.ID}'
+        path: $['durable-id']
+      - lld_macro: '{#LOCATION}'
+        path: $['location']
+      - lld_macro: '{#ENCLOSURE}'
+        path: $['enclosure-id']
+      - lld_macro: '{#DRAWER}'
+        path: $['drawer-id']
+      - lld_macro: '{#SLOT}'
+        path: $['slot']
+      - lld_macro: '{#MODEL}'
+        path: $['model']
+      - lld_macro: '{#SERIAL}'
+        path: $['serial-number']
+      - lld_macro: '{#DISKGROUP}'
+        path: $['disk-group']
+      graph_prototypes:
+      - uuid: f82c076b8098405b9763afb1f9d23d67
+        name: 'Disk [{#LOCATION}]: Performance'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.disk.iops["{#DURABLE.ID}"]
+        - color: F63100
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.disk.bps["{#DURABLE.ID}"]
+          sortorder: '1'
+          yaxisside: RIGHT
+      - uuid: f5d572e225c448b39ac3e1c1d66e531e
+        name: 'Disk [{#LOCATION}]: Temperature'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.disk.temperature["{#DURABLE.ID}"]
+    - uuid: 556d5878b9ca4b4f9f5a2e9bc1c78c0f
+      name: Disk groups discovery
+      type: DEPENDENT
+      key: seagate.exos.diskgroups.discovery
+      delay: '0'
+      item_prototypes:
+      - uuid: 1ba8cf0ea61e41a3845e3816b8e33d53
+        name: 'Disk group [{#NAME}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.get["{#NAME}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['name'] == "{#NAME}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.diskgroups
+        tags:
+        - tag: component
+          value: raw
+      - uuid: bd32089b2144407180d4bfb247689b2d
+        name: 'Disk group [{#NAME}]: Get statistics'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.stats.get["{#NAME}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['name'] == "{#NAME}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.diskgroupstats
+        tags:
+        - tag: component
+          value: raw
+      - uuid: 1f92f4f028a74fd78441e258f2861768
+        name: 'Disk group [{#NAME}]: Health'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.health["{#NAME}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['health-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Health
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: disk-group
+        trigger_prototypes:
+        - uuid: e2deb3087c834290b861f70e04a8d670
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.health["{#NAME}"])=1
+          name: 'Seagate Exos Storage: Disk group [{#NAME}] health is degraded'
+          priority: AVERAGE
+          description: The component reports degraded health.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 066bd99aab964ffaa41bddaeb102a335
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.health["{#NAME}"])=2
+          name: 'Seagate Exos Storage: Disk group [{#NAME}] health is in fault state'
+          priority: HIGH
+          description: The component reports a fault.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 22aea9b954da41c5a6d430e3a24ad427
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.health["{#NAME}"])=3
+          name: 'Seagate Exos Storage: Disk group [{#NAME}] health is unknown'
+          priority: WARNING
+          description: The component health is unknown.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 84bfa1a0b0dc4d2d935e79da3db19f75
+        name: 'Disk group [{#NAME}]: Status'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.status["{#NAME}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['status-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Disk group status
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: disk-group
+        trigger_prototypes:
+        - uuid: 419a7d448f4b46d4a1a5f2ba98629291
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=1 or last(/Seagate Exos
+            Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=8 or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=9
+          name: 'Seagate Exos Storage: Disk group [{#NAME}] is degraded'
+          priority: AVERAGE
+          description: Disk group is fault-tolerant but degraded, missing, or damaged.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 027c2f2724fb43a7a287f7c47ef89d8b
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=2 or last(/Seagate Exos
+            Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=3 or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=4
+            or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=5 or last(/Seagate Exos Storage
+            by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=6 or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=7
+          name: 'Seagate Exos Storage: Disk group [{#NAME}] is critical or offline'
+          priority: HIGH
+          description: Disk group is critical, offline, quarantined, or stopped.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 4e45558a440c47e1b1d6f8e6c437ff84
+        name: 'Disk group [{#NAME}]: Pool'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.pool["{#NAME}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['pool']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: disk-group
+      - uuid: 2fb29730c77c4d7698c36e486a76913c
+        name: 'Disk group [{#NAME}]: RAID type'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.raid["{#NAME}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['raidtype']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: disk-group
+      - uuid: aa139cffe1584a4ea23ba65c4f42c384
+        name: 'Disk group [{#NAME}]: Owner'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.owner["{#NAME}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['owner']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: disk-group
+      - uuid: 0a18ebc822394674b8b32693b45a89ff
+        name: 'Disk group [{#NAME}]: Preferred owner'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.preferred_owner["{#NAME}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['preferred-owner']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: disk-group
+      - uuid: 0f1f6925f1ba4bbf8d3dacab6c87203e
+        name: 'Disk group [{#NAME}]: Tier'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.tier["{#NAME}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['storage-tier']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: disk-group
+      - uuid: 65478f6809fd4028bfffade94f71cfa9
+        name: 'Disk group [{#NAME}]: Current job'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.job["{#NAME}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['current-job']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: disk-group
+        trigger_prototypes:
+        - uuid: 5cf1ee87671446f3bfb03e054996396c
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.job["{#NAME}"],#1)<>last(/Seagate Exos Storage
+            by HTTP/seagate.exos.diskgroup.job["{#NAME}"],#2)
+          name: 'Seagate Exos Storage: Disk group [{#NAME}] job state changed'
+          priority: INFO
+          description: A disk-group background job started, stopped, or changed.
+          manual_close: 'YES'
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: 469069a11e024a6ba46e02eb576e82de
+        name: 'Disk group [{#NAME}]: Owner numeric'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.owner_numeric["{#NAME}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['owner-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: disk-group
+        trigger_prototypes:
+        - uuid: 5b474b80ce7a40a0b7fe9304278cd6ef
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.owner_numeric["{#NAME}"])<>last(/Seagate Exos
+            Storage by HTTP/seagate.exos.diskgroup.preferred_owner_numeric["{#NAME}"]) and {$SEAGATE.OWNER.MISMATCH.ENABLED}=1
+          name: 'Seagate Exos Storage: Disk group [{#NAME}] owner differs from preferred owner'
+          priority: WARNING
+          description: Current owner differs from preferred owner.
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: a81c17d85e2e49d4b178902ee1b44608
+        name: 'Disk group [{#NAME}]: Preferred owner numeric'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.preferred_owner_numeric["{#NAME}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['preferred-owner-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: disk-group
+      - uuid: 71c2825cc9484e6fab78317e4ad1bd95
+        name: 'Disk group [{#NAME}]: Write-back enabled'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.writeback["{#NAME}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['write-back-enabled-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Yes/No
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: cache
+        trigger_prototypes:
+        - uuid: 674d80289f124c3b9182f2cf6c4f5c0b
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.writeback["{#NAME}"])=0
+          name: 'Seagate Exos Storage: Disk group [{#NAME}] write-back is disabled'
+          priority: HIGH
+          description: Disk group write-back caching is disabled.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: c961161075b84bd79ad586d6be122ebe
+        name: 'Disk group [{#NAME}]: Disk count'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.diskcount["{#NAME}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['diskcount']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: disk-group
+      - uuid: 13ab303153e64ae1aa0e04b46c8f2b35
+        name: 'Disk group [{#NAME}]: Spare count'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.sparecount["{#NAME}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['sparecount']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: disk-group
+      - uuid: cfc770dba72b4c0f9bc15e0a522c8c5e
+        name: 'Disk group [{#NAME}]: Total capacity'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.total["{#NAME}"]
+        delay: '0'
+        units: B
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['size-numeric']||0)*Number(o.blocksize||512);
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: capacity
+      - uuid: 53b973db98254645a647797ff10ab409
+        name: 'Disk group [{#NAME}]: Free capacity'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.free["{#NAME}"]
+        delay: '0'
+        units: B
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['freespace-numeric']||0)*Number(o.blocksize||512);
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: capacity
+      - uuid: d6295abee57b444ab1fdea4611109316
+        name: 'Disk group [{#NAME}]: Raw capacity'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.raw["{#NAME}"]
+        delay: '0'
+        units: B
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['raw-size-numeric']||0)*Number(o.blocksize||512);
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: capacity
+      - uuid: d0883eb661824e4c8252f94a65757ae1
+        name: 'Disk group [{#NAME}]: Used capacity'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.used_pct["{#NAME}"]
+        delay: '0'
+        value_type: FLOAT
+        units: '%'
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value),t=Number(o['size-numeric']||0),f=Number(o['freespace-numeric']||0); return t>0?(t-f)*100/t:0;
+        master_item:
+          key: seagate.exos.diskgroup.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: capacity
+        trigger_prototypes:
+        - uuid: 97eefea2269d43428b1d7e246b9c81f0
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.used_pct["{#NAME}"])>{$SEAGATE.DISKGROUP.USED.WARN}
+          name: 'Seagate Exos Storage: Disk group [{#NAME}] utilization is high'
+          priority: WARNING
+          description: Disk group utilization exceeded warning threshold.
+          tags:
+          - tag: scope
+            value: capacity
+          dependencies:
+          - name: 'Seagate Exos Storage: Disk group [{#NAME}] utilization is very high'
+            expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.used_pct["{#NAME}"])>{$SEAGATE.DISKGROUP.USED.HIGH}
+          - name: 'Seagate Exos Storage: Disk group [{#NAME}] utilization is critical'
+            expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.used_pct["{#NAME}"])>{$SEAGATE.DISKGROUP.USED.CRIT}
+        - uuid: f7f6afe4697f49fd9f2ef4093607e6d3
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.used_pct["{#NAME}"])>{$SEAGATE.DISKGROUP.USED.HIGH}
+          name: 'Seagate Exos Storage: Disk group [{#NAME}] utilization is very high'
+          priority: HIGH
+          description: Disk group utilization exceeded high threshold.
+          tags:
+          - tag: scope
+            value: capacity
+          dependencies:
+          - name: 'Seagate Exos Storage: Disk group [{#NAME}] utilization is critical'
+            expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.used_pct["{#NAME}"])>{$SEAGATE.DISKGROUP.USED.CRIT}
+        - uuid: 2906b2f3a4e14a408d6bb4aa98ef9bfc
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.used_pct["{#NAME}"])>{$SEAGATE.DISKGROUP.USED.CRIT}
+          name: 'Seagate Exos Storage: Disk group [{#NAME}] utilization is critical'
+          priority: HIGH
+          description: Disk group utilization exceeded critical threshold.
+          tags:
+          - tag: scope
+            value: capacity
+      - uuid: f2c818b3062a41dba6594cd4c0555ef2
+        name: 'Disk group [{#NAME}]: IOPS'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.iops["{#NAME}"]
+        delay: '0'
+        units: '!iops'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['iops']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.diskgroup.stats.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: c2cbe3de3e9141018bc5f0255bab4905
+        name: 'Disk group [{#NAME}]: Throughput'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.bps["{#NAME}"]
+        delay: '0'
+        units: Bps
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['bytes-per-second-numeric']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.diskgroup.stats.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 8ab25486274a462d8dc5dfb853750d62
+        name: 'Disk group [{#NAME}]: Response time'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.latency["{#NAME}"]
+        delay: '0'
+        value_type: FLOAT
+        units: s
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['avg-rsp-time']||0)/1000000;
+        master_item:
+          key: seagate.exos.diskgroup.stats.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 95fae31d7dfa48dea6f59a0e521e214d
+        name: 'Disk group [{#NAME}]: Read response time'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.read_latency["{#NAME}"]
+        delay: '0'
+        value_type: FLOAT
+        units: s
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['avg-read-rsp-time']||0)/1000000;
+        master_item:
+          key: seagate.exos.diskgroup.stats.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: fc8b9c0c788c40edab59bf572a04e816
+        name: 'Disk group [{#NAME}]: Write response time'
+        type: DEPENDENT
+        key: seagate.exos.diskgroup.write_latency["{#NAME}"]
+        delay: '0'
+        value_type: FLOAT
+        units: s
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['avg-write-rsp-time']||0)/1000000;
+        master_item:
+          key: seagate.exos.diskgroup.stats.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: performance
+      master_item:
+        key: seagate.exos.get.diskgroups
+      lld_macro_paths:
+      - lld_macro: '{#NAME}'
+        path: $['name']
+      - lld_macro: '{#SERIAL}'
+        path: $['serial-number']
+      - lld_macro: '{#POOL}'
+        path: $['pool']
+      graph_prototypes:
+      - uuid: e895e4792fa149d883a565c53ad48316
+        name: 'Disk group [{#NAME}]: Performance'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.diskgroup.iops["{#NAME}"]
+        - color: F63100
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.diskgroup.bps["{#NAME}"]
+          sortorder: '1'
+          yaxisside: RIGHT
+      - uuid: 20b0b2a64e144fbebec9947b9fab474e
+        name: 'Disk group [{#NAME}]: Response time'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.diskgroup.latency["{#NAME}"]
+        - color: F63100
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.diskgroup.read_latency["{#NAME}"]
+          sortorder: '1'
+        - color: 00611C
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.diskgroup.write_latency["{#NAME}"]
+          sortorder: '2'
+      - uuid: 9399e324319f4fc9826ad811c38b8a24
+        name: 'Disk group [{#NAME}]: Space utilization'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.diskgroup.used_pct["{#NAME}"]
+    - uuid: f1a414d98121459d8f183da47016ea7c
+      name: Pools discovery
+      type: DEPENDENT
+      key: seagate.exos.pools.discovery
+      delay: '0'
+      item_prototypes:
+      - uuid: 3ba6cbb25285488483b3fba60c66163f
+        name: 'Pool [{#NAME}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.pool.get["{#NAME}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['name'] == "{#NAME}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.pools
+        tags:
+        - tag: component
+          value: raw
+      - uuid: b752a64148aa4a7e913f2d0449cdc474
+        name: 'Pool [{#NAME}]: Get statistics'
+        type: DEPENDENT
+        key: seagate.exos.pool.stats.get["{#NAME}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['pool'] == "{#NAME}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.poolstats
+        tags:
+        - tag: component
+          value: raw
+      - uuid: 91ff92c36f2b4da6a1022206656a1c8d
+        name: 'Pool [{#NAME}]: Health'
+        type: DEPENDENT
+        key: seagate.exos.pool.health["{#NAME}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['health-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Health
+        master_item:
+          key: seagate.exos.pool.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: pool
+        trigger_prototypes:
+        - uuid: 2c550270efad47fd9a1650655a757474
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.pool.health["{#NAME}"])=1
+          name: 'Seagate Exos Storage: Pool [{#NAME}] health is degraded'
+          priority: AVERAGE
+          description: The component reports degraded health.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 96158501b29e4c749eed8325d3727b65
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.pool.health["{#NAME}"])=2
+          name: 'Seagate Exos Storage: Pool [{#NAME}] health is in fault state'
+          priority: HIGH
+          description: The component reports a fault.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: bedcc54088fb4f74b7f649e9cf8cdb48
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.pool.health["{#NAME}"])=3
+          name: 'Seagate Exos Storage: Pool [{#NAME}] health is unknown'
+          priority: WARNING
+          description: The component health is unknown.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 41be6b3a9e7f4568bd9dacae09f925c4
+        name: 'Pool [{#NAME}]: Total capacity'
+        type: DEPENDENT
+        key: seagate.exos.pool.total["{#NAME}"]
+        delay: '0'
+        units: B
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['total-size-numeric']||0)*Number(o.blocksize||512);
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.pool.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: capacity
+      - uuid: 0b0ca5d3424f4c3dbb8041f1100010b4
+        name: 'Pool [{#NAME}]: Available capacity'
+        type: DEPENDENT
+        key: seagate.exos.pool.available["{#NAME}"]
+        delay: '0'
+        units: B
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['total-avail-numeric']||0)*Number(o.blocksize||512);
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.pool.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: capacity
+      - uuid: 2069836418d64800b22ed8a99ae5e2e0
+        name: 'Pool [{#NAME}]: Used capacity'
+        type: DEPENDENT
+        key: seagate.exos.pool.used_pct["{#NAME}"]
+        delay: '0'
+        value_type: FLOAT
+        units: '%'
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value),t=Number(o['total-size-numeric']||0),a=Number(o['total-avail-numeric']||0); return t>0?(t-a)*100/t:0;
+        master_item:
+          key: seagate.exos.pool.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: capacity
+        trigger_prototypes:
+        - uuid: 7c3dffdf5b3f4fb0acea4500e11e7cde
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.pool.used_pct["{#NAME}"])>{$SEAGATE.POOL.USED.WARN}
+          name: 'Seagate Exos Storage: Pool [{#NAME}] utilization is high'
+          priority: WARNING
+          description: Pool utilization exceeded warning threshold.
+          tags:
+          - tag: scope
+            value: capacity
+          dependencies:
+          - name: 'Seagate Exos Storage: Pool [{#NAME}] utilization is very high'
+            expression: last(/Seagate Exos Storage by HTTP/seagate.exos.pool.used_pct["{#NAME}"])>{$SEAGATE.POOL.USED.HIGH}
+          - name: 'Seagate Exos Storage: Pool [{#NAME}] utilization is critical'
+            expression: last(/Seagate Exos Storage by HTTP/seagate.exos.pool.used_pct["{#NAME}"])>{$SEAGATE.POOL.USED.CRIT}
+        - uuid: 36ed6f8e62e640fc9be858205d2efb97
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.pool.used_pct["{#NAME}"])>{$SEAGATE.POOL.USED.HIGH}
+          name: 'Seagate Exos Storage: Pool [{#NAME}] utilization is very high'
+          priority: HIGH
+          description: Pool utilization exceeded high threshold.
+          tags:
+          - tag: scope
+            value: capacity
+          dependencies:
+          - name: 'Seagate Exos Storage: Pool [{#NAME}] utilization is critical'
+            expression: last(/Seagate Exos Storage by HTTP/seagate.exos.pool.used_pct["{#NAME}"])>{$SEAGATE.POOL.USED.CRIT}
+        - uuid: 829d1ebb881d451d9155b69364c069fa
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.pool.used_pct["{#NAME}"])>{$SEAGATE.POOL.USED.CRIT}
+          name: 'Seagate Exos Storage: Pool [{#NAME}] utilization is critical'
+          priority: HIGH
+          description: Pool utilization exceeded critical threshold.
+          tags:
+          - tag: scope
+            value: capacity
+      - uuid: 0a239616a85643ec8d03b3656e0c80e3
+        name: 'Pool [{#NAME}]: Overcommitted'
+        type: DEPENDENT
+        key: seagate.exos.pool.overcommitted["{#NAME}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['over-committed-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Yes/No
+        master_item:
+          key: seagate.exos.pool.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: capacity
+        trigger_prototypes:
+        - uuid: 0abedaf58a4c40cc8eb1ae2a4e76f4ef
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.pool.overcommitted["{#NAME}"])=1
+          name: 'Seagate Exos Storage: Pool [{#NAME}] is overcommitted'
+          priority: HIGH
+          description: The pool reports an overcommitted condition.
+          tags:
+          - tag: scope
+            value: capacity
+      - uuid: e8d543f3601c4eeba0fbfa8a68e892c1
+        name: 'Pool [{#NAME}]: IOPS'
+        type: DEPENDENT
+        key: seagate.exos.pool.iops["{#NAME}"]
+        delay: '0'
+        units: '!iops'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['iops']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.pool.stats.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 3aae47639909401fbe63593a0dfcbbb6
+        name: 'Pool [{#NAME}]: Throughput'
+        type: DEPENDENT
+        key: seagate.exos.pool.bps["{#NAME}"]
+        delay: '0'
+        units: Bps
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['bytes-per-second-numeric']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.pool.stats.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: d131714d70a943e4abb36e55bd4b2e4e
+        name: 'Pool [{#NAME}]: Response time'
+        type: DEPENDENT
+        key: seagate.exos.pool.latency["{#NAME}"]
+        delay: '0'
+        value_type: FLOAT
+        units: s
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['avg-rsp-time']||0)/1000000;
+        master_item:
+          key: seagate.exos.pool.stats.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 1579d7ca3bc84918ba876ce81f9dc403
+        name: 'Pool [{#NAME}]: Read response time'
+        type: DEPENDENT
+        key: seagate.exos.pool.read_latency["{#NAME}"]
+        delay: '0'
+        value_type: FLOAT
+        units: s
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['avg-read-rsp-time']||0)/1000000;
+        master_item:
+          key: seagate.exos.pool.stats.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: bda4d889425047acbd003ad9e8247d46
+        name: 'Pool [{#NAME}]: Write response time'
+        type: DEPENDENT
+        key: seagate.exos.pool.write_latency["{#NAME}"]
+        delay: '0'
+        value_type: FLOAT
+        units: s
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['avg-write-rsp-time']||0)/1000000;
+        master_item:
+          key: seagate.exos.pool.stats.get["{#NAME}"]
+        tags:
+        - tag: component
+          value: performance
+      master_item:
+        key: seagate.exos.get.pools
+      lld_macro_paths:
+      - lld_macro: '{#NAME}'
+        path: $['name']
+      - lld_macro: '{#SERIAL}'
+        path: $['serial-number']
+      graph_prototypes:
+      - uuid: 98d0217ee34c4e7690cdc38bf3e0463d
+        name: 'Pool [{#NAME}]: Performance'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.pool.iops["{#NAME}"]
+        - color: F63100
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.pool.bps["{#NAME}"]
+          sortorder: '1'
+          yaxisside: RIGHT
+      - uuid: 086a960dca8a4282990bd4b9809bf649
+        name: 'Pool [{#NAME}]: Response time'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.pool.latency["{#NAME}"]
+        - color: F63100
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.pool.read_latency["{#NAME}"]
+          sortorder: '1'
+        - color: 00611C
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.pool.write_latency["{#NAME}"]
+          sortorder: '2'
+      - uuid: 0a8afd903e7f438da12f9bb7a7adfcf9
+        name: 'Pool [{#NAME}]: Space utilization'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.pool.used_pct["{#NAME}"]
+    - uuid: 52dd415d83304372be81fb5f57590b25
+      name: Volumes discovery
+      type: DEPENDENT
+      key: seagate.exos.volumes.discovery
+      delay: '0'
+      item_prototypes:
+      - uuid: 8e93631b63d34b51ab9125965e8c2ea0
+        name: 'Volume [{#NAME}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['durable-id'] == "{#DURABLE.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.volumes
+        tags:
+        - tag: component
+          value: raw
+      - uuid: a4b8bdd9726f4b86ad2e85f17702026c
+        name: 'Volume [{#NAME}]: Get statistics'
+        type: DEPENDENT
+        key: seagate.exos.volume.stats.get["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['serial-number'] == "{#SERIAL}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.volumestats
+        tags:
+        - tag: component
+          value: raw
+      - uuid: e198872129da40dbbe5e0bd44d93ee9d
+        name: 'Volume [{#NAME}]: Health'
+        type: DEPENDENT
+        key: seagate.exos.volume.health["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['health-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Health
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: volume
+        trigger_prototypes:
+        - uuid: 05d39c0389ba4cbaa488cb7280eba94b
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.volume.health["{#DURABLE.ID}"])=1
+          name: 'Seagate Exos Storage: Volume [{#NAME}] health is degraded'
+          priority: WARNING
+          description: The component reports degraded health.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: b2973ed12162494b8168d9cd1df289f1
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.volume.health["{#DURABLE.ID}"])=2
+          name: 'Seagate Exos Storage: Volume [{#NAME}] health is in fault state'
+          priority: HIGH
+          description: The component reports a fault.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 5ab607f260a04adcb4159160a802277e
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.volume.health["{#DURABLE.ID}"])=3
+          name: 'Seagate Exos Storage: Volume [{#NAME}] health is unknown'
+          priority: WARNING
+          description: The component health is unknown.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 6901b607c2a4410784e638bfeffd0405
+        name: 'Volume [{#NAME}]: Pool'
+        type: DEPENDENT
+        key: seagate.exos.volume.pool["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['storage-pool-name']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: volume
+      - uuid: f468ba1851154dbb910e282ea8e6ac63
+        name: 'Volume [{#NAME}]: Owner'
+        type: DEPENDENT
+        key: seagate.exos.volume.owner["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['owner']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: volume
+      - uuid: 25af01856406493abffff3c01e58f095
+        name: 'Volume [{#NAME}]: Preferred owner'
+        type: DEPENDENT
+        key: seagate.exos.volume.preferred_owner["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['preferred-owner']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: volume
+      - uuid: 8aecf17c6a204fc79fb10377d777e1e4
+        name: 'Volume [{#NAME}]: Write policy'
+        type: DEPENDENT
+        key: seagate.exos.volume.write_policy["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['write-policy']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: volume
+      - uuid: 699bcad68dc44309a2545865b82d4e09
+        name: 'Volume [{#NAME}]: Cache optimization'
+        type: DEPENDENT
+        key: seagate.exos.volume.cache_optimization["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['cache-optimization']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: volume
+      - uuid: 84bc19475dc44267aad986d986119336
+        name: 'Volume [{#NAME}]: Read-ahead'
+        type: DEPENDENT
+        key: seagate.exos.volume.read_ahead["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['read-ahead-size']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: volume
+      - uuid: d5481924c09647578067607b71a55e7f
+        name: 'Volume [{#NAME}]: Tier affinity'
+        type: DEPENDENT
+        key: seagate.exos.volume.tier_affinity["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['tier-affinity']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: volume
+      - uuid: d522b51f79ab4da2ac030e3dc2d10c1b
+        name: 'Volume [{#NAME}]: Owner numeric'
+        type: DEPENDENT
+        key: seagate.exos.volume.owner_numeric["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['owner-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: volume
+        trigger_prototypes:
+        - uuid: 1b944a220bd14f11916580a2d145bf99
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.volume.owner_numeric["{#DURABLE.ID}"])<>last(/Seagate
+            Exos Storage by HTTP/seagate.exos.volume.preferred_owner_numeric["{#DURABLE.ID}"]) and {$SEAGATE.OWNER.MISMATCH.ENABLED}=1
+          name: 'Seagate Exos Storage: Volume [{#NAME}] owner differs from preferred owner'
+          priority: WARNING
+          description: Current owner differs from preferred owner.
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: c8b8c8297eeb41d38991f2bdba9f4144
+        name: 'Volume [{#NAME}]: Preferred owner numeric'
+        type: DEPENDENT
+        key: seagate.exos.volume.preferred_owner_numeric["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['preferred-owner-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: volume
+      - uuid: 8127eb712d8b41f1870b0b247cf707a7
+        name: 'Volume [{#NAME}]: Write-back enabled'
+        type: DEPENDENT
+        key: seagate.exos.volume.writeback["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return String(o['write-policy']||'').toLowerCase()==='write-back'?1:0;
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Yes/No
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: cache
+        trigger_prototypes:
+        - uuid: 97b7d7c675a24c19a137a455abf6216e
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.volume.writeback["{#DURABLE.ID}"])=0 and {$SEAGATE.VOLUME.WRITEBACK.REQUIRED:"{#NAME}"}=1
+          name: 'Seagate Exos Storage: Volume [{#NAME}] is not using write-back'
+          priority: HIGH
+          description: The volume is not using write-back policy. Disable the context macro for intentionally configured write-through
+            volumes.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: db489810e22b43ee97eb9cc083c7da3d
+        name: 'Volume [{#NAME}]: Operation progress'
+        type: DEPENDENT
+        key: seagate.exos.volume.progress["{#DURABLE.ID}"]
+        delay: '0'
+        units: '%'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['progress-numeric']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: volume
+        trigger_prototypes:
+        - uuid: 931debd6431740f2b7cf37fa716eaca7
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.volume.progress["{#DURABLE.ID}"])>0 and last(/Seagate
+            Exos Storage by HTTP/seagate.exos.volume.progress["{#DURABLE.ID}"])<100
+          name: 'Seagate Exos Storage: Volume [{#NAME}] operation is active'
+          priority: INFO
+          description: A volume operation is in progress.
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: b34743ef7c424b558d997bfcbbd70d79
+        name: 'Volume [{#NAME}]: Size'
+        type: DEPENDENT
+        key: seagate.exos.volume.size["{#DURABLE.ID}"]
+        delay: '0'
+        units: B
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['size-numeric']||0)*Number(o.blocksize||512);
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: capacity
+      - uuid: 36216e56cad4455aadb8e4601d2b68cd
+        name: 'Volume [{#NAME}]: Allocated size'
+        type: DEPENDENT
+        key: seagate.exos.volume.allocated["{#DURABLE.ID}"]
+        delay: '0'
+        units: B
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['allocated-size-numeric']||0)*Number(o.blocksize||512);
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.volume.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: capacity
+      - uuid: c270645a66f247b288c3560fed928ae5
+        name: 'Volume [{#NAME}]: IOPS'
+        type: DEPENDENT
+        key: seagate.exos.volume.iops["{#DURABLE.ID}"]
+        delay: '0'
+        units: '!iops'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['iops']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.volume.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: bdac08f428b847f98c5f3bd2a3a96ef2
+        name: 'Volume [{#NAME}]: Throughput'
+        type: DEPENDENT
+        key: seagate.exos.volume.bps["{#DURABLE.ID}"]
+        delay: '0'
+        units: Bps
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['bytes-per-second-numeric']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.volume.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 649840903693417baf16926a110fb1c1
+        name: 'Volume [{#NAME}]: Reads'
+        type: DEPENDENT
+        key: seagate.exos.volume.reads["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-reads']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.volume.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: fcac8ceebd7342b4adeea586cbf932de
+        name: 'Volume [{#NAME}]: Writes'
+        type: DEPENDENT
+        key: seagate.exos.volume.writes["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-writes']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.volume.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 6daa3c592ede436e8cabde38a68f1212
+        name: 'Volume [{#NAME}]: Write cache utilization'
+        type: DEPENDENT
+        key: seagate.exos.volume.write_cache_pct["{#DURABLE.ID}"]
+        delay: '0'
+        units: '%'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['write-cache-percent']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.volume.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      master_item:
+        key: seagate.exos.get.volumes
+      lld_macro_paths:
+      - lld_macro: '{#DURABLE.ID}'
+        path: $['durable-id']
+      - lld_macro: '{#NAME}'
+        path: $['volume-name']
+      - lld_macro: '{#SERIAL}'
+        path: $['serial-number']
+      - lld_macro: '{#POOL}'
+        path: $['storage-pool-name']
+      graph_prototypes:
+      - uuid: a60bfaf0ee94413488e2590c32640d3e
+        name: 'Volume [{#NAME}]: Performance'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.volume.iops["{#DURABLE.ID}"]
+        - color: F63100
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.volume.bps["{#DURABLE.ID}"]
+          sortorder: '1'
+          yaxisside: RIGHT
+    - uuid: 1dc6eb1ff9cd42fc831bb8d7766c2f15
+      name: Storage tiers discovery
+      type: DEPENDENT
+      key: seagate.exos.tiers.discovery
+      delay: '0'
+      item_prototypes:
+      - uuid: 8f6c85849ad547a2834136dbf00375bc
+        name: 'Tier [{#POOL}/{#TIER}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.tier.get["{#SERIAL}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['serial-number'] == "{#SERIAL}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.tiers
+        tags:
+        - tag: component
+          value: raw
+      - uuid: bcf81c7f2d1945cc97be6606b69b0860
+        name: 'Tier [{#POOL}/{#TIER}]: Get statistics'
+        type: DEPENDENT
+        key: seagate.exos.tier.stats.get["{#SERIAL}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['serial-number'] == "{#SERIAL}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.tierstats
+        tags:
+        - tag: component
+          value: raw
+      - uuid: 66e7701616334e879027a2760f7717b1
+        name: 'Tier [{#POOL}/{#TIER}]: Disk count'
+        type: DEPENDENT
+        key: seagate.exos.tier.diskcount["{#SERIAL}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['diskcount']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.tier.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: tier
+      - uuid: 39d9da55fdfa424d8c016109b3e187b4
+        name: 'Tier [{#POOL}/{#TIER}]: Raw capacity'
+        type: DEPENDENT
+        key: seagate.exos.tier.raw["{#SERIAL}"]
+        delay: '0'
+        units: B
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['raw-size-numeric']||0)*Number(o.blocksize||512);
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.tier.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: capacity
+      - uuid: 6cb4c2ba3e7e4555a54dafe61f2efe39
+        name: 'Tier [{#POOL}/{#TIER}]: Total capacity'
+        type: DEPENDENT
+        key: seagate.exos.tier.total["{#SERIAL}"]
+        delay: '0'
+        units: B
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['total-size-numeric']||0)*Number(o.blocksize||512);
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.tier.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: capacity
+      - uuid: 6ac345825e924d1d8d1cea80c497efa3
+        name: 'Tier [{#POOL}/{#TIER}]: Allocated capacity'
+        type: DEPENDENT
+        key: seagate.exos.tier.allocated["{#SERIAL}"]
+        delay: '0'
+        units: B
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['allocated-size-numeric']||0)*Number(o.blocksize||512);
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.tier.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: capacity
+      - uuid: aea0f398ba844bb29cd90c25b81a2945
+        name: 'Tier [{#POOL}/{#TIER}]: Available capacity'
+        type: DEPENDENT
+        key: seagate.exos.tier.available["{#SERIAL}"]
+        delay: '0'
+        units: B
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['available-size-numeric']||0)*Number(o.blocksize||512);
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.tier.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: capacity
+      - uuid: 0c291440ca964ee4b8e7526ef69d261a
+        name: 'Tier [{#POOL}/{#TIER}]: Used capacity'
+        type: DEPENDENT
+        key: seagate.exos.tier.used_pct["{#SERIAL}"]
+        delay: '0'
+        value_type: FLOAT
+        units: '%'
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value),t=Number(o['total-size-numeric']||0),a=Number(o['allocated-size-numeric']||0); return
+            t>0?a*100/t:0;
+        master_item:
+          key: seagate.exos.tier.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: capacity
+        trigger_prototypes:
+        - uuid: 7eea222b3e5f43dca553b7dd1ca9d6f9
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.tier.used_pct["{#SERIAL}"])>{$SEAGATE.TIER.USED.WARN}
+          name: 'Seagate Exos Storage: Tier [{#POOL}/{#TIER}] utilization is high'
+          priority: WARNING
+          description: Tier utilization exceeded warning threshold.
+          tags:
+          - tag: scope
+            value: capacity
+          dependencies:
+          - name: 'Seagate Exos Storage: Tier [{#POOL}/{#TIER}] utilization is critical'
+            expression: last(/Seagate Exos Storage by HTTP/seagate.exos.tier.used_pct["{#SERIAL}"])>{$SEAGATE.TIER.USED.CRIT}
+        - uuid: 3b4ff7ae9c184856afffb05f5a7a400b
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.tier.used_pct["{#SERIAL}"])>{$SEAGATE.TIER.USED.CRIT}
+          name: 'Seagate Exos Storage: Tier [{#POOL}/{#TIER}] utilization is critical'
+          priority: HIGH
+          description: Tier utilization exceeded critical threshold.
+          tags:
+          - tag: scope
+            value: capacity
+      - uuid: 0a3a74251e0145249f5a9794b05c4e7e
+        name: 'Tier [{#POOL}/{#TIER}]: IOPS'
+        type: DEPENDENT
+        key: seagate.exos.tier.iops["{#SERIAL}"]
+        delay: '0'
+        units: '!iops'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['iops']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.tier.stats.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: aab08e09d91743bdb3ee31d32f4ffec8
+        name: 'Tier [{#POOL}/{#TIER}]: Throughput'
+        type: DEPENDENT
+        key: seagate.exos.tier.bps["{#SERIAL}"]
+        delay: '0'
+        units: Bps
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['bytes-per-second-numeric']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.tier.stats.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: f37974980496454288a0c49bda8bf9ce
+        name: 'Tier [{#POOL}/{#TIER}]: Response time'
+        type: DEPENDENT
+        key: seagate.exos.tier.latency["{#SERIAL}"]
+        delay: '0'
+        value_type: FLOAT
+        units: s
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['avg-rsp-time']||0)/1000000;
+        master_item:
+          key: seagate.exos.tier.stats.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 44c385799a924a5f8d356bada6154ec6
+        name: 'Tier [{#POOL}/{#TIER}]: Read response time'
+        type: DEPENDENT
+        key: seagate.exos.tier.read_latency["{#SERIAL}"]
+        delay: '0'
+        value_type: FLOAT
+        units: s
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['avg-read-rsp-time']||0)/1000000;
+        master_item:
+          key: seagate.exos.tier.stats.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 4f08138c93b44c78871e7da409bcae96
+        name: 'Tier [{#POOL}/{#TIER}]: Write response time'
+        type: DEPENDENT
+        key: seagate.exos.tier.write_latency["{#SERIAL}"]
+        delay: '0'
+        value_type: FLOAT
+        units: s
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['avg-write-rsp-time']||0)/1000000;
+        master_item:
+          key: seagate.exos.tier.stats.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 40ae6878e987414c8058802dccac7c55
+        name: 'Tier [{#POOL}/{#TIER}]: Pages allocated per minute'
+        type: DEPENDENT
+        key: seagate.exos.tier.pages_alloc["{#SERIAL}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['pages-alloc-per-minute']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.tier.stats.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 22b72b48092147ccadbffd172ab0cdc9
+        name: 'Tier [{#POOL}/{#TIER}]: Pages deallocated per minute'
+        type: DEPENDENT
+        key: seagate.exos.tier.pages_dealloc["{#SERIAL}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['pages-dealloc-per-minute']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.tier.stats.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 699650823cf542479030db0ddb735dc9
+        name: 'Tier [{#POOL}/{#TIER}]: Pages reclaimed'
+        type: DEPENDENT
+        key: seagate.exos.tier.pages_reclaimed["{#SERIAL}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['pages-reclaimed']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.tier.stats.get["{#SERIAL}"]
+        tags:
+        - tag: component
+          value: performance
+      master_item:
+        key: seagate.exos.get.tiers
+      lld_macro_paths:
+      - lld_macro: '{#SERIAL}'
+        path: $['serial-number']
+      - lld_macro: '{#POOL}'
+        path: $['pool']
+      - lld_macro: '{#TIER}'
+        path: $['tier']
+      graph_prototypes:
+      - uuid: 60af5c3a295a4c7f8d5c138ea74fad07
+        name: 'Tier [{#POOL}/{#TIER}]: Performance'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.tier.iops["{#SERIAL}"]
+        - color: F63100
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.tier.bps["{#SERIAL}"]
+          sortorder: '1'
+          yaxisside: RIGHT
+      - uuid: 9a5cf7dcd82a42b29b2e2f055b3009fb
+        name: 'Tier [{#POOL}/{#TIER}]: Response time'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.tier.latency["{#SERIAL}"]
+        - color: F63100
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.tier.read_latency["{#SERIAL}"]
+          sortorder: '1'
+        - color: 00611C
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.tier.write_latency["{#SERIAL}"]
+          sortorder: '2'
+      - uuid: 59d2ed458f3741448d64ad5e3dc7fe46
+        name: 'Tier [{#POOL}/{#TIER}]: Space utilization'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.tier.used_pct["{#SERIAL}"]
+    - uuid: 3117de5bb0294d2481489d735f3ad3ca
+      name: Enclosures discovery
+      type: DEPENDENT
+      key: seagate.exos.enclosures.discovery
+      delay: '0'
+      item_prototypes:
+      - uuid: 4969f590315149539dff3bc3c1779ecf
+        name: 'Enclosure [{#ENCLOSURE.ID}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.enclosure.get["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['durable-id'] == "{#DURABLE.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.enclosures
+        tags:
+        - tag: component
+          value: raw
+      - uuid: 5a6dbea532004091a12a3386c323896d
+        name: 'Enclosure [{#ENCLOSURE.ID}]: Health'
+        type: DEPENDENT
+        key: seagate.exos.enclosure.health["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['health-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Health
+        master_item:
+          key: seagate.exos.enclosure.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: enclosure
+        trigger_prototypes:
+        - uuid: e2e700c037e5477d81d21443281c8626
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.enclosure.health["{#DURABLE.ID}"])=1
+          name: 'Seagate Exos Storage: Enclosure [{#ENCLOSURE.ID}] health is degraded'
+          priority: AVERAGE
+          description: The component reports degraded health.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 237df4b033a345a6b6f2cdb8674c0c14
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.enclosure.health["{#DURABLE.ID}"])=2
+          name: 'Seagate Exos Storage: Enclosure [{#ENCLOSURE.ID}] health is in fault state'
+          priority: HIGH
+          description: The component reports a fault.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: b0b4b66ae676407084d227ba9a3be5c8
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.enclosure.health["{#DURABLE.ID}"])=3
+          name: 'Seagate Exos Storage: Enclosure [{#ENCLOSURE.ID}] health is unknown'
+          priority: WARNING
+          description: The component health is unknown.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: bd14df9b55a648f89c7d6c8bb778c77a
+        name: 'Enclosure [{#ENCLOSURE.ID}]: Status'
+        type: DEPENDENT
+        key: seagate.exos.enclosure.status["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['status-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Enclosure status
+        master_item:
+          key: seagate.exos.enclosure.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: enclosure
+        trigger_prototypes:
+        - uuid: c2982b5e809047fea975b34b13b6a7e8
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.enclosure.status["{#DURABLE.ID}"])<>1
+          name: 'Seagate Exos Storage: Enclosure [{#ENCLOSURE.ID}] status is abnormal'
+          priority: HIGH
+          description: The enclosure SES status is not OK.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 3ef714c9690741599cfb02372790ca22
+        name: 'Enclosure [{#ENCLOSURE.ID}]: Model'
+        type: DEPENDENT
+        key: seagate.exos.enclosure.model["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['model']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.enclosure.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: enclosure
+      - uuid: 674ae6de899f444ea623563faeb63c43
+        name: 'Enclosure [{#ENCLOSURE.ID}]: Serial number'
+        type: DEPENDENT
+        key: seagate.exos.enclosure.serial["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['midplane-serial-number']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.enclosure.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: enclosure
+      - uuid: fae1368168404937914c07c22e3b32d1
+        name: 'Enclosure [{#ENCLOSURE.ID}]: Type'
+        type: DEPENDENT
+        key: seagate.exos.enclosure.type["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['type']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.enclosure.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: enclosure
+      - uuid: 56012accedd5444da7eea4f26fae58db
+        name: 'Enclosure [{#ENCLOSURE.ID}]: Revision'
+        type: DEPENDENT
+        key: seagate.exos.enclosure.revision["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['revision']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.enclosure.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: enclosure
+      - uuid: f4d6ba14fbf041cb83d851fb0f67bf4b
+        name: 'Enclosure [{#ENCLOSURE.ID}]: Disk count'
+        type: DEPENDENT
+        key: seagate.exos.enclosure.diskcount["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-disks']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.enclosure.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: enclosure
+      - uuid: d40f5ec71fea4fc7a372dd175f751644
+        name: 'Enclosure [{#ENCLOSURE.ID}]: Power supply count'
+        type: DEPENDENT
+        key: seagate.exos.enclosure.psucount["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-power-supplies']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.enclosure.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: enclosure
+      - uuid: ef9b81c895d348caaeb8ec27766c2eae
+        name: 'Enclosure [{#ENCLOSURE.ID}]: Cooling element count'
+        type: DEPENDENT
+        key: seagate.exos.enclosure.coolingcount["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-coolings-elements']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.enclosure.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: enclosure
+      - uuid: c7b96ceadcd146439e519d5ccc89cc2c
+        name: 'Enclosure [{#ENCLOSURE.ID}]: Power consumption'
+        type: DEPENDENT
+        key: seagate.exos.enclosure.power["{#DURABLE.ID}"]
+        delay: '0'
+        units: W
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['enclosure-power']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.enclosure.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: power
+      master_item:
+        key: seagate.exos.get.enclosures
+      lld_macro_paths:
+      - lld_macro: '{#DURABLE.ID}'
+        path: $['durable-id']
+      - lld_macro: '{#ENCLOSURE.ID}'
+        path: $['enclosure-id']
+      - lld_macro: '{#MODEL}'
+        path: $['model']
+      - lld_macro: '{#SERIAL}'
+        path: $['midplane-serial-number']
+      graph_prototypes:
+      - uuid: 56ef3f280269411f8d599496a1a33bc6
+        name: 'Enclosure [{#ENCLOSURE.ID}]: Power consumption'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.enclosure.power["{#DURABLE.ID}"]
+    - uuid: 644a2fed26e04fe7a3aa6a33971f5c6d
+      name: FRUs discovery
+      type: DEPENDENT
+      key: seagate.exos.frus.discovery
+      delay: '0'
+      item_prototypes:
+      - uuid: 981359cf95de493289c9cd3c66865026
+        name: 'FRU [{#NAME}/{#LOCATION}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.fru.get["{#LLD.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['lld-id'] == "{#LLD.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.frus
+        tags:
+        - tag: component
+          value: raw
+      - uuid: c3611a527f0d4715ad9a8982467570e7
+        name: 'FRU [{#NAME}/{#LOCATION}]: Status'
+        type: DEPENDENT
+        key: seagate.exos.fru.status["{#LLD.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['fru-status-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: FRU status
+        master_item:
+          key: seagate.exos.fru.get["{#LLD.ID}"]
+        tags:
+        - tag: component
+          value: fru
+        trigger_prototypes:
+        - uuid: f4ae3422f9c64bfaa0151c16ca05b0a2
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.fru.status["{#LLD.ID}"])<>4
+          name: 'Seagate Exos Storage: FRU [{#NAME}/{#LOCATION}] status is abnormal'
+          priority: HIGH
+          description: The field-replaceable unit is not in OK state.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 875f8373d025476e8018eb97c55556ef
+        name: 'FRU [{#NAME}/{#LOCATION}]: Part number'
+        type: DEPENDENT
+        key: seagate.exos.fru.part["{#LLD.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['part-number']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.fru.get["{#LLD.ID}"]
+        tags:
+        - tag: component
+          value: fru
+      - uuid: 57feea54fe434be2949cd0458901a968
+        name: 'FRU [{#NAME}/{#LOCATION}]: Serial number'
+        type: DEPENDENT
+        key: seagate.exos.fru.serial["{#LLD.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['serial-number']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.fru.get["{#LLD.ID}"]
+        tags:
+        - tag: component
+          value: fru
+      - uuid: dee9e44362864108a9193461e69bf858
+        name: 'FRU [{#NAME}/{#LOCATION}]: Revision'
+        type: DEPENDENT
+        key: seagate.exos.fru.revision["{#LLD.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['revision']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.fru.get["{#LLD.ID}"]
+        tags:
+        - tag: component
+          value: fru
+      - uuid: 405abf5debb648ed89a507cfd062dfb5
+        name: 'FRU [{#NAME}/{#LOCATION}]: Description'
+        type: DEPENDENT
+        key: seagate.exos.fru.description["{#LLD.ID}"]
+        delay: '0'
+        value_type: TEXT
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['description']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.fru.get["{#LLD.ID}"]
+        tags:
+        - tag: component
+          value: fru
+      master_item:
+        key: seagate.exos.get.frus
+      lld_macro_paths:
+      - lld_macro: '{#LLD.ID}'
+        path: $['lld-id']
+      - lld_macro: '{#NAME}'
+        path: $['name']
+      - lld_macro: '{#LOCATION}'
+        path: $['fru-location']
+      - lld_macro: '{#ENCLOSURE}'
+        path: $['enclosure-id']
+    - uuid: 84e4ab7f11424b67bde60e7521433f9c
+      name: Fans discovery
+      type: DEPENDENT
+      key: seagate.exos.fans.discovery
+      delay: '0'
+      item_prototypes:
+      - uuid: bc6c98ddb7ae49158c4b6966f746393a
+        name: 'Fan [{#NAME}/{#LOCATION}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.fan.get["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['durable-id'] == "{#DURABLE.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.fans
+        tags:
+        - tag: component
+          value: raw
+      - uuid: 383d785cf3c04377872657921f999b3e
+        name: 'Fan [{#NAME}/{#LOCATION}]: Health'
+        type: DEPENDENT
+        key: seagate.exos.fan.health["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['health-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Health
+        master_item:
+          key: seagate.exos.fan.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: fan
+        trigger_prototypes:
+        - uuid: 0b98b20d574f4c85af688225be57dcc9
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.fan.health["{#DURABLE.ID}"])=1
+          name: 'Seagate Exos Storage: Fan [{#NAME}/{#LOCATION}] health is degraded'
+          priority: AVERAGE
+          description: The component reports degraded health.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 359afb8d28324f7aa7a92956c48c0da1
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.fan.health["{#DURABLE.ID}"])=2
+          name: 'Seagate Exos Storage: Fan [{#NAME}/{#LOCATION}] health is in fault state'
+          priority: HIGH
+          description: The component reports a fault.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 169572675cd2488290d880c60c4e204e
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.fan.health["{#DURABLE.ID}"])=3
+          name: 'Seagate Exos Storage: Fan [{#NAME}/{#LOCATION}] health is unknown'
+          priority: WARNING
+          description: The component health is unknown.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: d98013ab76fc463190f59fa2c7f85f70
+        name: 'Fan [{#NAME}/{#LOCATION}]: Status'
+        type: DEPENDENT
+        key: seagate.exos.fan.status["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['status-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Fan status
+        master_item:
+          key: seagate.exos.fan.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: fan
+        trigger_prototypes:
+        - uuid: 4a5c22c78b484fafaa14c2a61cbdc46d
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.fan.status["{#DURABLE.ID}"])<>0
+          name: 'Seagate Exos Storage: Fan [{#NAME}/{#LOCATION}] is not Up'
+          priority: HIGH
+          description: Fan status is not Up.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: fb6afb0159924265beb4106c12ff0fc1
+        name: 'Fan [{#NAME}/{#LOCATION}]: Speed'
+        type: DEPENDENT
+        key: seagate.exos.fan.speed["{#DURABLE.ID}"]
+        delay: '0'
+        units: rpm
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['speed']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.fan.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: fan
+        trigger_prototypes:
+        - uuid: 0d118feccb16437fba442dba2e1a7638
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.fan.speed["{#DURABLE.ID}"])=0 and last(/Seagate Exos
+            Storage by HTTP/seagate.exos.fan.status["{#DURABLE.ID}"])=0
+          name: 'Seagate Exos Storage: Fan [{#NAME}/{#LOCATION}] speed is zero'
+          priority: HIGH
+          description: The fan is reported Up but speed is zero.
+          tags:
+          - tag: scope
+            value: availability
+      master_item:
+        key: seagate.exos.get.fans
+      lld_macro_paths:
+      - lld_macro: '{#DURABLE.ID}'
+        path: $['durable-id']
+      - lld_macro: '{#NAME}'
+        path: $['name']
+      - lld_macro: '{#LOCATION}'
+        path: $['location']
+      graph_prototypes:
+      - uuid: 800f56ad10644cd9a97484c6aa5c2110
+        name: 'Fan [{#NAME}/{#LOCATION}]: Speed'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.fan.speed["{#DURABLE.ID}"]
+    - uuid: ac6b19fa8ca041749360af83a2f40aa8
+      name: Power supplies discovery
+      type: DEPENDENT
+      key: seagate.exos.psus.discovery
+      delay: '0'
+      item_prototypes:
+      - uuid: 351bbc3d741f4e1cbe755093dbb16df1
+        name: 'Power supply [{#LOCATION}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.psu.get["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['durable-id'] == "{#DURABLE.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.psus
+        tags:
+        - tag: component
+          value: raw
+      - uuid: 3d44a02c726442ad9eb7161a063a9898
+        name: 'Power supply [{#LOCATION}]: Health'
+        type: DEPENDENT
+        key: seagate.exos.psu.health["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['health-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Health
+        master_item:
+          key: seagate.exos.psu.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: power
+        trigger_prototypes:
+        - uuid: bf4ac4e8337f404fa866905d369112ae
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.psu.health["{#DURABLE.ID}"])=1
+          name: 'Seagate Exos Storage: Power supply [{#LOCATION}] health is degraded'
+          priority: AVERAGE
+          description: The component reports degraded health.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 0c0e46b751a2407ca4c08f32149edc27
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.psu.health["{#DURABLE.ID}"])=2
+          name: 'Seagate Exos Storage: Power supply [{#LOCATION}] health is in fault state'
+          priority: HIGH
+          description: The component reports a fault.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: f03abdcb86744b318a5ccd9a5595e7f5
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.psu.health["{#DURABLE.ID}"])=3
+          name: 'Seagate Exos Storage: Power supply [{#LOCATION}] health is unknown'
+          priority: WARNING
+          description: The component health is unknown.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 999943380e4244318a8cdd0b15720dd5
+        name: 'Power supply [{#LOCATION}]: Status'
+        type: DEPENDENT
+        key: seagate.exos.psu.status["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['status-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Status
+        master_item:
+          key: seagate.exos.psu.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: power
+        trigger_prototypes:
+        - uuid: 0375a17dc8cf4dc7864fe06b52adbb5d
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.psu.status["{#DURABLE.ID}"])<>0
+          name: 'Seagate Exos Storage: Power supply [{#LOCATION}] status is abnormal'
+          priority: HIGH
+          description: Power supply status is not Up.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 9c9a13bac708443196f4790d60d8b85e
+        name: 'Power supply [{#LOCATION}]: Part number'
+        type: DEPENDENT
+        key: seagate.exos.psu.part["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['part-number']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.psu.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: power
+      - uuid: 548d1b12d3e848b28d0323e068e54f8e
+        name: 'Power supply [{#LOCATION}]: Serial number'
+        type: DEPENDENT
+        key: seagate.exos.psu.serial["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['serial-number']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.psu.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: power
+      - uuid: 74784bbd2b154b6987dc99c2e93d9b55
+        name: 'Power supply [{#LOCATION}]: Firmware'
+        type: DEPENDENT
+        key: seagate.exos.psu.firmware["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['fw-revision']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.psu.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: power
+      - uuid: fe8316c2f5ee4fe2aa3d41189cb7d2b7
+        name: 'Power supply [{#LOCATION}]: Model'
+        type: DEPENDENT
+        key: seagate.exos.psu.model["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['model']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.psu.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: power
+      master_item:
+        key: seagate.exos.get.psus
+      lld_macro_paths:
+      - lld_macro: '{#DURABLE.ID}'
+        path: $['durable-id']
+      - lld_macro: '{#LOCATION}'
+        path: $['location']
+      - lld_macro: '{#ENCLOSURE}'
+        path: $['enclosure-id']
+      - lld_macro: '{#SERIAL}'
+        path: $['serial-number']
+    - uuid: 88311c5f62fa448fa72a6af5f4c805c0
+      name: Sensors discovery
+      type: DEPENDENT
+      key: seagate.exos.sensors.discovery
+      delay: '0'
+      item_prototypes:
+      - uuid: fd22d90a162b4e12ba02582844830e13
+        name: 'Sensor [{#NAME}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.sensor.get["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['durable-id'] == "{#DURABLE.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.sensors
+        tags:
+        - tag: component
+          value: raw
+      - uuid: 18e6c959f1f04e0089432703fb3a8c29
+        name: 'Sensor [{#NAME}]: Status'
+        type: DEPENDENT
+        key: seagate.exos.sensor.status["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['status-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Sensor status
+        master_item:
+          key: seagate.exos.sensor.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: sensor
+        trigger_prototypes:
+        - uuid: bcd4042825f744559df0769967740dc4
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.sensor.status["{#DURABLE.ID}"])=3
+          name: 'Seagate Exos Storage: Sensor [{#NAME}] reports Warning'
+          priority: WARNING
+          description: The storage sensor reports Warning.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 1d02430686ad490e8d6c2274f13636a5
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.sensor.status["{#DURABLE.ID}"])=2 or last(/Seagate Exos
+            Storage by HTTP/seagate.exos.sensor.status["{#DURABLE.ID}"])=4
+          name: 'Seagate Exos Storage: Sensor [{#NAME}] reports Critical or Unrecoverable'
+          priority: HIGH
+          description: The storage sensor reports Critical or Unrecoverable state.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 700fe28e50d943d986d3c096bb67ce0b
+        name: 'Sensor [{#NAME}]: Value'
+        type: DEPENDENT
+        key: seagate.exos.sensor.value["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['value']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.sensor.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: sensor
+      - uuid: 1a254570c2174d9784d0ec46c7bb0871
+        name: 'Sensor [{#NAME}]: Type'
+        type: DEPENDENT
+        key: seagate.exos.sensor.type["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['sensor-type']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.sensor.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: sensor
+      master_item:
+        key: seagate.exos.get.sensors
+      lld_macro_paths:
+      - lld_macro: '{#DURABLE.ID}'
+        path: $['durable-id']
+      - lld_macro: '{#NAME}'
+        path: $['sensor-name']
+      - lld_macro: '{#TYPE}'
+        path: $['sensor-type']
+      - lld_macro: '{#ENCLOSURE}'
+        path: $['enclosure-id']
+      - lld_macro: '{#CONTROLLER}'
+        path: $['controller-id']
+    - uuid: 55e359837c5c441a82725168f7b0cece
+      name: SAS links discovery
+      type: DEPENDENT
+      key: seagate.exos.saslinks.discovery
+      delay: '0'
+      item_prototypes:
+      - uuid: d3ba00ffc672479caf77150a065d0b96
+        name: 'SAS link [{#NAME}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.saslink.get["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['durable-id'] == "{#DURABLE.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.saslinks
+        tags:
+        - tag: component
+          value: raw
+      - uuid: e073ffc81c1744769c112ac88d684a55
+        name: 'SAS link [{#NAME}]: Health'
+        type: DEPENDENT
+        key: seagate.exos.saslink.health["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['health-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Health
+        master_item:
+          key: seagate.exos.saslink.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: sas
+        trigger_prototypes:
+        - uuid: 2c87d857b92c47ffa0ff3f75a1ad19f5
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.saslink.health["{#DURABLE.ID}"])=1
+          name: 'Seagate Exos Storage: SAS link [{#NAME}] health is degraded'
+          priority: AVERAGE
+          description: The component reports degraded health.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: c03898bc1e0a4448bb707a49913dad9c
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.saslink.health["{#DURABLE.ID}"])=2
+          name: 'Seagate Exos Storage: SAS link [{#NAME}] health is in fault state'
+          priority: HIGH
+          description: The component reports a fault.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 08c46706f32d4bfa97fde28a729a2b88
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.saslink.health["{#DURABLE.ID}"])=3
+          name: 'Seagate Exos Storage: SAS link [{#NAME}] health is unknown'
+          priority: WARNING
+          description: The component health is unknown.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: b68929c1d4814b32b6da2269073a2244
+        name: 'SAS link [{#NAME}]: Status'
+        type: DEPENDENT
+        key: seagate.exos.saslink.status["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['status-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Status
+        master_item:
+          key: seagate.exos.saslink.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: sas
+        trigger_prototypes:
+        - uuid: f4e8e50bfb1a401db8362bc09f27e96d
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.saslink.status["{#DURABLE.ID}"])<>0 and {#SAS.PORT.TYPE.NUMERIC}<>5
+          name: 'Seagate Exos Storage: SAS link [{#NAME}] status is abnormal'
+          priority: HIGH
+          description: SAS link status is abnormal for a non-expansion link. External Expansion Port Universal links are excluded
+            from status-only alerting because an unused or terminal expansion port can legitimately be Disconnected. Expansion-port
+            health and expected enclosure count are monitored separately.
+          tags:
+          - tag: scope
+            value: availability
+      master_item:
+        key: seagate.exos.get.saslinks
+      lld_macro_paths:
+      - lld_macro: '{#DURABLE.ID}'
+        path: $['durable-id']
+      - lld_macro: '{#NAME}'
+        path: $['name']
+      - lld_macro: '{#CONTROLLER}'
+        path: $['controller']
+      - lld_macro: '{#ENCLOSURE}'
+        path: $['enclosure-id']
+      - lld_macro: '{#SAS.PORT.TYPE.NUMERIC}'
+        path: $['sas-port-type-numeric']
+    - uuid: 4ee67ee41a9c4745b544bd73b3c5089f
+      name: Host ports discovery
+      type: DEPENDENT
+      key: seagate.exos.ports.discovery
+      delay: '0'
+      item_prototypes:
+      - uuid: 0dc3a9ebbd1c4661b34f1fd88b502464
+        name: 'Host port [{#PORT.ID}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.port.get["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['durable-id'] == "{#DURABLE.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.ports
+        tags:
+        - tag: component
+          value: raw
+      - uuid: 183fd01fe894488f9d80a01f0445cfb5
+        name: 'Host port [{#PORT.ID}]: Get statistics'
+        type: DEPENDENT
+        key: seagate.exos.port.stats.get["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['durable-id'] == "{#DURABLE.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.portstats
+        tags:
+        - tag: component
+          value: raw
+      - uuid: 40ce4866087d49f7b245a41cd549cc19
+        name: 'Host port [{#PORT.ID}]: Health'
+        type: DEPENDENT
+        key: seagate.exos.port.health["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['health-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Health
+        master_item:
+          key: seagate.exos.port.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: port
+        trigger_prototypes:
+        - uuid: 33b536bf968b46cfa60a0765c192ed04
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.health["{#DURABLE.ID}"])=1
+          name: 'Seagate Exos Storage: Host port [{#PORT.ID}] health is degraded'
+          priority: AVERAGE
+          description: The component reports degraded health.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 506a51c9098d4ada89eeca43b776629a
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.health["{#DURABLE.ID}"])=2
+          name: 'Seagate Exos Storage: Host port [{#PORT.ID}] health is in fault state'
+          priority: HIGH
+          description: The component reports a fault.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 5178ce5b712140ec95c682e550dbfa4b
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.health["{#DURABLE.ID}"])=3
+          name: 'Seagate Exos Storage: Host port [{#PORT.ID}] health is unknown'
+          priority: WARNING
+          description: The component health is unknown.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 103141e003a0494fbe7ec6f159de5f99
+        name: 'Host port [{#PORT.ID}]: Status'
+        type: DEPENDENT
+        key: seagate.exos.port.status["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['status-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Status
+        master_item:
+          key: seagate.exos.port.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: port
+        trigger_prototypes:
+        - uuid: 1bf16789cde3481e818bcd0c1cd65bc3
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.status["{#DURABLE.ID}"])<>0 and {$SEAGATE.PORT.DOWN.ENABLED:"{#PORT.ID}"}=1
+          name: 'Seagate Exos Storage: Host port [{#PORT.ID}] is down'
+          priority: HIGH
+          description: The host port is not Up. Disable the context macro for intentionally unused ports.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 4920ecc261084d949d71df076c8353dc
+        name: 'Host port [{#PORT.ID}]: Port type'
+        type: DEPENDENT
+        key: seagate.exos.port.type["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['port-type']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.port.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: port
+      - uuid: 434d1835b19b484aa6cfebcd01d87685
+        name: 'Host port [{#PORT.ID}]: IP address'
+        type: DEPENDENT
+        key: seagate.exos.port.ip["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['ip-address']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.port.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: port
+      - uuid: a03fd28ea41046fbbc7b543853e8473e
+        name: 'Host port [{#PORT.ID}]: MAC address'
+        type: DEPENDENT
+        key: seagate.exos.port.mac["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['mac-address']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.port.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: port
+      - uuid: 5c28a23f95f94de78a92014687db2503
+        name: 'Host port [{#PORT.ID}]: SFP vendor'
+        type: DEPENDENT
+        key: seagate.exos.port.sfp_vendor["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['sfp-vendor']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.port.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: port
+      - uuid: 53398487838b49d7a105cfa14e2be7e2
+        name: 'Host port [{#PORT.ID}]: SFP part number'
+        type: DEPENDENT
+        key: seagate.exos.port.sfp_part["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['sfp-part-number']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 30m
+        master_item:
+          key: seagate.exos.port.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: port
+      - uuid: 90b8b95695fb4832b80f3570909733ce
+        name: 'Host port [{#PORT.ID}]: Actual speed'
+        type: DEPENDENT
+        key: seagate.exos.port.speed["{#DURABLE.ID}"]
+        delay: '0'
+        units: Gbps
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['actual-speed-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.port.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: port
+        trigger_prototypes:
+        - uuid: 1a7906cd0ab041d78bdf401188c9cb03
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.speed["{#DURABLE.ID}"],#1)<>last(/Seagate Exos
+            Storage by HTTP/seagate.exos.port.speed["{#DURABLE.ID}"],#2)
+          name: 'Seagate Exos Storage: Host port [{#PORT.ID}] negotiated speed changed'
+          priority: WARNING
+          description: The negotiated host-port speed changed.
+          manual_close: 'YES'
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: 31209daacf7d490ba966f32a6c60f6dd
+        name: 'Host port [{#PORT.ID}]: SFP present'
+        type: DEPENDENT
+        key: seagate.exos.port.sfp_present["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['sfp-present-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: SFP present
+        master_item:
+          key: seagate.exos.port.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: port
+        trigger_prototypes:
+        - uuid: fb71b2a6685b48d58e8902eeafe6b967
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.sfp_present["{#DURABLE.ID}"])=0 and last(/Seagate
+            Exos Storage by HTTP/seagate.exos.port.sfp_present["{#DURABLE.ID}"],#2)=1 and {$SEAGATE.PORT.DOWN.ENABLED:"{#PORT.ID}"}=1
+          name: 'Seagate Exos Storage: SFP removed from host port [{#PORT.ID}]'
+          priority: HIGH
+          description: An SFP that was present was removed from this host port.
+          tags:
+          - tag: scope
+            value: notice
+      - uuid: 4c9b3672aaea45b1a3d468a7c3dc5819
+        name: 'Host port [{#PORT.ID}]: SFP status'
+        type: DEPENDENT
+        key: seagate.exos.port.sfp_status["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['sfp-status-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: SFP status
+        master_item:
+          key: seagate.exos.port.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: port
+        trigger_prototypes:
+        - uuid: 51ec1b542d4e4a829f861629e9fdc448
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.sfp_present["{#DURABLE.ID}"])=1 and last(/Seagate
+            Exos Storage by HTTP/seagate.exos.port.sfp_status["{#DURABLE.ID}"])<>3 and {$SEAGATE.PORT.DOWN.ENABLED:"{#PORT.ID}"}=1
+          name: 'Seagate Exos Storage: SFP status is abnormal on host port [{#PORT.ID}]'
+          priority: HIGH
+          description: The installed SFP is incompatible or uses the incorrect protocol.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: 830449a6c17a4ff8b40bd30c0bb16dbb
+        name: 'Host port [{#PORT.ID}]: IOPS'
+        type: DEPENDENT
+        key: seagate.exos.port.iops["{#DURABLE.ID}"]
+        delay: '0'
+        units: '!iops'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['iops']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.port.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: e3dbed2a5a2a4e2a8593bab48514c32d
+        name: 'Host port [{#PORT.ID}]: Throughput'
+        type: DEPENDENT
+        key: seagate.exos.port.bps["{#DURABLE.ID}"]
+        delay: '0'
+        units: Bps
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['bytes-per-second-numeric']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.port.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 637da318c2eb4e87b813f91ed7ed8c94
+        name: 'Host port [{#PORT.ID}]: Queue depth'
+        type: DEPENDENT
+        key: seagate.exos.port.queue_depth["{#DURABLE.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['queue-depth']
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.port.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: d08b157c0d0744e088cdeab6bb992676
+        name: 'Host port [{#PORT.ID}]: Read I/O rate'
+        type: DEPENDENT
+        key: seagate.exos.port.read_iops_derived["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: FLOAT
+        units: '!iops'
+        description: Read operations per second derived from the cumulative number-of-reads counter. Used to weight host-port
+          read latency for the 4005/4865 system latency fallback.
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-reads']
+          error_handler: DISCARD_VALUE
+        - type: CHANGE_PER_SECOND
+          parameters:
+          - ''
+        master_item:
+          key: seagate.exos.port.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+        - tag: host-port
+          value: '{#PORT.ID}'
+      - uuid: fa32d8bedace46f8b7d3d572e0ab9d79
+        name: 'Host port [{#PORT.ID}]: Write I/O rate'
+        type: DEPENDENT
+        key: seagate.exos.port.write_iops_derived["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: FLOAT
+        units: '!iops'
+        description: Write operations per second derived from the cumulative number-of-writes counter. Used to weight host-port
+          write latency for the 4005/4865 system latency fallback.
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['number-of-writes']
+          error_handler: DISCARD_VALUE
+        - type: CHANGE_PER_SECOND
+          parameters:
+          - ''
+        master_item:
+          key: seagate.exos.port.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+        - tag: host-port
+          value: '{#PORT.ID}'
+      - uuid: b0e44a5dc1274ab7abbe012b1d12a1e7
+        name: 'Host port [{#PORT.ID}]: Read latency weighted contribution'
+        type: CALCULATED
+        key: seagate.exos.port.read_latency_weighted["{#DURABLE.ID}"]
+        delay: '{$SEAGATE.INTERVAL.PERFORMANCE}'
+        history: 1d
+        value_type: FLOAT
+        trends: '0'
+        params: last(//seagate.exos.port.read_latency["{#DURABLE.ID}"])*1000000*last(//seagate.exos.port.read_iops_derived["{#DURABLE.ID}"])
+        description: 'Internal weighted contribution: host-port read average response time in microseconds multiplied by derived
+          read IOPS.'
+        tags:
+        - tag: component
+          value: calculation
+        - tag: host-port
+          value: '{#PORT.ID}'
+      - uuid: e4d67d5f3bb94ee4a4783023e230b0bd
+        name: 'Host port [{#PORT.ID}]: Write latency weighted contribution'
+        type: CALCULATED
+        key: seagate.exos.port.write_latency_weighted["{#DURABLE.ID}"]
+        delay: '{$SEAGATE.INTERVAL.PERFORMANCE}'
+        history: 1d
+        value_type: FLOAT
+        trends: '0'
+        params: last(//seagate.exos.port.write_latency["{#DURABLE.ID}"])*1000000*last(//seagate.exos.port.write_iops_derived["{#DURABLE.ID}"])
+        description: 'Internal weighted contribution: host-port write average response time in microseconds multiplied by
+          derived write IOPS.'
+        tags:
+        - tag: component
+          value: calculation
+        - tag: host-port
+          value: '{#PORT.ID}'
+      - uuid: 10558887c8454ad7bde6e096c21a206f
+        name: 'Host port [{#PORT.ID}]: Response time'
+        type: DEPENDENT
+        key: seagate.exos.port.latency["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: FLOAT
+        units: s
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['avg-rsp-time']||0)/1000000;
+        master_item:
+          key: seagate.exos.port.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: a5ba9235dd0645e0adb0b512a74f7265
+        name: 'Host port [{#PORT.ID}]: Read response time'
+        type: DEPENDENT
+        key: seagate.exos.port.read_latency["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: FLOAT
+        units: s
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['avg-read-rsp-time']||0)/1000000;
+        master_item:
+          key: seagate.exos.port.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      - uuid: 17a8fd3c88554b7fbf32e4e842775e6d
+        name: 'Host port [{#PORT.ID}]: Write response time'
+        type: DEPENDENT
+        key: seagate.exos.port.write_latency["{#DURABLE.ID}"]
+        delay: '0'
+        value_type: FLOAT
+        units: s
+        preprocessing:
+        - type: JAVASCRIPT
+          parameters:
+          - var o=JSON.parse(value); return Number(o['avg-write-rsp-time']||0)/1000000;
+        master_item:
+          key: seagate.exos.port.stats.get["{#DURABLE.ID}"]
+        tags:
+        - tag: component
+          value: performance
+      master_item:
+        key: seagate.exos.get.ports
+      lld_macro_paths:
+      - lld_macro: '{#DURABLE.ID}'
+        path: $['durable-id']
+      - lld_macro: '{#PORT.ID}'
+        path: $['lld-port-id']
+      - lld_macro: '{#CONTROLLER}'
+        path: $['controller']
+      - lld_macro: '{#PORT}'
+        path: $['port']
+      - lld_macro: '{#TYPE}'
+        path: $['port-type']
+      graph_prototypes:
+      - uuid: e8e35b3a0aae4dd4a346e50de8cd02fd
+        name: 'Host port [{#PORT.ID}]: Performance'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.port.iops["{#DURABLE.ID}"]
+        - color: F63100
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.port.bps["{#DURABLE.ID}"]
+          sortorder: '1'
+          yaxisside: RIGHT
+      - uuid: 14ca3988c59b4c389c8192d94ce9431f
+        name: 'Host port [{#PORT.ID}]: Response time'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.port.latency["{#DURABLE.ID}"]
+        - color: F63100
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.port.read_latency["{#DURABLE.ID}"]
+          sortorder: '1'
+        - color: 00611C
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.port.write_latency["{#DURABLE.ID}"]
+          sortorder: '2'
+      - uuid: c0275606de084c2db0b8e34b5da81c63
+        name: 'Host port [{#PORT.ID}]: Queue depth'
+        graph_items:
+        - color: 199C0D
+          item:
+            host: Seagate Exos Storage by HTTP
+            key: seagate.exos.port.queue_depth["{#DURABLE.ID}"]
+      preprocessing:
+      - type: JAVASCRIPT
+        parameters:
+        - var a=JSON.parse(value); for(var i=0;i<a.length;i++) a[i]['lld-port-id']=String(a[i].controller||'')+String(a[i].port||'');
+          return JSON.stringify(a);
+    - uuid: 8953ff9703684b2b95a7e4b66ea00ce9
+      name: Replication sets discovery
+      type: DEPENDENT
+      key: seagate.exos.replications.discovery
+      delay: '0'
+      description: Discovers configured replication sets. Runtime field behavior requires validation on an array with active
+        replication.
+      item_prototypes:
+      - uuid: da7c7aa62780424e8c8c02ca6f1d1ec9
+        name: 'Replication set [{#NAME}]: Get data'
+        type: DEPENDENT
+        key: seagate.exos.replication.get["{#LLD.ID}"]
+        delay: '0'
+        value_type: TEXT
+        history: '0'
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $[?(@['lld-id'] == "{#LLD.ID}")].first()
+          error_handler: DISCARD_VALUE
+        master_item:
+          key: seagate.exos.get.replicationsets
+        tags:
+        - tag: component
+          value: raw
+      - uuid: d9bfd21d5456440c9d553d7256357f7a
+        name: 'Replication set [{#NAME}]: Health'
+        type: DEPENDENT
+        key: seagate.exos.replication.health["{#LLD.ID}"]
+        delay: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['health-numeric']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        valuemap:
+          name: Health
+        master_item:
+          key: seagate.exos.replication.get["{#LLD.ID}"]
+        tags:
+        - tag: component
+          value: replication
+        trigger_prototypes:
+        - uuid: 03760b169aa44a13a6b3ad36ea89a73a
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.replication.health["{#LLD.ID}"])=1
+          name: 'Seagate Exos Storage: Replication set [{#NAME}] health is degraded'
+          priority: AVERAGE
+          description: The component reports degraded health.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: 2af682f7662a4859a5dda11be4349ebf
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.replication.health["{#LLD.ID}"])=2
+          name: 'Seagate Exos Storage: Replication set [{#NAME}] health is in fault state'
+          priority: HIGH
+          description: The component reports a fault.
+          tags:
+          - tag: scope
+            value: availability
+        - uuid: dbc80086afdc4daaa7d85ec36f814d87
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.replication.health["{#LLD.ID}"])=3
+          name: 'Seagate Exos Storage: Replication set [{#NAME}] health is unknown'
+          priority: WARNING
+          description: The component health is unknown.
+          tags:
+          - tag: scope
+            value: availability
+      - uuid: c0d15512acd24e029087efb1b8075ced
+        name: 'Replication set [{#NAME}]: Status'
+        type: DEPENDENT
+        key: seagate.exos.replication.status["{#LLD.ID}"]
+        delay: '0'
+        value_type: CHAR
+        trends: '0'
+        preprocessing:
+        - type: JSONPATH
+          parameters:
+          - $['status']
+          error_handler: DISCARD_VALUE
+        - type: DISCARD_UNCHANGED_HEARTBEAT
+          parameters:
+          - 1h
+        master_item:
+          key: seagate.exos.replication.get["{#LLD.ID}"]
+        tags:
+        - tag: component
+          value: replication
+      master_item:
+        key: seagate.exos.get.replicationsets
+      lld_macro_paths:
+      - lld_macro: '{#LLD.ID}'
+        path: $['lld-id']
+      - lld_macro: '{#NAME}'
+        path: $['name']
+      - lld_macro: '{#SERIAL}'
+        path: $['serial-number']
+    tags:
+    - tag: class
+      value: storage
+    - tag: target
+      value: seagate-exos
+    - tag: vendor
+      value: seagate
+    macros:
+    - macro: '{$SEAGATE.API.HOST}'
+      description: Primary storage management controller hostname or IP address.
+    - macro: '{$SEAGATE.API.HOST.SECONDARY}'
+      value: ''
+      description: Optional partner controller management hostname or IP address.
+    - macro: '{$SEAGATE.API.PORT}'
+      value: '443'
+      description: Storage management API TCP port used in every API URL. Defaults to HTTPS TCP/443; override this macro at
+        host level when the array management API listens on a different port.
+    - macro: '{$SEAGATE.API.SCHEME}'
+      value: https
+      description: 'API scheme: https or http.'
+    - macro: '{$SEAGATE.API.USERNAME}'
+      value: zbx_monitor
+      description: Dedicated storage API username with Monitor/read-only and Web/API access.
+    - macro: '{$SEAGATE.API.PASSWORD}'
+      type: SECRET_TEXT
+      description: Read-only storage API password. Configure at host level.
+    - macro: '{$SEAGATE.HTTP.PROXY}'
+      value: ''
+      description: 'Optional HTTP proxy used by all Script master items. Format example: http://proxy.example:8080.'
+    - macro: '{$SEAGATE.DATA.TIMEOUT}'
+      value: 60s
+      description: Timeout for Script master items.
+    - macro: '{$SEAGATE.INTERVAL.AVAILABILITY}'
+      value: 1m
+      description: API availability polling interval.
+    - macro: '{$SEAGATE.INTERVAL.CORE}'
+      value: 2m
+      description: Core hardware and health polling interval.
+    - macro: '{$SEAGATE.INTERVAL.PERFORMANCE}'
+      value: 1m
+      description: Performance polling interval.
+    - macro: '{$SEAGATE.INTERVAL.EVENTS}'
+      value: 1m
+      description: Event and alert polling interval.
+    - macro: '{$SEAGATE.INTERVAL.INVENTORY}'
+      value: 30m
+      description: Inventory polling interval. Default 30m so dashboard-facing inventory values such as product ID and firmware
+        bundle always have a recent sample.
+    - macro: '{$SEAGATE.EVENTS.LAST}'
+      value: '100'
+      description: 'Number of recent events requested. Maximum enforced by script: 1000.'
+    - macro: '{$SEAGATE.ALERTS.MODE}'
+      value: auto
+      description: 'Structured Alerts API mode: auto, enabled, or disabled.'
+    - macro: '{$SEAGATE.REDUNDANCY.REQUIRED}'
+      value: '1'
+      description: Set to 1 to alert when storage is not redundant.
+    - macro: '{$SEAGATE.NTP.REQUIRED}'
+      value: '0'
+      description: Set to 1 to alert when NTP is not activated.
+    - macro: '{$SEAGATE.ENCLOSURE.EXPECTED}'
+      value: '1'
+      description: Expected total enclosure count, including the controller enclosure. Use 1 for a standalone array, 2 for
+        controller enclosure plus one expansion enclosure, and so on.
+    - macro: '{$SEAGATE.PORT.DOWN.ENABLED}'
+      value: '1'
+      description: Enable host-port/SFP alerts. Override by context, for example {$SEAGATE.PORT.DOWN.ENABLED:"A3"}=0.
+    - macro: '{$SEAGATE.VOLUME.WRITEBACK.REQUIRED}'
+      value: '1'
+      description: Require write-back policy. Override by volume context when write-through is intentional.
+    - macro: '{$SEAGATE.OWNER.MISMATCH.ENABLED}'
+      value: '0'
+      description: Reserved for optional owner/preferred-owner alert policy.
+    - macro: '{$SEAGATE.CONTROLLER.CPU.WARN}'
+      value: '90'
+      description: Controller CPU utilization warning threshold in percent.
+    - macro: '{$SEAGATE.DISK.TEMP.WARN}'
+      value: '50'
+      description: Disk temperature warning threshold in degrees Celsius.
+    - macro: '{$SEAGATE.DISK.TEMP.CRIT}'
+      value: '60'
+      description: Disk temperature critical threshold in degrees Celsius.
+    - macro: '{$SEAGATE.SSD.LIFE.WARN}'
+      value: '10'
+      description: SSD remaining-life warning threshold in percent. Value 255 means N/A.
+    - macro: '{$SEAGATE.DISKGROUP.USED.WARN}'
+      value: '80'
+      description: Disk-group used-space warning threshold in percent.
+    - macro: '{$SEAGATE.DISKGROUP.USED.HIGH}'
+      value: '90'
+      description: Disk-group used-space high threshold in percent.
+    - macro: '{$SEAGATE.DISKGROUP.USED.CRIT}'
+      value: '95'
+      description: Disk-group used-space critical threshold in percent.
+    - macro: '{$SEAGATE.POOL.USED.WARN}'
+      value: '80'
+      description: Pool used-space warning threshold in percent.
+    - macro: '{$SEAGATE.POOL.USED.HIGH}'
+      value: '90'
+      description: Pool used-space high threshold in percent.
+    - macro: '{$SEAGATE.POOL.USED.CRIT}'
+      value: '95'
+      description: Pool used-space critical threshold in percent.
+    - macro: '{$SEAGATE.TIER.USED.WARN}'
+      value: '85'
+      description: Tier used-space warning threshold in percent.
+    - macro: '{$SEAGATE.TIER.USED.CRIT}'
+      value: '95'
+      description: Tier used-space critical threshold in percent.
+    dashboards:
+    - uuid: 439da5017030424db53e1910db62e9f7
+      name: Overview
+      pages:
+      - name: Overview
+        widgets:
+        - type: item
+          name: API availability
+          width: '12'
+          height: '3'
+          fields:
+          - type: ITEM
+            name: itemid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              key: seagate.exos.api.available
+          - type: STRING
+            name: reference
+            value: AAAAA
+        - type: item
+          name: System health
+          x: '12'
+          width: '12'
+          height: '3'
+          fields:
+          - type: ITEM
+            name: itemid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              key: seagate.exos.system.health
+          - type: STRING
+            name: reference
+            value: AAAAB
+        - type: item
+          name: Product
+          x: '24'
+          width: '12'
+          height: '3'
+          fields:
+          - type: ITEM
+            name: itemid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              key: seagate.exos.system.product_id
+          - type: STRING
+            name: reference
+            value: AAAAC
+        - type: item
+          name: Firmware bundle
+          x: '36'
+          width: '18'
+          height: '3'
+          fields:
+          - type: ITEM
+            name: itemid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              key: seagate.exos.system.bundle_version
+          - type: STRING
+            name: reference
+            value: AAAAD
+        - type: item
+          name: System latency source
+          x: '54'
+          width: '18'
+          height: '3'
+          fields:
+          - type: ITEM
+            name: itemid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              key: seagate.exos.system.latency.source
+          - type: STRING
+            name: reference
+            value: AAAAE
+        - type: graph
+          name: Average system latency
+          'y': '3'
+          width: '36'
+          height: '5'
+          fields:
+          - type: GRAPH
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: System latency
+          - type: STRING
+            name: reference
+            value: AAAAF
+        - type: graph
+          name: Maximum system latency
+          x: '36'
+          'y': '3'
+          width: '36'
+          height: '5'
+          fields:
+          - type: GRAPH
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: System maximum latency (4006 native)
+          - type: STRING
+            name: reference
+            value: AAAAG
+        - type: problems
+          name: Active problems
+          'y': '8'
+          width: '72'
+          height: '6'
+          fields:
+          - type: STRING
+            name: reference
+            value: AAAAH
+          - type: INTEGER
+            name: show
+            value: '3'
+          - type: INTEGER
+            name: show_opdata
+            value: '2'
+          - type: INTEGER
+            name: show_tags
+            value: '1'
+          - type: STRING
+            name: tag_priority
+            value: scope
+      - name: Components
+        widgets:
+        - type: graphprototype
+          name: Controller performance
+          width: '36'
+          height: '5'
+          fields:
+          - type: INTEGER
+            name: columns
+            value: '1'
+          - type: GRAPH_PROTOTYPE
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: 'Controller [{#CONTROLLER.ID}]: Performance'
+          - type: STRING
+            name: reference
+            value: BAAAA
+        - type: graphprototype
+          name: Disk performance
+          x: '36'
+          width: '36'
+          height: '5'
+          fields:
+          - type: INTEGER
+            name: columns
+            value: '1'
+          - type: GRAPH_PROTOTYPE
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: 'Disk [{#LOCATION}]: Performance'
+          - type: STRING
+            name: reference
+            value: BAAAB
+        - type: graphprototype
+          name: Pool performance
+          'y': '5'
+          width: '36'
+          height: '5'
+          fields:
+          - type: INTEGER
+            name: columns
+            value: '1'
+          - type: GRAPH_PROTOTYPE
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: 'Pool [{#NAME}]: Performance'
+          - type: STRING
+            name: reference
+            value: BAAAC
+        - type: graphprototype
+          name: Volume performance
+          x: '36'
+          'y': '5'
+          width: '36'
+          height: '5'
+          fields:
+          - type: INTEGER
+            name: columns
+            value: '1'
+          - type: GRAPH_PROTOTYPE
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: 'Volume [{#NAME}]: Performance'
+          - type: STRING
+            name: reference
+            value: BAAAD
+        - type: graphprototype
+          name: Host port performance
+          'y': '10'
+          width: '36'
+          height: '5'
+          fields:
+          - type: INTEGER
+            name: columns
+            value: '1'
+          - type: GRAPH_PROTOTYPE
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: 'Host port [{#PORT.ID}]: Performance'
+          - type: STRING
+            name: reference
+            value: BAAAE
+        - type: graphprototype
+          name: Disk temperature
+          x: '36'
+          'y': '10'
+          width: '36'
+          height: '5'
+          fields:
+          - type: INTEGER
+            name: columns
+            value: '1'
+          - type: GRAPH_PROTOTYPE
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: 'Disk [{#LOCATION}]: Temperature'
+          - type: STRING
+            name: reference
+            value: BAAAF
+    valuemaps:
+    - uuid: 1791af26432b4aa898933b1fdeebd835
+      name: Yes/No
+      mappings:
+      - value: '0'
+        newvalue: 'No'
+      - value: '1'
+        newvalue: 'Yes'
+    - uuid: 5cdf393903894f38bc1ad3c143445151
+      name: Health
+      mappings:
+      - value: '0'
+        newvalue: OK
+      - value: '1'
+        newvalue: Degraded
+      - value: '2'
+        newvalue: Fault
+      - value: '3'
+        newvalue: Unknown
+      - value: '4'
+        newvalue: N/A
+    - uuid: fb59224b774c4859bc3aefbf04d3e496
+      name: Controller status
+      mappings:
+      - value: '0'
+        newvalue: Operational
+      - value: '1'
+        newvalue: Down
+      - value: '2'
+        newvalue: Not installed
+    - uuid: d56b8fc9633e47d896c1fda795afde7b
+      name: Disk status
+      mappings:
+      - value: '0'
+        newvalue: Up
+      - value: '1'
+        newvalue: Not Up
+    - uuid: d894931d4ff14923a16a79fe197da90b
+      name: Disk group status
+      mappings:
+      - value: '0'
+        newvalue: FTOL
+      - value: '1'
+        newvalue: FTDN
+      - value: '2'
+        newvalue: CRIT
+      - value: '3'
+        newvalue: OFFL
+      - value: '4'
+        newvalue: QTCR
+      - value: '5'
+        newvalue: QTOF
+      - value: '6'
+        newvalue: QTDN
+      - value: '7'
+        newvalue: STOP
+      - value: '8'
+        newvalue: MSNG
+      - value: '9'
+        newvalue: DMGD
+      - value: '10'
+        newvalue: UNKN
+      - value: '11'
+        newvalue: QTDN
+      - value: '250'
+        newvalue: UP
+    - uuid: c0459c167cf24513b27faf939f21d16b
+      name: Disk temperature status
+      mappings:
+      - value: '1'
+        newvalue: OK
+      - value: '2'
+        newvalue: Critical
+      - value: '3'
+        newvalue: Warning
+      - value: '4'
+        newvalue: Unknown
+    - uuid: a6790f9ae29145efad0ea10539db9830
+      name: Enclosure status
+      mappings:
+      - value: '0'
+        newvalue: Unsupported
+      - value: '1'
+        newvalue: OK
+      - value: '2'
+        newvalue: Critical
+      - value: '3'
+        newvalue: Warning
+      - value: '4'
+        newvalue: Unrecoverable
+      - value: '5'
+        newvalue: Not installed
+      - value: '6'
+        newvalue: Unknown
+      - value: '7'
+        newvalue: Unavailable
+    - uuid: 95a29d8a72004136b5dfe6bb30f0d133
+      name: Fan status
+      mappings:
+      - value: '0'
+        newvalue: Up
+      - value: '1'
+        newvalue: Error
+      - value: '2'
+        newvalue: 'Off'
+      - value: '3'
+        newvalue: Missing
+    - uuid: dc6b6cc570854a74a3360b82b4c4ec46
+      name: FRU status
+      mappings:
+      - value: '0'
+        newvalue: Invalid data
+      - value: '1'
+        newvalue: Fault
+      - value: '2'
+        newvalue: Absent
+      - value: '3'
+        newvalue: Power off
+      - value: '4'
+        newvalue: OK
+    - uuid: 04e3788e8edc43d496759bfa022c4828
+      name: Sensor status
+      mappings:
+      - value: '0'
+        newvalue: Unsupported
+      - value: '1'
+        newvalue: OK
+      - value: '2'
+        newvalue: Critical
+      - value: '3'
+        newvalue: Warning
+      - value: '4'
+        newvalue: Unrecoverable
+      - value: '5'
+        newvalue: Not installed
+      - value: '6'
+        newvalue: Unknown
+      - value: '7'
+        newvalue: Unavailable
+    - uuid: ff353228e304444e83be16883c614962
+      name: Status
+      mappings:
+      - value: '0'
+        newvalue: Up
+      - value: '1'
+        newvalue: Warning
+      - value: '2'
+        newvalue: Error
+      - value: '3'
+        newvalue: Not present
+      - value: '4'
+        newvalue: Unknown
+      - value: '6'
+        newvalue: Disconnected
+    - uuid: c23bfe2da2c046c5a6d0b1246f41006e
+      name: SFP status
+      mappings:
+      - value: '0'
+        newvalue: Not compatible
+      - value: '1'
+        newvalue: Incorrect protocol
+      - value: '2'
+        newvalue: Not present
+      - value: '3'
+        newvalue: OK
+    - uuid: 7f4b05d892154e019e00f99dce7d1297
+      name: SFP present
+      mappings:
+      - value: '0'
+        newvalue: Not present
+      - value: '1'
+        newvalue: Present
+    - uuid: 037b45a0d62048c6a25d3fcdf1eaa0af
+      name: SMART state
+      mappings:
+      - value: '0'
+        newvalue: Detect only/Disabled
+      - value: '1'
+        newvalue: Enabled
+      - value: '2'
+        newvalue: Disabled
+    - uuid: 6a95e9e2c65b4ce8b97026b119914649
+      name: Event severity
+      mappings:
+      - value: '0'
+        newvalue: Informational
+      - value: '1'
+        newvalue: Warning
+      - value: '2'
+        newvalue: Error
+      - value: '3'
+        newvalue: Critical
+      - value: '4'
+        newvalue: Resolved
+  graphs:
+  - uuid: 495b817859a54d20b723a62e8fc11085
+    name: System latency
+    graph_items:
+    - color: 199C0D
+      item:
+        host: Seagate Exos Storage by HTTP
+        key: seagate.exos.system.latency.read_avg
+    - sortorder: '1'
+      color: F63100
+      item:
+        host: Seagate Exos Storage by HTTP
+        key: seagate.exos.system.latency.write_avg
+  - uuid: 0053beecc0b042d4901ca530fb61c3eb
+    name: System maximum latency (4006 native)
+    graph_items:
+    - color: 2774A4
+      item:
+        host: Seagate Exos Storage by HTTP
+        key: seagate.exos.system.latency.read_max
+    - sortorder: '1'
+      color: F7941D
+      item:
+        host: Seagate Exos Storage by HTTP
+        key: seagate.exos.system.latency.write_max

--- a/Storage_Devices/Seagate/template_seagate_exos_x_4005_4006/7.0/template_seagate_exos_x_4005_4006.yaml
+++ b/Storage_Devices/Seagate/template_seagate_exos_x_4005_4006/7.0/template_seagate_exos_x_4005_4006.yaml
@@ -14,13 +14,15 @@ zabbix_export:
 
       Configure {$SEAGATE.API.HOST}, {$SEAGATE.API.PORT}, {$SEAGATE.API.USERNAME}, and secret {$SEAGATE.API.PASSWORD}. {$SEAGATE.API.PORT} defaults to 443. Optionally configure {$SEAGATE.API.HOST.SECONDARY}, {$SEAGATE.API.PORT.PRIMARY}, {$SEAGATE.API.PORT.SECONDARY}, and {$SEAGATE.HTTP.PROXY}. Controller-specific port macros inherit {$SEAGATE.API.PORT} when left empty, preserving compatibility with existing hosts. Separate primary and secondary ports support NAT/port-forwarding designs where both controllers are reached through the same public IP or DNS name.
 
+      Version 1.1.2 makes host-port down alerting transition-aware. Ports that are already disconnected when monitoring begins do not create a problem. A problem opens only after a monitored port transitions from Up to a non-Up state and remains open until the port returns to Up.
+
       Structured Alerts are auto-enabled for the tested 4006 identity. The tested 4005/4865 is monitored through component state plus the common Event Log. For guaranteed delivery of every asynchronous event, also configure the array native syslog or SNMP event forwarding.
 
       Author: Guilherme Campos (@guicampos21)
       License: MIT
     vendor:
       name: SentrixIT
-      version: 1.1.1
+      version: 1.1.2
     groups:
     - name: Templates/SAN
     items:
@@ -298,9 +300,8 @@ zabbix_export:
       history: '0'
       value_type: TEXT
       trends: '0'
-      description: Read-only performance statistics. On Exos X 4006, the collector also queries native system read/write average
-        and maximum response-time metrics. On 4005/4865, the Metrics Framework is unsupported and system average latency is
-        derived from I/O-weighted host-port statistics.
+      description: Read-only performance statistics. On Exos X 4006, the collector also queries native system read/write average and maximum response-time
+        metrics. On 4005/4865, the Metrics Framework is unsupported and system average latency is derived from I/O-weighted host-port statistics.
       params: |
         function validate(p) {
             ['scheme','host','username','password'].forEach(function (f) {
@@ -801,8 +802,8 @@ zabbix_export:
       tags:
       - tag: component
         value: inventory
-      description: Management endpoint currently used by the API collector, stored as host:port. An unchanged value is stored
-        at least every 30 minutes for dashboards.
+      description: Management endpoint currently used by the API collector, stored as host:port. An unchanged value is stored at least every 30
+        minutes for dashboards.
     - uuid: a92e6bbf81ac4235936212c08c22927a
       name: API response time
       type: DEPENDENT
@@ -914,8 +915,7 @@ zabbix_export:
       delay: '0'
       history: 7d
       trends: '0'
-      description: 1 when the native Exos Metrics Framework returned valid system latency data; 0 when the host-port weighted
-        fallback is used.
+      description: 1 when the native Exos Metrics Framework returned valid system latency data; 0 when the host-port weighted fallback is used.
       preprocessing:
       - type: JSONPATH
         parameters:
@@ -937,8 +937,8 @@ zabbix_export:
       history: 31d
       value_type: CHAR
       trends: '0'
-      description: Source used for the unified system latency items. Exos X 4006 uses the native Metrics Framework; 4005/4865
-        uses an I/O-weighted aggregate of host-port response times. An unchanged value is stored at least every 30 minutes.
+      description: Source used for the unified system latency items. Exos X 4006 uses the native Metrics Framework; 4005/4865 uses an I/O-weighted
+        aggregate of host-port response times. An unchanged value is stored at least every 30 minutes.
       preprocessing:
       - type: JSONPATH
         parameters:
@@ -962,8 +962,8 @@ zabbix_export:
       value_type: FLOAT
       trends: '0'
       units: '!µs'
-      description: Native system read average response time from the Exos X 4006 Metrics Framework. Internal source for the
-        unified system latency item.
+      description: Native system read average response time from the Exos X 4006 Metrics Framework. Internal source for the unified system latency
+        item.
       preprocessing:
       - type: JSONPATH
         parameters:
@@ -986,8 +986,8 @@ zabbix_export:
       value_type: FLOAT
       trends: '0'
       units: '!µs'
-      description: Native system write average response time from the Exos X 4006 Metrics Framework. Internal source for the
-        unified system latency item.
+      description: Native system write average response time from the Exos X 4006 Metrics Framework. Internal source for the unified system latency
+        item.
       preprocessing:
       - type: JSONPATH
         parameters:
@@ -1008,8 +1008,8 @@ zabbix_export:
       delay: '0'
       value_type: FLOAT
       units: '!µs'
-      description: Native system maximum read response time. Available on Exos X 4006 via the Metrics Framework; no equivalent
-        maximum-latency metric was found for the tested 4005/4865 API.
+      description: Native system maximum read response time. Available on Exos X 4006 via the Metrics Framework; no equivalent maximum-latency
+        metric was found for the tested 4005/4865 API.
       preprocessing:
       - type: JSONPATH
         parameters:
@@ -1027,8 +1027,8 @@ zabbix_export:
       delay: '0'
       value_type: FLOAT
       units: '!µs'
-      description: Native system maximum write response time. Available on Exos X 4006 via the Metrics Framework; no equivalent
-        maximum-latency metric was found for the tested 4005/4865 API.
+      description: Native system maximum write response time. Available on Exos X 4006 via the Metrics Framework; no equivalent maximum-latency
+        metric was found for the tested 4005/4865 API.
       preprocessing:
       - type: JSONPATH
         parameters:
@@ -1047,8 +1047,8 @@ zabbix_export:
       value_type: FLOAT
       units: '!µs'
       params: sum(last_foreach(//seagate.exos.port.read_latency_weighted[*]))/max(sum(last_foreach(//seagate.exos.port.read_iops_derived[*])),1)
-      description: 4005/4865 system read latency fallback. It aggregates host-port average read response times using the derived
-        read I/O rate of each port as weight.
+      description: 4005/4865 system read latency fallback. It aggregates host-port average read response times using the derived read I/O rate
+        of each port as weight.
       tags:
       - tag: component
         value: performance
@@ -1062,8 +1062,8 @@ zabbix_export:
       value_type: FLOAT
       units: '!µs'
       params: sum(last_foreach(//seagate.exos.port.write_latency_weighted[*]))/max(sum(last_foreach(//seagate.exos.port.write_iops_derived[*])),1)
-      description: 4005/4865 system write latency fallback. It aggregates host-port average write response times using the
-        derived write I/O rate of each port as weight.
+      description: 4005/4865 system write latency fallback. It aggregates host-port average write response times using the derived write I/O rate
+        of each port as weight.
       tags:
       - tag: component
         value: performance
@@ -1077,8 +1077,8 @@ zabbix_export:
       value_type: FLOAT
       units: '!µs'
       params: last(//seagate.exos.system.latency.native_supported)*last(//seagate.exos.system.latency.native.read_avg)+(1-last(//seagate.exos.system.latency.native_supported))*last(//seagate.exos.system.latency.fallback.read_avg)
-      description: Unified system read average response time. Uses the native Exos X 4006 system metric when available, otherwise
-        the 4005/4865 host-port weighted fallback.
+      description: Unified system read average response time. Uses the native Exos X 4006 system metric when available, otherwise the 4005/4865
+        host-port weighted fallback.
       tags:
       - tag: component
         value: performance
@@ -1090,8 +1090,8 @@ zabbix_export:
       value_type: FLOAT
       units: '!µs'
       params: last(//seagate.exos.system.latency.native_supported)*last(//seagate.exos.system.latency.native.write_avg)+(1-last(//seagate.exos.system.latency.native_supported))*last(//seagate.exos.system.latency.fallback.write_avg)
-      description: Unified system write average response time. Uses the native Exos X 4006 system metric when available, otherwise
-        the 4005/4865 host-port weighted fallback.
+      description: Unified system write average response time. Uses the native Exos X 4006 system metric when available, otherwise the 4005/4865
+        host-port weighted fallback.
       tags:
       - tag: component
         value: performance
@@ -1774,8 +1774,8 @@ zabbix_export:
         name: 'Seagate Exos Storage: Enclosure count is below expected'
         event_name: 'Seagate Exos Storage: Enclosure count is below expected (current {ITEM.LASTVALUE1}, expected {$SEAGATE.ENCLOSURE.EXPECTED})'
         priority: HIGH
-        description: The storage reports fewer enclosures than expected. Set {$SEAGATE.ENCLOSURE.EXPECTED} to the controller
-          enclosure plus all expansion enclosures that should normally be present. Default is 1.
+        description: The storage reports fewer enclosures than expected. Set {$SEAGATE.ENCLOSURE.EXPECTED} to the controller enclosure plus all
+          expansion enclosures that should normally be present. Default is 1.
         tags:
         - tag: scope
           value: availability
@@ -2064,8 +2064,7 @@ zabbix_export:
         value: inventory
       triggers:
       - uuid: 25395b0aa19d49c2b97b98d5164488b2
-        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.system.bundle_version,#1)<>last(/Seagate Exos Storage
-          by HTTP/seagate.exos.system.bundle_version,#2)
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.system.bundle_version,#1)<>last(/Seagate Exos Storage by HTTP/seagate.exos.system.bundle_version,#2)
         name: 'Seagate Exos Storage: System firmware bundle changed'
         priority: INFO
         description: The storage system firmware bundle version changed.
@@ -2094,8 +2093,8 @@ zabbix_export:
         value: events
       triggers:
       - uuid: 99bd65a502f442a9af41d33cf1126f75
-        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_warning.id,#1)<>last(/Seagate Exos Storage
-          by HTTP/seagate.exos.event.latest_warning.id,#2) and length(last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_warning.message))>0
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_warning.id,#1)<>last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_warning.id,#2)
+          and length(last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_warning.message))>0
         name: 'Seagate Exos Storage: New warning event detected'
         priority: WARNING
         event_name: 'Seagate Exos Storage: New warning event {ITEM.LASTVALUE1}: {ITEM.LASTVALUE2}'
@@ -2143,8 +2142,8 @@ zabbix_export:
         value: events
       triggers:
       - uuid: b98adb3aaf4140a58116ab15bb3b1319
-        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_error.id,#1)<>last(/Seagate Exos Storage
-          by HTTP/seagate.exos.event.latest_error.id,#2) and length(last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_error.message))>0
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_error.id,#1)<>last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_error.id,#2)
+          and length(last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_error.message))>0
         name: 'Seagate Exos Storage: New error event detected'
         priority: HIGH
         event_name: 'Seagate Exos Storage: New error event {ITEM.LASTVALUE1}: {ITEM.LASTVALUE2}'
@@ -2192,8 +2191,8 @@ zabbix_export:
         value: events
       triggers:
       - uuid: 697c09d9c5d5412baeeb9082bbecd3f1
-        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_critical.id,#1)<>last(/Seagate Exos Storage
-          by HTTP/seagate.exos.event.latest_critical.id,#2) and length(last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_critical.message))>0
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_critical.id,#1)<>last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_critical.id,#2)
+          and length(last(/Seagate Exos Storage by HTTP/seagate.exos.event.latest_critical.message))>0
         name: 'Seagate Exos Storage: New critical event detected'
         priority: HIGH
         event_name: 'Seagate Exos Storage: New critical event {ITEM.LASTVALUE1}: {ITEM.LASTVALUE2}'
@@ -2278,8 +2277,7 @@ zabbix_export:
         value: alerts
       triggers:
       - uuid: 6c505c2deffc4488ab56fb918a4350e4
-        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.alerts.active_warning)>0 and length(last(/Seagate Exos
-          Storage by HTTP/seagate.exos.alerts.summary))>=0
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.alerts.active_warning)>0 and length(last(/Seagate Exos Storage by HTTP/seagate.exos.alerts.summary))>=0
         name: 'Seagate Exos Storage: Active warning alert conditions'
         priority: WARNING
         event_name: 'Seagate Exos Storage: {ITEM.LASTVALUE1} active warning alert(s): {ITEM.LASTVALUE2}'
@@ -2304,8 +2302,7 @@ zabbix_export:
         value: alerts
       triggers:
       - uuid: 1555f477104f458eb3a8c0d51a07e107
-        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.alerts.active_error)>0 and length(last(/Seagate Exos Storage
-          by HTTP/seagate.exos.alerts.summary))>=0
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.alerts.active_error)>0 and length(last(/Seagate Exos Storage by HTTP/seagate.exos.alerts.summary))>=0
         name: 'Seagate Exos Storage: Active error alert conditions'
         priority: HIGH
         event_name: 'Seagate Exos Storage: {ITEM.LASTVALUE1} active error alert(s): {ITEM.LASTVALUE2}'
@@ -2330,8 +2327,7 @@ zabbix_export:
         value: alerts
       triggers:
       - uuid: f9e2b88d018742c9bffcf8b54680f9a8
-        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.alerts.active_critical)>0 and length(last(/Seagate Exos
-          Storage by HTTP/seagate.exos.alerts.summary))>=0
+        expression: last(/Seagate Exos Storage by HTTP/seagate.exos.alerts.active_critical)>0 and length(last(/Seagate Exos Storage by HTTP/seagate.exos.alerts.summary))>=0
         name: 'Seagate Exos Storage: Active critical alert conditions'
         priority: HIGH
         event_name: 'Seagate Exos Storage: {ITEM.LASTVALUE1} active critical alert(s): {ITEM.LASTVALUE2}'
@@ -2579,8 +2575,8 @@ zabbix_export:
           value: controller
         trigger_prototypes:
         - uuid: c18eb3215dc248dc8696dbca40ee8f72
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.controller.firmware["{#CONTROLLER.ID}"],#1)<>last(/Seagate
-            Exos Storage by HTTP/seagate.exos.controller.firmware["{#CONTROLLER.ID}"],#2)
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.controller.firmware["{#CONTROLLER.ID}"],#1)<>last(/Seagate Exos Storage
+            by HTTP/seagate.exos.controller.firmware["{#CONTROLLER.ID}"],#2)
           name: 'Seagate Exos Storage: Controller [{#CONTROLLER.ID}] firmware changed'
           priority: INFO
           description: The controller firmware version changed.
@@ -3096,8 +3092,7 @@ zabbix_export:
           value: disk
         trigger_prototypes:
         - uuid: 3e4d32ae53594dd99b230247fb210ec5
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.firmware["{#DURABLE.ID}"],#1)<>last(/Seagate Exos
-            Storage by HTTP/seagate.exos.disk.firmware["{#DURABLE.ID}"],#2)
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.firmware["{#DURABLE.ID}"],#1)<>last(/Seagate Exos Storage by HTTP/seagate.exos.disk.firmware["{#DURABLE.ID}"],#2)
           name: 'Seagate Exos Storage: Disk [{#LOCATION}] firmware changed'
           priority: INFO
           description: The disk firmware revision changed.
@@ -3247,8 +3242,7 @@ zabbix_export:
           value: disk
         trigger_prototypes:
         - uuid: 3a72651b21e9457b81596537aa5ff776
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.job["{#DURABLE.ID}"],#1)<>last(/Seagate Exos Storage
-            by HTTP/seagate.exos.disk.job["{#DURABLE.ID}"],#2)
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.job["{#DURABLE.ID}"],#1)<>last(/Seagate Exos Storage by HTTP/seagate.exos.disk.job["{#DURABLE.ID}"],#2)
           name: 'Seagate Exos Storage: Disk [{#LOCATION}] job state changed'
           priority: INFO
           description: A disk background job started, stopped, or changed.
@@ -3408,8 +3402,8 @@ zabbix_export:
           value: disk
         trigger_prototypes:
         - uuid: 63313472f4894290b40b5604c70d3f55
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.ssd_life["{#DURABLE.ID}"])<{$SEAGATE.SSD.LIFE.WARN}
-            and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.ssd_life["{#DURABLE.ID}"])<>255
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.ssd_life["{#DURABLE.ID}"])<{$SEAGATE.SSD.LIFE.WARN} and last(/Seagate
+            Exos Storage by HTTP/seagate.exos.disk.ssd_life["{#DURABLE.ID}"])<>255
           name: 'Seagate Exos Storage: Disk [{#LOCATION}] SSD life is low'
           priority: WARNING
           description: SSD remaining life is below the configured threshold.
@@ -3525,8 +3519,8 @@ zabbix_export:
           value: disk
         trigger_prototypes:
         - uuid: 0f94148c71934b09a521b643645a137a
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.media_errors["{#DURABLE.ID}"])>last(/Seagate Exos
-            Storage by HTTP/seagate.exos.disk.media_errors["{#DURABLE.ID}"],#2) and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.media_errors["{#DURABLE.ID}"])>0
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.media_errors["{#DURABLE.ID}"])>last(/Seagate Exos Storage by HTTP/seagate.exos.disk.media_errors["{#DURABLE.ID}"],#2)
+            and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.media_errors["{#DURABLE.ID}"])>0
           name: 'Seagate Exos Storage: Disk [{#LOCATION}] media errors increased'
           priority: HIGH
           description: The cumulative media errors counter increased.
@@ -3550,9 +3544,8 @@ zabbix_export:
           value: disk
         trigger_prototypes:
         - uuid: 6dc7abe022994f68b85b7a182bf25c75
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.nonmedia_errors["{#DURABLE.ID}"])>last(/Seagate
-            Exos Storage by HTTP/seagate.exos.disk.nonmedia_errors["{#DURABLE.ID}"],#2) and last(/Seagate Exos Storage by
-            HTTP/seagate.exos.disk.nonmedia_errors["{#DURABLE.ID}"])>0
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.nonmedia_errors["{#DURABLE.ID}"])>last(/Seagate Exos Storage by HTTP/seagate.exos.disk.nonmedia_errors["{#DURABLE.ID}"],#2)
+            and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.nonmedia_errors["{#DURABLE.ID}"])>0
           name: 'Seagate Exos Storage: Disk [{#LOCATION}] non-media errors increased'
           priority: WARNING
           description: The cumulative non-media errors counter increased.
@@ -3576,8 +3569,8 @@ zabbix_export:
           value: disk
         trigger_prototypes:
         - uuid: d6e6ce3fb5614b74b54b723b491259fe
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.timeouts["{#DURABLE.ID}"])>last(/Seagate Exos Storage
-            by HTTP/seagate.exos.disk.timeouts["{#DURABLE.ID}"],#2) and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.timeouts["{#DURABLE.ID}"])>0
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.timeouts["{#DURABLE.ID}"])>last(/Seagate Exos Storage by HTTP/seagate.exos.disk.timeouts["{#DURABLE.ID}"],#2)
+            and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.timeouts["{#DURABLE.ID}"])>0
           name: 'Seagate Exos Storage: Disk [{#LOCATION}] i/o timeouts increased'
           priority: HIGH
           description: The cumulative i/o timeouts counter increased.
@@ -3601,8 +3594,8 @@ zabbix_export:
           value: disk
         trigger_prototypes:
         - uuid: 088aa5aaf5a641ebbc001fdaa554668e
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.no_response["{#DURABLE.ID}"])>last(/Seagate Exos
-            Storage by HTTP/seagate.exos.disk.no_response["{#DURABLE.ID}"],#2) and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.no_response["{#DURABLE.ID}"])>0
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.no_response["{#DURABLE.ID}"])>last(/Seagate Exos Storage by HTTP/seagate.exos.disk.no_response["{#DURABLE.ID}"],#2)
+            and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.no_response["{#DURABLE.ID}"])>0
           name: 'Seagate Exos Storage: Disk [{#LOCATION}] no-response events increased'
           priority: HIGH
           description: The cumulative no-response events counter increased.
@@ -3626,8 +3619,8 @@ zabbix_export:
           value: disk
         trigger_prototypes:
         - uuid: 7f8e8e831f03400a9b54cf85450c35b3
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.bad_blocks["{#DURABLE.ID}"])>last(/Seagate Exos
-            Storage by HTTP/seagate.exos.disk.bad_blocks["{#DURABLE.ID}"],#2) and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.bad_blocks["{#DURABLE.ID}"])>0
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.bad_blocks["{#DURABLE.ID}"])>last(/Seagate Exos Storage by HTTP/seagate.exos.disk.bad_blocks["{#DURABLE.ID}"],#2)
+            and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.bad_blocks["{#DURABLE.ID}"])>0
           name: 'Seagate Exos Storage: Disk [{#LOCATION}] bad blocks increased'
           priority: HIGH
           description: The cumulative bad blocks counter increased.
@@ -3651,8 +3644,8 @@ zabbix_export:
           value: disk
         trigger_prototypes:
         - uuid: 1e6a2dfda6cb48e0bd824b926f3c95c2
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.reassigns["{#DURABLE.ID}"])>last(/Seagate Exos
-            Storage by HTTP/seagate.exos.disk.reassigns["{#DURABLE.ID}"],#2) and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.reassigns["{#DURABLE.ID}"])>0
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.disk.reassigns["{#DURABLE.ID}"])>last(/Seagate Exos Storage by HTTP/seagate.exos.disk.reassigns["{#DURABLE.ID}"],#2)
+            and last(/Seagate Exos Storage by HTTP/seagate.exos.disk.reassigns["{#DURABLE.ID}"])>0
           name: 'Seagate Exos Storage: Disk [{#LOCATION}] block reassignments increased'
           priority: WARNING
           description: The cumulative block reassignments counter increased.
@@ -3808,8 +3801,8 @@ zabbix_export:
           value: disk-group
         trigger_prototypes:
         - uuid: 419a7d448f4b46d4a1a5f2ba98629291
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=1 or last(/Seagate Exos
-            Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=8 or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=9
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=1 or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=8
+            or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=9
           name: 'Seagate Exos Storage: Disk group [{#NAME}] is degraded'
           priority: AVERAGE
           description: Disk group is fault-tolerant but degraded, missing, or damaged.
@@ -3817,10 +3810,9 @@ zabbix_export:
           - tag: scope
             value: availability
         - uuid: 027c2f2724fb43a7a287f7c47ef89d8b
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=2 or last(/Seagate Exos
-            Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=3 or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=4
-            or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=5 or last(/Seagate Exos Storage
-            by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=6 or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=7
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=2 or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=3
+            or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=4 or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=5
+            or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=6 or last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.status["{#NAME}"])=7
           name: 'Seagate Exos Storage: Disk group [{#NAME}] is critical or offline'
           priority: HIGH
           description: Disk group is critical, offline, quarantined, or stopped.
@@ -3949,8 +3941,7 @@ zabbix_export:
           value: disk-group
         trigger_prototypes:
         - uuid: 5cf1ee87671446f3bfb03e054996396c
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.job["{#NAME}"],#1)<>last(/Seagate Exos Storage
-            by HTTP/seagate.exos.diskgroup.job["{#NAME}"],#2)
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.job["{#NAME}"],#1)<>last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.job["{#NAME}"],#2)
           name: 'Seagate Exos Storage: Disk group [{#NAME}] job state changed'
           priority: INFO
           description: A disk-group background job started, stopped, or changed.
@@ -3978,8 +3969,8 @@ zabbix_export:
           value: disk-group
         trigger_prototypes:
         - uuid: 5b474b80ce7a40a0b7fe9304278cd6ef
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.owner_numeric["{#NAME}"])<>last(/Seagate Exos
-            Storage by HTTP/seagate.exos.diskgroup.preferred_owner_numeric["{#NAME}"]) and {$SEAGATE.OWNER.MISMATCH.ENABLED}=1
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.owner_numeric["{#NAME}"])<>last(/Seagate Exos Storage by HTTP/seagate.exos.diskgroup.preferred_owner_numeric["{#NAME}"])
+            and {$SEAGATE.OWNER.MISMATCH.ENABLED}=1
           name: 'Seagate Exos Storage: Disk group [{#NAME}] owner differs from preferred owner'
           priority: WARNING
           description: Current owner differs from preferred owner.
@@ -4872,8 +4863,8 @@ zabbix_export:
           value: volume
         trigger_prototypes:
         - uuid: 1b944a220bd14f11916580a2d145bf99
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.volume.owner_numeric["{#DURABLE.ID}"])<>last(/Seagate
-            Exos Storage by HTTP/seagate.exos.volume.preferred_owner_numeric["{#DURABLE.ID}"]) and {$SEAGATE.OWNER.MISMATCH.ENABLED}=1
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.volume.owner_numeric["{#DURABLE.ID}"])<>last(/Seagate Exos Storage by HTTP/seagate.exos.volume.preferred_owner_numeric["{#DURABLE.ID}"])
+            and {$SEAGATE.OWNER.MISMATCH.ENABLED}=1
           name: 'Seagate Exos Storage: Volume [{#NAME}] owner differs from preferred owner'
           priority: WARNING
           description: Current owner differs from preferred owner.
@@ -4922,8 +4913,7 @@ zabbix_export:
           expression: last(/Seagate Exos Storage by HTTP/seagate.exos.volume.writeback["{#DURABLE.ID}"])=0 and {$SEAGATE.VOLUME.WRITEBACK.REQUIRED:"{#NAME}"}=1
           name: 'Seagate Exos Storage: Volume [{#NAME}] is not using write-back'
           priority: HIGH
-          description: The volume is not using write-back policy. Disable the context macro for intentionally configured write-through
-            volumes.
+          description: The volume is not using write-back policy. Disable the context macro for intentionally configured write-through volumes.
           tags:
           - tag: scope
             value: availability
@@ -4945,8 +4935,7 @@ zabbix_export:
           value: volume
         trigger_prototypes:
         - uuid: 931debd6431740f2b7cf37fa716eaca7
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.volume.progress["{#DURABLE.ID}"])>0 and last(/Seagate
-            Exos Storage by HTTP/seagate.exos.volume.progress["{#DURABLE.ID}"])<100
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.volume.progress["{#DURABLE.ID}"])>0 and last(/Seagate Exos Storage by HTTP/seagate.exos.volume.progress["{#DURABLE.ID}"])<100
           name: 'Seagate Exos Storage: Volume [{#NAME}] operation is active'
           priority: INFO
           description: A volume operation is in progress.
@@ -5234,8 +5223,7 @@ zabbix_export:
         preprocessing:
         - type: JAVASCRIPT
           parameters:
-          - var o=JSON.parse(value),t=Number(o['total-size-numeric']||0),a=Number(o['allocated-size-numeric']||0); return
-            t>0?a*100/t:0;
+          - var o=JSON.parse(value),t=Number(o['total-size-numeric']||0),a=Number(o['allocated-size-numeric']||0); return t>0?a*100/t:0;
         master_item:
           key: seagate.exos.tier.get["{#SERIAL}"]
         tags:
@@ -5960,8 +5948,7 @@ zabbix_export:
           value: fan
         trigger_prototypes:
         - uuid: 0d118feccb16437fba442dba2e1a7638
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.fan.speed["{#DURABLE.ID}"])=0 and last(/Seagate Exos
-            Storage by HTTP/seagate.exos.fan.status["{#DURABLE.ID}"])=0
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.fan.speed["{#DURABLE.ID}"])=0 and last(/Seagate Exos Storage by HTTP/seagate.exos.fan.status["{#DURABLE.ID}"])=0
           name: 'Seagate Exos Storage: Fan [{#NAME}/{#LOCATION}] speed is zero'
           priority: HIGH
           description: The fan is reported Up but speed is zero.
@@ -6228,8 +6215,7 @@ zabbix_export:
           - tag: scope
             value: availability
         - uuid: 1d02430686ad490e8d6c2274f13636a5
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.sensor.status["{#DURABLE.ID}"])=2 or last(/Seagate Exos
-            Storage by HTTP/seagate.exos.sensor.status["{#DURABLE.ID}"])=4
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.sensor.status["{#DURABLE.ID}"])=2 or last(/Seagate Exos Storage by HTTP/seagate.exos.sensor.status["{#DURABLE.ID}"])=4
           name: 'Seagate Exos Storage: Sensor [{#NAME}] reports Critical or Unrecoverable'
           priority: HIGH
           description: The storage sensor reports Critical or Unrecoverable state.
@@ -6383,9 +6369,9 @@ zabbix_export:
           expression: last(/Seagate Exos Storage by HTTP/seagate.exos.saslink.status["{#DURABLE.ID}"])<>0 and {#SAS.PORT.TYPE.NUMERIC}<>5
           name: 'Seagate Exos Storage: SAS link [{#NAME}] status is abnormal'
           priority: HIGH
-          description: SAS link status is abnormal for a non-expansion link. External Expansion Port Universal links are excluded
-            from status-only alerting because an unused or terminal expansion port can legitimately be Disconnected. Expansion-port
-            health and expected enclosure count are monitored separately.
+          description: SAS link status is abnormal for a non-expansion link. External Expansion Port Universal links are excluded from status-only
+            alerting because an unused or terminal expansion port can legitimately be Disconnected. Expansion-port health and expected enclosure
+            count are monitored separately.
           tags:
           - tag: scope
             value: availability
@@ -6511,13 +6497,19 @@ zabbix_export:
           value: port
         trigger_prototypes:
         - uuid: 1bf16789cde3481e818bcd0c1cd65bc3
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.status["{#DURABLE.ID}"])<>0 and {$SEAGATE.PORT.DOWN.ENABLED:"{#PORT.ID}"}=1
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.status["{#DURABLE.ID}"])<>0 and last(/Seagate Exos Storage by HTTP/seagate.exos.port.status["{#DURABLE.ID}"],#2)=0
+            and {$SEAGATE.PORT.DOWN.ENABLED:"{#PORT.ID}"}=1
           name: 'Seagate Exos Storage: Host port [{#PORT.ID}] is down'
           priority: HIGH
-          description: The host port is not Up. Disable the context macro for intentionally unused ports.
+          description: Opens only when the host port transitions from Up to a non-Up state. Ports that are already disconnected when monitoring
+            begins do not create a problem. After a real Up-to-non-Up transition, the problem remains open until the port returns to Up. Use the
+            contextual {$SEAGATE.PORT.DOWN.ENABLED:"{#PORT.ID}"} macro to completely disable host-port/SFP alerting for a specific port.
           tags:
           - tag: scope
             value: availability
+          recovery_mode: RECOVERY_EXPRESSION
+          recovery_expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.status["{#DURABLE.ID}"])=0
+          manual_close: 'YES'
       - uuid: 4920ecc261084d949d71df076c8353dc
         name: 'Host port [{#PORT.ID}]: Port type'
         type: DEPENDENT
@@ -6639,8 +6631,7 @@ zabbix_export:
           value: port
         trigger_prototypes:
         - uuid: 1a7906cd0ab041d78bdf401188c9cb03
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.speed["{#DURABLE.ID}"],#1)<>last(/Seagate Exos
-            Storage by HTTP/seagate.exos.port.speed["{#DURABLE.ID}"],#2)
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.speed["{#DURABLE.ID}"],#1)<>last(/Seagate Exos Storage by HTTP/seagate.exos.port.speed["{#DURABLE.ID}"],#2)
           name: 'Seagate Exos Storage: Host port [{#PORT.ID}] negotiated speed changed'
           priority: WARNING
           description: The negotiated host-port speed changed.
@@ -6670,8 +6661,8 @@ zabbix_export:
           value: port
         trigger_prototypes:
         - uuid: fb71b2a6685b48d58e8902eeafe6b967
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.sfp_present["{#DURABLE.ID}"])=0 and last(/Seagate
-            Exos Storage by HTTP/seagate.exos.port.sfp_present["{#DURABLE.ID}"],#2)=1 and {$SEAGATE.PORT.DOWN.ENABLED:"{#PORT.ID}"}=1
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.sfp_present["{#DURABLE.ID}"])=0 and last(/Seagate Exos Storage by HTTP/seagate.exos.port.sfp_present["{#DURABLE.ID}"],#2)=1
+            and {$SEAGATE.PORT.DOWN.ENABLED:"{#PORT.ID}"}=1
           name: 'Seagate Exos Storage: SFP removed from host port [{#PORT.ID}]'
           priority: HIGH
           description: An SFP that was present was removed from this host port.
@@ -6700,8 +6691,8 @@ zabbix_export:
           value: port
         trigger_prototypes:
         - uuid: 51ec1b542d4e4a829f861629e9fdc448
-          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.sfp_present["{#DURABLE.ID}"])=1 and last(/Seagate
-            Exos Storage by HTTP/seagate.exos.port.sfp_status["{#DURABLE.ID}"])<>3 and {$SEAGATE.PORT.DOWN.ENABLED:"{#PORT.ID}"}=1
+          expression: last(/Seagate Exos Storage by HTTP/seagate.exos.port.sfp_present["{#DURABLE.ID}"])=1 and last(/Seagate Exos Storage by HTTP/seagate.exos.port.sfp_status["{#DURABLE.ID}"])<>3
+            and {$SEAGATE.PORT.DOWN.ENABLED:"{#PORT.ID}"}=1
           name: 'Seagate Exos Storage: SFP status is abnormal on host port [{#PORT.ID}]'
           priority: HIGH
           description: The installed SFP is incompatible or uses the incorrect protocol.
@@ -6762,8 +6753,8 @@ zabbix_export:
         delay: '0'
         value_type: FLOAT
         units: '!iops'
-        description: Read operations per second derived from the cumulative number-of-reads counter. Used to weight host-port
-          read latency for the 4005/4865 system latency fallback.
+        description: Read operations per second derived from the cumulative number-of-reads counter. Used to weight host-port read latency for
+          the 4005/4865 system latency fallback.
         preprocessing:
         - type: JSONPATH
           parameters:
@@ -6786,8 +6777,8 @@ zabbix_export:
         delay: '0'
         value_type: FLOAT
         units: '!iops'
-        description: Write operations per second derived from the cumulative number-of-writes counter. Used to weight host-port
-          write latency for the 4005/4865 system latency fallback.
+        description: Write operations per second derived from the cumulative number-of-writes counter. Used to weight host-port write latency
+          for the 4005/4865 system latency fallback.
         preprocessing:
         - type: JSONPATH
           parameters:
@@ -6812,8 +6803,7 @@ zabbix_export:
         value_type: FLOAT
         trends: '0'
         params: last(//seagate.exos.port.read_latency["{#DURABLE.ID}"])*1000000*last(//seagate.exos.port.read_iops_derived["{#DURABLE.ID}"])
-        description: 'Internal weighted contribution: host-port read average response time in microseconds multiplied by derived
-          read IOPS.'
+        description: 'Internal weighted contribution: host-port read average response time in microseconds multiplied by derived read IOPS.'
         tags:
         - tag: component
           value: calculation
@@ -6828,8 +6818,7 @@ zabbix_export:
         value_type: FLOAT
         trends: '0'
         params: last(//seagate.exos.port.write_latency["{#DURABLE.ID}"])*1000000*last(//seagate.exos.port.write_iops_derived["{#DURABLE.ID}"])
-        description: 'Internal weighted contribution: host-port write average response time in microseconds multiplied by
-          derived write IOPS.'
+        description: 'Internal weighted contribution: host-port write average response time in microseconds multiplied by derived write IOPS.'
         tags:
         - tag: component
           value: calculation
@@ -6937,15 +6926,13 @@ zabbix_export:
       preprocessing:
       - type: JAVASCRIPT
         parameters:
-        - var a=JSON.parse(value); for(var i=0;i<a.length;i++) a[i]['lld-port-id']=String(a[i].controller||'')+String(a[i].port||'');
-          return JSON.stringify(a);
+        - var a=JSON.parse(value); for(var i=0;i<a.length;i++) a[i]['lld-port-id']=String(a[i].controller||'')+String(a[i].port||''); return JSON.stringify(a);
     - uuid: 8953ff9703684b2b95a7e4b66ea00ce9
       name: Replication sets discovery
       type: DEPENDENT
       key: seagate.exos.replications.discovery
       delay: '0'
-      description: Discovers configured replication sets. Runtime field behavior requires validation on an array with active
-        replication.
+      description: Discovers configured replication sets. Runtime field behavior requires validation on an array with active replication.
       item_prototypes:
       - uuid: da7c7aa62780424e8c8c02ca6f1d1ec9
         name: 'Replication set [{#NAME}]: Get data'
@@ -7051,12 +7038,11 @@ zabbix_export:
       description: Primary storage management controller hostname or IP address.
     - macro: '{$SEAGATE.API.HOST.SECONDARY}'
       value: ''
-      description: Optional partner-controller management hostname or IP address. It may be the same value as the primary
-        host when the controllers are exposed through different NAT or port-forwarding ports.
+      description: Optional partner-controller management hostname or IP address. It may be the same value as the primary host when the controllers
+        are exposed through different NAT or port-forwarding ports.
     - macro: '{$SEAGATE.API.PORT}'
       value: '443'
-      description: Default storage management API TCP port. Used by both controllers unless overridden by a controller-specific
-        port macro.
+      description: Default storage management API TCP port. Used by both controllers unless overridden by a controller-specific port macro.
     - macro: '{$SEAGATE.API.PORT.PRIMARY}'
       value: ''
       description: Optional primary-controller API TCP port. When empty, inherits {$SEAGATE.API.PORT}.
@@ -7092,8 +7078,8 @@ zabbix_export:
       description: Event and alert polling interval.
     - macro: '{$SEAGATE.INTERVAL.INVENTORY}'
       value: 30m
-      description: Inventory polling interval. Default 30m so dashboard-facing inventory values such as product ID and firmware
-        bundle always have a recent sample.
+      description: Inventory polling interval. Default 30m so dashboard-facing inventory values such as product ID and firmware bundle always
+        have a recent sample.
     - macro: '{$SEAGATE.EVENTS.LAST}'
       value: '100'
       description: 'Number of recent events requested. Maximum enforced by script: 1000.'
@@ -7108,11 +7094,12 @@ zabbix_export:
       description: Set to 1 to alert when NTP is not activated.
     - macro: '{$SEAGATE.ENCLOSURE.EXPECTED}'
       value: '1'
-      description: Expected total enclosure count, including the controller enclosure. Use 1 for a standalone array, 2 for
-        controller enclosure plus one expansion enclosure, and so on.
+      description: Expected total enclosure count, including the controller enclosure. Use 1 for a standalone array, 2 for controller enclosure
+        plus one expansion enclosure, and so on.
     - macro: '{$SEAGATE.PORT.DOWN.ENABLED}'
       value: '1'
-      description: Enable host-port/SFP alerts. Override by context, for example {$SEAGATE.PORT.DOWN.ENABLED:"A3"}=0.
+      description: Enable transition-aware host-port and SFP alerts. A port-down problem opens only after Up changes to a non-Up state and remains
+        open until the port returns to Up. Override by context, for example {$SEAGATE.PORT.DOWN.ENABLED:"A3"}=0, to completely ignore a port.
     - macro: '{$SEAGATE.VOLUME.WRITEBACK.REQUIRED}'
       value: '1'
       description: Require write-back policy. Override by volume context when write-through is intentional.

--- a/Storage_Devices/Seagate/template_seagate_exos_x_4005_4006/7.0/template_seagate_exos_x_4005_4006.yaml
+++ b/Storage_Devices/Seagate/template_seagate_exos_x_4005_4006/7.0/template_seagate_exos_x_4005_4006.yaml
@@ -12,7 +12,7 @@ zabbix_export:
 
       The template uses Zabbix Script master items, dependent items, low-level discovery, trigger prototypes, graph prototypes, template dashboards, macros, and value maps. Authentication uses SHA-256(username + "_" + password), obtains a sessionKey, and executes only read-only show or query commands.
 
-      Configure {$SEAGATE.API.HOST}, {$SEAGATE.API.PORT}, {$SEAGATE.API.USERNAME}, and secret {$SEAGATE.API.PASSWORD}. {$SEAGATE.API.PORT} defaults to 443. Optionally configure {$SEAGATE.API.HOST.SECONDARY} and {$SEAGATE.HTTP.PROXY}. Review context macros for intentionally unused host ports and intentionally write-through volumes.
+      Configure {$SEAGATE.API.HOST}, {$SEAGATE.API.PORT}, {$SEAGATE.API.USERNAME}, and secret {$SEAGATE.API.PASSWORD}. {$SEAGATE.API.PORT} defaults to 443. Optionally configure {$SEAGATE.API.HOST.SECONDARY}, {$SEAGATE.API.PORT.PRIMARY}, {$SEAGATE.API.PORT.SECONDARY}, and {$SEAGATE.HTTP.PROXY}. Controller-specific port macros inherit {$SEAGATE.API.PORT} when left empty, preserving compatibility with existing hosts. Separate primary and secondary ports support NAT/port-forwarding designs where both controllers are reached through the same public IP or DNS name.
 
       Structured Alerts are auto-enabled for the tested 4006 identity. The tested 4005/4865 is monitored through component state plus the common Event Log. For guaranteed delivery of every asynchronous event, also configure the array native syslog or SNMP event forwarding.
 
@@ -20,7 +20,7 @@ zabbix_export:
       License: MIT
     vendor:
       name: SentrixIT
-      version: 1.1.0
+      version: 1.1.1
     groups:
     - name: Templates/SAN
     items:
@@ -41,18 +41,24 @@ zabbix_export:
             if (p.scheme !== 'https' && p.scheme !== 'http') throw 'Unsupported API scheme: ' + p.scheme;
             if (typeof p.port === 'undefined' || p.port === '') p.port = '443';
             if (!/^\d+$/.test(String(p.port)) || Number(p.port) < 1 || Number(p.port) > 65535)
-                throw 'Invalid API TCP port: ' + p.port;
+                throw 'Invalid default API TCP port: ' + p.port;
+            if (typeof p.port_primary === 'undefined' || p.port_primary === '') p.port_primary = p.port;
+            if (!/^\d+$/.test(String(p.port_primary)) || Number(p.port_primary) < 1 || Number(p.port_primary) > 65535)
+                throw 'Invalid primary API TCP port: ' + p.port_primary;
+            if (typeof p.port_secondary === 'undefined' || p.port_secondary === '') p.port_secondary = p.port;
+            if (!/^\d+$/.test(String(p.port_secondary)) || Number(p.port_secondary) < 1 || Number(p.port_secondary) > 65535)
+                throw 'Invalid secondary API TCP port: ' + p.port_secondary;
         }
-        function baseUrl(p, host) { return p.scheme + '://' + host + ':' + String(p.port) + '/'; }
+        function baseUrl(p, host, port) { return p.scheme + '://' + host + ':' + String(port) + '/'; }
         function finalStatus(o) {
             if (!o || !o.status || !o.status.length) return null;
             return o.status[o.status.length - 1];
         }
-        function loginAt(p, host) {
+        function loginAt(p, host, port) {
             var r = new HttpRequest(), body, o, st, http;
             if (p.http_proxy) r.setProxy(p.http_proxy);
             r.addHeader('datatype: json');
-            body = r.get(baseUrl(p,host) + 'api/login/' + sha256(p.username + '_' + p.password));
+            body = r.get(baseUrl(p,host,port) + 'api/login/' + sha256(p.username + '_' + p.password));
             http = r.getStatus();
             if (http === 401 || http === 403) throw 'AUTH: Login HTTP ' + http + ' at ' + host;
             if (http < 200 || http >= 300) throw 'CONNECT: Login HTTP ' + http + ' at ' + host;
@@ -61,13 +67,13 @@ zabbix_export:
             if (!st || String(st['response-type'] || '').toLowerCase() !== 'success' || !o.status[0].response)
                 throw 'AUTH: Authentication failed at ' + host + ': ' + (st ? st.response : 'missing status');
             r.addHeader('sessionKey: ' + o.status[0].response);
-            return {request:r, host:host, base:baseUrl(p,host)};
+            return {request:r, host:host, port:String(port), base:baseUrl(p,host,port)};
         }
         function connect(p) {
-            try { return loginAt(p,p.host); }
+            try { return loginAt(p,p.host,p.port_primary); }
             catch(e1) {
-                if (p.secondary && p.secondary !== p.host) {
-                    try { return loginAt(p,p.secondary); }
+                if (p.secondary && (p.secondary !== p.host || String(p.port_secondary) !== String(p.port_primary))) {
+                    try { return loginAt(p,p.secondary,p.port_secondary); }
                     catch(e2) { throw String(e1) + '; secondary: ' + String(e2); }
                 }
                 throw e1;
@@ -103,7 +109,7 @@ zabbix_export:
         try {
             validate(p);
             var c = connect(p), body, o, st;
-            out.endpoint = c.host;
+            out.endpoint = c.host + ':' + c.port;
             body = c.request.get(c.base + 'api/show/system');
             out.system_http = c.request.getStatus();
             if (out.system_http < 200 || out.system_http >= 300) throw 'show system HTTP ' + out.system_http;
@@ -131,6 +137,10 @@ zabbix_export:
         value: '{$SEAGATE.API.PASSWORD}'
       - name: port
         value: '{$SEAGATE.API.PORT}'
+      - name: port_primary
+        value: '{$SEAGATE.API.PORT.PRIMARY}'
+      - name: port_secondary
+        value: '{$SEAGATE.API.PORT.SECONDARY}'
       - name: scheme
         value: '{$SEAGATE.API.SCHEME}'
       - name: secondary
@@ -157,18 +167,24 @@ zabbix_export:
             if (p.scheme !== 'https' && p.scheme !== 'http') throw 'Unsupported API scheme: ' + p.scheme;
             if (typeof p.port === 'undefined' || p.port === '') p.port = '443';
             if (!/^\d+$/.test(String(p.port)) || Number(p.port) < 1 || Number(p.port) > 65535)
-                throw 'Invalid API TCP port: ' + p.port;
+                throw 'Invalid default API TCP port: ' + p.port;
+            if (typeof p.port_primary === 'undefined' || p.port_primary === '') p.port_primary = p.port;
+            if (!/^\d+$/.test(String(p.port_primary)) || Number(p.port_primary) < 1 || Number(p.port_primary) > 65535)
+                throw 'Invalid primary API TCP port: ' + p.port_primary;
+            if (typeof p.port_secondary === 'undefined' || p.port_secondary === '') p.port_secondary = p.port;
+            if (!/^\d+$/.test(String(p.port_secondary)) || Number(p.port_secondary) < 1 || Number(p.port_secondary) > 65535)
+                throw 'Invalid secondary API TCP port: ' + p.port_secondary;
         }
-        function baseUrl(p, host) { return p.scheme + '://' + host + ':' + String(p.port) + '/'; }
+        function baseUrl(p, host, port) { return p.scheme + '://' + host + ':' + String(port) + '/'; }
         function finalStatus(o) {
             if (!o || !o.status || !o.status.length) return null;
             return o.status[o.status.length - 1];
         }
-        function loginAt(p, host) {
+        function loginAt(p, host, port) {
             var r = new HttpRequest(), body, o, st, http;
             if (p.http_proxy) r.setProxy(p.http_proxy);
             r.addHeader('datatype: json');
-            body = r.get(baseUrl(p,host) + 'api/login/' + sha256(p.username + '_' + p.password));
+            body = r.get(baseUrl(p,host,port) + 'api/login/' + sha256(p.username + '_' + p.password));
             http = r.getStatus();
             if (http === 401 || http === 403) throw 'AUTH: Login HTTP ' + http + ' at ' + host;
             if (http < 200 || http >= 300) throw 'CONNECT: Login HTTP ' + http + ' at ' + host;
@@ -177,13 +193,13 @@ zabbix_export:
             if (!st || String(st['response-type'] || '').toLowerCase() !== 'success' || !o.status[0].response)
                 throw 'AUTH: Authentication failed at ' + host + ': ' + (st ? st.response : 'missing status');
             r.addHeader('sessionKey: ' + o.status[0].response);
-            return {request:r, host:host, base:baseUrl(p,host)};
+            return {request:r, host:host, port:String(port), base:baseUrl(p,host,port)};
         }
         function connect(p) {
-            try { return loginAt(p,p.host); }
+            try { return loginAt(p,p.host,p.port_primary); }
             catch(e1) {
-                if (p.secondary && p.secondary !== p.host) {
-                    try { return loginAt(p,p.secondary); }
+                if (p.secondary && (p.secondary !== p.host || String(p.port_secondary) !== String(p.port_primary))) {
+                    try { return loginAt(p,p.secondary,p.port_secondary); }
                     catch(e2) { throw String(e1) + '; secondary: ' + String(e2); }
                 }
                 throw e1;
@@ -217,7 +233,7 @@ zabbix_export:
 
         var p = JSON.parse(value), data = {errors:''}, errors = [], o, i, detail, phy = [], bad = 0;
         try {
-            validate(p); var c = connect(p); data.endpoint = c.host;
+            validate(p); var c = connect(p); data.endpoint = c.host + ':' + c.port;
             o=fetchApi(c,'show/system','system',errors,false); data.system=o?first(o.system):{};
             o=fetchApi(c,'show/redundancy-mode','redundancy-mode',errors,false); data.redundancy=o?first(o.redundancy):{};
             o=fetchApi(c,'show/fde-state','fde-state',errors,false); data.fde=o?first(o['fde-state']):{};
@@ -261,6 +277,10 @@ zabbix_export:
         value: '{$SEAGATE.API.PASSWORD}'
       - name: port
         value: '{$SEAGATE.API.PORT}'
+      - name: port_primary
+        value: '{$SEAGATE.API.PORT.PRIMARY}'
+      - name: port_secondary
+        value: '{$SEAGATE.API.PORT.SECONDARY}'
       - name: scheme
         value: '{$SEAGATE.API.SCHEME}'
       - name: secondary
@@ -289,18 +309,24 @@ zabbix_export:
             if (p.scheme !== 'https' && p.scheme !== 'http') throw 'Unsupported API scheme: ' + p.scheme;
             if (typeof p.port === 'undefined' || p.port === '') p.port = '443';
             if (!/^\d+$/.test(String(p.port)) || Number(p.port) < 1 || Number(p.port) > 65535)
-                throw 'Invalid API TCP port: ' + p.port;
+                throw 'Invalid default API TCP port: ' + p.port;
+            if (typeof p.port_primary === 'undefined' || p.port_primary === '') p.port_primary = p.port;
+            if (!/^\d+$/.test(String(p.port_primary)) || Number(p.port_primary) < 1 || Number(p.port_primary) > 65535)
+                throw 'Invalid primary API TCP port: ' + p.port_primary;
+            if (typeof p.port_secondary === 'undefined' || p.port_secondary === '') p.port_secondary = p.port;
+            if (!/^\d+$/.test(String(p.port_secondary)) || Number(p.port_secondary) < 1 || Number(p.port_secondary) > 65535)
+                throw 'Invalid secondary API TCP port: ' + p.port_secondary;
         }
-        function baseUrl(p, host) { return p.scheme + '://' + host + ':' + String(p.port) + '/'; }
+        function baseUrl(p, host, port) { return p.scheme + '://' + host + ':' + String(port) + '/'; }
         function finalStatus(o) {
             if (!o || !o.status || !o.status.length) return null;
             return o.status[o.status.length - 1];
         }
-        function loginAt(p, host) {
+        function loginAt(p, host, port) {
             var r = new HttpRequest(), body, o, st, http;
             if (p.http_proxy) r.setProxy(p.http_proxy);
             r.addHeader('datatype: json');
-            body = r.get(baseUrl(p,host) + 'api/login/' + sha256(p.username + '_' + p.password));
+            body = r.get(baseUrl(p,host,port) + 'api/login/' + sha256(p.username + '_' + p.password));
             http = r.getStatus();
             if (http === 401 || http === 403) throw 'AUTH: Login HTTP ' + http + ' at ' + host;
             if (http < 200 || http >= 300) throw 'CONNECT: Login HTTP ' + http + ' at ' + host;
@@ -309,13 +335,13 @@ zabbix_export:
             if (!st || String(st['response-type'] || '').toLowerCase() !== 'success' || !o.status[0].response)
                 throw 'AUTH: Authentication failed at ' + host + ': ' + (st ? st.response : 'missing status');
             r.addHeader('sessionKey: ' + o.status[0].response);
-            return {request:r, host:host, base:baseUrl(p,host)};
+            return {request:r, host:host, port:String(port), base:baseUrl(p,host,port)};
         }
         function connect(p) {
-            try { return loginAt(p,p.host); }
+            try { return loginAt(p,p.host,p.port_primary); }
             catch(e1) {
-                if (p.secondary && p.secondary !== p.host) {
-                    try { return loginAt(p,p.secondary); }
+                if (p.secondary && (p.secondary !== p.host || String(p.port_secondary) !== String(p.port_primary))) {
+                    try { return loginAt(p,p.secondary,p.port_secondary); }
                     catch(e2) { throw String(e1) + '; secondary: ' + String(e2); }
                 }
                 throw e1;
@@ -386,7 +412,7 @@ zabbix_export:
             write_avg_us: 0
         };
         try {
-            validate(p); var c=connect(p); data.endpoint=c.host;
+            validate(p); var c=connect(p); data.endpoint=c.host+':'+c.port;
             o=fetchApi(c,'show/controller-statistics','controller-statistics',errors,false); a=o?array(o,'controller-statistics'):[]; for(i=0;i<a.length;i++) if(a[i]['durable-id']) a[i]['durable-id']=String(a[i]['durable-id']).toLowerCase(); data['controller-statistics']=a;
             o=fetchApi(c,'show/disk-statistics','disk-statistics',errors,false); data['disk-statistics']=o?array(o,'disk-statistics'):[];
             o=fetchApi(c,'show/disk-group-statistics','disk-group-statistics',errors,false); data['disk-group-statistics']=o?array(o,'disk-group-statistics'):[];
@@ -427,6 +453,10 @@ zabbix_export:
         value: '{$SEAGATE.API.PASSWORD}'
       - name: port
         value: '{$SEAGATE.API.PORT}'
+      - name: port_primary
+        value: '{$SEAGATE.API.PORT.PRIMARY}'
+      - name: port_secondary
+        value: '{$SEAGATE.API.PORT.SECONDARY}'
       - name: scheme
         value: '{$SEAGATE.API.SCHEME}'
       - name: secondary
@@ -453,18 +483,24 @@ zabbix_export:
             if (p.scheme !== 'https' && p.scheme !== 'http') throw 'Unsupported API scheme: ' + p.scheme;
             if (typeof p.port === 'undefined' || p.port === '') p.port = '443';
             if (!/^\d+$/.test(String(p.port)) || Number(p.port) < 1 || Number(p.port) > 65535)
-                throw 'Invalid API TCP port: ' + p.port;
+                throw 'Invalid default API TCP port: ' + p.port;
+            if (typeof p.port_primary === 'undefined' || p.port_primary === '') p.port_primary = p.port;
+            if (!/^\d+$/.test(String(p.port_primary)) || Number(p.port_primary) < 1 || Number(p.port_primary) > 65535)
+                throw 'Invalid primary API TCP port: ' + p.port_primary;
+            if (typeof p.port_secondary === 'undefined' || p.port_secondary === '') p.port_secondary = p.port;
+            if (!/^\d+$/.test(String(p.port_secondary)) || Number(p.port_secondary) < 1 || Number(p.port_secondary) > 65535)
+                throw 'Invalid secondary API TCP port: ' + p.port_secondary;
         }
-        function baseUrl(p, host) { return p.scheme + '://' + host + ':' + String(p.port) + '/'; }
+        function baseUrl(p, host, port) { return p.scheme + '://' + host + ':' + String(port) + '/'; }
         function finalStatus(o) {
             if (!o || !o.status || !o.status.length) return null;
             return o.status[o.status.length - 1];
         }
-        function loginAt(p, host) {
+        function loginAt(p, host, port) {
             var r = new HttpRequest(), body, o, st, http;
             if (p.http_proxy) r.setProxy(p.http_proxy);
             r.addHeader('datatype: json');
-            body = r.get(baseUrl(p,host) + 'api/login/' + sha256(p.username + '_' + p.password));
+            body = r.get(baseUrl(p,host,port) + 'api/login/' + sha256(p.username + '_' + p.password));
             http = r.getStatus();
             if (http === 401 || http === 403) throw 'AUTH: Login HTTP ' + http + ' at ' + host;
             if (http < 200 || http >= 300) throw 'CONNECT: Login HTTP ' + http + ' at ' + host;
@@ -473,13 +509,13 @@ zabbix_export:
             if (!st || String(st['response-type'] || '').toLowerCase() !== 'success' || !o.status[0].response)
                 throw 'AUTH: Authentication failed at ' + host + ': ' + (st ? st.response : 'missing status');
             r.addHeader('sessionKey: ' + o.status[0].response);
-            return {request:r, host:host, base:baseUrl(p,host)};
+            return {request:r, host:host, port:String(port), base:baseUrl(p,host,port)};
         }
         function connect(p) {
-            try { return loginAt(p,p.host); }
+            try { return loginAt(p,p.host,p.port_primary); }
             catch(e1) {
-                if (p.secondary && p.secondary !== p.host) {
-                    try { return loginAt(p,p.secondary); }
+                if (p.secondary && (p.secondary !== p.host || String(p.port_secondary) !== String(p.port_primary))) {
+                    try { return loginAt(p,p.secondary,p.port_secondary); }
                     catch(e2) { throw String(e1) + '; secondary: ' + String(e2); }
                 }
                 throw e1;
@@ -513,7 +549,7 @@ zabbix_export:
 
         var p=JSON.parse(value), data={errors:''}, errors=[], o, sys={}, ah=false, pools=[], tiers=[], pmap={}, i;
         try {
-            validate(p); var c=connect(p); data.endpoint=c.host;
+            validate(p); var c=connect(p); data.endpoint=c.host+':'+c.port;
             o=fetchApi(c,'show/system','system',errors,false); sys=o?first(o.system):{}; data.system=sys;
             o=fetchApi(c,'show/versions','versions',errors,false); data.versions=o?array(o,'versions'):[];
             o=fetchApi(c,'show/pools','pools',errors,false); pools=o?array(o,'pools'):[]; for(i=0;i<pools.length;i++)pmap[String(pools[i].name)]=Number(pools[i].blocksize||512);
@@ -542,6 +578,10 @@ zabbix_export:
         value: '{$SEAGATE.API.PASSWORD}'
       - name: port
         value: '{$SEAGATE.API.PORT}'
+      - name: port_primary
+        value: '{$SEAGATE.API.PORT.PRIMARY}'
+      - name: port_secondary
+        value: '{$SEAGATE.API.PORT.SECONDARY}'
       - name: scheme
         value: '{$SEAGATE.API.SCHEME}'
       - name: secondary
@@ -568,18 +608,24 @@ zabbix_export:
             if (p.scheme !== 'https' && p.scheme !== 'http') throw 'Unsupported API scheme: ' + p.scheme;
             if (typeof p.port === 'undefined' || p.port === '') p.port = '443';
             if (!/^\d+$/.test(String(p.port)) || Number(p.port) < 1 || Number(p.port) > 65535)
-                throw 'Invalid API TCP port: ' + p.port;
+                throw 'Invalid default API TCP port: ' + p.port;
+            if (typeof p.port_primary === 'undefined' || p.port_primary === '') p.port_primary = p.port;
+            if (!/^\d+$/.test(String(p.port_primary)) || Number(p.port_primary) < 1 || Number(p.port_primary) > 65535)
+                throw 'Invalid primary API TCP port: ' + p.port_primary;
+            if (typeof p.port_secondary === 'undefined' || p.port_secondary === '') p.port_secondary = p.port;
+            if (!/^\d+$/.test(String(p.port_secondary)) || Number(p.port_secondary) < 1 || Number(p.port_secondary) > 65535)
+                throw 'Invalid secondary API TCP port: ' + p.port_secondary;
         }
-        function baseUrl(p, host) { return p.scheme + '://' + host + ':' + String(p.port) + '/'; }
+        function baseUrl(p, host, port) { return p.scheme + '://' + host + ':' + String(port) + '/'; }
         function finalStatus(o) {
             if (!o || !o.status || !o.status.length) return null;
             return o.status[o.status.length - 1];
         }
-        function loginAt(p, host) {
+        function loginAt(p, host, port) {
             var r = new HttpRequest(), body, o, st, http;
             if (p.http_proxy) r.setProxy(p.http_proxy);
             r.addHeader('datatype: json');
-            body = r.get(baseUrl(p,host) + 'api/login/' + sha256(p.username + '_' + p.password));
+            body = r.get(baseUrl(p,host,port) + 'api/login/' + sha256(p.username + '_' + p.password));
             http = r.getStatus();
             if (http === 401 || http === 403) throw 'AUTH: Login HTTP ' + http + ' at ' + host;
             if (http < 200 || http >= 300) throw 'CONNECT: Login HTTP ' + http + ' at ' + host;
@@ -588,13 +634,13 @@ zabbix_export:
             if (!st || String(st['response-type'] || '').toLowerCase() !== 'success' || !o.status[0].response)
                 throw 'AUTH: Authentication failed at ' + host + ': ' + (st ? st.response : 'missing status');
             r.addHeader('sessionKey: ' + o.status[0].response);
-            return {request:r, host:host, base:baseUrl(p,host)};
+            return {request:r, host:host, port:String(port), base:baseUrl(p,host,port)};
         }
         function connect(p) {
-            try { return loginAt(p,p.host); }
+            try { return loginAt(p,p.host,p.port_primary); }
             catch(e1) {
-                if (p.secondary && p.secondary !== p.host) {
-                    try { return loginAt(p,p.secondary); }
+                if (p.secondary && (p.secondary !== p.host || String(p.port_secondary) !== String(p.port_primary))) {
+                    try { return loginAt(p,p.secondary,p.port_secondary); }
                     catch(e2) { throw String(e1) + '; secondary: ' + String(e2); }
                 }
                 throw e1;
@@ -629,7 +675,7 @@ zabbix_export:
         var p=JSON.parse(value), data={errors:''}, errors=[], o, ev=[], al=[], sys={}, ah=false, i, e;
         function latestBySeverity(events,sev){ var best={}; for(var j=0;j<events.length;j++){ var x=events[j]; if(Number(x['severity-numeric'])===sev && Number(x['event-id']||0)>Number(best['event-id']||0)) best=x; } return best; }
         try {
-            validate(p); var c=connect(p); data.endpoint=c.host;
+            validate(p); var c=connect(p); data.endpoint=c.host+':'+c.port;
             o=fetchApi(c,'show/system','system',errors,false); sys=o?first(o.system):{};
             var n=parseInt(p.events_last,10); if(!n||n<1)n=100; if(n>1000)n=1000;
             o=fetchApi(c,'show/events/last/'+n+'/detail','events',errors,false); ev=o?array(o,'events'):[]; data.events=ev;
@@ -661,6 +707,10 @@ zabbix_export:
         value: '{$SEAGATE.API.PASSWORD}'
       - name: port
         value: '{$SEAGATE.API.PORT}'
+      - name: port_primary
+        value: '{$SEAGATE.API.PORT.PRIMARY}'
+      - name: port_secondary
+        value: '{$SEAGATE.API.PORT.SECONDARY}'
       - name: scheme
         value: '{$SEAGATE.API.SCHEME}'
       - name: secondary
@@ -751,8 +801,8 @@ zabbix_export:
       tags:
       - tag: component
         value: inventory
-      description: Management endpoint currently used by the API collector. An unchanged value is stored at least every 30
-        minutes for dashboards.
+      description: Management endpoint currently used by the API collector, stored as host:port. An unchanged value is stored
+        at least every 30 minutes for dashboards.
     - uuid: a92e6bbf81ac4235936212c08c22927a
       name: API response time
       type: DEPENDENT
@@ -7001,11 +7051,18 @@ zabbix_export:
       description: Primary storage management controller hostname or IP address.
     - macro: '{$SEAGATE.API.HOST.SECONDARY}'
       value: ''
-      description: Optional partner controller management hostname or IP address.
+      description: Optional partner-controller management hostname or IP address. It may be the same value as the primary
+        host when the controllers are exposed through different NAT or port-forwarding ports.
     - macro: '{$SEAGATE.API.PORT}'
       value: '443'
-      description: Storage management API TCP port used in every API URL. Defaults to HTTPS TCP/443; override this macro at
-        host level when the array management API listens on a different port.
+      description: Default storage management API TCP port. Used by both controllers unless overridden by a controller-specific
+        port macro.
+    - macro: '{$SEAGATE.API.PORT.PRIMARY}'
+      value: ''
+      description: Optional primary-controller API TCP port. When empty, inherits {$SEAGATE.API.PORT}.
+    - macro: '{$SEAGATE.API.PORT.SECONDARY}'
+      value: ''
+      description: Optional secondary-controller API TCP port. When empty, inherits {$SEAGATE.API.PORT}.
     - macro: '{$SEAGATE.API.SCHEME}'
       value: https
       description: 'API scheme: https or http.'
@@ -7017,7 +7074,7 @@ zabbix_export:
       description: Read-only storage API password. Configure at host level.
     - macro: '{$SEAGATE.HTTP.PROXY}'
       value: ''
-      description: 'Optional HTTP proxy used by all Script master items. Format example: http://proxy.example:8080.'
+      description: 'Optional HTTP proxy used by all Script master items. Example: http://proxy.example:8080.'
     - macro: '{$SEAGATE.DATA.TIMEOUT}'
       value: 60s
       description: Timeout for Script master items.
@@ -7098,236 +7155,6 @@ zabbix_export:
     - macro: '{$SEAGATE.TIER.USED.CRIT}'
       value: '95'
       description: Tier used-space critical threshold in percent.
-    dashboards:
-    - uuid: 439da5017030424db53e1910db62e9f7
-      name: Overview
-      pages:
-      - name: Overview
-        widgets:
-        - type: item
-          name: API availability
-          width: '12'
-          height: '3'
-          fields:
-          - type: ITEM
-            name: itemid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              key: seagate.exos.api.available
-          - type: STRING
-            name: reference
-            value: AAAAA
-        - type: item
-          name: System health
-          x: '12'
-          width: '12'
-          height: '3'
-          fields:
-          - type: ITEM
-            name: itemid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              key: seagate.exos.system.health
-          - type: STRING
-            name: reference
-            value: AAAAB
-        - type: item
-          name: Product
-          x: '24'
-          width: '12'
-          height: '3'
-          fields:
-          - type: ITEM
-            name: itemid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              key: seagate.exos.system.product_id
-          - type: STRING
-            name: reference
-            value: AAAAC
-        - type: item
-          name: Firmware bundle
-          x: '36'
-          width: '18'
-          height: '3'
-          fields:
-          - type: ITEM
-            name: itemid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              key: seagate.exos.system.bundle_version
-          - type: STRING
-            name: reference
-            value: AAAAD
-        - type: item
-          name: System latency source
-          x: '54'
-          width: '18'
-          height: '3'
-          fields:
-          - type: ITEM
-            name: itemid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              key: seagate.exos.system.latency.source
-          - type: STRING
-            name: reference
-            value: AAAAE
-        - type: graph
-          name: Average system latency
-          'y': '3'
-          width: '36'
-          height: '5'
-          fields:
-          - type: GRAPH
-            name: graphid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              name: System latency
-          - type: STRING
-            name: reference
-            value: AAAAF
-        - type: graph
-          name: Maximum system latency
-          x: '36'
-          'y': '3'
-          width: '36'
-          height: '5'
-          fields:
-          - type: GRAPH
-            name: graphid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              name: System maximum latency (4006 native)
-          - type: STRING
-            name: reference
-            value: AAAAG
-        - type: problems
-          name: Active problems
-          'y': '8'
-          width: '72'
-          height: '6'
-          fields:
-          - type: STRING
-            name: reference
-            value: AAAAH
-          - type: INTEGER
-            name: show
-            value: '3'
-          - type: INTEGER
-            name: show_opdata
-            value: '2'
-          - type: INTEGER
-            name: show_tags
-            value: '1'
-          - type: STRING
-            name: tag_priority
-            value: scope
-      - name: Components
-        widgets:
-        - type: graphprototype
-          name: Controller performance
-          width: '36'
-          height: '5'
-          fields:
-          - type: INTEGER
-            name: columns
-            value: '1'
-          - type: GRAPH_PROTOTYPE
-            name: graphid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              name: 'Controller [{#CONTROLLER.ID}]: Performance'
-          - type: STRING
-            name: reference
-            value: BAAAA
-        - type: graphprototype
-          name: Disk performance
-          x: '36'
-          width: '36'
-          height: '5'
-          fields:
-          - type: INTEGER
-            name: columns
-            value: '1'
-          - type: GRAPH_PROTOTYPE
-            name: graphid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              name: 'Disk [{#LOCATION}]: Performance'
-          - type: STRING
-            name: reference
-            value: BAAAB
-        - type: graphprototype
-          name: Pool performance
-          'y': '5'
-          width: '36'
-          height: '5'
-          fields:
-          - type: INTEGER
-            name: columns
-            value: '1'
-          - type: GRAPH_PROTOTYPE
-            name: graphid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              name: 'Pool [{#NAME}]: Performance'
-          - type: STRING
-            name: reference
-            value: BAAAC
-        - type: graphprototype
-          name: Volume performance
-          x: '36'
-          'y': '5'
-          width: '36'
-          height: '5'
-          fields:
-          - type: INTEGER
-            name: columns
-            value: '1'
-          - type: GRAPH_PROTOTYPE
-            name: graphid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              name: 'Volume [{#NAME}]: Performance'
-          - type: STRING
-            name: reference
-            value: BAAAD
-        - type: graphprototype
-          name: Host port performance
-          'y': '10'
-          width: '36'
-          height: '5'
-          fields:
-          - type: INTEGER
-            name: columns
-            value: '1'
-          - type: GRAPH_PROTOTYPE
-            name: graphid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              name: 'Host port [{#PORT.ID}]: Performance'
-          - type: STRING
-            name: reference
-            value: BAAAE
-        - type: graphprototype
-          name: Disk temperature
-          x: '36'
-          'y': '10'
-          width: '36'
-          height: '5'
-          fields:
-          - type: INTEGER
-            name: columns
-            value: '1'
-          - type: GRAPH_PROTOTYPE
-            name: graphid.0
-            value:
-              host: Seagate Exos Storage by HTTP
-              name: 'Disk [{#LOCATION}]: Temperature'
-          - type: STRING
-            name: reference
-            value: BAAAF
     valuemaps:
     - uuid: 1791af26432b4aa898933b1fdeebd835
       name: Yes/No
@@ -7522,6 +7349,236 @@ zabbix_export:
         newvalue: Critical
       - value: '4'
         newvalue: Resolved
+    dashboards:
+    - uuid: 439da5017030424db53e1910db62e9f7
+      name: Overview
+      pages:
+      - name: Overview
+        widgets:
+        - type: item
+          name: API availability
+          width: '12'
+          height: '3'
+          fields:
+          - type: ITEM
+            name: itemid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              key: seagate.exos.api.available
+          - type: STRING
+            name: reference
+            value: AAAAA
+        - type: item
+          name: System health
+          x: '12'
+          width: '12'
+          height: '3'
+          fields:
+          - type: ITEM
+            name: itemid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              key: seagate.exos.system.health
+          - type: STRING
+            name: reference
+            value: AAAAB
+        - type: item
+          name: Product
+          x: '24'
+          width: '12'
+          height: '3'
+          fields:
+          - type: ITEM
+            name: itemid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              key: seagate.exos.system.product_id
+          - type: STRING
+            name: reference
+            value: AAAAC
+        - type: item
+          name: Firmware bundle
+          x: '36'
+          width: '18'
+          height: '3'
+          fields:
+          - type: ITEM
+            name: itemid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              key: seagate.exos.system.bundle_version
+          - type: STRING
+            name: reference
+            value: AAAAD
+        - type: item
+          name: System latency source
+          x: '54'
+          width: '18'
+          height: '3'
+          fields:
+          - type: ITEM
+            name: itemid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              key: seagate.exos.system.latency.source
+          - type: STRING
+            name: reference
+            value: AAAAE
+        - type: graph
+          name: Average system latency
+          y: '3'
+          width: '36'
+          height: '5'
+          fields:
+          - type: GRAPH
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: System latency
+          - type: STRING
+            name: reference
+            value: AAAAF
+        - type: graph
+          name: Maximum system latency
+          x: '36'
+          y: '3'
+          width: '36'
+          height: '5'
+          fields:
+          - type: GRAPH
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: System maximum latency (4006 native)
+          - type: STRING
+            name: reference
+            value: AAAAG
+        - type: problems
+          name: Active problems
+          y: '8'
+          width: '72'
+          height: '6'
+          fields:
+          - type: STRING
+            name: reference
+            value: AAAAH
+          - type: INTEGER
+            name: show
+            value: '3'
+          - type: INTEGER
+            name: show_opdata
+            value: '2'
+          - type: INTEGER
+            name: show_tags
+            value: '1'
+          - type: STRING
+            name: tag_priority
+            value: scope
+      - name: Components
+        widgets:
+        - type: graphprototype
+          name: Controller performance
+          width: '36'
+          height: '5'
+          fields:
+          - type: INTEGER
+            name: columns
+            value: '1'
+          - type: GRAPH_PROTOTYPE
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: 'Controller [{#CONTROLLER.ID}]: Performance'
+          - type: STRING
+            name: reference
+            value: BAAAA
+        - type: graphprototype
+          name: Disk performance
+          x: '36'
+          width: '36'
+          height: '5'
+          fields:
+          - type: INTEGER
+            name: columns
+            value: '1'
+          - type: GRAPH_PROTOTYPE
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: 'Disk [{#LOCATION}]: Performance'
+          - type: STRING
+            name: reference
+            value: BAAAB
+        - type: graphprototype
+          name: Pool performance
+          y: '5'
+          width: '36'
+          height: '5'
+          fields:
+          - type: INTEGER
+            name: columns
+            value: '1'
+          - type: GRAPH_PROTOTYPE
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: 'Pool [{#NAME}]: Performance'
+          - type: STRING
+            name: reference
+            value: BAAAC
+        - type: graphprototype
+          name: Volume performance
+          x: '36'
+          y: '5'
+          width: '36'
+          height: '5'
+          fields:
+          - type: INTEGER
+            name: columns
+            value: '1'
+          - type: GRAPH_PROTOTYPE
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: 'Volume [{#NAME}]: Performance'
+          - type: STRING
+            name: reference
+            value: BAAAD
+        - type: graphprototype
+          name: Host port performance
+          y: '10'
+          width: '36'
+          height: '5'
+          fields:
+          - type: INTEGER
+            name: columns
+            value: '1'
+          - type: GRAPH_PROTOTYPE
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: 'Host port [{#PORT.ID}]: Performance'
+          - type: STRING
+            name: reference
+            value: BAAAE
+        - type: graphprototype
+          name: Disk temperature
+          x: '36'
+          y: '10'
+          width: '36'
+          height: '5'
+          fields:
+          - type: INTEGER
+            name: columns
+            value: '1'
+          - type: GRAPH_PROTOTYPE
+            name: graphid.0
+            value:
+              host: Seagate Exos Storage by HTTP
+              name: 'Disk [{#LOCATION}]: Temperature'
+          - type: STRING
+            name: reference
+            value: BAAAF
   graphs:
   - uuid: 495b817859a54d20b723a62e8fc11085
     name: System latency


### PR DESCRIPTION
## Summary

Updates the Seagate Exos X 4005/4006 Zabbix 7.0+ template from version 1.1.1
to version 1.1.2.

This patch corrects host-port availability alerting for arrays with
intentionally unused FC or iSCSI ports.

## Version 1.1.2

The previous trigger opened a problem whenever a discovered host port was not
`Up`. As a result, ports that had never been connected could produce false
alarms.

The updated trigger now opens only after this transition:

```text
Up -> non-Up
```

Ports that are already `Disconnected` when monitoring begins no longer create
a problem.

A dedicated recovery expression keeps a real port-down problem open until the
port returns to `Up`, even if it remains down for multiple polling cycles or
for several days.

## Compatibility

- Preserves the existing host-port trigger UUID
- Preserves all existing template object UUIDs
- Preserves the contextual `{$SEAGATE.PORT.DOWN.ENABLED:"{#PORT.ID}"}` override
- Preserves controller-specific API ports and same-host/different-port NAT
  failover added in version 1.1.1
- Preserves the storage tags and current severity policy
- Does not add external scripts, agents, or write operations

## Upgrade note

Legacy unused-port problems opened by version 1.1.1 may need to be manually
closed once after importing version 1.1.2. The updated trigger permits manual
close. Those problems will not reopen unless the port later reaches `Up` and
then transitions to a non-Up state.

## Validation

- YAML parse passed
- Zabbix export version 7.0 preserved
- 427 unique UUIDv4 object identifiers preserved
- 78 fixed items, 14 discovery rules, and 192 item prototypes preserved
- 24 fixed triggers and 80 trigger prototypes preserved
- 2 fixed graphs and 19 graph prototypes preserved
- Current severity policy preserved
- Host-port transition and recovery expressions validated
- All five Script master items passed JavaScript syntax validation
- Heartbeat policy preserved
- Static transition/recovery scenarios passed

## Files

The upstream contribution still contains only:

- `README.md`
- `template_seagate_exos_x_4005_4006.yaml`

## Author and license

Author: Guilherme Campos (`@guicampos21`)

License: MIT
