### PR TITLE
Update MikroTik CCR v7 REST template: prefix-count-change triggers, VRRP recovery

### DIFF
--- a/Network_Devices/Mikrotik/template_mikrotik_ccr_v7_rest/7.0/README.md
+++ b/Network_Devices/Mikrotik/template_mikrotik_ccr_v7_rest/7.0/README.md
@@ -77,4 +77,6 @@ Standalone, pure-REST Zabbix template for MikroTik CCR routers. Does not require
 
 ## License
 
-MIT License. Maintained by [@paskotis](https://github.com/paskotis) in this repository; this directory is the canonical source for the template.
+MIT License. Maintained by [@paskotis](https://github.com/paskotis).
+
+Development happens at [paskotis/mikrotik-ccr-v7-rest-zabbix-template](https://github.com/paskotis/mikrotik-ccr-v7-rest-zabbix-template), which carries the changelog and release tags. **Please file issues and feature requests there** rather than against this repository. Releases are published here by pull request, so this copy may lag slightly.

--- a/Network_Devices/Mikrotik/template_mikrotik_ccr_v7_rest/7.0/README.md
+++ b/Network_Devices/Mikrotik/template_mikrotik_ccr_v7_rest/7.0/README.md
@@ -8,14 +8,14 @@ Standalone, pure-REST Zabbix template for MikroTik CCR routers. Does not require
 - **Hardware health:** temperatures (CPU/SFP/switch/board), fans, PSUs (LLD + state items).
 - **Interfaces:** LLD for interfaces with counters (rx/tx bytes/packets), errors, drops; counters converted to bps/pps.
 - **Ethernet / SFP DOM:** per-port SFP optical telemetry (TX/RX power, temperature, voltage, bias), module presence and vendor info.
-- **BGP:** per-peer discovery (state, sent/received prefix counts, byte counters, uptime).
+- **BGP:** per-peer discovery (state, sent/received prefix counts, byte counters, uptime), including detection of partial prefix withdraws that never reach a count of zero.
 - **VRRP:** per-VRRP discovery and state monitoring (master/backup/init/fault/disabled/invalid), with expected-role macros to avoid false alarms.
 - **Connection tracking:** totals, IPv4/IPv6 breakdowns and utilisation %.
 - **ICMP checks:** reachability and latency from the Zabbix server.
 
 ## Requirements
 
-- RouterOS 7.x (validated against 7.21.4 long-term on CCR2004-1G-12S+2XS)
+- RouterOS 7.x (validated on CCR2004-1G-12S+2XS and CCR2116, from 7.21.4 long-term through 7.23)
 - Zabbix 7.0+
 - RouterOS `www` service enabled (`/rest/*` endpoint)
 - A RouterOS user with `read,api,rest-api` policy (no write privileges required)
@@ -38,6 +38,7 @@ Standalone, pure-REST Zabbix template for MikroTik CCR routers. Does not require
 - The template defaults to plain HTTP (`http` / port `80`) to avoid certificate management. Lock the `www` service to your Zabbix collector IP using the RouterOS service `address` ACL. Override `{$ROUTEROS.REST.SCHEME}` and `{$ROUTEROS.REST.PORT}` per host if you prefer HTTPS.
 - RouterOS logs each successful REST login to the system log by default. To reduce log noise: `/system logging set 0 topics=info,!account`
 - If triggers show unknown macro errors after import, re-import and ensure **Template macros** is checked.
+- **Prefix-count-changed triggers — set `{$ROUTEROS.BGP.CHANGE.MATCHES}` before you rely on them.** Two BGP triggers (`prefix count (received) changed` and `prefix count (sent) changed`) fire on *any* movement in the prefix count, in either direction, and are sticky: they stay open until closed manually. Their purpose is to catch *partial* withdraws — a drop from N to N-1 never reaches zero, so the `0 prefixes` triggers cannot see it. They are only meaningful on sessions where the prefix count is expected to be **stable**, such as iBGP / route-reflector sessions or peers carrying a small fixed prefix set. On a full-table eBGP peer, or any peer where you add and withdraw prefixes deliberately, the count moves constantly and a problem will be raised almost immediately. The macro defaults to `.*` (all discovered sessions); narrow it to the sessions you want (e.g. `^ibgp-`), or set it to `^$` to disable both triggers. Scoping is applied via an LLD override, so non-matching sessions never discover the triggers at all.
 
 ## Macros reference
 
@@ -51,6 +52,14 @@ Standalone, pure-REST Zabbix template for MikroTik CCR routers. Does not require
 | `{$ROUTEROS.POLL.FAST}` | `10s` | Poll cadence for interfaces and BGP counters |
 | `{$ROUTEROS.POLL.NORMAL}` | `1m` | Poll cadence for system resources and VRRP |
 | `{$ROUTEROS.POLL.SLOW}` | `5m` | Poll cadence for health sensors and SFP DOM |
+| `{$ROUTEROS.IFACE.NAME.MATCHES}` | `.*` | Interface names to include in interface LLD |
+| `{$ROUTEROS.IFACE.NAME.NOT_MATCHES}` | `^$` | Interface names to exclude (defaults to never matching) |
+| `{$ROUTEROS.IFACE.TYPE.MATCHES}` | `^(ether\|vlan\|bond\|vrrp\|bridge)$` | Interface types to include |
+| `{$ROUTEROS.ETH.NAME.MATCHES}` | `.*` | Ethernet port names to include in SFP DOM LLD |
+| `{$ROUTEROS.BGP.SESSION.MATCHES}` | `.*` | BGP session names to include in BGP LLD |
+| `{$ROUTEROS.BGP.CHANGE.MATCHES}` | `.*` | BGP sessions that receive the prefix-count-changed triggers — **tune this**, see Important notes |
+| `{$ROUTEROS.VRRP.NAME.MATCHES}` | `.*` | VRRP names to include in VRRP LLD |
+| `{$ROUTEROS.HEALTH.NAME.MATCHES}` | `.*` | Health sensor names to include in numeric LLD |
 | `{$ROUTEROS.CPU.LOAD.HIGH}` | `85` | CPU load alert threshold (%) |
 | `{$ROUTEROS.MEM.UTIL.HIGH}` | `85` | Memory utilisation alert threshold (%) |
 | `{$ROUTEROS.DISK.UTIL.HIGH}` | `85` | Disk utilisation alert threshold (%) |
@@ -68,4 +77,4 @@ Standalone, pure-REST Zabbix template for MikroTik CCR routers. Does not require
 
 ## License
 
-MIT License. Source repository: [github.com/paskotis/mikrotik-ccr-v7-rest-zabbix-template](https://github.com/paskotis/mikrotik-ccr-v7-rest-zabbix-template)
+MIT License. Maintained by [@paskotis](https://github.com/paskotis) in this repository; this directory is the canonical source for the template.

--- a/Network_Devices/Mikrotik/template_mikrotik_ccr_v7_rest/7.0/template_mikrotik_ccr_v7_rest.yaml
+++ b/Network_Devices/Mikrotik/template_mikrotik_ccr_v7_rest/7.0/template_mikrotik_ccr_v7_rest.yaml
@@ -24,7 +24,8 @@ zabbix_export:
             — disabled is treated as "maintenance", NOT as an alert state
           - Connection tracking: total, IPv4, IPv6, max, utilisation %
 
-        Validated 2026-05-21 against CCR2004-1G-12S+2XS, RouterOS 7.21.4 (long-term).
+        Validated against CCR2004-1G-12S+2XS and CCR2116, RouterOS 7.21.4 (long-term)
+        through 7.23.
 
         Requires per-host:
           - {$ROUTEROS.REST.USER} and {$ROUTEROS.REST.PASSWORD} (SECRET_TEXT)
@@ -79,6 +80,21 @@ zabbix_export:
         - macro: '{$ROUTEROS.BGP.SESSION.MATCHES}'
           value: '.*'
           description: 'Regex of BGP session names to include.'
+        - macro: '{$ROUTEROS.BGP.CHANGE.MATCHES}'
+          value: '.*'
+          description: |
+            Regex of BGP session names that get the two "prefix count changed" triggers
+            (received and sent). Defaults to all discovered sessions.
+            TUNE THIS. Those triggers fire on ANY movement in the prefix count, in either
+            direction, and they are sticky (manual close). On a session whose count moves
+            routinely — a full-table eBGP peer, or any peer where you add and withdraw
+            prefixes deliberately — a problem will be raised almost immediately and stay
+            open until you close it. They are most useful on sessions where the prefix
+            count is expected to be STABLE, so that any movement is by definition
+            unexpected: iBGP / route-reflector sessions, or peers carrying a small fixed
+            prefix set.
+            Narrow to those sessions (e.g. '^ibgp-'), or set to '^$' to disable both
+            triggers entirely.
         - macro: '{$ROUTEROS.VRRP.NAME.MATCHES}'
           value: '.*'
           description: 'Regex of VRRP names to include.'
@@ -1826,11 +1842,16 @@ zabbix_export:
             - uuid: 9248df5c9e344421ace2eb6e1516e124
               expression: 'last(/MikroTik CCR v7 REST/routeros.bgp.prefix_count[{#BGP_NAME}])=0 and last(/MikroTik CCR v7 REST/routeros.bgp.established[{#BGP_NAME}])=1 and (change(/MikroTik CCR v7 REST/routeros.bgp.prefix_count[{#BGP_NAME}])<>0 or change(/MikroTik CCR v7 REST/routeros.bgp.established[{#BGP_NAME}])>0)'
               name: 'BGP {#BGP_NAME}: established with 0 prefixes received'
-              priority: WARNING
+              priority: HIGH
               recovery_mode: NONE
               manual_close: 'YES'
               description: |
                 Session is up but receives no routes — filter chain issue or peer advertises nothing.
+                Rated HIGH (matching "0 prefixes sent") because this is a silently-degraded
+                state rather than a visible outage: on an upstream session no routes are being
+                learned from that peer, and traffic may still flow via a static default route,
+                masking the fault; on an iBGP or route-reflector session it means the mesh has
+                gone empty. Neither shows up as a down interface or a down session.
                 EDGE-TRIGGERED: fires only on the transition into the bad state (received-prefix
                 count moves to 0, or the session (re)establishes already at 0). While it sits flat
                 at 0 the expression is false, so recovery_mode NONE + manual_close means a manual
@@ -1887,6 +1908,66 @@ zabbix_export:
                 - tag: peer
                   value: '{#BGP_NAME}'
 
+            - uuid: dd78256dff9644939fa78475c1a6b5d5
+              expression: 'change(/MikroTik CCR v7 REST/routeros.bgp.prefix_count[{#BGP_NAME}])<>0 and last(/MikroTik CCR v7 REST/routeros.bgp.established[{#BGP_NAME}])=1'
+              name: 'BGP {#BGP_NAME}: prefix count (received) changed'
+              priority: HIGH
+              recovery_mode: NONE
+              manual_close: 'YES'
+              description: |
+                Received-prefix count moved (ANY change, in either direction) while the
+                session is established. Catches PARTIAL withdraws that the "0 prefixes
+                received" trigger cannot see — one prefix disappearing out of several,
+                because it went inactive at the advertising end or an outbound filter entry
+                was removed there. A drop from N to N-1 never reaches 0, so only this
+                trigger sees it.
+                EDGE-TRIGGERED and sticky (recovery_mode NONE, manual close): a problem is
+                raised on the first change and stays open as the record of it; close it once
+                you have reconciled the new count against what you expect, which re-arms it.
+                Suppressed while the session is down (dependency), but note it will fire once
+                on session re-establishment as the count returns.
+                SCOPED by {$ROUTEROS.BGP.CHANGE.MATCHES} via an LLD override — read that
+                macro's description before relying on this trigger, as the default (all
+                sessions) is noisy on peers whose prefix count moves routinely.
+              dependencies:
+                - name: 'BGP {#BGP_NAME} (AS{#BGP_REMOTE_AS}): session not established'
+                  expression: 'last(/MikroTik CCR v7 REST/routeros.bgp.established[{#BGP_NAME}])=0'
+              tags:
+                - tag: component
+                  value: bgp
+                - tag: peer
+                  value: '{#BGP_NAME}'
+
+            - uuid: 64dbac6622004ccfb4a0ded83cf247f5
+              expression: 'change(/MikroTik CCR v7 REST/routeros.bgp.sent_count[{#BGP_NAME}])<>0 and last(/MikroTik CCR v7 REST/routeros.bgp.established[{#BGP_NAME}])=1'
+              name: 'BGP {#BGP_NAME}: prefix count (sent) changed'
+              priority: HIGH
+              recovery_mode: NONE
+              manual_close: 'YES'
+              description: |
+                Sent-prefix count moved (ANY change, in either direction) while the session
+                is established. Catches PARTIAL withdraws that the "0 prefixes sent" trigger
+                cannot see: going from N to N-1 when a single origination goes inactive fires
+                HERE, never at 0.
+                EDGE-TRIGGERED and sticky (recovery_mode NONE, manual close): a problem is
+                raised on the first change and stays open as the record of it; close it once
+                you have reconciled the new count against what you expect, which re-arms it.
+                Suppressed while the session is down (dependency), but note it will fire once
+                on session re-establishment as the count returns.
+                SCOPED by {$ROUTEROS.BGP.CHANGE.MATCHES} via an LLD override — read that
+                macro's description before relying on this trigger.
+                LIMITATION: it cannot see a prefix that was never advertised in the first
+                place, because nothing changed. Confirming that intended originations are
+                actually present is a provisioning-time check, not something this covers.
+              dependencies:
+                - name: 'BGP {#BGP_NAME} (AS{#BGP_REMOTE_AS}): session not established'
+                  expression: 'last(/MikroTik CCR v7 REST/routeros.bgp.established[{#BGP_NAME}])=0'
+              tags:
+                - tag: component
+                  value: bgp
+                - tag: peer
+                  value: '{#BGP_NAME}'
+
           graph_prototypes:
             - uuid: 1439c41243914fd8ac5da39e8b766dd9
               name: 'BGP {#BGP_NAME}: prefixes (sent/received)'
@@ -1918,6 +1999,20 @@ zabbix_export:
                   item:
                     host: 'MikroTik CCR v7 REST'
                     key: 'routeros.bgp.remote_bytes[{#BGP_NAME}]'
+          overrides:
+            - name: 'Prefix-count-change triggers: only for sessions matching {$ROUTEROS.BGP.CHANGE.MATCHES}'
+              step: '1'
+              filter:
+                conditions:
+                  - macro: '{#BGP_NAME}'
+                    value: '{$ROUTEROS.BGP.CHANGE.MATCHES}'
+                    operator: NOT_MATCHES_REGEX
+                    formulaid: A
+              operations:
+                - operationobject: TRIGGER_PROTOTYPE
+                  operator: REGEXP
+                  value: 'changed$'
+                  discover: NO_DISCOVER
 
         # ---------------- VRRP LLD (REST) ----------------
         - uuid: 9e0d238e194e45e7abb33558f47a3605
@@ -2068,7 +2163,8 @@ zabbix_export:
               expression: '(last(/MikroTik CCR v7 REST/routeros.vrrp.state[{#VRRP_NAME}])=0 or last(/MikroTik CCR v7 REST/routeros.vrrp.state[{#VRRP_NAME}])=1) and last(/MikroTik CCR v7 REST/routeros.vrrp.state[{#VRRP_NAME}])<>{$ROUTEROS.VRRP.EXPECTED_STATE}'
               name: 'VRRP {#VRRP_NAME}: not in expected role'
               priority: DISASTER
-              recovery_mode: NONE
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'last(/MikroTik CCR v7 REST/routeros.vrrp.state[{#VRRP_NAME}])={$ROUTEROS.VRRP.EXPECTED_STATE}'
               manual_close: 'YES'
               description: |
                 Current state is master or backup but does not match the host-level
@@ -2079,6 +2175,12 @@ zabbix_export:
                     if vrrp-uplink should specifically be backup on this host.
                 init/fault, invalid, disabled (maintenance) states are handled by other
                 triggers and do not fire this one.
+                Recovery: auto-resolves only when the state returns to the role the macro
+                expects — deliberately NOT when the VRRP merely leaves master/backup for
+                init/fault/invalid, which is a different problem owned by another trigger.
+                This rides through a transient fault during failback instead of flapping
+                closed and reopening. manual_close remains available for the case where the
+                box is intentionally left in maintenance with the problem still open.
               tags:
                 - tag: component
                   value: vrrp


### PR DESCRIPTION
Updates the MikroTik CCR v7 REST template (Zabbix 7.0) with changes proven on a production CCR fleet since the template was first merged.

## Template changes

**New: partial prefix-withdraw detection.** Two trigger prototypes, `prefix count (received) changed` and `prefix count (sent) changed`, fire on any movement in the BGP prefix count while the session is established. This covers a gap the existing `0 prefixes` triggers cannot see: a drop from N to N-1 never reaches zero, so a single prefix going inactive at the advertising end is currently invisible. Both are edge-triggered and sticky (`recovery_mode: NONE` + manual close) so the event survives as a record until reconciled.

**New: `{$ROUTEROS.BGP.CHANGE.MATCHES}` and an LLD override.** The two triggers above are scoped by this macro through an LLD override, so sessions that do not match never discover them at all. They are most useful where the prefix count is expected to be stable — iBGP / route-reflector sessions, or peers carrying a small fixed prefix set. The macro defaults to `.*`; both the macro description and the README explain when and why to narrow it.

**Severity: `established with 0 prefixes received` WARNING → HIGH.** This matches the existing `established with 0 prefixes sent` trigger, which was already HIGH — the pair was inconsistent. The condition is a silently-degraded state rather than a visible outage: on an upstream session no routes are being learned from the peer while traffic may still flow via a static default, masking the fault; on an iBGP or route-reflector session it means the mesh has gone empty. Neither appears as a down interface or a down session.

**Recovery: VRRP `not in expected role`.** Previously manual-close only. Now carries a recovery expression that resolves when the state returns to the role `{$ROUTEROS.VRRP.EXPECTED_STATE}` expects. It deliberately does not resolve when the VRRP merely leaves master/backup for init/fault/invalid, since that is a different condition with its own dedicated trigger — this lets it ride through a transient fault during failback instead of flapping closed and reopening. `manual_close` is retained for boxes intentionally left in maintenance.

**Validation statement** widened to CCR2004-1G-12S+2XS and CCR2116, RouterOS 7.21.4 long-term through 7.23.

## README changes

- Documents the new macro, plus the eight LLD filter macros that were missing from the macro reference table entirely.
- Adds a note explaining the prefix-count-change triggers and when to narrow their scope.
- Replaces a dead source-repository link.

## Compatibility

All 123 existing object UUIDs are preserved; the only new UUIDs belong to the two new trigger prototypes. Existing installations keep item history and trigger state on re-import.
