### PR TITLE
feat(opnsense): add cron jobs and comprehensive HA monitoring

### DIFF
--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This template monitors OPNsense firewalls via the built-in REST API using HTTP JSON agent requests.
-It collects data about system resources (CPU, memory, disk, uptime), firewall states and actions,
+It collects data about system resources (CPU, memory, disk, uptime), configured cron jobs, firewall states and actions,
 gateway health, network interfaces, CARP high-availability status, WireGuard peers, and UPS status
 via NUT (Network UPS Tools).
 
@@ -25,6 +25,7 @@ on the firewall.
   - `diagnostics/traffic`
   - `routes/gateway`
   - `core/firmware`
+  - `cron/settings`
   - `nut/diagnostics`
   - `ipsec/sessions/searchPhase(1|2)` 
   - `wireguard/service/show`
@@ -38,6 +39,7 @@ on the firewall.
 | page-status-carp                       | Interfaces: Virtual IPs: Status           |
 | page-status-trafficgraph               | Reporting: Traffic                        |
 | page-system-firmware-manualupdate      | System: Firmware                          |
+| page-system-cron                       | System: Settings: Cron                    |
 | page-system-gateways                   | System: Gateways                          |
 | page-system-login-logout               | Lobby: Dashboard                          |
 | page-status-ipsec | Status: IPsec |
@@ -82,6 +84,8 @@ on the firewall.
 | `{$OPNS.KEY}` | *(empty)* | OPNsense API key. **Required.** |
 | `{$OPNS.SECRET}` | *(empty)* | OPNsense API secret. **Required.** |
 | `{$OPNS.CPU.LOAD.MAX}` | `2` | Maximum CPU load average before triggering a warning. |
+| `{$OPNS.CRON.JOB.MATCHES}` | `.+` | Regex filter for cron job descriptions to discover. |
+| `{$OPNS.CRON.JOB.NOT_MATCHES}` | `^$` | Regex filter for cron job descriptions to exclude from discovery. |
 | `{$OPNS.MEMORY.UTIL.MAX}` | `90` | Maximum memory utilization (%) before triggering an alert. |
 | `{$OPNS.STATE.TABLE.UTIL.MAX}` | `90` | Maximum state table utilization (%) before triggering a warning. |
 | `{$OPNS.GW.MIN.PACKET.LOSS}` | `10` | Packet loss (%) to trigger a gateway packet loss alert. |
@@ -119,6 +123,7 @@ on the firewall.
 | Firmware update count | `opns.firmware.update.count` | Dependent | – | Number of available firmware package or set updates. |
 | Firmware update packages | `opns.firmware.update.packages` | Dependent | – | List of available package or set updates. |
 | Firmware update requires reboot | `opns.firmware.update.reboot` | Dependent | – | Returns `1` when the available firmware update requires a reboot. |
+| Cron job count | `opns.cron.job.count` | Dependent | – | Number of configured OPNsense cron jobs. |
 
 ### Firewall Items
 
@@ -174,6 +179,7 @@ items and discovery rules.
 | RAW Load | `opns.raw.load` | 5m | `/api/diagnostics/system/system_time` |
 | RAW Memorystatus | `opns.raw.memory.status` | 5m | `/api/diagnostics/system/systemResources` |
 | RAW Disk | `opns.raw.disk` | 5m | `/api/diagnostics/system/system_disk` |
+| RAW Cron Jobs | `opns.raw.cron.jobs` | 5m | `/api/cron/settings/searchJobs` |
 | RAW Gatewaystatus | `opns.raw.gateway.status` | 1m | `/api/routes/gateway/status` |
 | RAW Firewall States | `opns.raw.fw.states` | 1m | `/api/diagnostics/firewall/pfStates` |
 | RAW Firewallaction | `opns.raw.fw.action` | 1m | `/api/diagnostics/firewall/stats?group_by=action` |
@@ -199,6 +205,7 @@ items and discovery rules.
 | OPNsense firmware update check failed | **Warning** | Firmware update check returned `error`. |
 | State table usage is high | **Warning** | State table utilization exceeds `{$OPNS.STATE.TABLE.UTIL.MAX}` % for the last 3 values. |
 | {HOST.NAME} has been restarted | **Info** | System uptime is less than 600 seconds (10 minutes). |
