### PR TITLE
Add Zabbix 7.0 port of Dell SmartFabric OS10 (Advanced)

### DIFF
--- a/Network_Devices/Dell/template_smartfabric_os10_advanced/7.0/README.md
+++ b/Network_Devices/Dell/template_smartfabric_os10_advanced/7.0/README.md
@@ -1,0 +1,19 @@
+# Dell SmartFabric OS10 by SNMP (Advanced) — 7.0 vs 7.4
+
+This is a Zabbix 7.0-compatible port of the [7.4 advanced template](../7.4/template_smartfabric_os10_advanced.yaml). Functionally equivalent, with these differences:
+
+## Card Discovery flattened
+
+The 7.4 template nests `Card Discovery` under `Chassis Discovery` via `parent_discovery_rule`, a feature that only exists in Zabbix 7.4+. This port makes `Card Discovery` a standalone, non-nested rule fed by a new top-level item (`SNMP walk Card table`) that walks the whole card table in one pass and derives both the chassis and card index from the row's compound SNMP index.
+
+Side effect: card items/tags now key on `{#CHASSIS_ID}` (numeric chassis index) instead of `{#CHASSIS_PPID}` (chassis serial number). Card-side keying (`{#CARD_PPID}`, serial number) is unchanged.
+
+## CPU utilization is fully discovery-driven
+
+The 7.4 template ships two hardcoded `CALCULATED` items (`CPU 1 Usage`, `CPU 2 Usage`) pointing at fixed SNMP indices, feeding two dashboard Gauge widgets — because Gauge widgets can't bind to LLD-discovered items. This port drops both hardcoded items and their gauges, and instead adds a graph prototype on the existing `CPU usage Discovery` rule, shown on a new "CPU Usage" dashboard page (one graph per discovered CPU). No hardcoded indices, and it scales to however many CPUs a given switch actually reports.
+
+The discovered CPU items are named `CPU {#CPU_NUM}` (1, 2, 3, ... in walk order) instead of the raw, often unreadable SNMP index, via a discovery-rule-level JS preprocessing step. They're also tagged `component: cpu`.
+
+## Everything else
+
+Items, remaining discovery rules, triggers, macros, valuemaps, and other dashboard pages are unchanged from the 7.4 template.

