### PR TITLE
Add PowerDNS Recursor monitoring template

### DIFF
--- a/Applications/DNS/template_powerdns_recursor_by_http/7.4/README.md
+++ b/Applications/DNS/template_powerdns_recursor_by_http/7.4/README.md
@@ -1,0 +1,224 @@
+# Zabbix Template: PowerDNS Recursor by HTTP
+
+[![Zabbix](https://img.shields.io/badge/Zabbix-7.4-d40000)](https://www.zabbix.com/)
+[![PowerDNS Recursor](https://img.shields.io/badge/PowerDNS%20Recursor-5.x-4b8bbe)](https://doc.powerdns.com/recursor/)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](../../../../LICENSE)
+
+Zabbix 7.4 template for monitoring a standard single-instance PowerDNS
+Recursor deployment through its built-in HTTP API.
+
+The template assumes that the DNS service listens on port 53 and the HTTP API
+listens on port 8082. Both ports are macros and can be overridden without
+editing the template.
+
+## Features
+
+- Agentless statistics collection through the Recursor HTTP API
+- One API request per minute per monitored host
+- Master/dependent item design to reduce API load
+- DNS TCP service availability check on port 53
+- Query and outgoing-query rates
+- Record-cache and packet-cache hit/miss rates
+- Five-minute record-cache and packet-cache hit ratios
+- SERVFAIL, NXDOMAIN, timeout and policy-result rates
+- Capacity, age and UDP receive-buffer drop/error rates
+- Concurrent queries, query-answer latency and cache entry counts
+- Resident memory, uptime and security-status metrics
+- Availability and over-capacity triggers
+- No helper script, UserParameter, sudoers rule or `rec_control get-all`
+  dependency
+
+## Requirements
+
+- Zabbix 7.4 server or proxy with network access to the Recursor HTTP API
+- PowerDNS Recursor 5.x with the webservice and REST API enabled
+- One standard Recursor instance represented by each Zabbix host
+- DNS service on TCP port 53 by default
+- An API key accepted by PowerDNS Recursor
+
+Zabbix Agent is not required for this template. The HTTP Agent request and the
+TCP service check are executed by the Zabbix server or assigned proxy.
+
+## Repository contents
+
+```text
+.
+├── README.md
+├── template_powerdns_recursor_by_http.yaml
+└── files/
+    └── recursor-api.yml.example
+```
+
+## PowerDNS Recursor configuration
+
+Copy the relevant `webservice` settings from
+[`files/recursor-api.yml.example`](files/recursor-api.yml.example) into
+your Recursor YAML configuration and replace the documentation-only addresses.
+
+For Recursor 4.6 and later, generate a hashed API key interactively:
+
+```bash
+rec_control hash-password
+```
+
+Place the generated complete hash in `webservice.api_key`. The Zabbix secret
+macro must contain the original plaintext API key, not the hash.
+
+Check the active configuration file name and validate the configuration using
+the commands provided by your package. Then restart Recursor because the
+webserver listen settings are startup settings. A common systemd deployment can
+be restarted with:
+
+```bash
+sudo systemctl restart pdns-recursor
+sudo systemctl --no-pager --full status pdns-recursor
+```
+
+## Test the API
+
+Run this from the Zabbix server or the proxy assigned to the monitored host:
+
+```bash
+read -rsp 'Recursor API key: ' RECURSOR_API_KEY
+echo
+
+curl -fsS \
+  -H "X-API-Key: ${RECURSOR_API_KEY}" \
+  'http://192.0.2.10:8082/api/v1/servers/localhost/statistics'
+
+unset RECURSOR_API_KEY
+```
+
+A successful request returns HTTP 200 and a JSON array of statistic objects.
+Also test the standard DNS TCP port from the same monitoring path:
+
+```bash
+nc -vz 192.0.2.10 53
+```
+
+## Import and link the template
+
+1. In Zabbix, open **Data collection → Templates**.
+2. Select **Import**.
+3. Import `template_powerdns_recursor_by_http.yaml`.
+4. Link `PowerDNS Recursor by HTTP` to the Recursor host.
+5. Set `{$PDNS.RECURSOR.API.KEY}` as a host-level **Secret text** macro.
+6. Override the API scheme, API port or DNS port if your standard deployment
+   differs from the defaults.
+7. Wait for two collection intervals, then check **Monitoring → Latest data**.
+
+Rate items use change-per-second preprocessing and need two master-item samples
+before the first value can be calculated.
+
+## Template macros
+
+| Macro | Default | Description |
+|---|---:|---|
+| `{$PDNS.RECURSOR.API.KEY}` | Empty | Plaintext Recursor API key sent in the `X-API-Key` header. Store it as Secret text. |
+| `{$PDNS.RECURSOR.API.PORT}` | `8082` | Recursor HTTP API port. |
+| `{$PDNS.RECURSOR.API.SCHEME}` | `http` | API scheme: `http` or `https`. |
+| `{$PDNS.RECURSOR.DNS.PORT}` | `53` | DNS service port used by the TCP availability item. |
+| `{$PDNS.RECURSOR.HTTP.TIMEOUT}` | `10s` | HTTP Agent request timeout. |
+
+The API master item uses this URL:
+
+```text
+{$PDNS.RECURSOR.API.SCHEME}://{HOST.CONN}:{$PDNS.RECURSOR.API.PORT}/api/v1/servers/localhost/statistics
+```
+
+## Collected metrics
+
+The template contains 28 items in total.
+
+| Category | Metrics |
+|---|---|
+| Availability | DNS TCP service state and HTTP API statistics master item |
+| Traffic | Questions, outgoing queries, TCP questions and IPv6 questions per second |
+| Cache | Record/packet-cache hits, misses, five-minute hit ratios and entry counts |
+| Responses | SERVFAIL and NXDOMAIN answers per second |
+| Resolver health | Outgoing timeouts and query-answer latency |
+| Policy | Policy drops and policy NXDOMAIN results |
+| Capacity | Over-capacity drops, too-old drops and concurrent queries |
+| Network | IPv4 and IPv6 UDP receive-buffer errors |
+| Resources | Real memory usage and uptime |
+| Security | PowerDNS security status |
+
+## Triggers
+
+| Severity | Trigger | Condition |
+|---|---|---|
+| High | PowerDNS Recursor: DNS TCP service is unavailable | TCP service check remains unavailable for three minutes |
+| High | PowerDNS Recursor: API statistics are unavailable | No API master-item data for three minutes |
+| High | PowerDNS Recursor: Queries are being dropped due to capacity | Over-capacity drops remain above zero for five minutes |
+
+## Security recommendations
+
+- Restrict `webservice.allow_from` to the Zabbix server or assigned proxy.
+- Restrict the API port with the host and network firewalls as well.
+- Store the API key in Zabbix as **Secret text**.
+- Use a hashed API key in the Recursor configuration when supported.
+- Do not expose the API to `0.0.0.0/0` or `::/0`.
+- Prefer HTTPS when the monitoring path crosses an untrusted network.
+- Do not commit production addresses, credentials or configuration files.
+
+## Troubleshooting
+
+### API item is unsupported
+
+Test the exact API URL from the assigned Zabbix proxy/server. Verify routing,
+firewall rules, `webservice.webserver`, the bind address, `allow_from`, the API
+key and the host interface configuration in Zabbix.
+
+### HTTP 401 or 403
+
+Confirm that the Zabbix macro contains the plaintext key corresponding to the
+hash configured in Recursor. Confirm that the source address of the Zabbix
+server/proxy is present in `webservice.allow_from`.
+
+### DNS availability is down while UDP queries work
+
+The template deliberately checks TCP port 53 because DNS requires both UDP and
+TCP service. Verify that Recursor is listening on TCP, the firewall permits TCP
+53, and `{$PDNS.RECURSOR.DNS.PORT}` matches the deployment.
+
+### Dependent items have no data
+
+Check the API master item first. Some statistics depend on Recursor version,
+build options or enabled features. Missing fields are intentionally discarded
+by preprocessing. Rate items require two samples.
+
+### Multiple Recursor instances exist on one host
+
+This public template models the standard single-instance deployment. Create a
+separate Zabbix host/interface per reachable API endpoint or maintain a custom
+multi-instance template outside this repository.
+
+## Compatibility
+
+- Template export version: Zabbix 7.4
+- Target service: PowerDNS Recursor 5.x
+- Verified application version: PowerDNS Recursor 5.4.0
+- Deployment model: one Recursor instance per Zabbix host
+- Default DNS port: 53
+- Default API port: 8082
+
+The template should be imported and tested in the target Zabbix release before
+production use. Do not change the export version field manually to claim
+compatibility with another Zabbix release.
+
+## Documentation
+
+- [PowerDNS Recursor HTTP API](https://doc.powerdns.com/recursor/http-api/)
+- [PowerDNS Recursor statistics endpoint](https://doc.powerdns.com/recursor/common/api/endpoint-statistics.html)
+- [PowerDNS Recursor YAML webservice settings](https://doc.powerdns.com/recursor/yamlsettings.html#webservice-address)
+- [Zabbix HTTP Agent items](https://www.zabbix.com/documentation/7.4/en/manual/config/items/itemtypes/http)
+- [Zabbix template import](https://www.zabbix.com/documentation/7.4/en/manual/xml_export_import)
+
+## License
+
+This template and its accompanying files are licensed under the
+[MIT License](../../../../LICENSE).
+
+## Author
+
+Emre Melih Çelik ([@imagineTh4t](https://github.com/imagineTh4t))

--- a/Applications/DNS/template_powerdns_recursor_by_http/7.4/files/recursor-api.yml.example
+++ b/Applications/DNS/template_powerdns_recursor_by_http/7.4/files/recursor-api.yml.example
@@ -1,0 +1,18 @@
+# Example PowerDNS Recursor 5.x webservice/API configuration for Zabbix.
+# Replace the documentation-only addresses and API-key hash.
+# Never commit a production credential to a public repository.
+
+webservice:
+  webserver: true
+  address: 192.0.2.10
+  port: 8082
+  allow_from:
+    - 198.51.100.20/32
+  api_key: REPLACE_WITH_HASH_FROM_rec_control_hash-password
+
+# 192.0.2.10 is the example Recursor address.
+# 198.51.100.20 is the example Zabbix server/proxy address.
+# Generate the stored value interactively:
+#   rec_control hash-password
+# Put the original plaintext key in the Zabbix SECRET_TEXT macro.
+# The DNS listener remains on the standard port 53; port 8082 is API-only.

--- a/Applications/DNS/template_powerdns_recursor_by_http/7.4/template_powerdns_recursor_by_http.yaml
+++ b/Applications/DNS/template_powerdns_recursor_by_http/7.4/template_powerdns_recursor_by_http.yaml
@@ -1,0 +1,594 @@
+zabbix_export:
+  version: '7.4'
+  template_groups:
+    - uuid: 77a0c394c1b9463eb4add12bc4d7a405
+      name: Templates/Applications
+  templates:
+    - uuid: 6da2bdddd420497cab2b6447845c35ca
+      template: 'PowerDNS Recursor by HTTP'
+      name: 'PowerDNS Recursor by HTTP'
+      description: |
+        PowerDNS Recursor 5.x monitoring through the built-in HTTP API.
+        The template targets the standard deployment model: one Recursor per
+        monitored host, DNS service on port 53, and the HTTP API on port 8082.
+        One HTTP Agent master item collects all statistics; dependent items
+        extract individual metrics. No helper script, UserParameter, sudoers
+        rule, or rec_control invocation is required.
+      vendor:
+        name: Community
+        version: 2.0.0
+      groups:
+        - name: Templates/Applications
+      items:
+        - uuid: 6c31535aff9c481c8a743f2e1ed65a58
+          name: 'PowerDNS Recursor: DNS TCP service availability'
+          type: SIMPLE
+          key: 'net.tcp.service[tcp,{HOST.CONN},{$PDNS.RECURSOR.DNS.PORT}]'
+          description: 'Checks whether the Recursor accepts TCP connections on the standard DNS service port. The default port is 53.'
+          valuemap:
+            name: 'PowerDNS Recursor service state'
+          tags:
+            - tag: component
+              value: health
+          triggers:
+            - uuid: 0ba5b0c4958245d2a7a8adbe8efc4221
+              expression: 'max(/PowerDNS Recursor by HTTP/net.tcp.service[tcp,{HOST.CONN},{$PDNS.RECURSOR.DNS.PORT}],3m)=0'
+              name: 'PowerDNS Recursor: DNS TCP service is unavailable'
+              priority: HIGH
+              description: 'The Recursor has not accepted TCP connections on the configured DNS port for three minutes.'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: 0e574d9805e942fab5b4c34bfa1a5455
+          name: 'PowerDNS Recursor: API statistics'
+          type: HTTP_AGENT
+          key: pdns.recursor.api.statistics
+          history: '0'
+          value_type: TEXT
+          description: 'Raw statistics returned by the PowerDNS Recursor HTTP API. All metric items depend on this single request.'
+          timeout: '{$PDNS.RECURSOR.HTTP.TIMEOUT}'
+          url: '{$PDNS.RECURSOR.API.SCHEME}://{HOST.CONN}:{$PDNS.RECURSOR.API.PORT}/api/v1/servers/localhost/statistics'
+          headers:
+            - name: X-API-Key
+              value: '{$PDNS.RECURSOR.API.KEY}'
+          tags:
+            - tag: component
+              value: raw
+          triggers:
+            - uuid: 3b5850ec2c954706ad9394d674904894
+              expression: 'nodata(/PowerDNS Recursor by HTTP/pdns.recursor.api.statistics,3m)=1'
+              name: 'PowerDNS Recursor: API statistics are unavailable'
+              priority: HIGH
+              description: 'No Recursor API statistics have been received for three minutes.'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: ddb2141d7c304e858af2b5007c88ec68
+          name: 'PowerDNS Recursor: Packet cache hit ratio (5m)'
+          type: CALCULATED
+          key: pdns.recursor.cache.packet.hit.ratio
+          value_type: FLOAT
+          units: '%'
+          params: '100 * avg(//pdns.recursor.rate[packetcache-hits],5m) / (avg(//pdns.recursor.rate[packetcache-hits],5m) + avg(//pdns.recursor.rate[packetcache-misses],5m))'
+          description: 'Five-minute packet-cache hit ratio calculated from hit and miss operation rates.'
+          tags:
+            - tag: component
+              value: cache
+        - uuid: 52fd19bc677d40c0b39f6cfe7f0953c2
+          name: 'PowerDNS Recursor: Record cache hit ratio (5m)'
+          type: CALCULATED
+          key: pdns.recursor.cache.record.hit.ratio
+          value_type: FLOAT
+          units: '%'
+          params: '100 * avg(//pdns.recursor.rate[cache-hits],5m) / (avg(//pdns.recursor.rate[cache-hits],5m) + avg(//pdns.recursor.rate[cache-misses],5m))'
+          description: 'Five-minute record-cache hit ratio calculated from hit and miss operation rates.'
+          tags:
+            - tag: component
+              value: cache
+        - uuid: 78d6b61766584b6d82e7068e6825ee02
+          name: 'PowerDNS Recursor: Outgoing queries per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[all-outqueries]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "all-outqueries")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: traffic
+        - uuid: 63070c8e3d654574b8fe9ca0809e26ca
+          name: 'PowerDNS Recursor: Record cache hits per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[cache-hits]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "cache-hits")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: cache
+        - uuid: 20abe66975bb4462ab12a8646d89fe06
+          name: 'PowerDNS Recursor: Record cache misses per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[cache-misses]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "cache-misses")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: cache
+        - uuid: babcee62af62400483e9e2955b77830d
+          name: 'PowerDNS Recursor: IPv6 questions per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[ipv6-questions]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "ipv6-questions")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: traffic
+        - uuid: b0a67a9c45a347b7b41c23801a69837c
+          name: 'PowerDNS Recursor: NXDOMAIN answers per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[nxdomain-answers]'
+          value_type: FLOAT
+          units: rps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "nxdomain-answers")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: answers
+        - uuid: 7f8584a5d266446da22b1f09fe62aa23
+          name: 'PowerDNS Recursor: Outgoing timeouts per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[outgoing-timeouts]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "outgoing-timeouts")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: errors
+        - uuid: bf1cae046ba94daebb39dd8e2c74b94e
+          name: 'PowerDNS Recursor: Over-capacity drops per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[over-capacity-drops]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "over-capacity-drops")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: drops
+          triggers:
+            - uuid: 5944cfbe8fd349a78f2e6540fbc1c337
+              expression: 'min(/PowerDNS Recursor by HTTP/pdns.recursor.rate[over-capacity-drops],5m)>0'
+              name: 'PowerDNS Recursor: Queries are being dropped due to capacity'
+              priority: HIGH
+              description: 'The worker-thread capacity limit has caused drops continuously during the last five minutes.'
+              tags:
+                - tag: scope
+                  value: performance
+        - uuid: c124dab8fb224fea9c40b4b309fb8b57
+          name: 'PowerDNS Recursor: Packet cache hits per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[packetcache-hits]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "packetcache-hits")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: cache
+        - uuid: 923d47a03e4b4dc8aaaddb8f73e80aeb
+          name: 'PowerDNS Recursor: Packet cache misses per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[packetcache-misses]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "packetcache-misses")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: cache
+        - uuid: 7a0bce4578ea4bee8552852293f3b892
+          name: 'PowerDNS Recursor: Policy drops per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[policy-drops]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "policy-drops")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: policy
+        - uuid: 42fa3fc004f1450c8f96d8f4c6906535
+          name: 'PowerDNS Recursor: Policy NXDOMAIN results per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[policy-result-nxdomain]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "policy-result-nxdomain")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: policy
+        - uuid: 759567e3d65c43bc819d36ed233d2e01
+          name: 'PowerDNS Recursor: Questions per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[questions]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "questions")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: traffic
+        - uuid: cde18cec7a45460ab9632e515fc98a83
+          name: 'PowerDNS Recursor: SERVFAIL answers per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[servfail-answers]'
+          value_type: FLOAT
+          units: rps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "servfail-answers")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: errors
+        - uuid: 3eb42142528247cd93952b4066ad8e08
+          name: 'PowerDNS Recursor: TCP questions per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[tcp-questions]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "tcp-questions")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: traffic
+        - uuid: 6b2699f499214c69be1ec9880d4c94b8
+          name: 'PowerDNS Recursor: Too-old drops per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[too-old-drops]'
+          value_type: FLOAT
+          units: qps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "too-old-drops")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: drops
+        - uuid: d812d56a05a742b0b0ed1e017a48f837
+          name: 'PowerDNS Recursor: UDP receive-buffer errors per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[udp-recvbuf-errors]'
+          value_type: FLOAT
+          units: eps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "udp-recvbuf-errors")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: network
+        - uuid: cb7f15b196814a62ab3383e4a062fec1
+          name: 'PowerDNS Recursor: UDP6 receive-buffer errors per second'
+          type: DEPENDENT
+          key: 'pdns.recursor.rate[udp6-recvbuf-errors]'
+          value_type: FLOAT
+          units: eps
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "udp6-recvbuf-errors")].value.first()'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: network
+        - uuid: a7a2b1906b134e719993d44a73c3a457
+          name: 'PowerDNS Recursor: Record cache entries'
+          type: DEPENDENT
+          key: 'pdns.recursor.value[cache-entries]'
+          units: entries
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "cache-entries")].value.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: cache
+        - uuid: 30b27a45d9dd429bbb291f88db9e54e6
+          name: 'PowerDNS Recursor: Concurrent queries'
+          type: DEPENDENT
+          key: 'pdns.recursor.value[concurrent-queries]'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "concurrent-queries")].value.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: queries
+        - uuid: 2d89e08d5ee44ca485b5dd39ede3e39f
+          name: 'PowerDNS Recursor: Packet cache entries'
+          type: DEPENDENT
+          key: 'pdns.recursor.value[packetcache-entries]'
+          units: entries
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "packetcache-entries")].value.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: cache
+        - uuid: e1c6754dde934e48ab4c1307000c107f
+          name: 'PowerDNS Recursor: Query-answer latency'
+          type: DEPENDENT
+          key: 'pdns.recursor.value[qa-latency]'
+          units: us
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "qa-latency")].value.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: latency
+        - uuid: 41dd2e03f7784a6b8b4ff60963354d93
+          name: 'PowerDNS Recursor: Real memory usage'
+          type: DEPENDENT
+          key: 'pdns.recursor.value[real-memory-usage]'
+          units: B
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "real-memory-usage")].value.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 9bf1955ca6844c0ba3d8d1cd3751c825
+          name: 'PowerDNS Recursor: Security status'
+          type: DEPENDENT
+          key: 'pdns.recursor.value[security-status]'
+          valuemap:
+            name: 'PowerDNS security status'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "security-status")].value.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: security
+        - uuid: 80f85172fb9144aa86be9d92f5111a5d
+          name: 'PowerDNS Recursor: Uptime'
+          type: DEPENDENT
+          key: 'pdns.recursor.value[uptime]'
+          units: uptime
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.name == "uptime")].value.first()'
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: pdns.recursor.api.statistics
+          tags:
+            - tag: component
+              value: system
+      macros:
+        - macro: '{$PDNS.RECURSOR.API.KEY}'
+          type: SECRET_TEXT
+          description: 'PowerDNS Recursor API key. Zabbix stores it as a secret and sends it in the X-API-Key header.'
+        - macro: '{$PDNS.RECURSOR.API.PORT}'
+          value: '8082'
+          description: 'PowerDNS Recursor built-in HTTP API port.'
+        - macro: '{$PDNS.RECURSOR.API.SCHEME}'
+          value: http
+          description: 'Use http or https according to the Recursor webservice configuration.'
+        - macro: '{$PDNS.RECURSOR.DNS.PORT}'
+          value: '53'
+          description: 'DNS service port. The community template uses the standard DNS port by default.'
+        - macro: '{$PDNS.RECURSOR.HTTP.TIMEOUT}'
+          value: 10s
+          description: 'HTTP Agent timeout for the Recursor API request.'
+      valuemaps:
+        - uuid: 34d1b633f12b4c5fbe2d5e754974cf99
+          name: 'PowerDNS Recursor service state'
+          mappings:
+            - value: '0'
+              newvalue: Down
+            - value: '1'
+              newvalue: Up
+        - uuid: 505f7339b515404c9d2386c63b81e23d
+          name: 'PowerDNS security status'
+          mappings:
+            - value: '0'
+              newvalue: 'Resolution failure'
+            - value: '1'
+              newvalue: OK
+            - value: '2'
+              newvalue: 'Upgrade recommended'
+            - value: '3'
+              newvalue: 'Upgrade mandatory'
+  graphs:
+    - uuid: 73d66bfbd15a48e0a7cb32b5443ea7e1
+      name: 'PowerDNS Recursor: Cache hit ratios'
+      graph_items:
+        - color: 1A7C11
+          item:
+            host: 'PowerDNS Recursor by HTTP'
+            key: pdns.recursor.cache.record.hit.ratio
+        - sortorder: '1'
+          color: 2774A4
+          item:
+            host: 'PowerDNS Recursor by HTTP'
+            key: pdns.recursor.cache.packet.hit.ratio
+    - uuid: f9ce6bb8babd4a1e8fe4077a1d123559
+      name: 'PowerDNS Recursor: Cache operation rates'
+      graph_items:
+        - color: 2E7D32
+          item:
+            host: 'PowerDNS Recursor by HTTP'
+            key: 'pdns.recursor.rate[cache-hits]'
+        - sortorder: '1'
+          color: F9A825
+          item:
+            host: 'PowerDNS Recursor by HTTP'
+            key: 'pdns.recursor.rate[cache-misses]'
+        - sortorder: '2'
+          color: 1565C0
+          item:
+            host: 'PowerDNS Recursor by HTTP'
+            key: 'pdns.recursor.rate[packetcache-hits]'
+        - sortorder: '3'
+          color: C62828
+          item:
+            host: 'PowerDNS Recursor by HTTP'
+            key: 'pdns.recursor.rate[packetcache-misses]'
+    - uuid: f1d648a07cbd48f791378da90b729980
+      name: 'PowerDNS Recursor: Error and drop rates'
+      graph_items:
+        - color: C62828
+          item:
+            host: 'PowerDNS Recursor by HTTP'
+            key: 'pdns.recursor.rate[servfail-answers]'
+        - sortorder: '1'
+          color: EF6C00
+          item:
+            host: 'PowerDNS Recursor by HTTP'
+            key: 'pdns.recursor.rate[outgoing-timeouts]'
+        - sortorder: '2'
+          color: 6A1B9A
+          item:
+            host: 'PowerDNS Recursor by HTTP'
+            key: 'pdns.recursor.rate[over-capacity-drops]'
+        - sortorder: '3'
+          color: 1565C0
+          item:
+            host: 'PowerDNS Recursor by HTTP'
+            key: 'pdns.recursor.rate[too-old-drops]'
+    - uuid: 660a4451a6844a0ab6c5b778e72572d8
+      name: 'PowerDNS Recursor: Query rates'
+      graph_items:
+        - color: 1A7C11
+          item:
+            host: 'PowerDNS Recursor by HTTP'
+            key: 'pdns.recursor.rate[questions]'
+        - sortorder: '1'
+          color: 2774A4
+          item:
+            host: 'PowerDNS Recursor by HTTP'
+            key: 'pdns.recursor.rate[all-outqueries]'


### PR DESCRIPTION
## Summary

Adds a Zabbix 7.4 template for monitoring PowerDNS Recursor through its built-in HTTP API.

The template:

- Collects statistics agentlessly using a single HTTP API request per interval
- Uses master and dependent items to minimize API load
- Monitors query rates, cache performance, response errors, capacity drops, UDP receive-buffer errors, memory usage, uptime and security status
- Checks DNS TCP service availability
- Includes triggers for DNS/API availability and over-capacity drops
- Includes configuration and usage documentation
- Includes an example PowerDNS Recursor webservice configuration

## Compatibility

- Zabbix 7.4
- PowerDNS Recursor 5.x
- Verified with PowerDNS Recursor 5.4.0

## Files added

- Template YAML export
- README with installation and configuration instructions
- Example Recursor HTTP API configuration