+| Cron job [{#CRON.DESCRIPTION}] is disabled | **Warning** | A discovered OPNsense cron job is disabled. |
 
 ### UPS Triggers
 
@@ -219,7 +226,22 @@ items and discovery rules.
 
 ## Discovery Rules
 
-### 1. Disk Discovery
+### 1. Cron Job Discovery
+
+| Property | Value |
+|----------|-------|
+| Key | `opns.cron.job.discovery` |
+| Type | Dependent (master: `opns.raw.cron.jobs`) |
+| Filters | `{#CRON.DESCRIPTION}` configurable via macros |
+| Keep lost resources | 1d |
+
+Each configured job exposes its enabled state, configd command, and five-field cron schedule. A
+warning is raised when a discovered job is disabled. The OPNsense Cron API exposes configuration,
+not per-run exit codes; this discovery therefore does not assert that a command completed successfully.
+
+---
+
+### 2. Disk Discovery
 
 | Property | Value |
 |----------|-------|
@@ -247,7 +269,7 @@ items and discovery rules.
 
 ---
 
-### 2. Gateway Discovery
+### 3. Gateway Discovery
 
 | Property | Value |
 |----------|-------|
@@ -277,7 +299,7 @@ items and discovery rules.
 
 ---
 
-### 3. FW Action Discovery
+### 4. FW Action Discovery
 
 | Property | Value |
 |----------|-------|
@@ -300,7 +322,7 @@ items and discovery rules.
 
 ---
 
-### 4. Interface CARP Discovery
+### 5. Interface CARP Discovery
 
 | Property | Value |
 |----------|-------|
@@ -326,7 +348,7 @@ items and discovery rules.
 
 ---
 
-### 5. Interface Stats Discovery
+### 6. Interface Stats Discovery
 
 | Property | Value |
 |----------|-------|
@@ -368,7 +390,7 @@ items and discovery rules.
 
 ---
 
-### 6. WireGuard Instance Discovery
+### 7. WireGuard Instance Discovery
 
 | Property | Value |
 |----------|-------|
@@ -394,7 +416,7 @@ items and discovery rules.
 
 ---
 
-### 7. WireGuard Peer Discovery
+### 8. WireGuard Peer Discovery
 
 | Property | Value |
 |----------|-------|

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -85,8 +85,8 @@ on the firewall.
 
 | Macro | Default Value | Description |
 |-------|---------------|-------------|
-| `{$OPNS.KEY}` | *(empty)* | OPNsense API key. **Required.** |
-| `{$OPNS.SECRET}` | *(empty)* | OPNsense API secret. **Required.** |
+| `{$OPNS.KEY}` | *(empty)* | OPNsense API key used as the HTTP Basic authentication username. **Required.** |
+| `{$OPNS.SECRET}` | *(empty, secret text)* | OPNsense API secret used as the HTTP Basic authentication password. **Required.** |
 | `{$OPNS.CPU.LOAD.MAX}` | `2` | Maximum CPU load average before triggering a warning. |
 | `{$OPNS.CRON.JOB.MATCHES}` | `.+` | Regex filter for cron job descriptions to discover. |
 | `{$OPNS.CRON.JOB.NOT_MATCHES}` | `^$` | Regex filter for cron job descriptions to exclude from discovery. |

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -96,8 +96,8 @@ on the firewall.
 | `{$OPNS.GW.HIGH.PACKET.LOSS}` | `50` | Packet loss (%) to trigger a high packet loss alert. |
 | `{$OPNS.HA.ENABLED}` | `true` | Enables HA triggers and HA discovery. Set to `false` on standalone firewalls without an HA setup. |
 | `{$OPNS.HA.CARP.STATUS.MATCHES}` | `^(MASTER\|BACKUP)$` | Accepted CARP status regex. Override it with a VIP-address macro context to enforce `MASTER` or `BACKUP` on a node. |
-| `{$OPNS.HA.CONFIG_SYNC.REQUIRED}` | `false` | Set to `true` on the XMLRPC synchronization source; keep `false` on the backup node because configuration sync is one-way. |
 | `{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN}` | `1` | Minimum number of remote creator IDs expected in the synchronized state table. |
+| `{$OPNS.HA.ROLE}` | `BACKUP` | HA node role. Set to `MASTER` on the XMLRPC synchronization source or `BACKUP` on the receiving node. |
 | `{$OPNS.LICENSE.EXPIRY.WARN}` | `30` | Days before OPNsense Business license expiry to trigger a warning. |
 | `{$OPNS.FS.FSNAME.MATCHES}` | `.+` | Regex filter for filesystem discovery – included mount points. |
 | `{$OPNS.FS.FSNAME.NOT_MATCHES}` | `^(/dev\|/sys\|/run\|/proc\|.+/shm$)` | Regex filter for filesystem discovery – excluded mount points. |
@@ -260,7 +260,7 @@ items and discovery rules.
 | CARP status is unexpected for VIP {#CARP.ADDRESS} | **High** | The status does not match `{$OPNS.HA.CARP.STATUS.MATCHES:"{#CARP.ADDRESS}"}`. |
 | HA state synchronization is not configured | **Warning** | CARP VIPs exist, but pfsync is disabled. |
 | No remote pfsync state creator is visible | **Warning** | Fewer remote creator IDs than configured were seen for 10 minutes. |
-| HA configuration synchronization is not configured | **Warning** | The node is marked as XMLRPC synchronization source, but no target is configured. |
+| HA configuration synchronization is not configured | **Warning** | The node role is `MASTER`, but no XMLRPC synchronization target is configured. |
 | HA peer is not reachable through XMLRPC | **High** | The configured XMLRPC peer did not answer for 10 minutes. |
 | HA peer firmware version differs | **Warning** | Local and remote OPNsense core versions differ. |
 | HA peer service […] is not running | **High** | A checkable service reported by the HA peer is stopped. |

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -4,8 +4,8 @@
 
 This template monitors OPNsense firewalls via the built-in REST API using HTTP JSON agent requests.
 It collects data about system resources (CPU, memory, disk, uptime), configured cron jobs, firewall states and actions,
-gateway health, network interfaces, CARP high-availability status, WireGuard peers, and UPS status
-via NUT (Network UPS Tools).
+gateway health, network interfaces, CARP, pfsync and XMLRPC high-availability status, WireGuard peers,
+and UPS status via NUT (Network UPS Tools).
 
 The template uses OPNsense API key/secret authentication and requires no agent installation
 on the firewall.
@@ -25,6 +25,8 @@ on the firewall.
   - `diagnostics/traffic`
   - `routes/gateway`
   - `core/firmware`
+  - `core/hasync`
+  - `core/hasync_status`
   - `cron/settings`
   - `nut/diagnostics`
   - `ipsec/sessions/searchPhase(1|2)` 
@@ -40,8 +42,10 @@ on the firewall.
 | page-status-trafficgraph               | Reporting: Traffic                        |
 | page-system-firmware-manualupdate      | System: Firmware                          |
 | page-system-cron                       | System: Settings: Cron                    |
+| page-system-hasync                     | System: High Availability                 |
 | page-system-gateways                   | System: Gateways                          |
 | page-system-login-logout               | Lobby: Dashboard                          |
+| page-status-habackup                    | Status: HA backup                         |
 | page-status-ipsec | Status: IPsec |
 | page-wireguard-diagnostics | VPN: WireGuard: Status |
 
@@ -90,6 +94,9 @@ on the firewall.
 | `{$OPNS.STATE.TABLE.UTIL.MAX}` | `90` | Maximum state table utilization (%) before triggering a warning. |
 | `{$OPNS.GW.MIN.PACKET.LOSS}` | `10` | Packet loss (%) to trigger a gateway packet loss alert. |
 | `{$OPNS.GW.HIGH.PACKET.LOSS}` | `50` | Packet loss (%) to trigger a high packet loss alert. |
+| `{$OPNS.HA.CARP.STATUS.MATCHES}` | `^(MASTER\|BACKUP)$` | Accepted CARP status regex. Override it with a VIP-address macro context to enforce `MASTER` or `BACKUP` on a node. |
+| `{$OPNS.HA.CONFIG_SYNC.REQUIRED}` | `0` | Set to `1` on the XMLRPC synchronization source; keep `0` on the backup node because configuration sync is one-way. |
+| `{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN}` | `1` | Minimum number of remote creator IDs expected in the synchronized state table. |
 | `{$OPNS.LICENSE.EXPIRY.WARN}` | `30` | Days before OPNsense Business license expiry to trigger a warning. |
 | `{$OPNS.FS.FSNAME.MATCHES}` | `.+` | Regex filter for filesystem discovery – included mount points. |
 | `{$OPNS.FS.FSNAME.NOT_MATCHES}` | `^(/dev\|/sys\|/run\|/proc\|.+/shm$)` | Regex filter for filesystem discovery – excluded mount points. |
@@ -132,6 +139,25 @@ on the firewall.
 | Firewall states current | `opns.fw.states.current` | Dependent | Current number of active firewall states. |
 | Firewall states max | `opns.fw.states.max` | Dependent | Maximum number of allowed firewall states. |
 | States table utilization in % | `opns.states.util` | Calculated | Percentage of the state table currently in use. |
+
+### High Availability Items
+
+| Name | Key | Description |
+|------|-----|-------------|
+| CARP VIP count | `opns.ha.carp.vip.count` | Number of configured CARP-mode VIPs. |
+| CARP is allowed | `opns.ha.carp.allowed` | Global CARP enable state. |
+| CARP maintenance mode | `opns.ha.carp.maintenance` | Persistent CARP maintenance state. |
+| CARP demotion level | `opns.ha.carp.demotion` | Current CARP demotion counter. |
+| CARP status message | `opns.ha.carp.status_message` | Global warning text reported by OPNsense. |
+| HA pfsync is configured | `opns.ha.pfsync.configured` | Whether a pfsync interface is configured. |
+| HA pfsync interface/peer/version/defer | `opns.ha.pfsync.*` | Effective state-synchronization configuration. |
+| HA pfsync remote node count | `opns.ha.pfsync.remote.count` | Remote creator IDs currently visible in the PF state table. |
+| HA configuration synchronization is configured | `opns.ha.config_sync.configured` | Whether an XMLRPC synchronization target is configured. |
+| HA configuration synchronization target | `opns.ha.config_sync.target` | Configured XMLRPC peer address. |
+| HA configuration synchronization items | `opns.ha.config_sync.items` | Configuration sections selected for XMLRPC synchronization. |
+| HA peer is reachable through XMLRPC | `opns.ha.peer.reachable` | Result of an XMLRPC firmware-version probe to the configured peer. |
+| HA peer firmware/base/kernel version | `opns.ha.peer.version*` | Versions returned by the peer. |
+| HA peer firmware version matches | `opns.ha.peer.version.match` | Whether local and remote OPNsense core versions match. |
 
 ### UPS Items (NUT)
 
@@ -186,6 +212,10 @@ items and discovery rules.
 | RAW Firewall Interfaces | `opns.raw.fw.interface.stat` | 1m | `/api/diagnostics/firewall/pf_statistics/interfaces` |
 | RAW Interfaces | `opns.raw.interfaces.stat` | 1m | `/api/diagnostics/traffic/_interface` |
 | RAW Carp Interfaces | `opns.raw.interfaces.carp` | 1m | `/api/diagnostics/interface/get_vip_status` |
+| RAW HA Settings | `opns.raw.ha.settings` | 5m | `/api/core/hasync/get` *(credentials are removed during preprocessing)* |
+| RAW HA pfsync Nodes | `opns.raw.ha.pfsync.nodes` | 1m | `/api/diagnostics/interface/get_pfsync_nodes` |
+| RAW HA Peer Version | `opns.raw.ha.peer.version` | 5m | `/api/core/hasync_status/version` |
+| RAW HA Peer Services | `opns.raw.ha.peer.services` | 5m | `/api/core/hasync_status/services` |
 | RAW Product Info | `opns.raw.product.info` | 30m | `/api/core/firmware/info` |
 | RAW Firmware Status | `opns.raw.firmware.status` | 1d | `/api/core/firmware/status` *(POST; runs update probe before fetching status)* |
 | RAW UPS | `opns.ups.raw` | 5m | `/api/nut/diagnostics/upsstatus` *(disabled by default)* |
@@ -216,6 +246,23 @@ items and discovery rules.
 | High Load on UPS Battery | **Average** | UPS load exceeds `{$OPNS.NUT.HIGH.LOAD}` % (default: 80%). |
 | Battery charge is below {$OPNS.NUT.BAT.LOW} | **Warning** | Battery charge is below `{$OPNS.NUT.BAT.LOW}` % (default: 30%). |
 | Remaining battery runtime is low | **High** | Estimated runtime is below `{$OPNS.NUT.BAT.RUNTIME}` seconds (default: 600s / 10 min). |
+
+### High Availability Triggers
+
+| Name | Severity | Description |
+|------|----------|-------------|
+| CARP is disabled | **High** | Global CARP operation is disabled while CARP VIPs exist. |
+| CARP persistent maintenance mode is active | **Warning** | The node remains in persistent maintenance mode. |
+| CARP demotion level is elevated | **Warning** | A positive demotion level can prevent promotion to MASTER. |
+| CARP reports a status warning | **Warning** | OPNsense returned a global CARP warning message. |
+| CARP status changed for VIP {#CARP.ADDRESS} | **High** | A CARP failover or failback occurred. |
+| CARP status is unexpected for VIP {#CARP.ADDRESS} | **High** | The status does not match `{$OPNS.HA.CARP.STATUS.MATCHES:"{#CARP.ADDRESS}"}`. |
+| HA state synchronization is not configured | **Warning** | CARP VIPs exist, but pfsync is disabled. |
+| No remote pfsync state creator is visible | **Warning** | Fewer remote creator IDs than configured were seen for 10 minutes. |
+| HA configuration synchronization is not configured | **Warning** | The node is marked as XMLRPC synchronization source, but no target is configured. |
+| HA peer is not reachable through XMLRPC | **High** | The configured XMLRPC peer did not answer for 10 minutes. |
+| HA peer firmware version differs | **Warning** | Local and remote OPNsense core versions differ. |
+| HA peer service […] is not running | **High** | A checkable service reported by the HA peer is stopped. |
 
 ### WireGuard Triggers
 
@@ -328,27 +375,48 @@ not per-run exit codes; this discovery therefore does not assert that a command 
 |----------|-------|
 | Key | `opns.interface.carp.discovery` |
 | Type | Dependent (master: `opns.raw.interfaces.carp`) |
-| LLD Macro | `{#OPNS.INTERFACE.NAME}` → `$.interface` |
+| LLD Macros | `{#CARP.ADDRESS}`, `{#CARP.INTERFACE}`, `{#CARP.VHID}`, `{#CARP.MODE}` |
+| Filter | CARP-mode VIPs only; IP aliases are excluded |
 | Keep lost resources | 1d |
 
 **Item Prototypes:**
 
 | Name | Key | Description |
 |------|-----|-------------|
-| Carp Status of {#OPNS.INTERFACE.NAME} | `opns.carp.status[{#OPNS.INTERFACE.NAME}]` | CARP status of the VIP (MASTER, BACKUP, INIT). Uses discard unchanged heartbeat (2h). |
+| CARP VIP {#CARP.ADDRESS} (…): Advertisement base | `opns.carp.advbase["{#CARP.ADDRESS}"]` | CARP advertisement base interval. |
+| CARP VIP {#CARP.ADDRESS} (…): Advertisement skew | `opns.carp.advskew["{#CARP.ADDRESS}"]` | CARP advertisement skew used in role election. |
+| CARP VIP {#CARP.ADDRESS} (…): Status | `opns.carp.status["{#CARP.ADDRESS}"]` | CARP status of the individual VIP (MASTER, BACKUP, INIT, DISABLED). Uses discard unchanged heartbeat (2h). |
 
 **Trigger Prototypes:**
 
 | Name | Severity | Description |
 |------|----------|-------------|
-| Carp Status Changed on {#OPNS.INTERFACE.NAME} | **High** | CARP status changed – indicates a failover event. |
+| CARP status changed for VIP {#CARP.ADDRESS} | **High** | CARP status changed – indicates a failover or failback event. |
+| CARP status is unexpected for VIP {#CARP.ADDRESS} | **High** | Status does not match the accepted regex. |
 
 > **Note:** If no CARP interfaces are configured, the discovery returns a custom error and
 > no items are created.
 
 ---
 
-### 6. Interface Stats Discovery
+### 6. HA Peer Service Discovery
+
+Discovers checkable services returned by `/api/core/hasync_status/services` and raises a high-severity
+problem when a remote service remains stopped for 10 minutes. Services marked `nocheck` by OPNsense
+are excluded.
+
+---
+
+### 7. HA pfsync Node Discovery
+
+Discovers creator IDs present in the PF state table and records whether each ID belongs to the local
+node. The aggregate remote-node trigger is evidence-based: a quiet HA peer that has created no
+currently retained states may not appear even when pfsync transport itself is functional. Adjust
+`{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN}` if this signal is not appropriate for the installation.
+
+---
+
+### 8. Interface Stats Discovery
 
 | Property | Value |
 |----------|-------|
@@ -390,7 +458,7 @@ not per-run exit codes; this discovery therefore does not assert that a command 
 
 ---
 
-### 7. WireGuard Instance Discovery
+### 9. WireGuard Instance Discovery
 
 | Property | Value |
 |----------|-------|
@@ -416,7 +484,7 @@ not per-run exit codes; this discovery therefore does not assert that a command 
 
 ---
 
-### 8. WireGuard Peer Discovery
+### 10. WireGuard Peer Discovery
 
 | Property | Value |
 |----------|-------|

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -94,6 +94,7 @@ on the firewall.
 | `{$OPNS.STATE.TABLE.UTIL.MAX}` | `90` | Maximum state table utilization (%) before triggering a warning. |
 | `{$OPNS.GW.MIN.PACKET.LOSS}` | `10` | Packet loss (%) to trigger a gateway packet loss alert. |
 | `{$OPNS.GW.HIGH.PACKET.LOSS}` | `50` | Packet loss (%) to trigger a high packet loss alert. |
+| `{$OPNS.HA.ENABLED}` | `1` | Enables HA triggers and HA discovery. Set to `0` on standalone firewalls without an HA setup. |
 | `{$OPNS.HA.CARP.STATUS.MATCHES}` | `^(MASTER\|BACKUP)$` | Accepted CARP status regex. Override it with a VIP-address macro context to enforce `MASTER` or `BACKUP` on a node. |
 | `{$OPNS.HA.CONFIG_SYNC.REQUIRED}` | `0` | Set to `1` on the XMLRPC synchronization source; keep `0` on the backup node because configuration sync is one-way. |
 | `{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN}` | `1` | Minimum number of remote creator IDs expected in the synchronized state table. |

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -97,7 +97,7 @@ on the firewall.
 | `{$OPNS.HA.ENABLED}` | `true` | Enables HA triggers and HA discovery. Set to `false` on standalone firewalls without an HA setup. |
 | `{$OPNS.HA.CARP.STATUS.MATCHES}` | `^(MASTER\|BACKUP)$` | Accepted CARP status regex. Override it with a VIP-address macro context to enforce `MASTER` or `BACKUP` on a node. |
 | `{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN}` | `1` | Minimum number of remote creator IDs expected in the synchronized state table. |
-| `{$OPNS.HA.ROLE}` | `BACKUP` | HA node role. Set to `MASTER` on the XMLRPC synchronization source or `BACKUP` on the receiving node. |
+| `{$OPNS.HA.ROLE}` | `MASTER` | HA node role. Set to `MASTER` on the XMLRPC synchronization source or `BACKUP` on the receiving node. |
 | `{$OPNS.LICENSE.EXPIRY.WARN}` | `30` | Days before OPNsense Business license expiry to trigger a warning. |
 | `{$OPNS.FS.FSNAME.MATCHES}` | `.+` | Regex filter for filesystem discovery – included mount points. |
 | `{$OPNS.FS.FSNAME.NOT_MATCHES}` | `^(/dev\|/sys\|/run\|/proc\|.+/shm$)` | Regex filter for filesystem discovery – excluded mount points. |

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -217,7 +217,7 @@ items and discovery rules.
 | RAW HA Peer Version | `opns.raw.ha.peer.version` | 5m | `/api/core/hasync_status/version` |
 | RAW HA Peer Services | `opns.raw.ha.peer.services` | 5m | `/api/core/hasync_status/services` |
 | RAW Product Info | `opns.raw.product.info` | 30m | `/api/core/firmware/info` |
-| RAW Firmware Status | `opns.raw.firmware.status` | 1d | `/api/core/firmware/status` *(POST; runs update probe before fetching status)* |
+| RAW Firmware Status | `opns.raw.firmware.status` | 6h | `/api/core/firmware/status` *(POST; runs update probe before fetching status)* |
 | RAW UPS | `opns.ups.raw` | 5m | `/api/nut/diagnostics/upsstatus` *(disabled by default)* |
 | RAW WireGuard | `opns.wireguard.raw` | 1m | `/api/wireguard/service/show` |
 

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -122,7 +122,7 @@ on the firewall.
 | System Uptime | `opns.system.uptime` | Dependent | – | Uptime converted to seconds. Displayed in Zabbix uptime format. |
 | Total Memory | `opns.memory.total` | Dependent | – | Total physical memory in bytes. |
 | Used Memory | `opns.memory.used` | Dependent | – | Used memory in bytes. |
-| ARC Memory | `opns.memory.arc` | Dependent | – | ZFS ARC memory usage in bytes. |
+| ARC Memory | `opns.memory.arc` | Dependent | – | ZFS ARC memory usage in bytes. Returns `0` when ARC data is absent, for example on UFS systems. |
 | Memory utilization in % | `opns.memory.util` | Calculated | – | Percentage of used memory relative to total memory. |
 | Licensed until | `opns.product.licenseuntil` | Dependent | – | OPNsense Business Edition license expiry (Unix timestamp). Returns `0` if not present. |
 | Firmware update status | `opns.firmware.update.status` | Dependent | – | Firmware update status (`none`, `update`, `upgrade`, or `error`). |

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -146,7 +146,7 @@ on the firewall.
 |------|-----|-------------|
 | CARP VIP count | `opns.ha.carp.vip.count` | Number of configured CARP-mode VIPs. |
 | CARP is allowed | `opns.ha.carp.allowed` | Global CARP enable state. |
-| CARP maintenance mode | `opns.ha.carp.maintenance` | Persistent CARP maintenance state. |
+| CARP maintenance mode | `opns.ha.carp.maintenance` | Persistent CARP maintenance state (`0` = inactive, `1` = active). |
 | CARP demotion level | `opns.ha.carp.demotion` | Current CARP demotion counter. |
 | CARP status message | `opns.ha.carp.status_message` | Global warning text reported by OPNsense. |
 | HA pfsync is configured | `opns.ha.pfsync.configured` | Whether a pfsync interface is configured. |

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -94,9 +94,9 @@ on the firewall.
 | `{$OPNS.STATE.TABLE.UTIL.MAX}` | `90` | Maximum state table utilization (%) before triggering a warning. |
 | `{$OPNS.GW.MIN.PACKET.LOSS}` | `10` | Packet loss (%) to trigger a gateway packet loss alert. |
 | `{$OPNS.GW.HIGH.PACKET.LOSS}` | `50` | Packet loss (%) to trigger a high packet loss alert. |
-| `{$OPNS.HA.ENABLED}` | `1` | Enables HA triggers and HA discovery. Set to `0` on standalone firewalls without an HA setup. |
+| `{$OPNS.HA.ENABLED}` | `true` | Enables HA triggers and HA discovery. Set to `false` on standalone firewalls without an HA setup. |
 | `{$OPNS.HA.CARP.STATUS.MATCHES}` | `^(MASTER\|BACKUP)$` | Accepted CARP status regex. Override it with a VIP-address macro context to enforce `MASTER` or `BACKUP` on a node. |
-| `{$OPNS.HA.CONFIG_SYNC.REQUIRED}` | `0` | Set to `1` on the XMLRPC synchronization source; keep `0` on the backup node because configuration sync is one-way. |
+| `{$OPNS.HA.CONFIG_SYNC.REQUIRED}` | `false` | Set to `true` on the XMLRPC synchronization source; keep `false` on the backup node because configuration sync is one-way. |
 | `{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN}` | `1` | Minimum number of remote creator IDs expected in the synchronized state table. |
 | `{$OPNS.LICENSE.EXPIRY.WARN}` | `30` | Days before OPNsense Business license expiry to trigger a warning. |
 | `{$OPNS.FS.FSNAME.MATCHES}` | `.+` | Regex filter for filesystem discovery – included mount points. |

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -529,6 +529,7 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.carp.maintenancemode
+            - type: BOOL_TO_DECIMAL
           master_item:
             key: opns.raw.interfaces.carp
           tags:

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -584,7 +584,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: 62c414e49433480c8671aab366016e62
-              expression: '"{$OPNS.HA.ENABLED}"="true" and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=0 and "{$OPNS.HA.CONFIG_SYNC.REQUIRED}"="true"'
+              expression: '"{$OPNS.HA.ENABLED}"="true" and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=0 and "{$OPNS.HA.ROLE}"="MASTER"'
               name: 'HA configuration synchronization is not configured'
               priority: WARNING
               description: 'This node is designated as the XMLRPC synchronization source, but no target is configured.'
@@ -2904,15 +2904,15 @@ zabbix_export:
         - macro: '{$OPNS.HA.CARP.STATUS.MATCHES}'
           value: ^(MASTER|BACKUP)$
           description: 'Accepted CARP status regex. Use a macro context with the VIP address to enforce a node-specific role.'
-        - macro: '{$OPNS.HA.CONFIG_SYNC.REQUIRED}'
-          value: 'false'
-          description: 'Set to true on the HA synchronization source to require an XMLRPC target. Keep false on the backup node.'
         - macro: '{$OPNS.HA.ENABLED}'
           value: 'true'
           description: 'Set to false on standalone firewalls to disable HA triggers and HA discovery.'
         - macro: '{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN}'
           value: '1'
           description: 'Minimum number of remote creator IDs expected in the synchronized state table.'
+        - macro: '{$OPNS.HA.ROLE}'
+          value: BACKUP
+          description: 'HA node role. Set to MASTER on the XMLRPC synchronization source or BACKUP on the receiving node.'
         - macro: '{$OPNS.KEY}'
           description: 'OPNsense API key used as the HTTP Basic authentication username. Create it under System -> Access -> Users -> API keys.'
         - macro: '{$OPNS.LICENSE.EXPIRY.WARN}'

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -2911,7 +2911,7 @@ zabbix_export:
           value: '1'
           description: 'Minimum number of remote creator IDs expected in the synchronized state table.'
         - macro: '{$OPNS.HA.ROLE}'
-          value: BACKUP
+          value: MASTER
           description: 'HA node role. Set to MASTER on the XMLRPC synchronization source or BACKUP on the receiving node.'
         - macro: '{$OPNS.KEY}'
           description: 'OPNsense API key used as the HTTP Basic authentication username. Create it under System -> Access -> Users -> API keys.'

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -11,7 +11,7 @@ zabbix_export:
       name: 'OPNsense by HTTP-JSON'
       vendor:
         name: 'community'
-        version: '0.30'
+        version: '0.31'
       groups:
         - name: 'Templates/Network devices'
         - name: 'Templates/Operating systems'
@@ -452,6 +452,34 @@ zabbix_export:
           tags:
             - tag: component
               value: firmware
+        - uuid: 9c1d61a643634b55b292644b9cac92ca
+          name: 'Cron job count'
+          type: DEPENDENT
+          key: opns.cron.job.count
+          history: 30d
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.total
+          master_item:
+            key: opns.raw.cron.jobs
+          tags:
+            - tag: component
+              value: cron
+        - uuid: 79739b6c18ab4e3a8fc484d7aa0c1efb
+          name: 'RAW Cron Jobs'
+          type: HTTP_AGENT
+          key: opns.raw.cron.jobs
+          delay: 5m
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/cron/settings/searchJobs'
+          tags:
+            - tag: component
+              value: raw
         - uuid: 164f961df24a445aa57872068e5a1f99
           name: 'RAW Disk'
           type: HTTP_AGENT
@@ -760,6 +788,97 @@ zabbix_export:
             - tag: component
               value: raw
       discovery_rules:
+        - uuid: 9be88752e6114e32b72109b70d5fe671
+          name: 'Cron Job Discovery'
+          type: DEPENDENT
+          key: opns.cron.job.discovery
+          filter:
+            conditions:
+              - macro: '{#CRON.DESCRIPTION}'
+                value: '{$OPNS.CRON.JOB.MATCHES}'
+              - macro: '{#CRON.DESCRIPTION}'
+                value: '{$OPNS.CRON.JOB.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+          lifetime: 1d
+          item_prototypes:
+            - uuid: a33322937cf84f81b381c85fa8d3f44f
+              name: 'Cron job [{#CRON.DESCRIPTION}]: Command'
+              type: DEPENDENT
+              key: 'opns.cron.job.command[{#CRON.UUID}]'
+              value_type: TEXT
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.rows[?(@.uuid == "{#CRON.UUID}")].command.first()'
+              master_item:
+                key: opns.raw.cron.jobs
+              tags:
+                - tag: component
+                  value: cron
+                - tag: origin
+                  value: '{#CRON.ORIGIN}'
+            - uuid: 5e373f6096a547de9e2b3829e19e320b
+              name: 'Cron job [{#CRON.DESCRIPTION}]: Enabled'
+              type: DEPENDENT
+              key: 'opns.cron.job.enabled[{#CRON.UUID}]'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.rows[?(@.uuid == "{#CRON.UUID}")].enabled.first()'
+              master_item:
+                key: opns.raw.cron.jobs
+              tags:
+                - tag: component
+                  value: cron
+                - tag: origin
+                  value: '{#CRON.ORIGIN}'
+              trigger_prototypes:
+                - uuid: c9f937bc3a514fe5a69708a2f57a3269
+                  expression: 'last(/OPNsense by HTTP-JSON/opns.cron.job.enabled[{#CRON.UUID}])=0'
+                  name: 'Cron job [{#CRON.DESCRIPTION}] is disabled'
+                  opdata: 'Enabled: {ITEM.LASTVALUE}'
+                  priority: WARNING
+                  description: 'The configured OPNsense cron job is disabled.'
+            - uuid: 8bbf255d75c34404b3a83b0fdf1c1139
+              name: 'Cron job [{#CRON.DESCRIPTION}]: Schedule'
+              type: DEPENDENT
+              key: 'opns.cron.job.schedule[{#CRON.UUID}]'
+              value_type: TEXT
+              trends: '0'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      var data = JSON.parse(value);
+                      var rows = data.rows || [];
+                      for (var i = 0; i < rows.length; i++) {
+                          if (rows[i].uuid === '{#CRON.UUID}') {
+                              return [rows[i].minutes, rows[i].hours, rows[i].days,
+                                  rows[i].months, rows[i].weekdays].join(' ');
+                          }
+                      }
+                      throw 'Cron job {#CRON.UUID} not found';
+              master_item:
+                key: opns.raw.cron.jobs
+              tags:
+                - tag: component
+                  value: cron
+                - tag: origin
+                  value: '{#CRON.ORIGIN}'
+          master_item:
+            key: opns.raw.cron.jobs
+          lld_macro_paths:
+            - lld_macro: '{#CRON.DESCRIPTION}'
+              path: $.description
+            - lld_macro: '{#CRON.ORIGIN}'
+              path: $.origin
+            - lld_macro: '{#CRON.UUID}'
+              path: $.uuid
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows
         - uuid: 42db664817fa4d23803fe5be9eb4e0a1
           name: 'Disk Discovery'
           type: DEPENDENT
@@ -2117,6 +2236,12 @@ zabbix_export:
       macros:
         - macro: '{$OPNS.CPU.LOAD.MAX}'
           value: '2'
+        - macro: '{$OPNS.CRON.JOB.MATCHES}'
+          value: .+
+          description: 'Regex filter for cron job descriptions to discover. Can be overridden on the host or linked template level.'
+        - macro: '{$OPNS.CRON.JOB.NOT_MATCHES}'
+          value: ^$
+          description: 'Regex filter for cron job descriptions to exclude from discovery. Can be overridden on the host or linked template level.'
         - macro: '{$OPNS.FS.FSNAME.MATCHES}'
           value: .+
           description: 'Used for filesystem discovery. Can be overridden on the host or linked template level.'

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -494,7 +494,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: 7b99dad942d84c008e9531820d238976
-              expression: 'last(/OPNsense by HTTP-JSON/opns.ha.carp.allowed)=0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
+              expression: '{$OPNS.HA.ENABLED}=1 and last(/OPNsense by HTTP-JSON/opns.ha.carp.allowed)=0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
               name: 'CARP is disabled'
               opdata: 'Allowed: {ITEM.LASTVALUE1}'
               priority: HIGH
@@ -515,7 +515,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: 989105f92053419d996862be22081fb2
-              expression: 'last(/OPNsense by HTTP-JSON/opns.ha.carp.demotion)>0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.maintenance)=0'
+              expression: '{$OPNS.HA.ENABLED}=1 and last(/OPNsense by HTTP-JSON/opns.ha.carp.demotion)>0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.maintenance)=0'
               name: 'CARP demotion level is elevated'
               opdata: 'Demotion: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -537,7 +537,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: f0fd244461ef43aa88473dc80c4dcae2
-              expression: 'last(/OPNsense by HTTP-JSON/opns.ha.carp.maintenance)=1 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
+              expression: '{$OPNS.HA.ENABLED}=1 and last(/OPNsense by HTTP-JSON/opns.ha.carp.maintenance)=1 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
               name: 'CARP persistent maintenance mode is active'
               opdata: 'Maintenance: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -561,7 +561,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: d12b75ec9a8e4886a967dd0153c2bc82
-              expression: 'find(/OPNsense by HTTP-JSON/opns.ha.carp.status_message,#1,"ne","OK")=1'
+              expression: '{$OPNS.HA.ENABLED}=1 and find(/OPNsense by HTTP-JSON/opns.ha.carp.status_message,#1,"ne","OK")=1'
               name: 'CARP reports a status warning'
               opdata: '{ITEM.LASTVALUE}'
               priority: WARNING
@@ -584,7 +584,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: 62c414e49433480c8671aab366016e62
-              expression: 'last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=0 and {$OPNS.HA.CONFIG_SYNC.REQUIRED}=1'
+              expression: '{$OPNS.HA.ENABLED}=1 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=0 and {$OPNS.HA.CONFIG_SYNC.REQUIRED}=1'
               name: 'HA configuration synchronization is not configured'
               priority: WARNING
               description: 'This node is designated as the XMLRPC synchronization source, but no target is configured.'
@@ -636,7 +636,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: 9afd9d8b95564e6fb965150bf3f12471
-              expression: 'max(/OPNsense by HTTP-JSON/opns.ha.peer.reachable,10m)=0 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
+              expression: '{$OPNS.HA.ENABLED}=1 and max(/OPNsense by HTTP-JSON/opns.ha.peer.reachable,10m)=0 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
               name: 'HA peer is not reachable through XMLRPC'
               opdata: 'Reachable: {ITEM.LASTVALUE1}'
               priority: HIGH
@@ -702,7 +702,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: e86ded9d3f9c4cbf89d9045c3a8d2349
-              expression: 'last(/OPNsense by HTTP-JSON/opns.ha.peer.version.match)=0 and last(/OPNsense by HTTP-JSON/opns.ha.peer.reachable)=1 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
+              expression: '{$OPNS.HA.ENABLED}=1 and last(/OPNsense by HTTP-JSON/opns.ha.peer.version.match)=0 and last(/OPNsense by HTTP-JSON/opns.ha.peer.reachable)=1 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
               name: 'HA peer firmware version differs'
               opdata: 'Versions match: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -725,7 +725,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: 8b6159b16d494e0c88963fe23fe1d2ec
-              expression: 'last(/OPNsense by HTTP-JSON/opns.ha.pfsync.configured)=0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
+              expression: '{$OPNS.HA.ENABLED}=1 and last(/OPNsense by HTTP-JSON/opns.ha.pfsync.configured)=0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
               name: 'HA state synchronization is not configured'
               priority: WARNING
               description: 'CARP VIPs exist, but no pfsync interface is configured.'
@@ -813,7 +813,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: bf106f6872b442a288a57fc4002e1687
-              expression: 'max(/OPNsense by HTTP-JSON/opns.ha.pfsync.remote.count,10m)<{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN} and last(/OPNsense by HTTP-JSON/opns.ha.pfsync.configured)=1'
+              expression: '{$OPNS.HA.ENABLED}=1 and max(/OPNsense by HTTP-JSON/opns.ha.pfsync.remote.count,10m)<{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN} and last(/OPNsense by HTTP-JSON/opns.ha.pfsync.configured)=1'
               name: 'No remote pfsync state creator is visible'
               opdata: 'Remote creators: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -1742,13 +1742,13 @@ zabbix_export:
                   value: '{#CARP.VHID}'
               trigger_prototypes:
                 - uuid: e5f549c43e8c4e99a0babe831f84bc4e
-                  expression: 'change(/OPNsense by HTTP-JSON/opns.carp.status["{#CARP.ADDRESS}"])<>0'
+                  expression: '{$OPNS.HA.ENABLED}=1 and change(/OPNsense by HTTP-JSON/opns.carp.status["{#CARP.ADDRESS}"])<>0'
                   name: 'CARP status changed for VIP {#CARP.ADDRESS}'
                   opdata: '{#CARP.ADDRESS}: {ITEM.LASTVALUE}'
                   priority: HIGH
                   description: 'The CARP role changed, indicating a failover or failback event.'
                 - uuid: c53ed53917d349c696702b8c5ddadae0
-                  expression: 'find(/OPNsense by HTTP-JSON/opns.carp.status["{#CARP.ADDRESS}"],#1,"regexp","{$OPNS.HA.CARP.STATUS.MATCHES:\"{#CARP.ADDRESS}\"}")=0'
+                  expression: '{$OPNS.HA.ENABLED}=1 and find(/OPNsense by HTTP-JSON/opns.carp.status["{#CARP.ADDRESS}"],#1,"regexp","{$OPNS.HA.CARP.STATUS.MATCHES:\"{#CARP.ADDRESS}\"}")=0'
                   name: 'CARP status is unexpected for VIP {#CARP.ADDRESS}'
                   opdata: 'Status: {ITEM.LASTVALUE}'
                   priority: HIGH
@@ -1765,11 +1765,17 @@ zabbix_export:
             - lld_macro: '{#CARP.VHID}'
               path: $.vhid
           preprocessing:
-            - type: JSONPATH
+            - type: JAVASCRIPT
               parameters:
-                - '$.rows[*]'
-              error_handler: CUSTOM_ERROR
-              error_handler_params: 'Could not locate any defined CARP interfaces.'
+                - |
+                  if ('{$OPNS.HA.ENABLED}' !== '1') {
+                      return '[]';
+                  }
+                  var data = JSON.parse(value);
+                  if (!data.rows) {
+                      throw 'Could not locate any defined CARP interfaces.';
+                  }
+                  return JSON.stringify(data.rows);
         - uuid: b8869284c47740a79fb1f84519f4735c
           name: 'HA Peer Service Discovery'
           type: DEPENDENT
@@ -1807,7 +1813,7 @@ zabbix_export:
                   value: '{#HA.SERVICE.NAME}'
               trigger_prototypes:
                 - uuid: 454f69e9878a42ffafda4fd8a9b6693c
-                  expression: 'max(/OPNsense by HTTP-JSON/opns.ha.peer.service.status["{#HA.SERVICE.UID}"],10m)=0 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
+                  expression: '{$OPNS.HA.ENABLED}=1 and max(/OPNsense by HTTP-JSON/opns.ha.peer.service.status["{#HA.SERVICE.UID}"],10m)=0 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
                   name: 'HA peer service [{#HA.SERVICE.DESCRIPTION}] is not running'
                   opdata: 'Status: {ITEM.LASTVALUE1}'
                   priority: HIGH
@@ -1824,9 +1830,17 @@ zabbix_export:
             - lld_macro: '{#HA.SERVICE.UID}'
               path: $.uid
           preprocessing:
-            - type: JSONPATH
+            - type: JAVASCRIPT
               parameters:
-                - $.rows
+                - |
+                  if ('{$OPNS.HA.ENABLED}' !== '1') {
+                      return '[]';
+                  }
+                  var data = JSON.parse(value);
+                  if (!data.rows) {
+                      throw 'HA peer service data does not contain rows.';
+                  }
+                  return JSON.stringify(data.rows);
         - uuid: 953017b50e5c42108b22753aa77226fa
           name: 'HA pfsync Node Discovery'
           type: DEPENDENT
@@ -1852,9 +1866,17 @@ zabbix_export:
             - lld_macro: '{#PFSYNC.CREATORID}'
               path: $.creatorid
           preprocessing:
-            - type: JSONPATH
+            - type: JAVASCRIPT
               parameters:
-                - $.rows
+                - |
+                  if ('{$OPNS.HA.ENABLED}' !== '1') {
+                      return '[]';
+                  }
+                  var data = JSON.parse(value);
+                  if (!data.rows) {
+                      throw 'HA pfsync node data does not contain rows.';
+                  }
+                  return JSON.stringify(data.rows);
         - uuid: 9941458d7de1441e950799233705bdbe
           name: 'Interface Stats Discovery'
           type: DEPENDENT
@@ -2885,6 +2907,9 @@ zabbix_export:
         - macro: '{$OPNS.HA.CONFIG_SYNC.REQUIRED}'
           value: '0'
           description: 'Set to 1 on the HA synchronization source to require an XMLRPC target. Keep 0 on the backup node.'
+        - macro: '{$OPNS.HA.ENABLED}'
+          value: '1'
+          description: 'Set to 0 on standalone firewalls to disable HA triggers and HA discovery.'
         - macro: '{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN}'
           value: '1'
           description: 'Minimum number of remote creator IDs expected in the synchronized state table.'

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -11,7 +11,7 @@ zabbix_export:
       name: 'OPNsense by HTTP-JSON'
       vendor:
         name: 'community'
-        version: '0.31'
+        version: '0.32'
       groups:
         - name: 'Templates/Network devices'
         - name: 'Templates/Operating systems'
@@ -452,6 +452,368 @@ zabbix_export:
           tags:
             - tag: component
               value: firmware
+        - uuid: 4d04720c72f4411fa5f7cd99cfad7f17
+          name: 'CARP VIP count'
+          type: DEPENDENT
+          key: opns.ha.carp.vip.count
+          history: 30d
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  var rows = data.rows || [];
+                  var count = 0;
+                  for (var i = 0; i < rows.length; i++) {
+                      if (rows[i].mode === 'carp') {
+                          count++;
+                      }
+                  }
+                  return count;
+          master_item:
+            key: opns.raw.interfaces.carp
+          tags:
+            - tag: component
+              value: ha
+        - uuid: fd79a86e76414ca38d4a45f6d18ae9ae
+          name: 'CARP is allowed'
+          type: DEPENDENT
+          key: opns.ha.carp.allowed
+          history: 30d
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.carp.allow
+          master_item:
+            key: opns.raw.interfaces.carp
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: 7b99dad942d84c008e9531820d238976
+              expression: 'last(/OPNsense by HTTP-JSON/opns.ha.carp.allowed)=0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
+              name: 'CARP is disabled'
+              opdata: 'Allowed: {ITEM.LASTVALUE1}'
+              priority: HIGH
+              description: 'CARP is temporarily disabled while CARP VIPs are configured.'
+        - uuid: 02db0d1b85944f2d9ea3f6770ad541d7
+          name: 'CARP demotion level'
+          type: DEPENDENT
+          key: opns.ha.carp.demotion
+          history: 30d
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.carp.demotion
+          master_item:
+            key: opns.raw.interfaces.carp
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: 989105f92053419d996862be22081fb2
+              expression: 'last(/OPNsense by HTTP-JSON/opns.ha.carp.demotion)>0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.maintenance)=0'
+              name: 'CARP demotion level is elevated'
+              opdata: 'Demotion: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'A positive CARP demotion level can prevent this node from becoming MASTER.'
+        - uuid: 88ee4fc92c53488d97af604cd4417736
+          name: 'CARP maintenance mode'
+          type: DEPENDENT
+          key: opns.ha.carp.maintenance
+          history: 30d
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.carp.maintenancemode
+          master_item:
+            key: opns.raw.interfaces.carp
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: f0fd244461ef43aa88473dc80c4dcae2
+              expression: 'last(/OPNsense by HTTP-JSON/opns.ha.carp.maintenance)=1 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
+              name: 'CARP persistent maintenance mode is active'
+              opdata: 'Maintenance: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'The firewall is in persistent CARP maintenance mode.'
+        - uuid: 78fd1b3810a540aab653fb0642a1231e
+          name: 'CARP status message'
+          type: DEPENDENT
+          key: opns.ha.carp.status_message
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  return data.carp && data.carp.status_msg ? data.carp.status_msg : 'OK';
+          master_item:
+            key: opns.raw.interfaces.carp
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: d12b75ec9a8e4886a967dd0153c2bc82
+              expression: 'find(/OPNsense by HTTP-JSON/opns.ha.carp.status_message,#1,"ne","OK")=1'
+              name: 'CARP reports a status warning'
+              opdata: '{ITEM.LASTVALUE}'
+              priority: WARNING
+              description: 'OPNsense reports a global CARP status warning.'
+        - uuid: 3dc8ff18a02d4f069cd3ef5a9ec5702b
+          name: 'HA configuration synchronization is configured'
+          type: DEPENDENT
+          key: opns.ha.config_sync.configured
+          history: 30d
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  return data.xmlrpc_configured;
+          master_item:
+            key: opns.raw.ha.settings
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: 62c414e49433480c8671aab366016e62
+              expression: 'last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=0 and {$OPNS.HA.CONFIG_SYNC.REQUIRED}=1'
+              name: 'HA configuration synchronization is not configured'
+              priority: WARNING
+              description: 'This node is designated as the XMLRPC synchronization source, but no target is configured.'
+        - uuid: 014669b71d5d4d208ee8e6db15385f8c
+          name: 'HA configuration synchronization items'
+          type: DEPENDENT
+          key: opns.ha.config_sync.items
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  return JSON.stringify(data.sync_items || {});
+          master_item:
+            key: opns.raw.ha.settings
+          tags:
+            - tag: component
+              value: ha
+        - uuid: a77c006dc95f4a8da5a3b192f2ae64cd
+          name: 'HA configuration synchronization target'
+          type: DEPENDENT
+          key: opns.ha.config_sync.target
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.xmlrpc_target
+          master_item:
+            key: opns.raw.ha.settings
+          tags:
+            - tag: component
+              value: ha
+        - uuid: c6fb744b4bab40d2a247054f56dad10c
+          name: 'HA peer is reachable through XMLRPC'
+          type: DEPENDENT
+          key: opns.ha.peer.reachable
+          history: 30d
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.reachable
+          master_item:
+            key: opns.raw.ha.peer.version
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: 9afd9d8b95564e6fb965150bf3f12471
+              expression: 'max(/OPNsense by HTTP-JSON/opns.ha.peer.reachable,10m)=0 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
+              name: 'HA peer is not reachable through XMLRPC'
+              opdata: 'Reachable: {ITEM.LASTVALUE1}'
+              priority: HIGH
+              description: 'The configured HA peer did not answer the OPNsense XMLRPC version probe.'
+        - uuid: 7658876fcb864b02b77019a1ff8c5db4
+          name: 'HA peer firmware version'
+          type: DEPENDENT
+          key: opns.ha.peer.version
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.remote_firmware
+          master_item:
+            key: opns.raw.ha.peer.version
+          tags:
+            - tag: component
+              value: ha
+        - uuid: 1ccf5cf49f33450391225bd4461733d0
+          name: 'HA peer base version'
+          type: DEPENDENT
+          key: opns.ha.peer.version.base
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.remote_base
+          master_item:
+            key: opns.raw.ha.peer.version
+          tags:
+            - tag: component
+              value: ha
+        - uuid: efcc2a309ca94a9686b96025455236ff
+          name: 'HA peer kernel version'
+          type: DEPENDENT
+          key: opns.ha.peer.version.kernel
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.remote_kernel
+          master_item:
+            key: opns.raw.ha.peer.version
+          tags:
+            - tag: component
+              value: ha
+        - uuid: d05fc49a5ef948a78eb0beaa609b62ad
+          name: 'HA peer firmware version matches'
+          type: DEPENDENT
+          key: opns.ha.peer.version.match
+          history: 30d
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.version_match
+          master_item:
+            key: opns.raw.ha.peer.version
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: e86ded9d3f9c4cbf89d9045c3a8d2349
+              expression: 'last(/OPNsense by HTTP-JSON/opns.ha.peer.version.match)=0 and last(/OPNsense by HTTP-JSON/opns.ha.peer.reachable)=1 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
+              name: 'HA peer firmware version differs'
+              opdata: 'Versions match: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'The local and remote OPNsense core firmware versions differ.'
+        - uuid: ca7f5c0fb792497bbc19f11f1e113e21
+          name: 'HA pfsync is configured'
+          type: DEPENDENT
+          key: opns.ha.pfsync.configured
+          history: 30d
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  return data.pfsync_configured;
+          master_item:
+            key: opns.raw.ha.settings
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: 8b6159b16d494e0c88963fe23fe1d2ec
+              expression: 'last(/OPNsense by HTTP-JSON/opns.ha.pfsync.configured)=0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
+              name: 'HA state synchronization is not configured'
+              priority: WARNING
+              description: 'CARP VIPs exist, but no pfsync interface is configured.'
+        - uuid: 3ab0bfbae06f4e698075acded4cefb3c
+          name: 'HA pfsync interface'
+          type: DEPENDENT
+          key: opns.ha.pfsync.interface
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.pfsync_interface
+          master_item:
+            key: opns.raw.ha.settings
+          tags:
+            - tag: component
+              value: ha
+        - uuid: c33587bb48bb4a37ab4613dfbc5bd641
+          name: 'HA pfsync peer IP'
+          type: DEPENDENT
+          key: opns.ha.pfsync.peer_ip
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.pfsync_peer_ip
+          master_item:
+            key: opns.raw.ha.settings
+          tags:
+            - tag: component
+              value: ha
+        - uuid: 2e460a58e56b4d7db4fc788048ad487c
+          name: 'HA pfsync protocol version'
+          type: DEPENDENT
+          key: opns.ha.pfsync.version
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.pfsync_version
+          master_item:
+            key: opns.raw.ha.settings
+          tags:
+            - tag: component
+              value: ha
+        - uuid: fb2213a0be0041f49fe81c0e3372822e
+          name: 'HA pfsync defer'
+          type: DEPENDENT
+          key: opns.ha.pfsync.defer
+          history: 30d
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.pfsync_defer
+          master_item:
+            key: opns.raw.ha.settings
+          tags:
+            - tag: component
+              value: ha
+        - uuid: 96ba168a8aad49e58c386a4122aef0b5
+          name: 'HA pfsync remote node count'
+          type: DEPENDENT
+          key: opns.ha.pfsync.remote.count
+          history: 30d
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  var rows = data.rows || [];
+                  var count = 0;
+                  for (var i = 0; i < rows.length; i++) {
+                      if (String(rows[i].this) !== '1') {
+                          count++;
+                      }
+                  }
+                  return count;
+          master_item:
+            key: opns.raw.ha.pfsync.nodes
+          tags:
+            - tag: component
+              value: ha
+          triggers:
+            - uuid: bf106f6872b442a288a57fc4002e1687
+              expression: 'max(/OPNsense by HTTP-JSON/opns.ha.pfsync.remote.count,10m)<{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN} and last(/OPNsense by HTTP-JSON/opns.ha.pfsync.configured)=1'
+              name: 'No remote pfsync state creator is visible'
+              opdata: 'Remote creators: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'No state created by a remote pfsync node has been observed during the last 10 minutes.'
         - uuid: 9c1d61a643634b55b292644b9cac92ca
           name: 'Cron job count'
           type: DEPENDENT
@@ -612,6 +974,111 @@ zabbix_export:
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
           url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/interface/get_vip_status'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: dfee8ebcd7fe4fb78940c353f35a07f7
+          name: 'RAW HA Peer Services'
+          type: HTTP_AGENT
+          key: opns.raw.ha.peer.services
+          delay: 5m
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/core/hasync_status/services'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: a0f4b127717f454da607d6c127738db2
+          name: 'RAW HA Peer Version'
+          type: HTTP_AGENT
+          key: opns.raw.ha.peer.version
+          delay: 5m
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data;
+                  try {
+                      data = JSON.parse(value);
+                  } catch (e) {
+                      return JSON.stringify({
+                          reachable: 0,
+                          version_match: 0,
+                          remote_firmware: 'unavailable',
+                          remote_base: 'unavailable',
+                          remote_kernel: 'unavailable',
+                          message: 'Invalid JSON response'
+                      });
+                  }
+                  var result = {
+                      reachable: 0,
+                      version_match: 0,
+                      remote_firmware: 'unavailable',
+                      remote_base: 'unavailable',
+                      remote_kernel: 'unavailable',
+                      message: data.message || ''
+                  };
+                  if (data.response && data.response.firmware && data.response.firmware.version) {
+                      result.reachable = 1;
+                      result.remote_firmware = data.response.firmware.version;
+                      result.remote_base = data.response.base && data.response.base.version ? data.response.base.version : 'unavailable';
+                      result.remote_kernel = data.response.kernel && data.response.kernel.version ? data.response.kernel.version : 'unavailable';
+                      result.version_match = data.response.firmware._my_version === data.response.firmware.version ? 1 : 0;
+                  }
+                  return JSON.stringify(result);
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/core/hasync_status/version'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: aa07e9c770ab4497929d15b6d5e4b55c
+          name: 'RAW HA Settings'
+          type: HTTP_AGENT
+          key: opns.raw.ha.settings
+          delay: 5m
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  var settings = data.hasync || {};
+                  return JSON.stringify({
+                      pfsync_configured: settings.pfsyncinterface ? 1 : 0,
+                      pfsync_interface: settings.pfsyncinterface || 'disabled',
+                      pfsync_peer_ip: settings.pfsyncpeerip || 'multicast',
+                      pfsync_version: settings.pfsyncversion || 'unknown',
+                      pfsync_defer: settings.pfsyncdefer || '0',
+                      xmlrpc_configured: settings.synchronizetoip ? 1 : 0,
+                      xmlrpc_target: settings.synchronizetoip || 'not configured',
+                      verify_peer: settings.verifypeer || '0',
+                      sync_items: settings.syncitems || {}
+                  });
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/core/hasync/get'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: e05193c2e24641f8aca0dde2219b0fb5
+          name: 'RAW HA pfsync Nodes'
+          type: HTTP_AGENT
+          key: opns.raw.ha.pfsync.nodes
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/interface/get_pfsync_nodes'
           tags:
             - tag: component
               value: raw
@@ -1207,39 +1674,183 @@ zabbix_export:
           name: 'Interface CARP Discovery'
           type: DEPENDENT
           key: opns.interface.carp.discovery
+          filter:
+            conditions:
+              - macro: '{#CARP.MODE}'
+                value: ^carp$
           lifetime: 1d
           item_prototypes:
-            - uuid: bcd3129d95bc4fec85eef33485aa454d
-              name: 'Carp Status of {#OPNS.INTERFACE.NAME}'
+            - uuid: 4819d62a4cba47a0b649e3dd1ab853e5
+              name: 'CARP VIP {#CARP.ADDRESS} ({#CARP.INTERFACE}, VHID {#CARP.VHID}): Advertisement base'
               type: DEPENDENT
-              key: 'opns.carp.status[{#OPNS.INTERFACE.NAME}]'
+              key: 'opns.carp.advbase["{#CARP.ADDRESS}"]'
+              units: s
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.rows[?(@.subnet == "{#CARP.ADDRESS}")].advbase.first()'
+              master_item:
+                key: opns.raw.interfaces.carp
+              tags:
+                - tag: component
+                  value: ha
+                - tag: interface
+                  value: '{#CARP.INTERFACE}'
+                - tag: vhid
+                  value: '{#CARP.VHID}'
+            - uuid: 38282b54fd7d48558f9662a7cdaa2b0b
+              name: 'CARP VIP {#CARP.ADDRESS} ({#CARP.INTERFACE}, VHID {#CARP.VHID}): Advertisement skew'
+              type: DEPENDENT
+              key: 'opns.carp.advskew["{#CARP.ADDRESS}"]'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.rows[?(@.subnet == "{#CARP.ADDRESS}")].advskew.first()'
+              master_item:
+                key: opns.raw.interfaces.carp
+              tags:
+                - tag: component
+                  value: ha
+                - tag: interface
+                  value: '{#CARP.INTERFACE}'
+                - tag: vhid
+                  value: '{#CARP.VHID}'
+            - uuid: bcd3129d95bc4fec85eef33485aa454d
+              name: 'CARP VIP {#CARP.ADDRESS} ({#CARP.INTERFACE}, VHID {#CARP.VHID}): Status'
+              type: DEPENDENT
+              key: 'opns.carp.status["{#CARP.ADDRESS}"]'
               value_type: TEXT
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$..[?(@.["interface"] == "{#OPNS.INTERFACE.NAME}")].["status"].first()'
+                    - '$.rows[?(@.subnet == "{#CARP.ADDRESS}")].status.first()'
                 - type: DISCARD_UNCHANGED_HEARTBEAT
                   parameters:
                     - 2h
               master_item:
                 key: opns.raw.interfaces.carp
+              tags:
+                - tag: component
+                  value: ha
+                - tag: interface
+                  value: '{#CARP.INTERFACE}'
+                - tag: vhid
+                  value: '{#CARP.VHID}'
               trigger_prototypes:
                 - uuid: e5f549c43e8c4e99a0babe831f84bc4e
-                  expression: 'change(/OPNsense by HTTP-JSON/opns.carp.status[{#OPNS.INTERFACE.NAME}])<>0'
-                  name: 'Carp Status Changed on {#OPNS.INTERFACE.NAME}'
-                  opdata: '{#OPNS.INTERFACE.NAME}: {ITEM.LASTVALUE}'
+                  expression: 'change(/OPNsense by HTTP-JSON/opns.carp.status["{#CARP.ADDRESS}"])<>0'
+                  name: 'CARP status changed for VIP {#CARP.ADDRESS}'
+                  opdata: '{#CARP.ADDRESS}: {ITEM.LASTVALUE}'
                   priority: HIGH
+                  description: 'The CARP role changed, indicating a failover or failback event.'
+                - uuid: c53ed53917d349c696702b8c5ddadae0
+                  expression: 'find(/OPNsense by HTTP-JSON/opns.carp.status["{#CARP.ADDRESS}"],#1,"regexp","{$OPNS.HA.CARP.STATUS.MATCHES:\"{#CARP.ADDRESS}\"}")=0'
+                  name: 'CARP status is unexpected for VIP {#CARP.ADDRESS}'
+                  opdata: 'Status: {ITEM.LASTVALUE}'
+                  priority: HIGH
+                  description: 'The CARP VIP status does not match the accepted status regex. Use a macro context for the VIP address to enforce MASTER or BACKUP on a specific node.'
           master_item:
             key: opns.raw.interfaces.carp
           lld_macro_paths:
-            - lld_macro: '{#OPNS.INTERFACE.NAME}'
+            - lld_macro: '{#CARP.ADDRESS}'
+              path: $.subnet
+            - lld_macro: '{#CARP.INTERFACE}'
               path: $.interface
+            - lld_macro: '{#CARP.MODE}'
+              path: $.mode
+            - lld_macro: '{#CARP.VHID}'
+              path: $.vhid
           preprocessing:
             - type: JSONPATH
               parameters:
                 - '$.rows[*]'
               error_handler: CUSTOM_ERROR
               error_handler_params: 'Could not locate any defined CARP interfaces.'
+        - uuid: b8869284c47740a79fb1f84519f4735c
+          name: 'HA Peer Service Discovery'
+          type: DEPENDENT
+          key: opns.ha.peer.service.discovery
+          filter:
+            conditions:
+              - macro: '{#HA.SERVICE.NOCHECK}'
+                value: ^1$
+                operator: NOT_MATCHES_REGEX
+          lifetime: 1d
+          item_prototypes:
+            - uuid: e9cd5bad26a74fd3a941d82c5123f572
+              name: 'HA peer service [{#HA.SERVICE.DESCRIPTION}]: Status'
+              type: DEPENDENT
+              key: 'opns.ha.peer.service.status["{#HA.SERVICE.UID}"]'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      var data = JSON.parse(value);
+                      var rows = data.rows || [];
+                      for (var i = 0; i < rows.length; i++) {
+                          if (rows[i].uid === '{#HA.SERVICE.UID}') {
+                              var status = String(rows[i].status).toLowerCase();
+                              return status === '1' || status === 'true' ? 1 : 0;
+                          }
+                      }
+                      throw 'HA peer service {#HA.SERVICE.UID} not found';
+              master_item:
+                key: opns.raw.ha.peer.services
+              tags:
+                - tag: component
+                  value: ha
+                - tag: service
+                  value: '{#HA.SERVICE.NAME}'
+              trigger_prototypes:
+                - uuid: 454f69e9878a42ffafda4fd8a9b6693c
+                  expression: 'max(/OPNsense by HTTP-JSON/opns.ha.peer.service.status["{#HA.SERVICE.UID}"],10m)=0 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
+                  name: 'HA peer service [{#HA.SERVICE.DESCRIPTION}] is not running'
+                  opdata: 'Status: {ITEM.LASTVALUE1}'
+                  priority: HIGH
+                  description: 'A monitored service on the configured HA peer is stopped.'
+          master_item:
+            key: opns.raw.ha.peer.services
+          lld_macro_paths:
+            - lld_macro: '{#HA.SERVICE.DESCRIPTION}'
+              path: $.description
+            - lld_macro: '{#HA.SERVICE.NAME}'
+              path: $.name
+            - lld_macro: '{#HA.SERVICE.NOCHECK}'
+              path: $.nocheck
+            - lld_macro: '{#HA.SERVICE.UID}'
+              path: $.uid
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows
+        - uuid: 953017b50e5c42108b22753aa77226fa
+          name: 'HA pfsync Node Discovery'
+          type: DEPENDENT
+          key: opns.ha.pfsync.node.discovery
+          lifetime: 1d
+          item_prototypes:
+            - uuid: 7304beffbccb4ab694049936ba047273
+              name: 'pfsync state creator [{#PFSYNC.CREATORID}]: Local node'
+              type: DEPENDENT
+              key: 'opns.ha.pfsync.node.local["{#PFSYNC.CREATORID}"]'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.rows[?(@.creatorid == "{#PFSYNC.CREATORID}")].this.first()'
+              master_item:
+                key: opns.raw.ha.pfsync.nodes
+              tags:
+                - tag: component
+                  value: ha
+          master_item:
+            key: opns.raw.ha.pfsync.nodes
+          lld_macro_paths:
+            - lld_macro: '{#PFSYNC.CREATORID}'
+              path: $.creatorid
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows
         - uuid: 9941458d7de1441e950799233705bdbe
           name: 'Interface Stats Discovery'
           type: DEPENDENT
@@ -2264,6 +2875,15 @@ zabbix_export:
           value: '50'
         - macro: '{$OPNS.GW.MIN.PACKET.LOSS}'
           value: '10'
+        - macro: '{$OPNS.HA.CARP.STATUS.MATCHES}'
+          value: ^(MASTER|BACKUP)$
+          description: 'Accepted CARP status regex. Use a macro context with the VIP address to enforce a node-specific role.'
+        - macro: '{$OPNS.HA.CONFIG_SYNC.REQUIRED}'
+          value: '0'
+          description: 'Set to 1 on the HA synchronization source to require an XMLRPC target. Keep 0 on the backup node.'
+        - macro: '{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN}'
+          value: '1'
+          description: 'Minimum number of remote creator IDs expected in the synchronized state table.'
         - macro: '{$OPNS.KEY}'
         - macro: '{$OPNS.LICENSE.EXPIRY.WARN}'
           value: '30'
@@ -2350,7 +2970,7 @@ zabbix_export:
                   fields:
                     - type: STRING
                       name: items.0
-                      value: 'Carp Status of *'
+                      value: 'CARP VIP *: Status'
                     - type: STRING
                       name: primary_label
                       value: '{ITEM.NAME}'

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -11,7 +11,7 @@ zabbix_export:
       name: 'OPNsense by HTTP-JSON'
       vendor:
         name: 'community'
-        version: '0.33'
+        version: '0.34'
       groups:
         - name: 'Templates/Network devices'
         - name: 'Templates/Operating systems'
@@ -2885,6 +2885,7 @@ zabbix_export:
           value: '1'
           description: 'Minimum number of remote creator IDs expected in the synchronized state table.'
         - macro: '{$OPNS.KEY}'
+          description: 'OPNsense API key used as the HTTP Basic authentication username. Create it under System -> Access -> Users -> API keys.'
         - macro: '{$OPNS.LICENSE.EXPIRY.WARN}'
           value: '30'
         - macro: '{$OPNS.MEMORY.UTIL.MAX}'
@@ -2897,6 +2898,8 @@ zabbix_export:
         - macro: '{$OPNS.NUT.HIGH.LOAD}'
           value: '80'
         - macro: '{$OPNS.SECRET}'
+          type: SECRET_TEXT
+          description: 'OPNsense API secret paired with {$OPNS.KEY} and used as the HTTP Basic authentication password.'
         - macro: '{$OPNS.STATE.TABLE.UTIL.MAX}'
           value: '90'
         - macro: '{$OPNS.PORT}'

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -11,7 +11,7 @@ zabbix_export:
       name: 'OPNsense by HTTP-JSON'
       vendor:
         name: 'community'
-        version: '0.32'
+        version: '0.33'
       groups:
         - name: 'Templates/Network devices'
         - name: 'Templates/Operating systems'
@@ -1148,7 +1148,7 @@ zabbix_export:
           name: 'RAW Firmware Status'
           type: HTTP_AGENT
           key: opns.raw.firmware.status
-          delay: 1d
+          delay: 6h
           history: 7d
           value_type: TEXT
           authtype: BASIC

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -494,7 +494,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: 7b99dad942d84c008e9531820d238976
-              expression: '{$OPNS.HA.ENABLED}=1 and last(/OPNsense by HTTP-JSON/opns.ha.carp.allowed)=0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
+              expression: '"{$OPNS.HA.ENABLED}"="true" and last(/OPNsense by HTTP-JSON/opns.ha.carp.allowed)=0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
               name: 'CARP is disabled'
               opdata: 'Allowed: {ITEM.LASTVALUE1}'
               priority: HIGH
@@ -515,7 +515,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: 989105f92053419d996862be22081fb2
-              expression: '{$OPNS.HA.ENABLED}=1 and last(/OPNsense by HTTP-JSON/opns.ha.carp.demotion)>0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.maintenance)=0'
+              expression: '"{$OPNS.HA.ENABLED}"="true" and last(/OPNsense by HTTP-JSON/opns.ha.carp.demotion)>0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.maintenance)=0'
               name: 'CARP demotion level is elevated'
               opdata: 'Demotion: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -537,7 +537,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: f0fd244461ef43aa88473dc80c4dcae2
-              expression: '{$OPNS.HA.ENABLED}=1 and last(/OPNsense by HTTP-JSON/opns.ha.carp.maintenance)=1 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
+              expression: '"{$OPNS.HA.ENABLED}"="true" and last(/OPNsense by HTTP-JSON/opns.ha.carp.maintenance)=1 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
               name: 'CARP persistent maintenance mode is active'
               opdata: 'Maintenance: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -561,7 +561,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: d12b75ec9a8e4886a967dd0153c2bc82
-              expression: '{$OPNS.HA.ENABLED}=1 and find(/OPNsense by HTTP-JSON/opns.ha.carp.status_message,#1,"ne","OK")=1'
+              expression: '"{$OPNS.HA.ENABLED}"="true" and find(/OPNsense by HTTP-JSON/opns.ha.carp.status_message,#1,"ne","OK")=1'
               name: 'CARP reports a status warning'
               opdata: '{ITEM.LASTVALUE}'
               priority: WARNING
@@ -584,7 +584,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: 62c414e49433480c8671aab366016e62
-              expression: '{$OPNS.HA.ENABLED}=1 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=0 and {$OPNS.HA.CONFIG_SYNC.REQUIRED}=1'
+              expression: '"{$OPNS.HA.ENABLED}"="true" and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=0 and "{$OPNS.HA.CONFIG_SYNC.REQUIRED}"="true"'
               name: 'HA configuration synchronization is not configured'
               priority: WARNING
               description: 'This node is designated as the XMLRPC synchronization source, but no target is configured.'
@@ -636,7 +636,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: 9afd9d8b95564e6fb965150bf3f12471
-              expression: '{$OPNS.HA.ENABLED}=1 and max(/OPNsense by HTTP-JSON/opns.ha.peer.reachable,10m)=0 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
+              expression: '"{$OPNS.HA.ENABLED}"="true" and max(/OPNsense by HTTP-JSON/opns.ha.peer.reachable,10m)=0 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
               name: 'HA peer is not reachable through XMLRPC'
               opdata: 'Reachable: {ITEM.LASTVALUE1}'
               priority: HIGH
@@ -702,7 +702,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: e86ded9d3f9c4cbf89d9045c3a8d2349
-              expression: '{$OPNS.HA.ENABLED}=1 and last(/OPNsense by HTTP-JSON/opns.ha.peer.version.match)=0 and last(/OPNsense by HTTP-JSON/opns.ha.peer.reachable)=1 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
+              expression: '"{$OPNS.HA.ENABLED}"="true" and last(/OPNsense by HTTP-JSON/opns.ha.peer.version.match)=0 and last(/OPNsense by HTTP-JSON/opns.ha.peer.reachable)=1 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
               name: 'HA peer firmware version differs'
               opdata: 'Versions match: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -725,7 +725,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: 8b6159b16d494e0c88963fe23fe1d2ec
-              expression: '{$OPNS.HA.ENABLED}=1 and last(/OPNsense by HTTP-JSON/opns.ha.pfsync.configured)=0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
+              expression: '"{$OPNS.HA.ENABLED}"="true" and last(/OPNsense by HTTP-JSON/opns.ha.pfsync.configured)=0 and last(/OPNsense by HTTP-JSON/opns.ha.carp.vip.count)>0'
               name: 'HA state synchronization is not configured'
               priority: WARNING
               description: 'CARP VIPs exist, but no pfsync interface is configured.'
@@ -813,7 +813,7 @@ zabbix_export:
               value: ha
           triggers:
             - uuid: bf106f6872b442a288a57fc4002e1687
-              expression: '{$OPNS.HA.ENABLED}=1 and max(/OPNsense by HTTP-JSON/opns.ha.pfsync.remote.count,10m)<{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN} and last(/OPNsense by HTTP-JSON/opns.ha.pfsync.configured)=1'
+              expression: '"{$OPNS.HA.ENABLED}"="true" and max(/OPNsense by HTTP-JSON/opns.ha.pfsync.remote.count,10m)<{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN} and last(/OPNsense by HTTP-JSON/opns.ha.pfsync.configured)=1'
               name: 'No remote pfsync state creator is visible'
               opdata: 'Remote creators: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -1742,13 +1742,13 @@ zabbix_export:
                   value: '{#CARP.VHID}'
               trigger_prototypes:
                 - uuid: e5f549c43e8c4e99a0babe831f84bc4e
-                  expression: '{$OPNS.HA.ENABLED}=1 and change(/OPNsense by HTTP-JSON/opns.carp.status["{#CARP.ADDRESS}"])<>0'
+                  expression: '"{$OPNS.HA.ENABLED}"="true" and change(/OPNsense by HTTP-JSON/opns.carp.status["{#CARP.ADDRESS}"])<>0'
                   name: 'CARP status changed for VIP {#CARP.ADDRESS}'
                   opdata: '{#CARP.ADDRESS}: {ITEM.LASTVALUE}'
                   priority: HIGH
                   description: 'The CARP role changed, indicating a failover or failback event.'
                 - uuid: c53ed53917d349c696702b8c5ddadae0
-                  expression: '{$OPNS.HA.ENABLED}=1 and find(/OPNsense by HTTP-JSON/opns.carp.status["{#CARP.ADDRESS}"],#1,"regexp","{$OPNS.HA.CARP.STATUS.MATCHES:\"{#CARP.ADDRESS}\"}")=0'
+                  expression: '"{$OPNS.HA.ENABLED}"="true" and find(/OPNsense by HTTP-JSON/opns.carp.status["{#CARP.ADDRESS}"],#1,"regexp","{$OPNS.HA.CARP.STATUS.MATCHES:\"{#CARP.ADDRESS}\"}")=0'
                   name: 'CARP status is unexpected for VIP {#CARP.ADDRESS}'
                   opdata: 'Status: {ITEM.LASTVALUE}'
                   priority: HIGH
@@ -1768,7 +1768,7 @@ zabbix_export:
             - type: JAVASCRIPT
               parameters:
                 - |
-                  if ('{$OPNS.HA.ENABLED}' !== '1') {
+                  if ('{$OPNS.HA.ENABLED}' !== 'true') {
                       return '[]';
                   }
                   var data = JSON.parse(value);
@@ -1813,7 +1813,7 @@ zabbix_export:
                   value: '{#HA.SERVICE.NAME}'
               trigger_prototypes:
                 - uuid: 454f69e9878a42ffafda4fd8a9b6693c
-                  expression: '{$OPNS.HA.ENABLED}=1 and max(/OPNsense by HTTP-JSON/opns.ha.peer.service.status["{#HA.SERVICE.UID}"],10m)=0 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
+                  expression: '"{$OPNS.HA.ENABLED}"="true" and max(/OPNsense by HTTP-JSON/opns.ha.peer.service.status["{#HA.SERVICE.UID}"],10m)=0 and last(/OPNsense by HTTP-JSON/opns.ha.config_sync.configured)=1'
                   name: 'HA peer service [{#HA.SERVICE.DESCRIPTION}] is not running'
                   opdata: 'Status: {ITEM.LASTVALUE1}'
                   priority: HIGH
@@ -1833,7 +1833,7 @@ zabbix_export:
             - type: JAVASCRIPT
               parameters:
                 - |
-                  if ('{$OPNS.HA.ENABLED}' !== '1') {
+                  if ('{$OPNS.HA.ENABLED}' !== 'true') {
                       return '[]';
                   }
                   var data = JSON.parse(value);
@@ -1869,7 +1869,7 @@ zabbix_export:
             - type: JAVASCRIPT
               parameters:
                 - |
-                  if ('{$OPNS.HA.ENABLED}' !== '1') {
+                  if ('{$OPNS.HA.ENABLED}' !== 'true') {
                       return '[]';
                   }
                   var data = JSON.parse(value);
@@ -2905,11 +2905,11 @@ zabbix_export:
           value: ^(MASTER|BACKUP)$
           description: 'Accepted CARP status regex. Use a macro context with the VIP address to enforce a node-specific role.'
         - macro: '{$OPNS.HA.CONFIG_SYNC.REQUIRED}'
-          value: '0'
-          description: 'Set to 1 on the HA synchronization source to require an XMLRPC target. Keep 0 on the backup node.'
+          value: 'false'
+          description: 'Set to true on the HA synchronization source to require an XMLRPC target. Keep false on the backup node.'
         - macro: '{$OPNS.HA.ENABLED}'
-          value: '1'
-          description: 'Set to 0 on standalone firewalls to disable HA triggers and HA discovery.'
+          value: 'true'
+          description: 'Set to false on standalone firewalls to disable HA triggers and HA discovery.'
         - macro: '{$OPNS.HA.PFSYNC.REMOTE.NODES.MIN}'
           value: '1'
           description: 'Minimum number of remote creator IDs expected in the synchronized state table.'

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -265,6 +265,9 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.memory.arc
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+          description: 'ZFS ARC memory usage in bytes. Returns 0 when ARC data is absent, for example on UFS systems.'
           master_item:
             key: opns.raw.memory.status
         - uuid: 552ff5f7fb0f49f0aa069311a22fe282

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -10,8 +10,8 @@ zabbix_export:
       template: 'OPNsense by HTTP-JSON'
       name: 'OPNsense by HTTP-JSON'
       vendor:
-        name: 'community'
-        version: '0.34'
+        name: '-templates'
+        version: '7.4-3'
       groups:
         - name: 'Templates/Network devices'
         - name: 'Templates/Operating systems'

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -10,7 +10,7 @@ zabbix_export:
       template: 'OPNsense by HTTP-JSON'
       name: 'OPNsense by HTTP-JSON'
       vendor:
-        name: '-templates'
+        name: 'community-templates'
         version: '7.4-3'
       groups:
         - name: 'Templates/Network devices'


### PR DESCRIPTION
## Summary

This PR extends the OPNsense HTTP JSON template with cron job monitoring and comprehensive high-availability monitoring.

## Changes

- Add discovery and monitoring of configured cron jobs
  - Monitor enabled state, command, and schedule
  - Add configurable include/exclude filters
  - Alert when a discovered cron job is disabled
- Expand HA monitoring
  - Monitor CARP state, maintenance mode, demotion level, and VIP roles
  - Monitor pfsync configuration and visible remote state creators
  - Monitor XMLRPC configuration, peer reachability, firmware versions, and services
  - Add HA-related triggers and discovery rules
- Add `{$OPNS.HA.ENABLED}` using `true`/`false`
  - Set to `false` on standalone firewalls
- Add `{$OPNS.HA.ROLE}` with `MASTER` and `BACKUP`
  - Defaults to `MASTER`
  - Replaces `{$OPNS.HA.CONFIG_SYNC.REQUIRED}`
- Convert the CARP maintenance boolean to a numeric value
- Return `0` for ARC memory when ARC data is unavailable on UFS systems
- Change `{$OPNS.SECRET}` to secret text
- Add descriptions for the API key and secret macros
- Change the firmware update interval to six hours
- Update template vendor metadata
- Extend the README with the new items, triggers, macros, permissions, and discovery rules

## Upgrade notes

- Set `{$OPNS.HA.ENABLED}` to `false` on hosts without an HA setup.
- Set `{$OPNS.HA.ROLE}` to `BACKUP` on the receiving HA node.
- Replace existing `{$OPNS.HA.CONFIG_SYNC.REQUIRED}` overrides with `{$OPNS.HA.ROLE}`.
- Grant the documented cron and HA API permissions to the OPNsense API user.

## Validation

- Successfully imported into Zabbix 7.4.13
- Verified CARP boolean conversion:
  - `false` → `0`
  - `true` → `1`
- Verified that disabled HA discovery returns an empty LLD result without making items unsupported
- Verified all HA triggers and trigger prototypes use the HA enable macro
- Validated YAML parsing and formatting