--- a/Network_Devices/Dell/template_smartfabric_os10_advanced/7.0/template_smartfabric_os10_advanced.yaml
+++ b/Network_Devices/Dell/template_smartfabric_os10_advanced/7.0/template_smartfabric_os10_advanced.yaml
@@ -1,0 +1,3724 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 36bff6c29af64692839d077febfc7079
+      name: 'Templates/Network devices'
+  templates:
+    - uuid: 1585799f5ecc498b9f1755f0b457e407
+      template: 'Dell SmartFabric OS10 by SNMP'
+      name: 'Dell SmartFabric OS10 by SNMP'
+      description: |
+        Template Dell SmartFabric OS10
+        
+        MIBs used:
+        EtherLike-MIB
+        HOST-RESOURCES-MIB
+        SNMPv2-MIB
+        IF-MIB
+        DELLEMC-OS10-CHASSIS-MIB
+      vendor:
+        name: community-templates
+        version: 7.0.1
+      groups:
+        - name: 'Templates/Network devices'
+      items:
+        - uuid: dbc5a797b649465dac36351ac594ca84
+          name: 'SNMP walk Chassis table'
+          type: SNMP_AGENT
+          snmp_oid: 'walk[1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.2,1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.3,1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.4,1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.5,1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.6,1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.7,1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.8,1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.9,1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.10,1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.11]'
+          key: dell.switch.chassis.walk
+          delay: 10m
+          history: '0'
+          value_type: TEXT
+          description: 'Scanning of Chassis Table `DELLEMC-OS10-CHASSIS-MIB::os10ChassisTable`.'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 7a4b79422d4d47dbbaae980c03ccbab0
+          name: 'SNMP walk Card table'
+          type: SNMP_AGENT
+          snmp_oid: 'walk[1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.2,1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.3,1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.4,1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.5,1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.6,1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.7,1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.8,1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.9]'
+          key: dell.switch.card.walk
+          delay: 10m
+          history: '0'
+          value_type: TEXT
+          description: 'Scanning of Card Table `DELLEMC-OS10-CHASSIS-MIB::os10CardTable` across all chassis.'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 153bbb6c7e1846c6b43cbcbf60904fdb
+          name: 'SNMP walk Fan tray table'
+          type: SNMP_AGENT
+          snmp_oid: 'walk[1.3.6.1.4.1.674.11000.5000.100.4.1.2.2.1.2,1.3.6.1.4.1.674.11000.5000.100.4.1.2.2.1.3,1.3.6.1.4.1.674.11000.5000.100.4.1.2.2.1.4,1.3.6.1.4.1.674.11000.5000.100.4.1.2.2.1.5]'
+          key: dell.switch.fan.tray.walk
+          history: '0'
+          value_type: TEXT
+          tags:
+            - tag: component
+              value: raw
+        - uuid: cd24db9bd5fc40cab87463ada9fc36c1
+          name: 'SNMP walk Fan table'
+          type: SNMP_AGENT
+          snmp_oid: 'walk[1.3.6.1.4.1.674.11000.5000.100.4.1.2.3.1.2,1.3.6.1.4.1.674.11000.5000.100.4.1.2.3.1.4,1.3.6.1.4.1.674.11000.5000.100.4.1.2.3.1.5,1.3.6.1.4.1.674.11000.5000.100.4.1.2.3.1.6,1.3.6.1.4.1.674.11000.5000.100.4.1.2.3.1.7]'
+          key: dell.switch.fan.walk
+          history: '0'
+          value_type: TEXT
+          description: 'Scanning of Power Supply Table `DELLEMC-OS10-CHASSIS-MIB::os10FanTable`.'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: bb52b3db778b401eabd3bb65e15b0b11
+          name: 'SNMP walk Power supply table'
+          type: SNMP_AGENT
+          snmp_oid: 'walk[1.3.6.1.4.1.674.11000.5000.100.4.1.2.1.1.2,1.3.6.1.4.1.674.11000.5000.100.4.1.2.1.1.4,1.3.6.1.4.1.674.11000.5000.100.4.1.2.1.1.6]'
+          key: dell.switch.psu.walk
+          history: '0'
+          value_type: TEXT
+          description: 'Scanning of Power Supply Table `DELLEMC-OS10-CHASSIS-MIB::os10PowerSupplyTable`.'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: d273df8ff1564db6bbda68d9ab8602c7
+          name: 'ICMP ping'
+          type: SIMPLE
+          key: icmpping
+          valuemap:
+            name: 'Service state'
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 5b82568340b243e3bcf632aa85fcc13a
+              expression: 'max(/Dell SmartFabric OS10 by SNMP/icmpping,#3)=0'
+              name: 'Dell SmartFabric OS10: Unavailable by ICMP ping'
+              priority: HIGH
+              description: 'Last three attempts returned timeout.  Please check device connectivity.'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: 784fa551375d40a8a6016a012120e5c0
+          name: 'ICMP loss'
+          type: SIMPLE
+          key: icmppingloss
+          value_type: FLOAT
+          units: '%'
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 45d03d73895d4706bb494b9db7516061
+              expression: 'min(/Dell SmartFabric OS10 by SNMP/icmppingloss,5m)>{$ICMP_LOSS_WARN} and min(/Dell SmartFabric OS10 by SNMP/icmppingloss,5m)<100'
+              name: 'Dell SmartFabric OS10: High ICMP ping loss'
+              opdata: 'Loss: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              dependencies:
+                - name: 'Dell SmartFabric OS10: Unavailable by ICMP ping'
+                  expression: 'max(/Dell SmartFabric OS10 by SNMP/icmpping,#3)=0'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: performance
+        - uuid: bd8b808f19d94608a7563b78671b9dfc
+          name: 'ICMP response time'
+          type: SIMPLE
+          key: icmppingsec
+          value_type: FLOAT
+          units: s
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 22cba9024c3e4395b3af8dfd75a9b3bb
+              expression: 'avg(/Dell SmartFabric OS10 by SNMP/icmppingsec,5m)>{$ICMP_RESPONSE_TIME_WARN}'
+              name: 'Dell SmartFabric OS10: High ICMP ping response time'
+              opdata: 'Value: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'Average ICMP response time is too high.'
+              dependencies:
+                - name: 'Dell SmartFabric OS10: High ICMP ping loss'
+                  expression: 'min(/Dell SmartFabric OS10 by SNMP/icmppingloss,5m)>{$ICMP_LOSS_WARN} and min(/Dell SmartFabric OS10 by SNMP/icmppingloss,5m)<100'
+                - name: 'Dell SmartFabric OS10: Unavailable by ICMP ping'
+                  expression: 'max(/Dell SmartFabric OS10 by SNMP/icmpping,#3)=0'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: performance
+        - uuid: 90f99ea3ccf842c488fca18ec8ae698f
+          name: 'SNMP traps (fallback)'
+          type: SNMP_TRAP
+          key: snmptrap.fallback
+          value_type: LOG
+          description: 'The item is used to collect all SNMP traps unmatched by other snmptrap items'
+          logtimefmt: 'hh:mm:sszyyyy/MM/dd'
+          tags:
+            - tag: component
+              value: network
+        - uuid: 37d5b4430f1e4e289c5a4b3e3818f04e
+          name: 'System contact details'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.4.0
+          key: 'system.contact[sysContact.0]'
+          delay: 15m
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            The textual identification of the contact person for this managed node, together with information on how to contact this person.  If no contact information is known, the value is the zero-length string.
+          inventory_link: CONTACT
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          tags:
+            - tag: component
+              value: system
+        - uuid: af9e0fa817b74f9aaf62f5f2eef30693
+          name: 'Interrupts per second'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.2021.11.59.0
+          key: 'system.cpu.intr[ssRawInterrupts.0]'
+          value_type: FLOAT
+          description: 'Number of interrupts processed.'
+          preprocessing:
+            - type: CHANGE_PER_SECOND
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: e79fcb9622d84043899f0d31d80070a2
+          name: 'Load average (1m avg)'
+          type: SNMP_AGENT
+          snmp_oid: '1.3.6.1.4.1.2021.10.1.3["index","1.3.6.1.4.1.2021.10.1.2", "Load-1"]'
+          key: 'system.cpu.load.avg1[laLoad.1]'
+          value_type: FLOAT
+          description: 'MIB: UCD-SNMP-MIB'
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: bd539b00749d4a8ea869beead16e722c
+          name: 'Load average (5m avg)'
+          type: SNMP_AGENT
+          snmp_oid: '1.3.6.1.4.1.2021.10.1.3["index","1.3.6.1.4.1.2021.10.1.2", "Load-5"]'
+          key: 'system.cpu.load.avg5[laLoad.2]'
+          value_type: FLOAT
+          description: 'MIB: UCD-SNMP-MIB'
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: b754d9836ac546a8ac9836b75b1f581b
+          name: 'Load average (15m avg)'
+          type: SNMP_AGENT
+          snmp_oid: '1.3.6.1.4.1.2021.10.1.3["index","1.3.6.1.4.1.2021.10.1.2", "Load-15"]'
+          key: 'system.cpu.load.avg15[laLoad.3]'
+          value_type: FLOAT
+          description: 'MIB: UCD-SNMP-MIB'
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: f7646e3dac114a888ba807b2ccf3e864
+          name: 'Number of CPUs'
+          type: DEPENDENT
+          key: 'system.cpu.num[snmp]'
+          description: 'Count the number of CPU cores by counting number of cores discovered in hrProcessorTable using LLD.'
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#SNMPVALUE}'
+                - 1.3.6.1.2.1.25.3.3.1.1
+                - '0'
+            - type: JAVASCRIPT
+              parameters:
+                - 'return JSON.parse(value).length;'
+          master_item:
+            key: system.cpu.walk
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: ace2f4ddc82e44ecb794e001bfa18269
+          name: 'Context switches per second'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.2021.11.60.0
+          key: 'system.cpu.switches[ssRawContexts.0]'
+          value_type: FLOAT
+          description: 'The combined rate at which all processors on the computer are switched from one thread to another.'
+          preprocessing:
+            - type: CHANGE_PER_SECOND
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: b89e53a11667480fb5634784972d7eb9
+          name: 'SNMP walk system CPUs'
+          type: SNMP_AGENT
+          snmp_oid: 'walk[1.3.6.1.2.1.25.3.3.1.1,1.3.6.1.4.1.2021.11.53.0,1.3.6.1.4.1.2021.11.52.0,1.3.6.1.4.1.2021.11.50.0,1.3.6.1.4.1.2021.11.64.0,1.3.6.1.4.1.2021.11.61.0,1.3.6.1.4.1.2021.11.51.0,1.3.6.1.4.1.2021.11.54.0,1.3.6.1.4.1.2021.11.56.0,1.3.6.1.4.1.2021.11.65.0,1.3.6.1.4.1.2021.11.66.0]'
+          key: system.cpu.walk
+          history: '0'
+          value_type: TEXT
+          description: |
+            MIB: HOST-RESOURCES-MIB
+            Discovering system CPUs.
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 266b0c8a6a3342889d656c35d41cd435
+          name: 'System description'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.1.0
+          key: 'system.descr[sysDescr.0]'
+          delay: 15m
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            A textual description of the entity. This value should
+            include the full name and version identification of the system's hardware type, software operating-system, and
+            networking software.
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          tags:
+            - tag: component
+              value: system
+        - uuid: c54291674cd4423c8021085a529aa902
+          name: 'Uptime (hardware)'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.25.1.1.0
+          key: 'system.hw.uptime[hrSystemUptime.0]'
+          delay: 30s
+          trends: '0'
+          units: uptime
+          description: |
+            MIB: HOST-RESOURCES-MIB
+            The amount of time since this host was last initialized. Note that this is different from sysUpTime in the SNMPv2-MIB [RFC1907] because sysUpTime is the uptime of the network management portion of the system.
+          preprocessing:
+            - type: CHECK_NOT_SUPPORTED
+              parameters:
+                - '-1'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: MULTIPLIER
+              parameters:
+                - '0.01'
+          tags:
+            - tag: component
+              value: system
+        - uuid: bb49caa1fda34557a13268c254d79bba
+          name: 'System location'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.6.0
+          key: 'system.location[sysLocation.0]'
+          delay: 15m
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            Physical location of the node (e.g., `equipment room`, `3rd floor`). If not provided, the value is a zero-length string.
+          inventory_link: LOCATION
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          tags:
+            - tag: component
+              value: system
+        - uuid: 28ec3384cabe442d9fe5b71a8c832cb3
+          name: 'System name'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.5.0
+          key: system.name
+          delay: 15m
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            An administratively-assigned name for this managed node.By convention, this is the node's fully-qualified domain name.  If the name is unknown, the value is the zero-length string.
+          inventory_link: NAME
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 4f413a039ad0478ca89e00f9810f475c
+              expression: 'last(/Dell SmartFabric OS10 by SNMP/system.name,#1)<>last(/Dell SmartFabric OS10 by SNMP/system.name,#2) and length(last(/Dell SmartFabric OS10 by SNMP/system.name))>0'
+              name: 'Dell SmartFabric OS10: System name has changed'
+              event_name: 'Network Generic Device: System name has changed (new name: {ITEM.VALUE})'
+              priority: INFO
+              description: 'The name of the system has changed. Acknowledge to close the problem manually.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+                - tag: scope
+                  value: security
+        - uuid: 5828de46c7454ead90709049b3ebbb2d
+          name: 'Uptime (network)'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.3.0
+          key: 'system.net.uptime[sysUpTime.0]'
+          delay: 30s
+          trends: '0'
+          units: uptime
+          description: |
+            MIB: SNMPv2-MIB
+            Time (in hundredths of a second) since the network management portion of the system was last re-initialized.
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.01'
+          tags:
+            - tag: component
+              value: system
+        - uuid: a4a658c00a294ca9a1a907c83853d621
+          name: 'System object ID'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.2.0
+          key: 'system.objectid[sysObjectID.0]'
+          delay: 15m
+          value_type: CHAR
+          description: |
+            MIB: SNMPv2-MIB
+            The vendor's authoritative identification of the network management subsystem contained in the entity.  This value is allocated within the SMI enterprises subtree (1.3.6.1.4.1) and provides an easy and unambiguous means for determining`what kind of box' is being managed.  For example, if vendor`Flintstones, Inc.' was assigned the subtree1.3.6.1.4.1.4242, it could assign the identifier 1.3.6.1.4.1.4242.1.1 to its `Fred Router'.
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          tags:
+            - tag: component
+              value: system
+        - uuid: 7af3d4e8972049309b08959a95982683
+          name: 'Free swap space'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.2021.4.4.0
+          key: 'system.swap.free[memAvailSwap.0]'
+          units: B
+          description: |
+            MIB: UCD-SNMP-MIB
+            The amount of swap space currently unused or available.
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            - tag: component
+              value: memory
+            - tag: component
+              value: storage
+        - uuid: b0c9cb2a41654e83907b341a9bceb514
+          name: 'Free swap space in %'
+          type: CALCULATED
+          key: 'system.swap.pfree[snmp]'
+          value_type: FLOAT
+          units: '%'
+          params: 'last(//system.swap.free[memAvailSwap.0])/last(//system.swap.total[memTotalSwap.0])*100'
+          description: 'The free space of the swap volume/file expressed in %.'
+          tags:
+            - tag: component
+              value: memory
+            - tag: component
+              value: storage
+        - uuid: 9c93e3811c5b42a9875384eb79d9f496
+          name: 'Total swap space'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.2021.4.3.0
+          key: 'system.swap.total[memTotalSwap.0]'
+          units: B
+          description: |
+            MIB: UCD-SNMP-MIB
+            The total amount of swap space configured for this host.
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            - tag: component
+              value: memory
+            - tag: component
+              value: storage
+        - uuid: a1aaa3f7e8d84ec58a7d9a66cc14a4a5
+          name: 'SNMP walk mounted filesystems'
+          type: SNMP_AGENT
+          snmp_oid: 'walk[1.3.6.1.4.1.2021.9.1.1,1.3.6.1.4.1.2021.9.1.2,1.3.6.1.4.1.2021.9.1.3,1.3.6.1.4.1.2021.9.1.10,1.3.6.1.4.1.2021.9.1.11,1.3.6.1.4.1.2021.9.1.12,1.3.6.1.4.1.2021.9.1.13,1.3.6.1.4.1.2021.9.1.14,1.3.6.1.4.1.2021.9.1.15,1.3.6.1.4.1.2021.9.1.16]'
+          key: vfs.fs.walk
+          history: '0'
+          value_type: TEXT
+          description: |
+            MIB: UCD-SNMP-MIB
+            Snmp walk through dskEntry table. Collected data used in filesystem lld and dependent item prototypes.
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - dskPath
+                - 1.3.6.1.4.1.2021.9.1.2
+                - '0'
+                - dskDevice
+                - 1.3.6.1.4.1.2021.9.1.3
+                - '0'
+                - dskPercentNode
+                - 1.3.6.1.4.1.2021.9.1.10
+                - '0'
+                - dskTotalLow
+                - 1.3.6.1.4.1.2021.9.1.11
+                - '0'
+                - dskTotalHigh
+                - 1.3.6.1.4.1.2021.9.1.12
+                - '0'
+                - dskAvailLow
+                - 1.3.6.1.4.1.2021.9.1.13
+                - '0'
+                - dskAvailHigh
+                - 1.3.6.1.4.1.2021.9.1.14
+                - '0'
+                - dskUsedLow
+                - 1.3.6.1.4.1.2021.9.1.15
+                - '0'
+                - dskUsedHigh
+                - 1.3.6.1.4.1.2021.9.1.16
+                - '0'
+                - dskEntry
+                - 1.3.6.1.4.1.2021.9.1.1
+                - '0'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 8d55b561a0c845da956ed00a6856d543
+          name: 'Available memory'
+          type: CALCULATED
+          key: 'vm.memory.available[snmp]'
+          units: B
+          params: 'last(//vm.memory.free[memAvailReal.0])+last(//vm.memory.buffers[memBuffer.0])+last(//vm.memory.cached[memCached.0])'
+          description: 'Please note that memory utilization is a rough estimate, since memory available is calculated as free+buffers+cached, which is not 100% accurate, but the best we can get using SNMP.'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: bae3f0d9dd964cf596e547117213ac33
+          name: 'Memory (buffers)'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.2021.4.14.0
+          key: 'vm.memory.buffers[memBuffer.0]'
+          units: B
+          description: |
+            MIB: UCD-SNMP-MIB
+            Memory used by kernel buffers (Buffers in /proc/meminfo).
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: fac67905d426484a84740dd7d4c7cd68
+          name: 'Memory (cached)'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.2021.4.15.0
+          key: 'vm.memory.cached[memCached.0]'
+          units: B
+          description: |
+            MIB: UCD-SNMP-MIB
+            Memory used by the page cache and slabs (Cached and Slab in /proc/meminfo).
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: d2bfaca1a62e406fb5d2333ca4491951
+          name: 'Free memory'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.2021.4.6.0
+          key: 'vm.memory.free[memAvailReal.0]'
+          units: B
+          description: 'MIB: UCD-SNMP-MIB'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 2baaa90b0e704994b2ea5deb304d1531
+          name: 'Total memory'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.2021.4.5.0
+          key: 'vm.memory.total[memTotalReal.0]'
+          units: B
+          description: |
+            MIB: UCD-SNMP-MIB
+            Total memory expressed in bytes.
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 3590fbbf105947eab6473fb21f91b028
+          name: 'Memory utilization'
+          type: CALCULATED
+          key: 'vm.memory.util[snmp]'
+          units: '%'
+          params: '(last(//vm.memory.total[memTotalReal.0])-(last(//vm.memory.free[memAvailReal.0])+last(//vm.memory.buffers[memBuffer.0])+last(//vm.memory.cached[memCached.0])))/last(//vm.memory.total[memTotalReal.0])*100'
+          description: 'Please note that memory utilization is a rough estimate, since memory available is calculated as free+buffers+cached, which is not 100% accurate, but the best we can get using SNMP.'
+          tags:
+            - tag: component
+              value: memory
+          triggers:
+            - uuid: 12c6d5461b394593b875be4f07a4cd35
+              expression: 'min(/Dell SmartFabric OS10 by SNMP/vm.memory.util[snmp],5m)>{$MEMORY.UTIL.MAX}'
+              name: 'Dell SmartFabric OS10: High memory utilization'
+              event_name: 'Dell SmartFabric OS10: High memory utilization (>{$MEMORY.UTIL.MAX}% for 5m)'
+              priority: AVERAGE
+              dependencies:
+                - name: 'Dell SmartFabric OS10: Lack of available memory'
+                  expression: 'max(/Dell SmartFabric OS10 by SNMP/vm.memory.available[snmp],5m)<{$MEMORY.AVAILABLE.MIN} and last(/Dell SmartFabric OS10 by SNMP/vm.memory.total[memTotalReal.0])>0'
+              tags:
+                - tag: scope
+                  value: capacity
+                - tag: scope
+                  value: performance
+        - uuid: 280d00d53a7a42bb81677d65acae6163
+          name: 'SNMP agent availability'
+          type: INTERNAL
+          key: 'zabbix[host,snmp,available]'
+          description: |
+            Availability of SNMP checks on the host. The value of this item corresponds to availability icons in the host list.
+            Possible values:
+            0 - not available
+            1 - available
+            2 - unknown
+          valuemap:
+            name: zabbix.host.available
+          tags:
+            - tag: component
+              value: health
+            - tag: component
+              value: network
+          triggers:
+            - uuid: c707e103b8a1465e8aea49a484613e63
+              expression: 'max(/Dell SmartFabric OS10 by SNMP/zabbix[host,snmp,available],{$SNMP.TIMEOUT})=0'
+              name: 'Dell SmartFabric OS10: No SNMP data collection'
+              opdata: 'Current state: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'SNMP is not available for polling. Please check device connectivity and SNMP settings.'
+              dependencies:
+                - name: 'Dell SmartFabric OS10: Unavailable by ICMP ping'
+                  expression: 'max(/Dell SmartFabric OS10 by SNMP/icmpping,#3)=0'
+              tags:
+                - tag: scope
+                  value: availability
+      discovery_rules:
+        - uuid: 02316ca88e67474e9906fa89d5a8c9ee
+          name: 'Card Discovery'
+          type: DEPENDENT
+          key: chassis.card.discovery
+          item_prototypes:
+            - uuid: 29001e7a7627478899164d9c54d92f89
+              name: 'Card [{#CHASSIS_ID}/{#SNMPINDEX}]: Description'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.card.desc[{#CHASSIS_ID},{#CARD_PPID}]'
+              value_type: TEXT
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '.1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.3.{#CHASSIS_ID}.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'dell.switch.chassis.card.walk[{#CHASSIS_ID},{#CARD_PPID}]'
+              tags:
+                - tag: card
+                  value: '{#CARD_PPID}'
+                - tag: chassis
+                  value: '{#CHASSIS_ID}'
+                - tag: component
+                  value: card
+            - uuid: 0445951d09c54332b260b5cea5add6ca
+              name: 'Card [{#CHASSIS_ID}/{#SNMPINDEX}]: Part Number'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.card.part[{#CHASSIS_ID},{#CARD_PPID}]'
+              value_type: TEXT
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '.1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.6.{#CHASSIS_ID}.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'dell.switch.chassis.card.walk[{#CHASSIS_ID},{#CARD_PPID}]'
+              tags:
+                - tag: card
+                  value: '{#CARD_PPID}'
+                - tag: chassis
+                  value: '{#CHASSIS_ID}'
+                - tag: component
+                  value: card
+            - uuid: 1a12c73e73e84d7ebaf85214153f0ba0
+              name: 'Card [{#CHASSIS_ID}/{#SNMPINDEX}]: Hardware Revision'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.card.revision[{#CHASSIS_ID},{#CARD_PPID}]'
+              value_type: TEXT
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '.1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.8.{#CHASSIS_ID}.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'dell.switch.chassis.card.walk[{#CHASSIS_ID},{#CARD_PPID}]'
+              tags:
+                - tag: card
+                  value: '{#CARD_PPID}'
+                - tag: chassis
+                  value: '{#CHASSIS_ID}'
+                - tag: component
+                  value: card
+            - uuid: 694312a6b8184390be3ee8d4a1160d73
+              name: 'Card [{#CHASSIS_ID}/{#SNMPINDEX}]: Service Tag'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.card.servicetag[{#CHASSIS_ID},{#CARD_PPID}]'
+              value_type: TEXT
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '.1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.9.{#CHASSIS_ID}.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'dell.switch.chassis.card.walk[{#CHASSIS_ID},{#CARD_PPID}]'
+              tags:
+                - tag: card
+                  value: '{#CARD_PPID}'
+                - tag: chassis
+                  value: '{#CHASSIS_ID}'
+                - tag: component
+                  value: card
+            - uuid: f76792b6828a4d9791ab62e264a12a7e
+              name: 'Card [{#CHASSIS_ID}/{#SNMPINDEX}]: Serial Number'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.card.sn[{#CHASSIS_ID},{#CARD_PPID}]'
+              value_type: TEXT
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '.1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.7.{#CHASSIS_ID}.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'dell.switch.chassis.card.walk[{#CHASSIS_ID},{#CARD_PPID}]'
+              tags:
+                - tag: card
+                  value: '{#CARD_PPID}'
+                - tag: chassis
+                  value: '{#CHASSIS_ID}'
+                - tag: component
+                  value: card
+              trigger_prototypes:
+                - uuid: 796be5434f8a461db5ee6c03f4044ede
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.card.sn[{#CHASSIS_ID},{#CARD_PPID}],#1)<>last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.card.sn[{#CHASSIS_ID},{#CARD_PPID}],#2) and length(last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.card.sn[{#CHASSIS_ID},{#CARD_PPID}]))>0'
+                  name: 'Dell SmartFabric OS10: Card {#CHASSIS_ID}/{#SNMPINDEX} has been replaced'
+                  event_name: 'Dell SmartFabric OS10: Card {#CHASSIS_ID}/{#SNMPINDEX} has been replaced (new serial number)'
+                  priority: INFO
+                  description: 'Card {#CHASSIS_ID}/{#SNMPINDEX} serial number has changed. Acknowledge to close the problem manually.'
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: notice
+            - uuid: c6f0d25374884de3afebbdefeca82cdb
+              name: 'Card [{#CHASSIS_ID}/{#SNMPINDEX}]: Status'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.card.status[{#CHASSIS_ID},{#CARD_PPID}]'
+              trends: '0'
+              valuemap:
+                name: 'DELLEMC-OS10-TC-MIB::Os10CardOperStatus'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '.1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.4.{#CHASSIS_ID}.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'dell.switch.chassis.card.walk[{#CHASSIS_ID},{#CARD_PPID}]'
+              tags:
+                - tag: card
+                  value: '{#CARD_PPID}'
+                - tag: chassis
+                  value: '{#CHASSIS_ID}'
+                - tag: component
+                  value: card
+              trigger_prototypes:
+                - uuid: b5a31767663a4cefa39b62fcccec687e
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.card.status[{#CHASSIS_ID},{#CARD_PPID}])<>1'
+                  name: 'Dell SmartFabric OS10: Card {#CHASSIS_ID}/{#SNMPINDEX} is not ready'
+                  priority: HIGH
+                  description: 'Card {#CHASSIS_ID}/{#SNMPINDEX} is not ready.'
+                  tags:
+                    - tag: scope
+                      value: availability
+            - uuid: 917319329dc745bba2da1eaca83e9364
+              name: 'Card [{#CHASSIS_ID}/{#SNMPINDEX}]: Temperature'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.card.temp[{#CHASSIS_ID},{#CARD_PPID}]'
+              trends: '0'
+              units: °C
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '.1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.5.{#CHASSIS_ID}.{#SNMPINDEX}'
+                    - '0'
+              master_item:
+                key: 'dell.switch.chassis.card.walk[{#CHASSIS_ID},{#CARD_PPID}]'
+              tags:
+                - tag: card
+                  value: '{#CARD_PPID}'
+                - tag: chassis
+                  value: '{#CHASSIS_ID}'
+                - tag: component
+                  value: card
+              trigger_prototypes:
+                - uuid: fd60ae646b634b4080888833fa2c7926
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.card.temp[{#CHASSIS_ID},{#CARD_PPID}])>{$DELL.OS10.SNMP.CARD.TEMP.CRIT:"{#CHASSIS_ID},{#CARD_PPID}"}'
+                  name: 'Dell SmartFabric OS10: Card {#CHASSIS_ID}/{#SNMPINDEX} temperature is critical'
+                  priority: HIGH
+                  description: 'Card {#CHASSIS_ID}/{#SNMPINDEX} temperature is critical.'
+                  tags:
+                    - tag: scope
+                      value: availability
+                - uuid: 4aac574a7b554e8ca16b25b0d4d2ff78
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.card.temp[{#CHASSIS_ID},{#CARD_PPID}])>{$DELL.OS10.SNMP.CARD.TEMP.WARN:"{#CHASSIS_ID},{#CARD_PPID}"}'
+                  name: 'Dell SmartFabric OS10: Card {#CHASSIS_ID}/{#SNMPINDEX} temperature is too high'
+                  priority: WARNING
+                  description: 'Card {#CHASSIS_ID}/{#SNMPINDEX} temperature is too high'
+                  dependencies:
+                    - name: 'Dell SmartFabric OS10: Card {#CHASSIS_ID}/{#SNMPINDEX} temperature is critical'
+                      expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.card.temp[{#CHASSIS_ID},{#CARD_PPID}])>{$DELL.OS10.SNMP.CARD.TEMP.CRIT:"{#CHASSIS_ID},{#CARD_PPID}"}'
+                  tags:
+                    - tag: scope
+                      value: availability
+            - uuid: dd89cc85d08a4871be3cd58f3f7d98f4
+              name: 'Card [{#CHASSIS_ID}/{#SNMPINDEX}]: Type'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.card.type[{#CHASSIS_ID},{#CARD_PPID}]'
+              trends: '0'
+              valuemap:
+                name: 'DELLEMC-OS10-TC-MIB::Os10SystemCardType'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '.1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.2.{#CHASSIS_ID}.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: 'dell.switch.chassis.card.walk[{#CHASSIS_ID},{#CARD_PPID}]'
+              tags:
+                - tag: card
+                  value: '{#CARD_PPID}'
+                - tag: chassis
+                  value: '{#CHASSIS_ID}'
+                - tag: component
+                  value: card
+            - uuid: 537c54719bc3465a90ed320151dde764
+              name: 'Card [{#CHASSIS_ID}/{#SNMPINDEX}]: Get card'
+              type: SNMP_AGENT
+              snmp_oid: 'walk[1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.2.{#CHASSIS_ID},1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.3.{#CHASSIS_ID},1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.4.{#CHASSIS_ID},1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.5.{#CHASSIS_ID},1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.6.{#CHASSIS_ID},1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.7.{#CHASSIS_ID},1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.8.{#CHASSIS_ID},1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.9.{#CHASSIS_ID}]'
+              key: 'dell.switch.chassis.card.walk[{#CHASSIS_ID},{#CARD_PPID}]'
+              history: '0'
+              value_type: TEXT
+              tags:
+                - tag: component
+                  value: raw
+          graph_prototypes:
+            - uuid: 09205779391342c49940ad8e826af611
+              name: 'Dell SmartFabric OS10: Card [{#CHASSIS_ID},{#SNMPINDEX}]: Temperature'
+              yaxismax: '0'
+              graph_items:
+                - color: 199C0D
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'dell.switch.chassis.card.temp[{#CHASSIS_ID},{#CARD_PPID}]'
+          master_item:
+            key: dell.switch.card.walk
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#CARD_PPID}'
+                - 1.3.6.1.4.1.674.11000.5000.100.4.1.1.4.1.7
+                - '0'
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+
+                  for (var i = 0; i < data.length; i++) {
+                      var idx = data[i]["{#SNMPINDEX}"].replace(/^\./, "").split(".");
+                      data[i]["{#CHASSIS_ID}"] = idx[0];
+                      data[i]["{#CARD_ID}"] = idx[1];
+                      data[i]["{#SNMPINDEX}"] = idx[1];
+                  }
+
+                  return JSON.stringify(data);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+        - uuid: 42ad807e604f4498b24cce5edbe63a9c
+          name: 'Chassis Discovery'
+          type: DEPENDENT
+          key: chassis.discovery
+          item_prototypes:
+            - uuid: be4d886e16d244d2a8df12aae9552d33
+              name: 'Chassis [{#SNMPINDEX}]: MAC Address'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.mac[{#SNMPINDEX}]'
+              value_type: TEXT
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.3.{#SNMPINDEX}'
+                    - '2'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: dell.switch.chassis.walk
+              tags:
+                - tag: chassis
+                  value: '{#CHASSIS_PPID}'
+                - tag: component
+                  value: chassis
+            - uuid: dc5ef3b444734fe7872707cb005cc63a
+              name: 'Chassis [{#SNMPINDEX}]: Number of Fan Trays'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.num_fan_trays[{#SNMPINDEX}]'
+              trends: '0'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.9.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: dell.switch.chassis.walk
+              tags:
+                - tag: chassis
+                  value: '{#CHASSIS_PPID}'
+                - tag: component
+                  value: chassis
+            - uuid: ea825cc04b6c4c9a9c3e7c8fce485713
+              name: 'Chassis [{#SNMPINDEX}]: Number of Power Supplies'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.num_power_supplies[{#SNMPINDEX}]'
+              trends: '0'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.10.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: dell.switch.chassis.walk
+              tags:
+                - tag: chassis
+                  value: '{#CHASSIS_PPID}'
+                - tag: component
+                  value: chassis
+            - uuid: 3841e7ac803c4e3cafa25af011b51d5f
+              name: 'Chassis [{#SNMPINDEX}]: Part Number'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.part[{#SNMPINDEX}]'
+              value_type: TEXT
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.4.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: dell.switch.chassis.walk
+              tags:
+                - tag: chassis
+                  value: '{#CHASSIS_PPID}'
+                - tag: component
+                  value: chassis
+            - uuid: f461bebfd66e4c9bb2898264863a3db8
+              name: 'Chassis [{#SNMPINDEX}]: Hardware Revision'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.revision[{#SNMPINDEX}]'
+              value_type: TEXT
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.6.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: dell.switch.chassis.walk
+              tags:
+                - tag: chassis
+                  value: '{#CHASSIS_PPID}'
+                - tag: component
+                  value: chassis
+            - uuid: 9cb8f94f942544179c295371719b3051
+              name: 'Chassis [{#SNMPINDEX}]: Service Tag'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.servicetag[{#SNMPINDEX}]'
+              value_type: TEXT
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.7.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: dell.switch.chassis.walk
+              tags:
+                - tag: chassis
+                  value: '{#CHASSIS_PPID}'
+                - tag: component
+                  value: chassis
+            - uuid: 606d0b8bfc1c4250854cfe4d2ce18c2d
+              name: 'Chassis [{#SNMPINDEX}]: Serial Number'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.sn[{#SNMPINDEX}]'
+              value_type: TEXT
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.5.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: dell.switch.chassis.walk
+              tags:
+                - tag: chassis
+                  value: '{#CHASSIS_PPID}'
+                - tag: component
+                  value: chassis
+              trigger_prototypes:
+                - uuid: ddecfd33349b48d8b3316b3c8ce97f41
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.sn[{#SNMPINDEX}],#1)<>last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.sn[{#SNMPINDEX}],#2) and length(last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.sn[{#SNMPINDEX}]))>0'
+                  name: 'Dell SmartFabric OS10: Chassis {#SNMPINDEX} has been replaced'
+                  event_name: 'Dell SmartFabric OS10: Chassis {#SNMPINDEX} has been replaced (new serial number)'
+                  priority: INFO
+                  description: 'Chassis {#SNMPINDEX} serial number has changed. Acknowledge to close the problem manually.'
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: notice
+            - uuid: 969892e98d5d437f8262855fe3ad60ce
+              name: 'Chassis [{#SNMPINDEX}]: Temperature'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.temperature[{#SNMPINDEX}]'
+              trends: '0'
+              units: °C
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.11.{#SNMPINDEX}'
+                    - '0'
+              master_item:
+                key: dell.switch.chassis.walk
+              tags:
+                - tag: chassis
+                  value: '{#CHASSIS_PPID}'
+                - tag: component
+                  value: chassis
+              trigger_prototypes:
+                - uuid: 4588e6459a584b69bfe6620325855535
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.temperature[{#SNMPINDEX}])>{$DELL.OS10.SNMP.CHASSIS.TEMP.CRIT:"{#CHASSIS_PPID}"}'
+                  name: 'Dell SmartFabric OS10: Chassis {#SNMPINDEX} temperature is critical'
+                  priority: HIGH
+                  description: 'Chassis {#SNMPINDEX} temperature is critical.'
+                  tags:
+                    - tag: scope
+                      value: availability
+                - uuid: de5df9e5bbd4408c887a576c53c6f887
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.temperature[{#SNMPINDEX}])>{$DELL.OS10.SNMP.CHASSIS.TEMP.WARN:"{#CHASSIS_PPID}"}'
+                  name: 'Dell SmartFabric OS10: Chassis {#SNMPINDEX} temperature is too high'
+                  priority: WARNING
+                  description: 'Chassis {#SNMPINDEX} temperature is too high.'
+                  dependencies:
+                    - name: 'Dell SmartFabric OS10: Chassis {#SNMPINDEX} temperature is critical'
+                      expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.chassis.temperature[{#SNMPINDEX}])>{$DELL.OS10.SNMP.CHASSIS.TEMP.CRIT:"{#CHASSIS_PPID}"}'
+                  tags:
+                    - tag: scope
+                      value: availability
+            - uuid: c404f35554044258ba57c0a953a1278c
+              name: 'Chassis [{#SNMPINDEX}]: Type'
+              type: DEPENDENT
+              key: 'dell.switch.chassis.type[{#SNMPINDEX}]'
+              trends: '0'
+              valuemap:
+                name: 'DELLEMC-OS10-TC-MIB::Os10ChassisDefType'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.2.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: dell.switch.chassis.walk
+              tags:
+                - tag: chassis
+                  value: '{#CHASSIS_PPID}'
+                - tag: component
+                  value: chassis
+          graph_prototypes:
+            - uuid: cce0b65754c0444ca004c62b04ebf9df
+              name: 'Dell SmartFabric OS10: Chassis [{#SNMPINDEX}]: Temperature'
+              graph_items:
+                - color: 199C0D
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'dell.switch.chassis.temperature[{#SNMPINDEX}]'
+          master_item:
+            key: dell.switch.chassis.walk
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#CHASSIS_PPID}'
+                - 1.3.6.1.4.1.674.11000.5000.100.4.1.1.3.1.5
+                - '0'
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  
+                  for (var i = 0; i < data.length; i++) {
+                      data[i]["{#CHASSIS_ID}"] = data[i]["{#SNMPINDEX}"];
+                  }
+                  
+                  return JSON.stringify(data);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+        - uuid: 354e5d325261467bb1a180e1c5076fa2
+          name: 'CPU discovery'
+          type: DEPENDENT
+          key: 'cpu.discovery[snmp]'
+          description: 'This discovery will create set of per core CPU metrics from UCD-SNMP-MIB, using {#CPU.COUNT} in preprocessing. That''s the only reason why LLD is used.'
+          master_item:
+            key: 'system.cpu.num[snmp]'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - 'return JSON.stringify([{"{#CPU.COUNT}": value, "{#SNMPINDEX}": 0, "{#SINGLETON}":""}])'
+        - uuid: dea3aa83bf564b83b6f0cb95e6a895cd
+          name: 'CPU usage Discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#CPULOAD},1.3.6.1.2.1.25.3.3.1.2]'
+          key: dell.switch.cpu.discovery
+          delay: 1h
+          item_prototypes:
+            - uuid: 0266e83a1748428191e82acaf3e75460
+              name: 'CPU {#CPU_NUM}'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.25.3.3.1.2.{#SNMPINDEX}'
+              key: 'cpu.util[{#SNMPINDEX}]'
+              units: '%'
+              tags:
+                - tag: component
+                  value: cpu
+          graph_prototypes:
+            - uuid: 7e57b53463ed4a6cbb28d9d1209d61aa
+              name: 'CPU {#CPU_NUM}: Utilization'
+              graph_items:
+                - color: 199C0D
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'cpu.util[{#SNMPINDEX}]'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+
+                  for (var i = 0; i < data.length; i++) {
+                      data[i]["{#CPU_NUM}"] = i + 1;
+                  }
+
+                  return JSON.stringify(data);
+        - uuid: cd9f431382944c149f198b412f542250
+          name: 'Fan Discovery'
+          type: DEPENDENT
+          key: fan.discovery
+          description: 'Fan discovery.'
+          item_prototypes:
+            - uuid: 62b1d0ba7e77490383df868187f33aad
+              name: 'Fan [{#SNMPINDEX}] (entity: {#FAN_ENTITY}, tray: {#FAN_ENTITYSLOT}, pos:{#FAN_ID}): Entity'
+              type: DEPENDENT
+              key: 'dell.switch.fan.entity[{#SNMPINDEX}]'
+              trends: '0'
+              valuemap:
+                name: 'DELLEMC-OS10-CHASSIS-MIB::os10FanEntity'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.2.3.1.4.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: dell.switch.fan.walk
+              tags:
+                - tag: component
+                  value: fan
+                - tag: fan
+                  value: '{#FAN_ENTITY}/{#FAN_ENTITYSLOT}/{#FAN_ID}'
+            - uuid: 5f9742740caa42a09c18b5635bee3845
+              name: 'Fan [{#SNMPINDEX}] (entity: {#FAN_ENTITY}, tray: {#FAN_ENTITYSLOT}, pos:{#FAN_ID}): Status'
+              type: DEPENDENT
+              key: 'dell.switch.fan.status[{#SNMPINDEX}]'
+              trends: '0'
+              valuemap:
+                name: 'DELLEMC-OS10-TC-MIB::Os10CmnOperStatus'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.2.3.1.7.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: dell.switch.fan.walk
+              tags:
+                - tag: component
+                  value: fan
+                - tag: fan
+                  value: '{#FAN_ENTITY}/{#FAN_ENTITYSLOT}/{#FAN_ID}'
+              trigger_prototypes:
+                - uuid: fe672abe0c814fe6a7e9e84048a77532
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.STATUS.CRIT:"down"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.STATUS.CRIT:"lowerLayerDown"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.STATUS.CRIT:"failed"}'
+                  name: 'Dell SmartFabric OS10: Fan [{#SNMPINDEX}] ({#FAN_ENTITY}/{#FAN_ENTITYSLOT}/{#FAN_ID}): Critical state'
+                  opdata: 'Current state: {ITEM.LASTVALUE1}'
+                  priority: AVERAGE
+                  description: 'Please check the fan for errors.'
+                  tags:
+                    - tag: scope
+                      value: availability
+                - uuid: 8cf599fa04774149b7e0de82940d1ec3
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.STATUS.WARN:"unknown"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.STATUS.WARN:"notPresent"}'
+                  name: 'Dell SmartFabric OS10: Fan [{#SNMPINDEX}] ({#FAN_ENTITY}/{#FAN_ENTITYSLOT}/{#FAN_ID}): Warning state'
+                  opdata: 'Current state: {ITEM.LASTVALUE1}'
+                  priority: WARNING
+                  dependencies:
+                    - name: 'Dell SmartFabric OS10: Fan [{#SNMPINDEX}] ({#FAN_ENTITY}/{#FAN_ENTITYSLOT}/{#FAN_ID}): Critical state'
+                      expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.STATUS.CRIT:"down"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.STATUS.CRIT:"lowerLayerDown"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.STATUS.CRIT:"failed"}'
+                  tags:
+                    - tag: scope
+                      value: availability
+          master_item:
+            key: dell.switch.fan.walk
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#FAN_DEVICE}'
+                - 1.3.6.1.4.1.674.11000.5000.100.4.1.2.3.1.2
+                - '0'
+                - '{#FAN_ENTITY}'
+                - 1.3.6.1.4.1.674.11000.5000.100.4.1.2.3.1.4
+                - '0'
+                - '{#FAN_ENTITYSLOT}'
+                - 1.3.6.1.4.1.674.11000.5000.100.4.1.2.3.1.5
+                - '0'
+                - '{#FAN_ID}'
+                - 1.3.6.1.4.1.674.11000.5000.100.4.1.2.3.1.6
+                - '0'
+                - '{#SNMPVALUE}'
+                - 1.3.6.1.4.1.674.11000.5000.100.4.1.2.3.1.7
+                - '0'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+        - uuid: 61f23a6e88f2424ea3339286d7684650
+          name: 'Fan Tray Discovery'
+          type: DEPENDENT
+          key: fan.tray.discovery
+          description: 'Fan tray discovery.'
+          item_prototypes:
+            - uuid: 488fbab14d9f489886a2c93771611079
+              name: 'Fan tray [{#SNMPINDEX}] ({#FAN_TRAY_PPID}): Status'
+              type: DEPENDENT
+              key: 'dell.switch.fan.tray.status[{#SNMPINDEX}]'
+              trends: '0'
+              description: |
+                MIB: DELLEMC-OS10-CHASSIS-MIB
+                This attribute defines the operating status of the fan tray.
+              valuemap:
+                name: 'DELLEMC-OS10-TC-MIB::Os10CmnOperStatus'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.2.2.1.4.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: dell.switch.fan.tray.walk
+              tags:
+                - tag: component
+                  value: fanTray
+                - tag: fanTray
+                  value: '{#FAN_TRAY_PPID}'
+              trigger_prototypes:
+                - uuid: a544987d946d4342a78ee5ad5a56e4a3
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.tray.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.TRAY.STATUS.CRIT:"down"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.tray.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.TRAY.STATUS.CRIT:"lowerLayerDown"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.tray.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.TRAY.STATUS.CRIT:"failed"}'
+                  name: 'Dell SmartFabric OS10: Fan Tray [{#SNMPINDEX}] ({#FAN_TRAY_PPID}): Critical state'
+                  opdata: 'Current state: {ITEM.LASTVALUE1}'
+                  priority: AVERAGE
+                  tags:
+                    - tag: scope
+                      value: availability
+                - uuid: 7f85d05d0fb34e3a9f3e1461b6ee0371
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.tray.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.TRAY.STATUS.WARN:"unknown"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.tray.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.TRAY.STATUS.WARN:"notPresent"}'
+                  name: 'Dell SmartFabric OS10: Fan Tray [{#SNMPINDEX}] ({#FAN_TRAY_PPID}): Warning state'
+                  opdata: 'Current state: {ITEM.LASTVALUE1}'
+                  priority: WARNING
+                  dependencies:
+                    - name: 'Dell SmartFabric OS10: Fan Tray [{#SNMPINDEX}] ({#FAN_TRAY_PPID}): Critical state'
+                      expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.tray.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.TRAY.STATUS.CRIT:"down"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.tray.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.TRAY.STATUS.CRIT:"lowerLayerDown"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.fan.tray.status[{#SNMPINDEX}])={$DELL.OS10.SNMP.FAN.TRAY.STATUS.CRIT:"failed"}'
+                  tags:
+                    - tag: scope
+                      value: availability
+          master_item:
+            key: dell.switch.fan.tray.walk
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#FAN_TRAY_PPID}'
+                - 1.3.6.1.4.1.674.11000.5000.100.4.1.2.2.1.5
+                - '0'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+        - uuid: 0423f84acd74401f85d46178734e915d
+          name: 'Network interfaces discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#IFOPERSTATUS},1.3.6.1.2.1.2.2.1.8,{#IFADMINSTATUS},1.3.6.1.2.1.2.2.1.7,{#IFALIAS},1.3.6.1.2.1.31.1.1.1.18,{#IFNAME},1.3.6.1.2.1.31.1.1.1.1,{#IFDESCR},1.3.6.1.2.1.2.2.1.2,{#IFTYPE},1.3.6.1.2.1.2.2.1.3]'
+          key: net.if.discovery
+          delay: 1h
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#IFADMINSTATUS}'
+                value: '{$NET.IF.IFADMINSTATUS.MATCHES}'
+              - macro: '{#IFADMINSTATUS}'
+                value: '{$NET.IF.IFADMINSTATUS.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFALIAS}'
+                value: '{$NET.IF.IFALIAS.MATCHES}'
+              - macro: '{#IFALIAS}'
+                value: '{$NET.IF.IFALIAS.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFDESCR}'
+                value: '{$NET.IF.IFDESCR.MATCHES}'
+              - macro: '{#IFDESCR}'
+                value: '{$NET.IF.IFDESCR.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFNAME}'
+                value: '{$NET.IF.IFNAME.MATCHES}'
+              - macro: '{#IFNAME}'
+                value: '{$NET.IF.IFNAME.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFOPERSTATUS}'
+                value: '{$NET.IF.IFOPERSTATUS.MATCHES}'
+              - macro: '{#IFOPERSTATUS}'
+                value: '{$NET.IF.IFOPERSTATUS.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFTYPE}'
+                value: '{$NET.IF.IFTYPE.MATCHES}'
+              - macro: '{#IFTYPE}'
+                value: '{$NET.IF.IFTYPE.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+          description: 'Discovering interfaces from IF-MIB.'
+          item_prototypes:
+            - uuid: 19ef006d7b264a7aba4f4afc12bd10e8
+              name: 'Interface {#IFNAME}({#IFALIAS}): Inbound packets discarded'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.13.{#SNMPINDEX}'
+              key: 'net.if.in.discards[ifInDiscards.{#SNMPINDEX}]'
+              delay: 3m
+              description: |
+                MIB: IF-MIB
+                The number of inbound packets which were chosen to be discarded
+                even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.
+                One possible reason for discarding such a packet could be to free up buffer space.
+                Discontinuities in the value of this counter can occur at re-initialization of the management system,
+                and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: 4d782f40ff0b4b5da89405a519454c08
+              name: 'Interface {#IFNAME}({#IFALIAS}): Inbound packets with errors'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.14.{#SNMPINDEX}'
+              key: 'net.if.in.errors[ifInErrors.{#SNMPINDEX}]'
+              delay: 3m
+              description: |
+                MIB: IF-MIB
+                For packet-oriented interfaces, the number of inbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of inbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: cf4bbf7b3c524ae5a98d75d60bbef209
+              name: 'Interface {#IFNAME}({#IFALIAS}): Bits received'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.10.{#SNMPINDEX}'
+              key: 'net.if.in[ifInOctets.{#SNMPINDEX}]'
+              delay: 3m
+              units: bps
+              description: |
+                MIB: IF-MIB
+                The total number of octets received on the interface,including framing characters. Discontinuities in the value of this counter can occur at re-initialization of the management system, and another times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: b26e127c02d14bd289705397529019cb
+              name: 'Interface {#IFNAME}({#IFALIAS}): Outbound packets discarded'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.19.{#SNMPINDEX}'
+              key: 'net.if.out.discards[ifOutDiscards.{#SNMPINDEX}]'
+              delay: 3m
+              description: |
+                MIB: IF-MIB
+                The number of outbound packets which were chosen to be discarded
+                even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.
+                One possible reason for discarding such a packet could be to free up buffer space.
+                Discontinuities in the value of this counter can occur at re-initialization of the management system,
+                and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: 16eece71e07d4cd8b62feaba9edfe6ff
+              name: 'Interface {#IFNAME}({#IFALIAS}): Outbound packets with errors'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.20.{#SNMPINDEX}'
+              key: 'net.if.out.errors[ifOutErrors.{#SNMPINDEX}]'
+              delay: 3m
+              description: |
+                MIB: IF-MIB
+                For packet-oriented interfaces, the number of outbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of outbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: a14a4bbd28184256ab44536c511088b7
+              name: 'Interface {#IFNAME}({#IFALIAS}): Bits sent'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.16.{#SNMPINDEX}'
+              key: 'net.if.out[ifOutOctets.{#SNMPINDEX}]'
+              delay: 3m
+              units: bps
+              description: |
+                MIB: IF-MIB
+                The total number of octets transmitted out of the interface, including framing characters. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: 22733912369d47919b166ec252f20d6a
+              name: 'Interface {#IFNAME}({#IFALIAS}): Speed'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.31.1.1.1.15.{#SNMPINDEX}'
+              key: 'net.if.speed[ifSpeed.{#SNMPINDEX}]'
+              delay: 5m
+              trends: '0'
+              units: bps
+              description: |
+                MIB: IF-MIB
+                An estimate of the interface's current bandwidth in bits per second.
+                For interfaces which do not vary in bandwidth or for those where no accurate estimation can be made,
+                this object should contain the nominal bandwidth.
+                If the bandwidth of the interface is greater than the maximum value reportable by this object then
+                this object should report its maximum value (4,294,967,295) and ifHighSpeed must be used to report the interface's speed.
+                For a sub-layer which has no concept of bandwidth, this object should be zero.
+              preprocessing:
+                - type: MULTIPLIER
+                  parameters:
+                    - '1000000'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: 60b1d2f7384b48d5adc6108a164eb3b5
+              name: 'Interface {#IFNAME}({#IFALIAS}): Operational status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.8.{#SNMPINDEX}'
+              key: 'net.if.status[ifOperStatus.{#SNMPINDEX}]'
+              trends: '0'
+              description: |
+                MIB: IF-MIB
+                The current operational state of the interface.
+                - The testing(3) state indicates that no operational packet scan be passed
+                - If ifAdminStatus is down(2) then ifOperStatus should be down(2)
+                - If ifAdminStatus is changed to up(1) then ifOperStatus should change to up(1) if the interface is ready to transmit and receive network traffic
+                - It should change todormant(5) if the interface is waiting for external actions (such as a serial line waiting for an incoming connection)
+                - It should remain in the down(2) state if and only if there is a fault that prevents it from going to the up(1) state
+                - It should remain in the notPresent(6) state if the interface has missing(typically, hardware) components.
+              valuemap:
+                name: 'IF-MIB::ifOperStatus'
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+              trigger_prototypes:
+                - uuid: 488101b296ba4d909baa49abc7422900
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+                  name: 'Network Generic Device: Interface {#IFNAME}({#IFALIAS}): Link down'
+                  opdata: 'Current state: {ITEM.LASTVALUE1}'
+                  priority: AVERAGE
+                  description: |
+                    This trigger expression works as follows:
+                    1. It can be triggered if the operations status is down.
+                    2. `{$IFCONTROL:"{#IFNAME}"}=1` - a user can redefine the context macro to "0", marking this interface as not important. No new trigger will be fired if this interface is down.
+                    3. `{TEMPLATE_NAME:METRIC.diff()}=1` - the trigger fires only if the operational status was up to (1) sometime before (so, does not fire for "eternal off" interfaces.)
+                    
+                    WARNING: if closed manually - it will not fire again on the next poll, because of .diff.
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: availability
+            - uuid: 440f1ff1080047a39682b67abc0ffa8f
+              name: 'Interface {#IFNAME}({#IFALIAS}): Interface type'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.3.{#SNMPINDEX}'
+              key: 'net.if.type[ifType.{#SNMPINDEX}]'
+              delay: 1h
+              trends: '0'
+              description: |
+                MIB: IF-MIB
+                The type of interface.
+                Additional values for ifType are assigned by the Internet Assigned Numbers Authority (IANA),
+                through updating the syntax of the IANAifType textual convention.
+              valuemap:
+                name: 'IF-MIB::ifType'
+              preprocessing:
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1d
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+          trigger_prototypes:
+            - uuid: 340b8a91b6af4567ad8fe76cf293e5e9
+              expression: |
+                change(/Dell SmartFabric OS10 by SNMP/net.if.speed[ifSpeed.{#SNMPINDEX}])<0 and last(/Dell SmartFabric OS10 by SNMP/net.if.speed[ifSpeed.{#SNMPINDEX}])>0
+                and (
+                last(/Dell SmartFabric OS10 by SNMP/net.if.type[ifType.{#SNMPINDEX}])=6 or
+                last(/Dell SmartFabric OS10 by SNMP/net.if.type[ifType.{#SNMPINDEX}])=7 or
+                last(/Dell SmartFabric OS10 by SNMP/net.if.type[ifType.{#SNMPINDEX}])=11 or
+                last(/Dell SmartFabric OS10 by SNMP/net.if.type[ifType.{#SNMPINDEX}])=62 or
+                last(/Dell SmartFabric OS10 by SNMP/net.if.type[ifType.{#SNMPINDEX}])=69 or
+                last(/Dell SmartFabric OS10 by SNMP/net.if.type[ifType.{#SNMPINDEX}])=117
+                )
+                and
+                (last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2)
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: |
+                (change(/Dell SmartFabric OS10 by SNMP/net.if.speed[ifSpeed.{#SNMPINDEX}])>0 and last(/Dell SmartFabric OS10 by SNMP/net.if.speed[ifSpeed.{#SNMPINDEX}],#2)>0) or
+                (last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2)
+              name: 'Network Generic Device: Interface {#IFNAME}({#IFALIAS}): Ethernet has changed to lower speed than it was before'
+              opdata: 'Current reported speed: {ITEM.LASTVALUE1}'
+              priority: INFO
+              description: 'This Ethernet connection has transitioned down from its known maximum speed. This might be a sign of autonegotiation issues. Acknowledge to close the problem manually.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'Network Generic Device: Interface {#IFNAME}({#IFALIAS}): Link down'
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
+                  recovery_expression: 'last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+              tags:
+                - tag: scope
+                  value: performance
+            - uuid: 1023dd9502894fbdab844a6021297099
+              expression: |
+                (avg(/Dell SmartFabric OS10 by SNMP/net.if.in[ifInOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Dell SmartFabric OS10 by SNMP/net.if.speed[ifSpeed.{#SNMPINDEX}]) or
+                avg(/Dell SmartFabric OS10 by SNMP/net.if.out[ifOutOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/Dell SmartFabric OS10 by SNMP/net.if.speed[ifSpeed.{#SNMPINDEX}])) and
+                last(/Dell SmartFabric OS10 by SNMP/net.if.speed[ifSpeed.{#SNMPINDEX}])>0
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: |
+                avg(/Dell SmartFabric OS10 by SNMP/net.if.in[ifInOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Dell SmartFabric OS10 by SNMP/net.if.speed[ifSpeed.{#SNMPINDEX}]) and
+                avg(/Dell SmartFabric OS10 by SNMP/net.if.out[ifOutOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/Dell SmartFabric OS10 by SNMP/net.if.speed[ifSpeed.{#SNMPINDEX}])
+              name: 'Network Generic Device: Interface {#IFNAME}({#IFALIAS}): High bandwidth usage'
+              event_name: 'Network Generic Device: Interface {#IFNAME}({#IFALIAS}): High bandwidth usage (>{$IF.UTIL.MAX:"{#IFNAME}"}%)'
+              opdata: 'In: {ITEM.LASTVALUE1}, out: {ITEM.LASTVALUE3}, speed: {ITEM.LASTVALUE2}'
+              priority: WARNING
+              description: 'The utilization of the network interface is close to its estimated maximum bandwidth.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'Network Generic Device: Interface {#IFNAME}({#IFALIAS}): Link down'
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
+                  recovery_expression: 'last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+              tags:
+                - tag: scope
+                  value: performance
+            - uuid: 8b9384aa1e59455eaa3abd10dd6171ac
+              expression: |
+                min(/Dell SmartFabric OS10 by SNMP/net.if.in.errors[ifInErrors.{#SNMPINDEX}],5m)>{$IF.ERRORS.WARN:"{#IFNAME}"}
+                or min(/Dell SmartFabric OS10 by SNMP/net.if.out.errors[ifOutErrors.{#SNMPINDEX}],5m)>{$IF.ERRORS.WARN:"{#IFNAME}"}
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: |
+                max(/Dell SmartFabric OS10 by SNMP/net.if.in.errors[ifInErrors.{#SNMPINDEX}],5m)<{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8
+                and max(/Dell SmartFabric OS10 by SNMP/net.if.out.errors[ifOutErrors.{#SNMPINDEX}],5m)<{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8
+              name: 'Network Generic Device: Interface {#IFNAME}({#IFALIAS}): High error rate'
+              event_name: 'Network Generic Device: Interface {#IFNAME}({#IFALIAS}): High error rate (>{$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)'
+              opdata: 'errors in: {ITEM.LASTVALUE1}, errors out: {ITEM.LASTVALUE2}'
+              priority: WARNING
+              description: 'It recovers when it is below 80% of the `{$IF.ERRORS.WARN:"{#IFNAME}"}` threshold.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'Network Generic Device: Interface {#IFNAME}({#IFALIAS}): Link down'
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))'
+                  recovery_expression: 'last(/Dell SmartFabric OS10 by SNMP/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or {$IFCONTROL:"{#IFNAME}"}=0'
+              tags:
+                - tag: scope
+                  value: performance
+          graph_prototypes:
+            - uuid: 3a1d1d47830040ff9e93c90b5499267e
+              name: 'Interface {#IFNAME}({#IFALIAS}): Network traffic'
+              graph_items:
+                - drawtype: GRADIENT_LINE
+                  color: 199C0D
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'net.if.in[ifInOctets.{#SNMPINDEX}]'
+                - sortorder: '1'
+                  drawtype: BOLD_LINE
+                  color: F63100
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'net.if.out[ifOutOctets.{#SNMPINDEX}]'
+                - sortorder: '2'
+                  color: 00611C
+                  yaxisside: RIGHT
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'net.if.out.errors[ifOutErrors.{#SNMPINDEX}]'
+                - sortorder: '3'
+                  color: F7941D
+                  yaxisside: RIGHT
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'net.if.in.errors[ifInErrors.{#SNMPINDEX}]'
+                - sortorder: '4'
+                  color: FC6EA3
+                  yaxisside: RIGHT
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'net.if.out.discards[ifOutDiscards.{#SNMPINDEX}]'
+                - sortorder: '5'
+                  color: 6C59DC
+                  yaxisside: RIGHT
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'net.if.in.discards[ifInDiscards.{#SNMPINDEX}]'
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 4h
+        - uuid: 08a9f6d6bc8d4612a7cf147f2bb59461
+          name: 'EtherLike-MIB Discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},1.3.6.1.2.1.10.7.2.1.19,{#IFOPERSTATUS},1.3.6.1.2.1.2.2.1.8,{#IFALIAS},1.3.6.1.2.1.31.1.1.1.18,{#IFNAME},1.3.6.1.2.1.31.1.1.1.1,{#IFDESCR},1.3.6.1.2.1.2.2.1.2]'
+          key: net.if.duplex.discovery
+          delay: 1h
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#IFOPERSTATUS}'
+                value: '1'
+              - macro: '{#SNMPVALUE}'
+                value: (2|3)
+          description: 'Discovering interfaces from IF-MIB and EtherLike-MIB. Interfaces with up(1) Operational Status are discovered.'
+          item_prototypes:
+            - uuid: 86a8e86ffbc847c591b750d34d0f6476
+              name: 'Interface {#IFNAME}({#IFALIAS}): Duplex status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.10.7.2.1.19.{#SNMPINDEX}'
+              key: 'net.if.duplex[dot3StatsDuplexStatus.{#SNMPINDEX}]'
+              description: |
+                MIB: EtherLike-MIB
+                The current mode of operation of the MAC
+                entity.  'unknown' indicates that the current
+                duplex mode could not be determined.
+                
+                Management control of the duplex mode is
+                accomplished through the MAU MIB.  When
+                an interface does not support autonegotiation,
+                or when autonegotiation is not enabled, the
+                duplex mode is controlled using
+                ifMauDefaultType.  When autonegotiation is
+                supported and enabled, duplex mode is controlled
+                using ifMauAutoNegAdvertisedBits.  In either
+                case, the currently operating duplex mode is
+                reflected both in this object and in ifMauType.
+                
+                Note that this object provides redundant
+                information with ifMauType.  Normally, redundant
+                objects are discouraged.  However, in this
+                instance, it allows a management application to
+                determine the duplex status of an interface
+                without having to know every possible value of
+                ifMauType.  This was felt to be sufficiently
+                valuable to justify the redundancy.
+                Reference: [IEEE 802.3 Std.], 30.3.1.1.32,aDuplexStatus.
+              valuemap:
+                name: 'EtherLike-MIB::dot3StatsDuplexStatus'
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#IFALIAS}'
+                - tag: interface
+                  value: '{#IFNAME}'
+              trigger_prototypes:
+                - uuid: 7c48d1a15a1f46e4848412e85e16c295
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/net.if.duplex[dot3StatsDuplexStatus.{#SNMPINDEX}])=2'
+                  name: 'Network Generic Device: Interface {#IFNAME}({#IFALIAS}): In half-duplex mode'
+                  priority: WARNING
+                  description: 'Please check autonegotiation settings and cabling.'
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: performance
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  try {
+                  	var data = JSON.parse(value);
+                  }
+                  catch (error) {
+                  	throw 'Failed to parse JSON of EtherLike-MIB discovery.';
+                  }
+                  var fields = ['{#SNMPVALUE}','{#IFOPERSTATUS}','{#IFALIAS}','{#IFNAME}','{#IFDESCR}'];
+                  data.forEach(function (element) {
+                  	fields.forEach(function (field) {
+                  		element[field] = element[field] || '';
+                  	});
+                  });
+                  return JSON.stringify(data);
+        - uuid: 63bb99a478af4250bb87e6da73524115
+          name: 'Power Supply Discovery'
+          type: DEPENDENT
+          key: psu.discovery
+          description: 'PSU discovery.'
+          item_prototypes:
+            - uuid: 1d4bb3e15b634cce9b88e56324d1bcbc
+              name: 'Power supply [{#SNMPINDEX}] (PPID: {#PSU_PPID}): Status'
+              type: DEPENDENT
+              key: 'dell.switch.sensor.psu.status[powerSupplyStatus.{#SNMPINDEX}]'
+              trends: '0'
+              valuemap:
+                name: 'DELLEMC-OS10-TC-MIB::Os10CmnOperStatus'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.4.1.674.11000.5000.100.4.1.2.1.1.4.{#SNMPINDEX}'
+                    - '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 6h
+              master_item:
+                key: dell.switch.psu.walk
+              tags:
+                - tag: component
+                  value: psu
+                - tag: psu
+                  value: '{#PSU_PPID}'
+              trigger_prototypes:
+                - uuid: 9a245d651393498abaf0c748564645f2
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.sensor.psu.status[powerSupplyStatus.{#SNMPINDEX}])={$DELL.OS10.SNMP.PSU.STATUS.CRIT:"down"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.sensor.psu.status[powerSupplyStatus.{#SNMPINDEX}])={$DELL.OS10.SNMP.PSU.STATUS.CRIT:"lowerLayerDown"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.sensor.psu.status[powerSupplyStatus.{#SNMPINDEX}])={$DELL.OS10.SNMP.PSU.STATUS.CRIT:"failed"}'
+                  name: 'Dell SmartFabric OS10: Power supply [{#SNMPINDEX}] ({#PSU_PPID}): Critical state'
+                  opdata: 'Current state: {ITEM.LASTVALUE1}'
+                  priority: AVERAGE
+                  description: 'Please check the power supply unit for errors.'
+                  tags:
+                    - tag: scope
+                      value: availability
+                - uuid: 54058d23f56a4532924b3b297e985781
+                  expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.sensor.psu.status[powerSupplyStatus.{#SNMPINDEX}])={$DELL.OS10.SNMP.PSU.STATUS.WARN:"unknown"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.sensor.psu.status[powerSupplyStatus.{#SNMPINDEX}])={$DELL.OS10.SNMP.PSU.STATUS.WARN:"notPresent"}'
+                  name: 'Dell SmartFabric OS10: Power supply [{#SNMPINDEX}] ({#PSU_PPID}): Warning state'
+                  opdata: 'Current state: {ITEM.LASTVALUE1}'
+                  priority: WARNING
+                  dependencies:
+                    - name: 'Dell SmartFabric OS10: Power supply [{#SNMPINDEX}] ({#PSU_PPID}): Critical state'
+                      expression: 'last(/Dell SmartFabric OS10 by SNMP/dell.switch.sensor.psu.status[powerSupplyStatus.{#SNMPINDEX}])={$DELL.OS10.SNMP.PSU.STATUS.CRIT:"down"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.sensor.psu.status[powerSupplyStatus.{#SNMPINDEX}])={$DELL.OS10.SNMP.PSU.STATUS.CRIT:"lowerLayerDown"} or last(/Dell SmartFabric OS10 by SNMP/dell.switch.sensor.psu.status[powerSupplyStatus.{#SNMPINDEX}])={$DELL.OS10.SNMP.PSU.STATUS.CRIT:"failed"}'
+                  tags:
+                    - tag: scope
+                      value: availability
+          master_item:
+            key: dell.switch.psu.walk
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#PSU_DEVICE}'
+                - 1.3.6.1.4.1.674.11000.5000.100.4.1.2.1.1.2
+                - '0'
+                - '{#SNMPVALUE}'
+                - 1.3.6.1.4.1.674.11000.5000.100.4.1.2.1.1.4
+                - '0'
+                - '{#PSU_PPID}'
+                - 1.3.6.1.4.1.674.11000.5000.100.4.1.2.1.1.6
+                - '0'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+        - uuid: d5960b6bd40d4f0e9e19e2ff669e4d5d
+          name: 'Mounted filesystem discovery'
+          type: DEPENDENT
+          key: 'vfs.fs.discovery[snmp]'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#FSDEVICE}'
+                value: '{$VFS.FS.FSDEVICE.MATCHES}'
+              - macro: '{#FSDEVICE}'
+                value: '{$VFS.FS.FSDEVICE.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#FSNAME}'
+                value: '{$VFS.FS.FSNAME.MATCHES}'
+              - macro: '{#FSNAME}'
+                value: '{$VFS.FS.FSNAME.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+          description: 'UCD-SNMP-MIB::dskEntry table discovery with storage filter'
+          item_prototypes:
+            - uuid: e38a7680f44049599689ef041012a2ec
+              name: 'FS [{#FSNAME}]: Space: Available'
+              type: DEPENDENT
+              key: 'vfs.fs.free[dskAvail.{#SNMPINDEX}]'
+              value_type: FLOAT
+              units: B
+              description: |
+                UCD-SNMP-MIB::dskEntry
+                Available storage space is calculated from two portions:
+                  dskAvailHigh
+                  dskAvailLow
+                Together they compose 64-bit number.
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      const portionHigh = 4294967296;
+                      
+                      const obj = JSON.parse(value);
+                      
+                      const dskAvailHigh = parseInt(obj['dskAvailHigh'], 10),
+                      	  dskAvailLow = parseInt(obj['dskAvailLow'], 10);
+                      
+                      return (dskAvailHigh * portionHigh + dskAvailLow) * 1024;
+              master_item:
+                key: 'vfs.fs.walk.data[dskEntry.{#SNMPINDEX}]'
+              tags:
+                - tag: component
+                  value: storage
+                - tag: filesystem
+                  value: '{#FSNAME}'
+            - uuid: f3e4297249cd40a6bdb40d1fe9a6bfa4
+              name: 'FS [{#FSNAME}]: Inodes: Free, in %'
+              type: DEPENDENT
+              key: 'vfs.fs.inode.pfree[{#SNMPINDEX}]'
+              value_type: FLOAT
+              units: '%'
+              description: |
+                MIB: UCD-SNMP-MIB
+                Free metadata space expressed as percentage.
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      var obj = JSON.parse(value);
+                      var dskPercentNode = obj['dskPercentNode'];
+                      
+                      return (100 - dskPercentNode);
+              master_item:
+                key: 'vfs.fs.walk.data[dskEntry.{#SNMPINDEX}]'
+              tags:
+                - tag: component
+                  value: storage
+                - tag: filesystem
+                  value: '{#FSNAME}'
+              trigger_prototypes:
+                - uuid: 68dc8105af27431e8162db25d6edc552
+                  expression: 'min(/Dell SmartFabric OS10 by SNMP/vfs.fs.inode.pfree[{#SNMPINDEX}],5m)<{$VFS.FS.INODE.PFREE.MIN.CRIT:"{#FSNAME}"}'
+                  name: 'Dell SmartFabric OS10: FS [{#FSNAME}]: Running out of free inodes'
+                  event_name: 'Dell SmartFabric OS10: FS [{#FSNAME}]: Running out of free inodes (free < {$VFS.FS.INODE.PFREE.MIN.CRIT:"{#FSNAME}"}%)'
+                  opdata: 'Free inodes: {ITEM.LASTVALUE1}'
+                  priority: AVERAGE
+                  description: 'Disk writing may fail if index nodes are exhausted, leading to error messages like "No space left on device" or "Disk is full", despite available free space.'
+                  tags:
+                    - tag: scope
+                      value: availability
+                    - tag: scope
+                      value: capacity
+                - uuid: c4e7eec43f5a4cccbc6025efe2825077
+                  expression: 'min(/Dell SmartFabric OS10 by SNMP/vfs.fs.inode.pfree[{#SNMPINDEX}],5m)<{$VFS.FS.INODE.PFREE.MIN.WARN:"{#FSNAME}"}'
+                  name: 'Dell SmartFabric OS10: FS [{#FSNAME}]: Running out of free inodes'
+                  event_name: 'Dell SmartFabric OS10: FS [{#FSNAME}]: Running out of free inodes (free < {$VFS.FS.INODE.PFREE.MIN.WARN:"{#FSNAME}"}%)'
+                  opdata: 'Free inodes: {ITEM.LASTVALUE1}'
+                  priority: WARNING
+                  description: 'Disk writing may fail if index nodes are exhausted, leading to error messages like "No space left on device" or "Disk is full", despite available free space.'
+                  dependencies:
+                    - name: 'Dell SmartFabric OS10: FS [{#FSNAME}]: Running out of free inodes'
+                      expression: 'min(/Dell SmartFabric OS10 by SNMP/vfs.fs.inode.pfree[{#SNMPINDEX}],5m)<{$VFS.FS.INODE.PFREE.MIN.CRIT:"{#FSNAME}"}'
+                  tags:
+                    - tag: scope
+                      value: availability
+                    - tag: scope
+                      value: capacity
+            - uuid: 3377e54aa77d406fa2486abecff80621
+              name: 'FS [{#FSNAME}]: Space: Used, in %'
+              type: DEPENDENT
+              key: 'vfs.fs.pused[{#SNMPINDEX}]'
+              value_type: FLOAT
+              units: '%'
+              description: |
+                UCD-SNMP-MIB::dskEntry
+                Space utilization is calculated as the percentage of currently used space compared to the maximum available space.
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      const portionHigh = 4294967296;
+                      
+                      const obj = JSON.parse(value);
+                      
+                      const dskAvailHigh = parseInt(obj['dskAvailHigh'], 10),
+                      	  dskAvailLow = parseInt(obj['dskAvailLow'], 10),
+                      	  dskUsedHigh = parseInt(obj['dskUsedHigh'], 10),
+                      	  dskUsedLow = parseInt(obj['dskUsedLow'], 10);
+                      
+                      const available = (dskAvailHigh * portionHigh + dskAvailLow) * 1024,
+                      	  used = (dskUsedHigh * portionHigh + dskUsedLow) * 1024;
+                      
+                      if ((available + used) <= 0) {
+                      	return 0;
+                      }
+                      
+                      return used / (used + available) * 100;
+              master_item:
+                key: 'vfs.fs.walk.data[dskEntry.{#SNMPINDEX}]'
+              tags:
+                - tag: component
+                  value: storage
+                - tag: filesystem
+                  value: '{#FSNAME}'
+              trigger_prototypes:
+                - uuid: 3ab41c7291344f04a05bf22bb29d68be
+                  expression: 'min(/Dell SmartFabric OS10 by SNMP/vfs.fs.pused[{#SNMPINDEX}],5m)>{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}'
+                  name: 'Dell SmartFabric OS10: Space is critically low'
+                  event_name: 'Dell SmartFabric OS10: FS [{#FSNAME}]: Space is critically low (used > {$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%, total {{?last(//vfs.fs.total[dskTotal.{#SNMPINDEX}])/1024/1024/1024}.fmtnum(1)}GB)'
+                  opdata: 'Space used: {{ITEM.LASTVALUE1}.fmtnum(1)}%'
+                  priority: AVERAGE
+                  description: |
+                    The volume's space usage exceeds the '{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%' limit;
+                    The trigger expression is based on the current used and maximum available spaces.
+                    Event name represents the total volume space, which can differ from the maximum available space, depending on the filesystem type.
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: availability
+                    - tag: scope
+                      value: capacity
+                - uuid: 8a25993f96dc49b3aad7aa8aa2f41e66
+                  expression: 'min(/Dell SmartFabric OS10 by SNMP/vfs.fs.pused[{#SNMPINDEX}],5m)>{$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}'
+                  name: 'Dell SmartFabric OS10: Space is low'
+                  event_name: 'Dell SmartFabric OS10: FS [{#FSNAME}]: Space is low (used > {$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%, total {{?last(//vfs.fs.total[dskTotal.{#SNMPINDEX}])/1024/1024/1024}.fmtnum(1)}GB)'
+                  opdata: 'Space used: {{ITEM.LASTVALUE1}.fmtnum(1)}%'
+                  priority: WARNING
+                  description: |
+                    The volume's space usage exceeds the '{$VFS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%' limit;
+                    The trigger expression is based on the current used and maximum available spaces.
+                    Event name represents the total volume space, which can differ from the maximum available space, depending on the filesystem type.
+                  manual_close: 'YES'
+                  dependencies:
+                    - name: 'Dell SmartFabric OS10: Space is critically low'
+                      expression: 'min(/Dell SmartFabric OS10 by SNMP/vfs.fs.pused[{#SNMPINDEX}],5m)>{$VFS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}'
+                  tags:
+                    - tag: scope
+                      value: availability
+                    - tag: scope
+                      value: capacity
+            - uuid: 93a9df1245434a279dad968a5a311397
+              name: 'FS [{#FSNAME}]: Space: Total'
+              type: DEPENDENT
+              key: 'vfs.fs.total[dskTotal.{#SNMPINDEX}]'
+              value_type: FLOAT
+              units: B
+              description: |
+                MIB: UCD-SNMP-MIB
+                Total storage is calculated from two portions:
+                  dskTotalHigh
+                  dskTotalLow
+                Together they compose 64-bit number.
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      const portionHigh = 4294967296;
+                      
+                      const obj = JSON.parse(value);
+                      
+                      const dskTotalHigh = parseInt(obj['dskTotalHigh'], 10),
+                      	  dskTotalLow = parseInt(obj['dskTotalLow'], 10);
+                      
+                      return (dskTotalHigh * portionHigh + dskTotalLow) * 1024;
+              master_item:
+                key: 'vfs.fs.walk.data[dskEntry.{#SNMPINDEX}]'
+              tags:
+                - tag: component
+                  value: storage
+                - tag: filesystem
+                  value: '{#FSNAME}'
+            - uuid: e287f1dcc7f54c84b874f02c937db5f4
+              name: 'FS [{#FSNAME}]: Space: Used'
+              type: DEPENDENT
+              key: 'vfs.fs.used[dskUsed.{#SNMPINDEX}]'
+              value_type: FLOAT
+              units: B
+              description: |
+                MIB: UCD-SNMP-MIB
+                Used storage is calculated from two portions:
+                  dskUsedHigh
+                  dskUsedLow
+                Together they compose 64-bit number.
+                Reserved space is not counted in.
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      const portionHigh = 4294967296;
+                      
+                      const obj = JSON.parse(value);
+                      
+                      const dskUsedHigh = parseInt(obj['dskUsedHigh'], 10),
+                      	  dskUsedLow = parseInt(obj['dskUsedLow'], 10);
+                      
+                      return (dskUsedHigh * portionHigh + dskUsedLow) * 1024;
+              master_item:
+                key: 'vfs.fs.walk.data[dskEntry.{#SNMPINDEX}]'
+              tags:
+                - tag: component
+                  value: storage
+                - tag: filesystem
+                  value: '{#FSNAME}'
+            - uuid: cc2427ebcb644745a920db038f9d737c
+              name: 'FS [{#FSNAME}]: Get data'
+              type: DEPENDENT
+              key: 'vfs.fs.walk.data[dskEntry.{#SNMPINDEX}]'
+              history: 1h
+              value_type: TEXT
+              description: |
+                MIB: UCD-SNMP-MIB
+                Intermediate data for subsequent processing.
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      var data = JSON.parse(value);
+                      
+                      result = data.filter(function(obj) {
+                      	return obj["{\#SNMPINDEX}"] === "{#SNMPINDEX}";
+                      })[0];
+                      
+                      return JSON.stringify(result);
+              master_item:
+                key: vfs.fs.walk
+              tags:
+                - tag: component
+                  value: raw
+                - tag: component
+                  value: storage
+                - tag: filesystem
+                  value: '{#FSNAME}'
+          graph_prototypes:
+            - uuid: 3e1b714e1ad742c98cac5ecaa3797ab8
+              name: 'FS [{#FSNAME}]: Space usage graph, in % (relative to max available)'
+              width: '600'
+              height: '340'
+              ymin_type_1: FIXED
+              ymax_type_1: FIXED
+              graph_items:
+                - drawtype: FILLED_REGION
+                  color: F63100
+                  calc_fnc: ALL
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'vfs.fs.pused[{#SNMPINDEX}]'
+            - uuid: 7b444dfe463845ec94750cec7d26f9f6
+              name: 'FS [{#FSNAME}]: Space utilization chart (relative to total)'
+              width: '600'
+              height: '340'
+              show_work_period: 'NO'
+              show_triggers: 'NO'
+              type: PIE
+              show_3d: 'YES'
+              graph_items:
+                - color: '787878'
+                  calc_fnc: LAST
+                  type: GRAPH_SUM
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'vfs.fs.total[dskTotal.{#SNMPINDEX}]'
+                - sortorder: '1'
+                  color: F63100
+                  calc_fnc: LAST
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'vfs.fs.used[dskUsed.{#SNMPINDEX}]'
+                - sortorder: '2'
+                  color: 199C09
+                  calc_fnc: LAST
+                  item:
+                    host: 'Dell SmartFabric OS10 by SNMP'
+                    key: 'vfs.fs.free[dskAvail.{#SNMPINDEX}]'
+          master_item:
+            key: vfs.fs.walk
+          lld_macro_paths:
+            - lld_macro: '{#FSDEVICE}'
+              path: $.dskDevice
+            - lld_macro: '{#FSNAME}'
+              path: $.dskPath
+            - lld_macro: '{#SNMPINDEX}'
+              path: $.index
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var filesystems = JSON.parse(value);
+                  
+                  result = filesystems.map(function (filesystem) {
+                  	return {
+                  		'dskPath': filesystem.dskPath,
+                  		'dskDevice': filesystem.dskDevice,
+                  		'index': filesystem['{#SNMPINDEX}']
+                  	};
+                  });
+                  
+                  return JSON.stringify(result);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+      tags:
+        - tag: class
+          value: network
+        - tag: target
+          value: dell
+        - tag: target
+          value: dell-smartfabric-os10
+      macros:
+        - macro: '{$CPU.UTIL.CRIT}'
+          value: '90'
+          description: 'Critical threshold of CPU utilization expressed in %.'
+        - macro: '{$DELL.OS10.SNMP.CARD.TEMP.CRIT}'
+          value: '65'
+          description: 'Warning temperature for switch card'
+        - macro: '{$DELL.OS10.SNMP.CARD.TEMP.WARN}'
+          value: '55'
+          description: 'Critical temperature for switch card'
+        - macro: '{$DELL.OS10.SNMP.CHASSIS.TEMP.CRIT}'
+          value: '65'
+          description: 'Warning temperature for chassis'
+        - macro: '{$DELL.OS10.SNMP.CHASSIS.TEMP.WARN}'
+          value: '55'
+          description: 'Critical temperature for chassis'
+        - macro: '{$DELL.OS10.SNMP.FAN.STATUS.CRIT:"down"}'
+          value: '2'
+          description: 'Statuscode of fan sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.FAN.STATUS.CRIT:"failed"}'
+          value: '8'
+          description: 'Statuscode of fan sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.FAN.STATUS.CRIT:"lowerLayerDown"}'
+          value: '7'
+          description: 'Statuscode of fan sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.FAN.STATUS.WARN:"notPresent"}'
+          value: '6'
+          description: 'Statuscode of fan sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.FAN.STATUS.WARN:"unknown"}'
+          value: '4'
+          description: 'Statuscode of fan sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.FAN.TRAY.STATUS.CRIT:"down"}'
+          value: '2'
+          description: 'Statuscode of fan tray sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.FAN.TRAY.STATUS.CRIT:"failed"}'
+          value: '8'
+          description: 'Statuscode of fan tray sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.FAN.TRAY.STATUS.CRIT:"lowerLayerDown"}'
+          value: '7'
+          description: 'Statuscode of fan tray sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.FAN.TRAY.STATUS.WARN:"notPresent"}'
+          value: '6'
+          description: 'Statuscode of fan tray sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.FAN.TRAY.STATUS.WARN:"unknown"}'
+          value: '4'
+          description: 'Statuscode of fan tray sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.PSU.STATUS.CRIT:"down"}'
+          value: '2'
+          description: 'Statuscode of psu sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.PSU.STATUS.CRIT:"failed"}'
+          value: '8'
+          description: 'Statuscode of psu sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.PSU.STATUS.CRIT:"lowerLayerDown"}'
+          value: '7'
+          description: 'Statuscode of psu sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.PSU.STATUS.WARN:"notPresent"}'
+          value: '6'
+          description: 'Statuscode of psu sensor for the trigger expression.'
+        - macro: '{$DELL.OS10.SNMP.PSU.STATUS.WARN:"unknown"}'
+          value: '4'
+          description: 'Statuscode of psu sensor for the trigger expression.'
+        - macro: '{$ICMP_LOSS_WARN}'
+          value: '20'
+          description: 'Warning threshold of ICMP packet loss in %.'
+        - macro: '{$ICMP_RESPONSE_TIME_WARN}'
+          value: '0.15'
+          description: 'Warning threshold of the average ICMP response time in seconds.'
+        - macro: '{$IF.ERRORS.WARN}'
+          value: '2'
+          description: 'Warning threshold of error packet rate. Can be used with interface name as context.'
+        - macro: '{$IF.UTIL.MAX}'
+          value: '95'
+          description: 'Used as a threshold in the interface utilization trigger.'
+        - macro: '{$IFCONTROL}'
+          value: '1'
+          description: 'Link status trigger will be fired only for interfaces where the context macro equals "1".'
+        - macro: '{$LOAD_AVG_PER_CPU.MAX.WARN}'
+          value: '1.5'
+          description: 'Load per CPU considered sustainable. Tune if needed.'
+        - macro: '{$MEMORY.AVAILABLE.MIN}'
+          value: 20M
+          description: 'Used as a threshold in the available memory trigger.'
+        - macro: '{$MEMORY.UTIL.MAX}'
+          value: '90'
+          description: 'Used as a threshold in the memory utilization trigger.'
+        - macro: '{$NET.IF.IFADMINSTATUS.MATCHES}'
+          value: '^.*'
+          description: 'Used in network interface discovery rule filters.'
+        - macro: '{$NET.IF.IFADMINSTATUS.NOT_MATCHES}'
+          value: ^2$
+          description: 'Ignore `down(2)` administrative status'
+        - macro: '{$NET.IF.IFALIAS.MATCHES}'
+          value: '.*'
+          description: 'Used in network interface discovery rule filters.'
+        - macro: '{$NET.IF.IFALIAS.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+          description: 'Used in network interface discovery rule filters.'
+        - macro: '{$NET.IF.IFDESCR.MATCHES}'
+          value: '.*'
+          description: 'Used in network interface discovery rule filters.'
+        - macro: '{$NET.IF.IFDESCR.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+          description: 'Used in network interface discovery rule filters.'
+        - macro: '{$NET.IF.IFNAME.MATCHES}'
+          value: '^.*$'
+          description: 'Used for network interface discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$NET.IF.IFNAME.NOT_MATCHES}'
+          value: '(^Software Loopback Interface|^NULL[0-9.]*$|^[Ll]o[0-9.]*$|^[Ss]ystem$|^Nu[0-9.]*$|^veth[0-9a-z]+$|docker[0-9]+|br-[a-z0-9]{12})'
+          description: 'Filters out `loopbacks`, `nulls`, docker `veth` links and `docker0 bridge` by default.'
+        - macro: '{$NET.IF.IFOPERSTATUS.MATCHES}'
+          value: '^.*$'
+          description: 'Used for network interface discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$NET.IF.IFOPERSTATUS.NOT_MATCHES}'
+          value: ^6$
+          description: 'Ignore `notPresent(6)`'
+        - macro: '{$NET.IF.IFTYPE.MATCHES}'
+          value: '.*'
+          description: 'Used in network interface discovery rule filters.'
+        - macro: '{$NET.IF.IFTYPE.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+          description: 'Used in network interface discovery rule filters.'
+        - macro: '{$SNMP.TIMEOUT}'
+          value: 5m
+          description: 'Time interval for the SNMP availability trigger.'
+        - macro: '{$SWAP.PFREE.MIN.WARN}'
+          value: '50'
+          description: 'The warning threshold of the minimum free swap.'
+        - macro: '{$VFS.DEV.DEVNAME.MATCHES}'
+          value: .+
+          description: 'Used in block device discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$VFS.DEV.DEVNAME.NOT_MATCHES}'
+          value: '^(loop[0-9]*|sd[a-z][0-9]+|nbd[0-9]+|sr[0-9]+|fd[0-9]+|dm-[0-9]+|ram[0-9]+|ploop[a-z0-9]+|md[0-9]*|hcp[0-9]*|zram[0-9]*)'
+          description: 'Used in block device discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$VFS.FS.FSDEVICE.MATCHES}'
+          value: .+
+          description: 'Used in filesystem discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$VFS.FS.FSDEVICE.NOT_MATCHES}'
+          value: '.*(tmpfs|shm)$'
+          description: 'Used in filesystem discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$VFS.FS.FSNAME.MATCHES}'
+          value: .+
+          description: 'Used in filesystem discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$VFS.FS.FSNAME.NOT_MATCHES}'
+          value: ^(/dev|/sys|/run|/proc|.+/shm$)
+          description: 'Used in filesystem discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$VFS.FS.INODE.PFREE.MIN.CRIT}'
+          value: '10'
+          description: 'The critical threshold of the filesystem metadata utilization.'
+        - macro: '{$VFS.FS.INODE.PFREE.MIN.WARN}'
+          value: '20'
+          description: 'The warning threshold of the filesystem metadata utilization.'
+        - macro: '{$VFS.FS.PUSED.MAX.CRIT}'
+          value: '90'
+          description: 'The critical threshold of the filesystem utilization.'
+        - macro: '{$VFS.FS.PUSED.MAX.WARN}'
+          value: '80'
+          description: 'The warning threshold of the filesystem utilization.'
+      dashboards:
+        - uuid: ef23c7a3c8434670b2501fd73061d5d4
+          name: Overview
+          pages:
+            - name: Overview
+              widgets:
+                - type: item
+                  name: 'System Description'
+                  width: '51'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: bg_color
+                      value: 2196F3
+                    - type: STRING
+                      name: description
+                      value: |
+                        {{ITEM.LASTVALUE}.regsub("(.*)", \1)}
+                        {{ITEM.LASTVALUE}.regsub("(?s).*?(Copyright.*?)[\r\n]", "\1")}
+                        {{ITEM.LASTVALUE}.regsub("(?s).*OS Version: ([^\r\n]+)", "OS Version: \1")}
+                        {{ITEM.LASTVALUE}.regsub("(?s).*System Type: ([^\r\n]+)", "System Type: \1")}
+                    - type: STRING
+                      name: desc_color
+                      value: FFFFFF
+                    - type: INTEGER
+                      name: desc_v_pos
+                      value: '1'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Dell SmartFabric OS10 by SNMP'
+                        key: 'system.descr[sysDescr.0]'
+                    - type: INTEGER
+                      name: show.0
+                      value: '1'
+                - type: honeycomb
+                  name: Fans
+                  'y': '4'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Fan [*Status'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("\[(.*?)\].*\((.*?)\)", "Fan \1")}'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: LWEPS
+                    - type: INTEGER
+                      name: secondary_label_decimal_places
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '1'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: D3212C
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '2'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: FF980E
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '3'
+                    - type: STRING
+                      name: thresholds.3.color
+                      value: D3212C
+                    - type: STRING
+                      name: thresholds.3.threshold
+                      value: '7'
+                - type: honeycomb
+                  name: 'Power supplies'
+                  'y': '8'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Power supply*Status'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("\[(.*?)\].*\((.*?)\)", "PSU \1")}'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: KRKUP
+                    - type: INTEGER
+                      name: secondary_label_decimal_places
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '1'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: D3212C
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '2'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: FF980E
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '3'
+                    - type: STRING
+                      name: thresholds.3.color
+                      value: D3212C
+                    - type: STRING
+                      name: thresholds.3.threshold
+                      value: '7'
+                - type: svggraph
+                  name: 'CPU Load Average (5m)'
+                  'y': '16'
+                  width: '24'
+                  height: '5'
+                  fields:
+                    - type: INTEGER
+                      name: ds.0.color_palette
+                      value: '4'
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '5'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'Load average (5m avg)'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: MDDVY
+                    - type: INTEGER
+                      name: righty
+                      value: '0'
+                - type: svggraph
+                  name: 'Memory Utilization'
+                  x: '24'
+                  'y': '16'
+                  width: '24'
+                  height: '5'
+                  fields:
+                    - type: INTEGER
+                      name: ds.0.color_palette
+                      value: '4'
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '5'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'Memory utilization'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: ALFPK
+                    - type: INTEGER
+                      name: righty
+                      value: '0'
+                - type: honeycomb
+                  name: 'Fan trays'
+                  x: '36'
+                  'y': '4'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Fan tray*Status'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("\[(.*?)\].*\((.*?)\)", "Fan Tray \1")}'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: SCNVC
+                    - type: INTEGER
+                      name: secondary_label_decimal_places
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '1'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: D3212C
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '2'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: FF980E
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '3'
+                    - type: STRING
+                      name: thresholds.3.color
+                      value: D3212C
+                    - type: STRING
+                      name: thresholds.3.threshold
+                      value: '7'
+                - type: honeycomb
+                  name: 'Chassis temperature sensors'
+                  x: '36'
+                  'y': '8'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Chassis*Temperature'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("\[(.*?)\]", "Chassis Temp \1")}'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: PEGXE
+                    - type: INTEGER
+                      name: secondary_label_decimal_places
+                      value: '0'
+                - type: gauge
+                  name: 'Memory Usage'
+                  x: '48'
+                  'y': '12'
+                  width: '24'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: description
+                      value: 'Memory Usage'
+                    - type: INTEGER
+                      name: desc_size
+                      value: '10'
+                    - type: INTEGER
+                      name: desc_v_pos
+                      value: '0'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Dell SmartFabric OS10 by SNMP'
+                        key: 'vm.memory.util[snmp]'
+                    - type: STRING
+                      name: max
+                      value: '100'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: INTEGER
+                      name: scale_size
+                      value: '10'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 0EC9AC
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '70'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: FF465C
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '90'
+                    - type: INTEGER
+                      name: th_show_arc
+                      value: '1'
+                    - type: INTEGER
+                      name: th_show_labels
+                      value: '1'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: svggraph
+                  name: 'ICMP Response Time'
+                  x: '48'
+                  'y': '16'
+                  width: '24'
+                  height: '5'
+                  fields:
+                    - type: INTEGER
+                      name: ds.0.color_palette
+                      value: '10'
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '5'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'ICMP response time'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: BPKXY
+                    - type: INTEGER
+                      name: righty
+                      value: '0'
+                - type: item
+                  name: 'System Name'
+                  x: '51'
+                  width: '21'
+                  fields:
+                    - type: STRING
+                      name: bg_color
+                      value: 2196F3
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Dell SmartFabric OS10 by SNMP'
+                        key: system.name
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: STRING
+                      name: value_color
+                      value: FFFFFF
+                - type: item
+                  name: 'Uptime Hardware'
+                  x: '51'
+                  'y': '2'
+                  width: '21'
+                  fields:
+                    - type: STRING
+                      name: bg_color
+                      value: 2196F3
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Dell SmartFabric OS10 by SNMP'
+                        key: 'system.hw.uptime[hrSystemUptime.0]'
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: STRING
+                      name: value_color
+                      value: FFFFFF
+            - name: 'Port Speed'
+              widgets:
+                - type: honeycomb
+                  name: 'Network Speed'
+                  width: '72'
+                  height: '9'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Interface ethernet1/1/*Speed'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub(".*/(\d+)\((.*)\)", "Port \1 (\2)")}'
+                    - type: STRING
+                      name: reference
+                      value: THVEJ
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 13191C
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FF681E
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '10000000'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '10000000000'
+                    - type: STRING
+                      name: thresholds.3.color
+                      value: 0040FF
+                    - type: STRING
+                      name: thresholds.3.threshold
+                      value: '100000000000'
+            - name: 'Network Traffic'
+              widgets:
+                - type: graphprototype
+                  name: 'Network Traffic'
+                  width: '72'
+                  height: '64'
+                  hide_header: 'YES'
+                  fields:
+                    - type: INTEGER
+                      name: columns
+                      value: '3'
+                    - type: GRAPH_PROTOTYPE
+                      name: graphid.0
+                      value:
+                        host: 'Dell SmartFabric OS10 by SNMP'
+                        name: 'Interface {#IFNAME}({#IFALIAS}): Network traffic'
+                    - type: STRING
+                      name: reference
+                      value: QOTFG
+                    - type: INTEGER
+                      name: rows
+                      value: '20'
+            - name: 'CPU Usage'
+              widgets:
+                - type: graphprototype
+                  name: 'CPU Usage'
+                  width: '72'
+                  height: '20'
+                  hide_header: 'YES'
+                  fields:
+                    - type: INTEGER
+                      name: columns
+                      value: '2'
+                    - type: GRAPH_PROTOTYPE
+                      name: graphid.0
+                      value:
+                        host: 'Dell SmartFabric OS10 by SNMP'
+                        name: 'CPU {#CPU_NUM}: Utilization'
+                    - type: STRING
+                      name: reference
+                      value: NXQCP
+                    - type: INTEGER
+                      name: rows
+                      value: '2'
+      valuemaps:
+        - uuid: c445e1ac516f4217b73d10ffe49cc4f1
+          name: 'DELLEMC-OS10-CHASSIS-MIB::os10FanEntity'
+          mappings:
+            - value: '1'
+              newvalue: ps
+            - value: '2'
+              newvalue: fanTray
+        - uuid: f033d86ee7024c73bb906a9b5f982334
+          name: 'DELLEMC-OS10-CHASSIS-MIB::os10PowerSupplyType'
+          mappings:
+            - value: '1'
+              newvalue: unknown
+            - value: '2'
+              newvalue: ac
+            - value: '3'
+              newvalue: dc
+        - uuid: 937e3a00e9324e8ebb8a3b41bd9cb37f
+          name: 'DELLEMC-OS10-TC-MIB::Os10CardOperStatus'
+          mappings:
+            - value: '1'
+              newvalue: ready
+            - value: '2'
+              newvalue: cardMisMatch
+            - value: '3'
+              newvalue: cardProblem
+            - value: '4'
+              newvalue: diagMode
+            - value: '5'
+              newvalue: cardAbsent
+            - value: '6'
+              newvalue: offline
+        - uuid: b663416fb5174bcc9ba132fcba5e197c
+          name: 'DELLEMC-OS10-TC-MIB::Os10ChassisDefType'
+          mappings:
+            - value: '1'
+              newvalue: s6000on
+            - value: '2'
+              newvalue: s4048on
+            - value: '3'
+              newvalue: s4048Ton
+            - value: '4'
+              newvalue: s3048on
+            - value: '5'
+              newvalue: s6010on
+            - value: '6'
+              newvalue: s4148Fon
+            - value: '7'
+              newvalue: s4128Fon
+            - value: '8'
+              newvalue: s4148Ton
+            - value: '9'
+              newvalue: s4128Ton
+            - value: '10'
+              newvalue: s4148FEon
+            - value: '11'
+              newvalue: s4148Uon
+            - value: '12'
+              newvalue: s4200on
+            - value: '13'
+              newvalue: mx5108Non
+            - value: '14'
+              newvalue: mx9116Non
+            - value: '15'
+              newvalue: s5148Fon
+            - value: '16'
+              newvalue: z9100on
+            - value: '17'
+              newvalue: s4248FBon
+            - value: '18'
+              newvalue: s4248FBLon
+            - value: '19'
+              newvalue: s4112Fon
+            - value: '20'
+              newvalue: s4112Ton
+            - value: '21'
+              newvalue: z9264Fon
+            - value: '22'
+              newvalue: z9224Fon
+            - value: '23'
+              newvalue: s5212Fon
+            - value: '24'
+              newvalue: s5224Fon
+            - value: '25'
+              newvalue: s5232Fon
+            - value: '26'
+              newvalue: s5248Fon
+            - value: '27'
+              newvalue: s5296Fon
+            - type: DEFAULT
+              newvalue: unknown
+        - uuid: 2d4fb58340f84e0eaa9144cf70215250
+          name: 'DELLEMC-OS10-TC-MIB::Os10CmnOperStatus'
+          mappings:
+            - value: '1'
+              newvalue: up
+            - value: '2'
+              newvalue: down
+            - value: '3'
+              newvalue: testing
+            - value: '4'
+              newvalue: unknown
+            - value: '5'
+              newvalue: dormant
+            - value: '6'
+              newvalue: notPresent
+            - value: '7'
+              newvalue: lowerLayerDown
+            - value: '8'
+              newvalue: failed
+        - uuid: dc08d989440f44c5b9d8e87a7895f313
+          name: 'DELLEMC-OS10-TC-MIB::Os10SystemCardType'
+          mappings:
+            - value: '0'
+              newvalue: notPresent
+            - value: '1'
+              newvalue: s6000on
+            - value: '2'
+              newvalue: s4048on
+            - value: '3'
+              newvalue: s4048Ton
+            - value: '4'
+              newvalue: s3048on
+            - value: '5'
+              newvalue: s6010on
+            - value: '6'
+              newvalue: s4148Fon
+            - value: '7'
+              newvalue: s4128Fon
+            - value: '8'
+              newvalue: s4148Ton
+            - value: '9'
+              newvalue: s4128Ton
+            - value: '10'
+              newvalue: s4148FEon
+            - value: '11'
+              newvalue: s4148Uon
+            - value: '12'
+              newvalue: s4200on
+            - value: '13'
+              newvalue: mx5108Non
+            - value: '14'
+              newvalue: mx9116Non
+            - value: '15'
+              newvalue: s5148Fon
+            - value: '16'
+              newvalue: z9100on
+            - value: '17'
+              newvalue: s4248FBon
+            - value: '18'
+              newvalue: s4248FBLon
+            - value: '19'
+              newvalue: s4112Fon
+            - value: '20'
+              newvalue: s4112Ton
+            - value: '21'
+              newvalue: z9264Fon
+            - value: '22'
+              newvalue: z9232Fon
+            - value: '23'
+              newvalue: s5212Fon
+            - value: '24'
+              newvalue: s5224Fon
+            - value: '25'
+              newvalue: s5232Fon
+            - value: '26'
+              newvalue: s5248Fon
+            - value: '27'
+              newvalue: s5296Fon
+            - value: '28'
+              newvalue: z9332Fon
+            - value: '29'
+              newvalue: n3248TEon
+            - type: DEFAULT
+              newvalue: unknown
+        - uuid: 27e7821e2cab4f349f7cadaca4bccc1c
+          name: 'EtherLike-MIB::dot3StatsDuplexStatus'
+          mappings:
+            - value: '1'
+              newvalue: unknown
+            - value: '2'
+              newvalue: halfDuplex
+            - value: '3'
+              newvalue: fullDuplex
+        - uuid: 0bdea9729c4c4c8fac55483c01897e9e
+          name: 'IF-MIB::ifOperStatus'
+          mappings:
+            - value: '1'
+              newvalue: up
+            - value: '2'
+              newvalue: down
+            - value: '4'
+              newvalue: unknown
+            - value: '5'
+              newvalue: dormant
+            - value: '6'
+              newvalue: notPresent
+            - value: '7'
+              newvalue: lowerLayerDown
+        - uuid: 8cf07894d5c8440db1f08e607df7c854
+          name: 'IF-MIB::ifType'
+          mappings:
+            - value: '1'
+              newvalue: other
+            - value: '2'
+              newvalue: regular1822
+            - value: '3'
+              newvalue: hdh1822
+            - value: '4'
+              newvalue: ddnX25
+            - value: '5'
+              newvalue: rfc877x25
+            - value: '6'
+              newvalue: ethernetCsmacd
+            - value: '7'
+              newvalue: iso88023Csmacd
+            - value: '8'
+              newvalue: iso88024TokenBus
+            - value: '9'
+              newvalue: iso88025TokenRing
+            - value: '10'
+              newvalue: iso88026Man
+            - value: '11'
+              newvalue: starLan
+            - value: '12'
+              newvalue: proteon10Mbit
+            - value: '13'
+              newvalue: proteon80Mbit
+            - value: '14'
+              newvalue: hyperchannel
+            - value: '15'
+              newvalue: fddi
+            - value: '16'
+              newvalue: lapb
+            - value: '17'
+              newvalue: sdlc
+            - value: '18'
+              newvalue: ds1
+            - value: '19'
+              newvalue: e1
+            - value: '20'
+              newvalue: basicISDN
+            - value: '21'
+              newvalue: primaryISDN
+            - value: '22'
+              newvalue: propPointToPointSerial
+            - value: '23'
+              newvalue: ppp
+            - value: '24'
+              newvalue: softwareLoopback
+            - value: '25'
+              newvalue: eon
+            - value: '26'
+              newvalue: ethernet3Mbit
+            - value: '27'
+              newvalue: nsip
+            - value: '28'
+              newvalue: slip
+            - value: '29'
+              newvalue: ultra
+            - value: '30'
+              newvalue: ds3
+            - value: '31'
+              newvalue: sip
+            - value: '32'
+              newvalue: frameRelay
+            - value: '33'
+              newvalue: rs232
+            - value: '34'
+              newvalue: para
+            - value: '35'
+              newvalue: arcnet
+            - value: '36'
+              newvalue: arcnetPlus
+            - value: '37'
+              newvalue: atm
+            - value: '38'
+              newvalue: miox25
+            - value: '39'
+              newvalue: sonet
+            - value: '40'
+              newvalue: x25ple
+            - value: '41'
+              newvalue: iso88022llc
+            - value: '42'
+              newvalue: localTalk
+            - value: '43'
+              newvalue: smdsDxi
+            - value: '44'
+              newvalue: frameRelayService
+            - value: '45'
+              newvalue: v35
+            - value: '46'
+              newvalue: hssi
+            - value: '47'
+              newvalue: hippi
+            - value: '48'
+              newvalue: modem
+            - value: '49'
+              newvalue: aal5
+            - value: '50'
+              newvalue: sonetPath
+            - value: '51'
+              newvalue: sonetVT
+            - value: '52'
+              newvalue: smdsIcip
+            - value: '53'
+              newvalue: propVirtual
+            - value: '54'
+              newvalue: propMultiplexor
+            - value: '55'
+              newvalue: ieee80212
+            - value: '56'
+              newvalue: fibreChannel
+            - value: '57'
+              newvalue: hippiInterface
+            - value: '58'
+              newvalue: frameRelayInterconnect
+            - value: '59'
+              newvalue: aflane8023
+            - value: '60'
+              newvalue: aflane8025
+            - value: '61'
+              newvalue: cctEmul
+            - value: '62'
+              newvalue: fastEther
+            - value: '63'
+              newvalue: isdn
+            - value: '64'
+              newvalue: v11
+            - value: '65'
+              newvalue: v36
+            - value: '66'
+              newvalue: g703at64k
+            - value: '67'
+              newvalue: g703at2mb
+            - value: '68'
+              newvalue: qllc
+            - value: '69'
+              newvalue: fastEtherFX
+            - value: '70'
+              newvalue: channel
+            - value: '71'
+              newvalue: ieee80211
+            - value: '72'
+              newvalue: ibm370parChan
+            - value: '73'
+              newvalue: escon
+            - value: '74'
+              newvalue: dlsw
+            - value: '75'
+              newvalue: isdns
+            - value: '76'
+              newvalue: isdnu
+            - value: '77'
+              newvalue: lapd
+            - value: '78'
+              newvalue: ipSwitch
+            - value: '79'
+              newvalue: rsrb
+            - value: '80'
+              newvalue: atmLogical
+            - value: '81'
+              newvalue: ds0
+            - value: '82'
+              newvalue: ds0Bundle
+            - value: '83'
+              newvalue: bsc
+            - value: '84'
+              newvalue: async
+            - value: '85'
+              newvalue: cnr
+            - value: '86'
+              newvalue: iso88025Dtr
+            - value: '87'
+              newvalue: eplrs
+            - value: '88'
+              newvalue: arap
+            - value: '89'
+              newvalue: propCnls
+            - value: '90'
+              newvalue: hostPad
+            - value: '91'
+              newvalue: termPad
+            - value: '92'
+              newvalue: frameRelayMPI
+            - value: '93'
+              newvalue: x213
+            - value: '94'
+              newvalue: adsl
+            - value: '95'
+              newvalue: radsl
+            - value: '96'
+              newvalue: sdsl
+            - value: '97'
+              newvalue: vdsl
+            - value: '98'
+              newvalue: iso88025CRFPInt
+            - value: '99'
+              newvalue: myrinet
+            - value: '100'
+              newvalue: voiceEM
+            - value: '101'
+              newvalue: voiceFXO
+            - value: '102'
+              newvalue: voiceFXS
+            - value: '103'
+              newvalue: voiceEncap
+            - value: '104'
+              newvalue: voiceOverIp
+            - value: '105'
+              newvalue: atmDxi
+            - value: '106'
+              newvalue: atmFuni
+            - value: '107'
+              newvalue: atmIma
+            - value: '108'
+              newvalue: pppMultilinkBundle
+            - value: '109'
+              newvalue: ipOverCdlc
+            - value: '110'
+              newvalue: ipOverClaw
+            - value: '111'
+              newvalue: stackToStack
+            - value: '112'
+              newvalue: virtualIpAddress
+            - value: '113'
+              newvalue: mpc
+            - value: '114'
+              newvalue: ipOverAtm
+            - value: '115'
+              newvalue: iso88025Fiber
+            - value: '116'
+              newvalue: tdlc
+            - value: '117'
+              newvalue: gigabitEthernet
+            - value: '118'
+              newvalue: hdlc
+            - value: '119'
+              newvalue: lapf
+            - value: '120'
+              newvalue: v37
+            - value: '121'
+              newvalue: x25mlp
+            - value: '122'
+              newvalue: x25huntGroup
+            - value: '123'
+              newvalue: trasnpHdlc
+            - value: '124'
+              newvalue: interleave
+            - value: '125'
+              newvalue: fast
+            - value: '126'
+              newvalue: ip
+            - value: '127'
+              newvalue: docsCableMaclayer
+            - value: '128'
+              newvalue: docsCableDownstream
+            - value: '129'
+              newvalue: docsCableUpstream
+            - value: '130'
+              newvalue: a12MppSwitch
+            - value: '131'
+              newvalue: tunnel
+            - value: '132'
+              newvalue: coffee
+            - value: '133'
+              newvalue: ces
+            - value: '134'
+              newvalue: atmSubInterface
+            - value: '135'
+              newvalue: l2vlan
+            - value: '136'
+              newvalue: l3ipvlan
+            - value: '137'
+              newvalue: l3ipxvlan
+            - value: '138'
+              newvalue: digitalPowerline
+            - value: '139'
+              newvalue: mediaMailOverIp
+            - value: '140'
+              newvalue: dtm
+            - value: '141'
+              newvalue: dcn
+            - value: '142'
+              newvalue: ipForward
+            - value: '143'
+              newvalue: msdsl
+            - value: '144'
+              newvalue: ieee1394
+            - value: '145'
+              newvalue: if-gsn
+            - value: '146'
+              newvalue: dvbRccMacLayer
+            - value: '147'
+              newvalue: dvbRccDownstream
+            - value: '148'
+              newvalue: dvbRccUpstream
+            - value: '149'
+              newvalue: atmVirtual
+            - value: '150'
+              newvalue: mplsTunnel
+            - value: '151'
+              newvalue: srp
+            - value: '152'
+              newvalue: voiceOverAtm
+            - value: '153'
+              newvalue: voiceOverFrameRelay
+            - value: '154'
+              newvalue: idsl
+            - value: '155'
+              newvalue: compositeLink
+            - value: '156'
+              newvalue: ss7SigLink
+            - value: '157'
+              newvalue: propWirelessP2P
+            - value: '158'
+              newvalue: frForward
+            - value: '159'
+              newvalue: rfc1483
+            - value: '160'
+              newvalue: usb
+            - value: '161'
+              newvalue: ieee8023adLag
+            - value: '162'
+              newvalue: bgppolicyaccounting
+            - value: '163'
+              newvalue: frf16MfrBundle
+            - value: '164'
+              newvalue: h323Gatekeeper
+            - value: '165'
+              newvalue: h323Proxy
+            - value: '166'
+              newvalue: mpls
+            - value: '167'
+              newvalue: mfSigLink
+            - value: '168'
+              newvalue: hdsl2
+            - value: '169'
+              newvalue: shdsl
+            - value: '170'
+              newvalue: ds1FDL
+            - value: '171'
+              newvalue: pos
+            - value: '172'
+              newvalue: dvbAsiIn
+            - value: '173'
+              newvalue: dvbAsiOut
+            - value: '174'
+              newvalue: plc
+            - value: '175'
+              newvalue: nfas
+            - value: '176'
+              newvalue: tr008
+            - value: '177'
+              newvalue: gr303RDT
+            - value: '178'
+              newvalue: gr303IDT
+            - value: '179'
+              newvalue: isup
+            - value: '180'
+              newvalue: propDocsWirelessMaclayer
+            - value: '181'
+              newvalue: propDocsWirelessDownstream
+            - value: '182'
+              newvalue: propDocsWirelessUpstream
+            - value: '183'
+              newvalue: hiperlan2
+            - value: '184'
+              newvalue: propBWAp2Mp
+            - value: '185'
+              newvalue: sonetOverheadChannel
+            - value: '186'
+              newvalue: digitalWrapperOverheadChannel
+            - value: '187'
+              newvalue: aal2
+            - value: '188'
+              newvalue: radioMAC
+            - value: '189'
+              newvalue: atmRadio
+            - value: '190'
+              newvalue: imt
+            - value: '191'
+              newvalue: mvl
+            - value: '192'
+              newvalue: reachDSL
+            - value: '193'
+              newvalue: frDlciEndPt
+            - value: '194'
+              newvalue: atmVciEndPt
+            - value: '195'
+              newvalue: opticalChannel
+            - value: '196'
+              newvalue: opticalTransport
+            - value: '197'
+              newvalue: propAtm
+            - value: '198'
+              newvalue: voiceOverCable
+            - value: '199'
+              newvalue: infiniband
+            - value: '200'
+              newvalue: teLink
+            - value: '201'
+              newvalue: q2931
+            - value: '202'
+              newvalue: virtualTg
+            - value: '203'
+              newvalue: sipTg
+            - value: '204'
+              newvalue: sipSig
+            - value: '205'
+              newvalue: docsCableUpstreamChannel
+            - value: '206'
+              newvalue: econet
+            - value: '207'
+              newvalue: pon155
+            - value: '208'
+              newvalue: pon622
+            - value: '209'
+              newvalue: bridge
+            - value: '210'
+              newvalue: linegroup
+            - value: '211'
+              newvalue: voiceEMFGD
+            - value: '212'
+              newvalue: voiceFGDEANA
+            - value: '213'
+              newvalue: voiceDID
+            - value: '214'
+              newvalue: mpegTransport
+            - value: '215'
+              newvalue: sixToFour
+            - value: '216'
+              newvalue: gtp
+            - value: '217'
+              newvalue: pdnEtherLoop1
+            - value: '218'
+              newvalue: pdnEtherLoop2
+            - value: '219'
+              newvalue: opticalChannelGroup
+            - value: '220'
+              newvalue: homepna
+            - value: '221'
+              newvalue: gfp
+            - value: '222'
+              newvalue: ciscoISLvlan
+            - value: '223'
+              newvalue: actelisMetaLOOP
+            - value: '224'
+              newvalue: fcipLink
+            - value: '225'
+              newvalue: rpr
+            - value: '226'
+              newvalue: qam
+            - value: '227'
+              newvalue: lmp
+            - value: '228'
+              newvalue: cblVectaStar
+            - value: '229'
+              newvalue: docsCableMCmtsDownstream
+            - value: '230'
+              newvalue: adsl2
+            - value: '231'
+              newvalue: macSecControlledIF
+            - value: '232'
+              newvalue: macSecUncontrolledIF
+            - value: '233'
+              newvalue: aviciOpticalEther
+            - value: '234'
+              newvalue: atmbond
+            - value: '235'
+              newvalue: voiceFGDOS
+            - value: '236'
+              newvalue: mocaVersion1
+            - value: '237'
+              newvalue: ieee80216WMAN
+            - value: '238'
+              newvalue: adsl2plus
+            - value: '239'
+              newvalue: dvbRcsMacLayer
+            - value: '240'
+              newvalue: dvbTdm
+            - value: '241'
+              newvalue: dvbRcsTdma
+            - value: '242'
+              newvalue: x86Laps
+            - value: '243'
+              newvalue: wwanPP
+            - value: '244'
+              newvalue: wwanPP2
+            - value: '245'
+              newvalue: voiceEBS
+            - value: '246'
+              newvalue: ifPwType
+            - value: '247'
+              newvalue: ilan
+            - value: '248'
+              newvalue: pip
+            - value: '249'
+              newvalue: aluELP
+            - value: '250'
+              newvalue: gpon
+            - value: '251'
+              newvalue: vdsl2
+            - value: '252'
+              newvalue: capwapDot11Profile
+            - value: '253'
+              newvalue: capwapDot11Bss
+            - value: '254'
+              newvalue: capwapWtpVirtualRadio
+            - value: '255'
+              newvalue: bits
+            - value: '256'
+              newvalue: docsCableUpstreamRfPort
+            - value: '257'
+              newvalue: cableDownstreamRfPort
+            - value: '258'
+              newvalue: vmwareVirtualNic
+            - value: '259'
+              newvalue: ieee802154
+            - value: '260'
+              newvalue: otnOdu
+            - value: '261'
+              newvalue: otnOtu
+            - value: '262'
+              newvalue: ifVfiType
+            - value: '263'
+              newvalue: g9981
+            - value: '264'
+              newvalue: g9982
+            - value: '265'
+              newvalue: g9983
+            - value: '266'
+              newvalue: aluEpon
+            - value: '267'
+              newvalue: aluEponOnu
+            - value: '268'
+              newvalue: aluEponPhysicalUni
+            - value: '269'
+              newvalue: aluEponLogicalLink
+            - value: '270'
+              newvalue: aluGponOnu
+            - value: '271'
+              newvalue: aluGponPhysicalUni
+            - value: '272'
+              newvalue: vmwareNicTeam
+            - value: '277'
+              newvalue: docsOfdmDownstream
+            - value: '278'
+              newvalue: docsOfdmaUpstream
+            - value: '279'
+              newvalue: gfast
+            - value: '280'
+              newvalue: sdci
+            - value: '281'
+              newvalue: xboxWireless
+            - value: '282'
+              newvalue: fastdsl
+            - value: '283'
+              newvalue: docsCableScte55d1FwdOob
+            - value: '284'
+              newvalue: docsCableScte55d1RetOob
+            - value: '285'
+              newvalue: docsCableScte55d2DsOob
+            - value: '286'
+              newvalue: docsCableScte55d2UsOob
+            - value: '287'
+              newvalue: docsCableNdf
+            - value: '288'
+              newvalue: docsCableNdr
+            - value: '289'
+              newvalue: ptm
+            - value: '290'
+              newvalue: ghn
+        - uuid: 77be059265434bddb37bbe25cdc4c761
+          name: 'Service state'
+          mappings:
+            - value: '0'
+              newvalue: Down
+            - value: '1'
+              newvalue: Up
+        - uuid: 3b3124f0c8be431a94b873d32e756207
+          name: zabbix.host.available
+          mappings:
+            - value: '0'
+              newvalue: 'not available'
+            - value: '1'
+              newvalue: available
+            - value: '2'
+              newvalue: unknown
+  triggers:
+    - uuid: 5b8c29d98c554c83b674114c5415c5c3
+      expression: 'max(/Dell SmartFabric OS10 by SNMP/system.swap.pfree[snmp],5m)<{$SWAP.PFREE.MIN.WARN} and last(/Dell SmartFabric OS10 by SNMP/system.swap.total[memTotalSwap.0])>0'
+      name: 'Dell SmartFabric OS10: High swap space usage'
+      event_name: 'Dell SmartFabric OS10: High swap space usage (less than {$SWAP.PFREE.MIN.WARN}% free)'
+      opdata: 'Free: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}'
+      priority: WARNING
+      description: 'If there is no swap configured, this trigger is ignored.'
+      dependencies:
+        - name: 'Dell SmartFabric OS10: High memory utilization'
+          expression: 'min(/Dell SmartFabric OS10 by SNMP/vm.memory.util[snmp],5m)>{$MEMORY.UTIL.MAX}'
+        - name: 'Dell SmartFabric OS10: Lack of available memory'
+          expression: 'max(/Dell SmartFabric OS10 by SNMP/vm.memory.available[snmp],5m)<{$MEMORY.AVAILABLE.MIN} and last(/Dell SmartFabric OS10 by SNMP/vm.memory.total[memTotalReal.0])>0'
+      tags:
+        - tag: scope
+          value: capacity
+    - uuid: 4c4965b1a03e49c9a7582afceba2674e
+      expression: '(last(/Dell SmartFabric OS10 by SNMP/system.hw.uptime[hrSystemUptime.0])>0 and last(/Dell SmartFabric OS10 by SNMP/system.hw.uptime[hrSystemUptime.0])<10m) or (last(/Dell SmartFabric OS10 by SNMP/system.hw.uptime[hrSystemUptime.0])=0 and last(/Dell SmartFabric OS10 by SNMP/system.net.uptime[sysUpTime.0])<10m)'
+      name: 'Dell SmartFabric OS10: Host has been restarted'
+      event_name: 'Network Generic Device: {HOST.NAME} has been restarted (uptime < 10m)'
+      priority: WARNING
+      description: 'Uptime is less than 10 minutes.'
+      manual_close: 'YES'
+      dependencies:
+        - name: 'Dell SmartFabric OS10: No SNMP data collection'
+          expression: 'max(/Dell SmartFabric OS10 by SNMP/zabbix[host,snmp,available],{$SNMP.TIMEOUT})=0'
+      tags:
+        - tag: scope
+          value: notice
+    - uuid: 9c0b48cbf07c4597bd91ae3d71a5e0dc
+      expression: 'max(/Dell SmartFabric OS10 by SNMP/vm.memory.available[snmp],5m)<{$MEMORY.AVAILABLE.MIN} and last(/Dell SmartFabric OS10 by SNMP/vm.memory.total[memTotalReal.0])>0'
+      name: 'Dell SmartFabric OS10: Lack of available memory'
+      event_name: 'Dell SmartFabric OS10: Lack of available memory (<{$MEMORY.AVAILABLE.MIN} of {ITEM.VALUE2})'
+      opdata: 'Available: {ITEM.LASTVALUE1}, total: {ITEM.LASTVALUE2}'
+      priority: AVERAGE
+      description: 'The system is running out of memory.'
+      tags:
+        - tag: scope
+          value: capacity
+        - tag: scope
+          value: performance
+    - uuid: 2fa1f4ccb79847c19c18d5d98fbcbb5c
+      expression: 'min(/Dell SmartFabric OS10 by SNMP/system.cpu.load.avg1[laLoad.1],5m)/last(/Dell SmartFabric OS10 by SNMP/system.cpu.num[snmp])>{$LOAD_AVG_PER_CPU.MAX.WARN} and last(/Dell SmartFabric OS10 by SNMP/system.cpu.load.avg5[laLoad.2])>0 and last(/Dell SmartFabric OS10 by SNMP/system.cpu.load.avg15[laLoad.3])>0'
+      name: 'Dell SmartFabric OS10: Load average is too high'
+      event_name: 'Dell SmartFabric OS10: Load average is too high (per CPU load over {$LOAD_AVG_PER_CPU.MAX.WARN} for 5m)'
+      opdata: 'Load averages(1m 5m 15m): ({ITEM.LASTVALUE1} {ITEM.LASTVALUE3} {ITEM.LASTVALUE4}), # of CPUs: {ITEM.LASTVALUE2}'
+      priority: AVERAGE
+      description: 'The load average per CPU is too high. The system may be slow to respond.'
+      tags:
+        - tag: scope
+          value: capacity
+        - tag: scope
+          value: performance
+  graphs:
+    - uuid: c6da18a1e88c4ccf9ce3f36cc2723379
+      name: 'Dell SmartFabric OS10: CPU jumps'
+      yaxismax: '0'
+      graph_items:
+        - color: 199C0D
+          item:
+            host: 'Dell SmartFabric OS10 by SNMP'
+            key: 'system.cpu.switches[ssRawContexts.0]'
+        - sortorder: '1'
+          color: F63100
+          item:
+            host: 'Dell SmartFabric OS10 by SNMP'
+            key: 'system.cpu.intr[ssRawInterrupts.0]'
+    - uuid: ed669309092a4db3b5313186d91dfb67
+      name: 'Dell SmartFabric OS10: Memory usage'
+      yaxismax: '0'
+      ymin_type_1: FIXED
+      graph_items:
+        - drawtype: BOLD_LINE
+          color: 199C0D
+          item:
+            host: 'Dell SmartFabric OS10 by SNMP'
+            key: 'vm.memory.total[memTotalReal.0]'
+        - sortorder: '1'
+          drawtype: GRADIENT_LINE
+          color: F63100
+          item:
+            host: 'Dell SmartFabric OS10 by SNMP'
+            key: 'vm.memory.available[snmp]'
+    - uuid: f4d066e286ae4e2bb55ed518ac4a7869
+      name: 'Dell SmartFabric OS10: Memory utilization'
+      ymin_type_1: FIXED
+      ymax_type_1: FIXED
+      graph_items:
+        - drawtype: GRADIENT_LINE
+          color: 199C0D
+          item:
+            host: 'Dell SmartFabric OS10 by SNMP'
+            key: 'vm.memory.util[snmp]'
+    - uuid: c0fdd5661f6347739d2b24c2e6778643
+      name: 'Dell SmartFabric OS10: Swap usage'
+      yaxismax: '0'
+      graph_items:
+        - color: 199C0D
+          item:
+            host: 'Dell SmartFabric OS10 by SNMP'
+            key: 'system.swap.free[memAvailSwap.0]'
+        - sortorder: '1'
+          color: F63100
+          item:
+            host: 'Dell SmartFabric OS10 by SNMP'
+            key: 'system.swap.total[memTotalSwap.0]'
+    - uuid: d731303a45f54e308bbc7ab71d4fe6a0
+      name: 'Dell SmartFabric OS10: System load'
+      yaxismax: '0'
+      ymin_type_1: FIXED
+      graph_items:
+        - color: 199C0D
+          item:
+            host: 'Dell SmartFabric OS10 by SNMP'
+            key: 'system.cpu.load.avg1[laLoad.1]'
+        - sortorder: '1'
+          color: F63100
+          item:
+            host: 'Dell SmartFabric OS10 by SNMP'
+            key: 'system.cpu.load.avg5[laLoad.2]'
+        - sortorder: '2'
+          color: 00611C
+          calc_fnc: ALL
+          item:
+            host: 'Dell SmartFabric OS10 by SNMP'
+            key: 'system.cpu.load.avg15[laLoad.3]'
+        - sortorder: '3'
+          color: F7941D
+          yaxisside: RIGHT
+          calc_fnc: ALL
+          item:
+            host: 'Dell SmartFabric OS10 by SNMP'
+            key: 'system.cpu.num[snmp]'


### PR DESCRIPTION
## Summary
- Ports `Network_Devices/Dell/template_smartfabric_os10_advanced/7.4` to Zabbix 7.0
- Flattens the nested `Card Discovery` rule, since `parent_discovery_rule` (nested LLD) is a Zabbix 7.4+ feature
- Replaces the two hardcoded `CPU 1/2 Usage` gauge items with a discovery-driven graph prototype on the existing `CPU usage Discovery` rule, so CPU monitoring scales to however many cores a switch actually reports
- See the [7.0 README](Network_Devices/Dell/template_smartfabric_os10_advanced/7.0/README.md) for full details vs the 7.4 template

## Test plan
- [x] Validated YAML structure
- [x] Imported successfully into a live Zabbix 7.0 test instance
- [x] Validated discovery, item prototypes, and dashboard against a real Dell S4128F-ON switch running OS10

🤖 Generated with [Claude Code](https://claude.com/claude-code)