### PR TITLE
Add item prototypes and graphs

### DIFF
--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/README.md
@@ -4,11 +4,16 @@
 
 This template monitors OPNsense firewalls via the built-in REST API using HTTP JSON agent requests.
 It collects data about system resources (CPU, memory, disk, uptime), firewall states and actions,
-gateway health, network interfaces, CARP high-availability status, WireGuard peers, certificates and UPS status
+gateway health, network interfaces, CARP high-availability status, WireGuard peers, and UPS status
 via NUT (Network UPS Tools).
 
 The template uses OPNsense API key/secret authentication and requires no agent installation
 on the firewall.
+
+It also covers the packet filter in depth: pf counters, the state and source tracking tables
+with their limits, the loaded ruleset with change detection, kernel network memory, netisr
+queues, IP and TCP protocol errors, clock synchronization, service state, swap, temperature
+sensors, and processor utilization split into user, system and interrupt time.
 
 ## Requirements
 
@@ -28,11 +33,17 @@ on the firewall.
   - `nut/diagnostics`
   - `ipsec/sessions/searchPhase(1|2)` 
   - `wireguard/service/show`
-  - `trust/cert`
+  - `diagnostics/activity`
+  - `diagnostics/cpu_usage`
+  - `diagnostics/interface/get_interface_statistics`, `get_memory_statistics`,
+    `get_netisr_statistics`, `get_protocol_statistics`
+  - `firewall/alias/get_table_size`
+  - `ntpd/service/status`
+  - `core/service/search`
   
 ### Permissions
 
-| Privilege ID                           | UI Name                                   |
+| Privilege ID                            | UI Name                                   |
 | -------------------------------------- | ----------------------------------------- |
 | page-diagnostics-logs-firewall-summary | Diagnostics: Logs: Firewall: Summary View |
 | page-diagnostics-pf-info               | Diagnostics: Firewall statistics          |
@@ -41,9 +52,32 @@ on the firewall.
 | page-system-firmware-manualupdate      | System: Firmware                          |
 | page-system-gateways                   | System: Gateways                          |
 | page-system-login-logout               | Lobby: Dashboard                          |
-| page-status-ipsec                      | Status: IPsec                             |
-| page-wireguard-diagnostics             | VPN: WireGuard: Status                    |
-| page-system-certmanager                | Trust: Certificates                       |
+| page-status-ipsec | Status: IPsec |
+| page-wireguard-diagnostics | VPN: WireGuard: Status |
+| page-nut | Nut |
+| page-diagnostics-netstat | Diagnostics: Netstat |
+| page-diagnostics-system-activity | Diagnostics: System Activity |
+| page-firewall-aliases | Firewall: Aliases |
+| page-status-ntp | Status: NTP |
+| page-status-services | Status: Services |
+
+Most of these are read only. Three are worth a conscious decision before granting them:
+
+| Privilege ID | Grants beyond reading |
+|--------------|-----------------------|
+| page-system-firmware-manualupdate | matches `api/core/firmware/*`, which includes reboot, poweroff, install and remove |
+| page-status-services | permits starting and stopping services. Without it the service discovery simply stays empty |
+| page-firewall-aliases | read only, but the same endpoints expose the contents of every alias |
+
+`page-nut` was missing from this table. It comes from the NUT plugin rather than from the
+core, its patterns are `ui/nut/*` and `api/nut/*`, and without it the UPS master returns
+HTTP 403 even after you enable the item as the setup section asks. It is only needed if you
+monitor a UPS.
+
+Two of them are easy to miss because the symptom appears on a raw item rather than on the
+item you are looking for. Without `page-system-firmware-manualupdate` the firmware update
+items, the business license item and the OPNsense version stay unsupported. Without
+`page-status-trafficgraph` the whole interface discovery stays empty.
 
 
 
@@ -62,8 +96,8 @@ on the firewall.
    - Link the template `OPNsense by HTTP-JSON`
 
 4. **Configure the required macros** on the host:
-   - `{$OPNS.KEY}` - Your OPNsense API key
-   - `{$OPNS.SECRET}` - Your OPNsense API secret
+   - `{$OPNS.KEY}` – Your OPNsense API key
+   - `{$OPNS.SECRET}` – Your OPNsense API secret
 
 5. **Verify connectivity**:
    - After a few minutes check that the item `RAW Gatewaystatus` is receiving data
@@ -79,250 +113,405 @@ on the firewall.
 
 ## Macros Used
 
-| Macro                             | Default Value                                                                                            | Description                                                            |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| `{$OPNS.KEY}`                     | *(empty)*                                                                                                | OPNsense API key. **Required.**                                        |
-| `{$OPNS.SECRET}`                  | *(empty)*                                                                                                | OPNsense API secret. **Required.**                                     |
-| `{$OPNS.PORT}`                    | *(empty)*                                                                                                | OPNsense API port (default: 443)                                       |
-| `{$OPNS.CPU.LOAD.MAX}`            | `2`                                                                                                      | Maximum CPU load average before triggering a warning.                  |
-| `{$OPNS.MEMORY.UTIL.MAX}`         | `90`                                                                                                     | Maximum memory utilization (%) before triggering an alert.             |
-| `{$OPNS.STATE.TABLE.UTIL.MAX}`    | `90`                                                                                                     | Maximum state table utilization (%) before triggering a warning.       |
-| `{$OPNS.GW.MIN.PACKET.LOSS}`      | `10`                                                                                                     | Packet loss (%) to trigger a gateway packet loss alert.                |
-| `{$OPNS.GW.HIGH.PACKET.LOSS}`     | `50`                                                                                                     | Packet loss (%) to trigger a high packet loss alert.                   |
-| `{$OPNS.LICENSE.EXPIRY.WARN}`     | `30`                                                                                                     | Days before OPNsense Business license expiry to trigger a warning.     |
-| `{$OPNS.FS.FSNAME.MATCHES}`       | `.+`                                                                                                     | Regex filter for filesystem discovery – included mount points.         |
-| `{$OPNS.FS.FSNAME.NOT_MATCHES}`   | `^(/dev\|/sys\|/run\|/proc\|.+/shm$)`                                                                    | Regex filter for filesystem discovery – excluded mount points.         |
-| `{$OPNS.FS.FSTYPE.MATCHES}`       | `^(btrfs\|ext2\|ext3\|ext4\|reiser\|xfs\|ffs\|ufs\|jfs\|jfs2\|vxfs\|hfs\|apfs\|refs\|ntfs\|fat32\|zfs)$` | Regex filter for filesystem discovery – included filesystem types.     |
-| `{$OPNS.FS.FSTYPE.NOT_MATCHES}`   | `^\s$`                                                                                                   | Regex filter for filesystem discovery – excluded filesystem types.     |
-| `{$OPNS.FS.PUSED.MAX.WARN}`       | `90`                                                                                                     | Warning threshold for filesystem space utilization (%).                |
-| `{$OPNS.FS.PUSED.MAX.CRIT}`       | `95`                                                                                                     | Critical threshold for filesystem space utilization (%).               |
-| `{$OPNS.NUT.BAT.LOW}`             | `30`                                                                                                     | Battery charge (%) below which a warning is triggered.                 |
-| `{$OPNS.NUT.BAT.RUNTIME}`         | `600`                                                                                                    | Remaining battery runtime (seconds) below which an alert is triggered. |
-| `{$OPNS.NUT.HIGH.LOAD}`           | `80`                                                                                                     | UPS load (%) above which a warning is triggered.                       |
-| `{$OPNS.WG.INSTANCE.MATCHES}`     | `.+`                                                                                                     | Regex filter for WireGuard instances to discover.                      |
-| `{$OPNS.WG.INSTANCE.NOT_MATCHES}` | `^$`                                                                                                     | Regex filter for WireGuard instances to exclude from discovery.        |
-| `{$OPNS.WG.PEER.MATCHES}`         | `.+`                                                                                                     | Regex filter for WireGuard peers to discover.                          |
-| `{$OPNS.WG.PEER.NOT_MATCHES}`     | `^$`                                                                                                     | Regex filter for WireGuard peers to exclude from discovery.            |
+| Macro | Default Value | Description |
+|-------|---------------|-------------|
+| `{$OPNS.KEY}` | *(empty)* | OPNsense API key. **Required.** |
+| `{$OPNS.SECRET}` | *(empty)* | OPNsense API secret. **Required.** |
+| `{$OPNS.CPU.LOAD.MAX}` | `2` | Maximum CPU load average before triggering a warning. |
+| `{$OPNS.MEMORY.UTIL.MAX}` | `90` | Maximum memory utilization (%) before triggering an alert. |
+| `{$OPNS.STATE.TABLE.UTIL.MAX}` | `90` | Maximum state table utilization (%) before triggering a warning. |
+| `{$OPNS.GW.MIN.PACKET.LOSS}` | `10` | Packet loss (%) to trigger a gateway packet loss alert. |
+| `{$OPNS.GW.HIGH.PACKET.LOSS}` | `50` | Packet loss (%) to trigger a high packet loss alert. |
+| `{$OPNS.LICENSE.EXPIRY.WARN}` | `30` | Days before OPNsense Business license expiry to trigger a warning. |
+| `{$OPNS.FS.FSNAME.MATCHES}` | `.+` | Regex filter for filesystem discovery – included mount points. |
+| `{$OPNS.FS.FSNAME.NOT_MATCHES}` | `^(/dev\|/sys\|/run\|/proc\|.+/shm$)` | Regex filter for filesystem discovery – excluded mount points. |
+| `{$OPNS.FS.FSTYPE.MATCHES}` | `^(btrfs\|ext2\|ext3\|ext4\|reiser\|xfs\|ffs\|ufs\|jfs\|jfs2\|vxfs\|hfs\|apfs\|refs\|ntfs\|fat32\|zfs)$` | Regex filter for filesystem discovery – included filesystem types. |
+| `{$OPNS.FS.FSTYPE.NOT_MATCHES}` | `^\s$` | Regex filter for filesystem discovery – excluded filesystem types. |
+| `{$OPNS.FS.PUSED.MAX.WARN}` | `90` | Warning threshold for filesystem space utilization (%). |
+| `{$OPNS.FS.PUSED.MAX.CRIT}` | `95` | Critical threshold for filesystem space utilization (%). |
+| `{$OPNS.NUT.BAT.LOW}` | `30` | Battery charge (%) below which a warning is triggered. |
+| `{$OPNS.NUT.BAT.RUNTIME}` | `600` | Remaining battery runtime (seconds) below which an alert is triggered. |
+| `{$OPNS.NUT.HIGH.LOAD}` | `80` | UPS load (%) above which a warning is triggered. |
+| `{$OPNS.WG.INSTANCE.MATCHES}` | `.+` | Regex filter for WireGuard instances to discover. |
+| `{$OPNS.WG.INSTANCE.NOT_MATCHES}` | `^$` | Regex filter for WireGuard instances to exclude from discovery. |
+| `{$OPNS.WG.PEER.MATCHES}` | `.+` | Regex filter for WireGuard peers to discover. |
+| `{$OPNS.WG.PEER.NOT_MATCHES}` | `^$` | Regex filter for WireGuard peers to exclude from discovery. |
+| `{$OPNS.CPU.UTIL.WARN}` | `85` | Processor utilization (%) that counts as high, averaged over ten minutes. |
+| `{$OPNS.LOAD.AVG5.WARN}` | `4` | Absolute five minute load average that counts as high. Depends on the core count, which is why the per core trigger is usually the better one. |
+| `{$OPNS.LOAD.PERCORE.WARN}` | `1` | Five minute load per core that counts as high. A value of 1 means the cores are exactly saturated. |
+| `{$OPNS.MBUF.UTIL.WARN}` | `80` | Percentage of the mbuf cluster limit in use that counts as filling up. |
+| `{$OPNS.NTP.OFFSET.WARN}` | `100` | Clock offset (ms) that counts as high. |
+| `{$OPNS.PF.SRCNODES.UTIL.CRIT}` | `90` | Fill level (%) of the source tracking table that counts as critical. |
+| `{$OPNS.PF.TABLES.UTIL.WARN}` | `80` | Share (%) of the pf table entry budget that counts as filling up. Relevant where block lists or GeoIP aliases are in use. |
+| `{$OPNS.SWAP.UTIL.WARN}` | `5` | Swap in use (%) that counts as a problem. A firewall should not swap at all, so the default is deliberately low. Overridable per device with the device path as context. |
+| `{$OPNS.TEMP.CRIT}` | `80` | Sensor temperature (°C) that counts as critical. Overridable per sensor with the sensor name as context, for example `{$OPNS.TEMP.CRIT:"dev.cpu.0.temperature"}`. |
+| `{$OPNS.IF.CONTROL}` | `1` | Set to `0`, optionally per interface as `{$OPNS.IF.CONTROL:"vtnet3"}`, to stop the interface down trigger for interfaces that are allowed to have no link. |
+| `{$OPNS.IF.NAME.NOT_MATCHES}` | `^(pflog\|pfsync\|enc\|lo)\d*$` | Interfaces excluded from the link state discovery. |
+| `{$OPNS.SERVICE.ID.NOT_MATCHES}` | `^$` | Services excluded from discovery, as a regular expression over the service identifier. The default excludes nothing. |
 
 ## Items Collected
 
 ### System Items
 
-| Name                            | Key                               | Type       | Update Interval | Description                                                                            |
-| ------------------------------- | --------------------------------- | ---------- | --------------- | -------------------------------------------------------------------------------------- |
-| CPU load                        | `opns.cpu.load`                   | Dependent  | –               | System load average (1 min).                                                           |
-| System Uptime                   | `opns.system.uptime`              | Dependent  | –               | Uptime converted to seconds. Displayed in Zabbix uptime format.                        |
-| Total Memory                    | `opns.memory.total`               | Dependent  | –               | Total physical memory in bytes.                                                        |
-| Used Memory                     | `opns.memory.used`                | Dependent  | –               | Used memory in bytes.                                                                  |
-| ARC Memory                      | `opns.memory.arc`                 | Dependent  | –               | ZFS ARC memory usage in bytes.                                                         |
-| Memory utilization in %         | `opns.memory.util`                | Calculated | –               | Percentage of used memory relative to total memory.                                    |
-| Licensed until                  | `opns.product.licenseuntil`       | Dependent  | –               | OPNsense Business Edition license expiry (Unix timestamp). Returns `0` if not present. |
-| Firmware update status          | `opns.firmware.update.status`     | Dependent  | –               | Firmware update status (`none`, `update`, `upgrade`, or `error`).                      |
-| Firmware update status message  | `opns.firmware.update.status_msg` | Dependent  | –               | Human-readable firmware update status message.                                         |
-| Firmware update count           | `opns.firmware.update.count`      | Dependent  | –               | Number of available firmware package or set updates.                                   |
-| Firmware update packages        | `opns.firmware.update.packages`   | Dependent  | –               | List of available package or set updates.                                              |
-| Firmware update requires reboot | `opns.firmware.update.reboot`     | Dependent  | –               | Returns `1` when the available firmware update requires a reboot.                      |
+| Name | Key | Type | Update Interval | Description |
+|------|-----|------|-----------------|-------------|
+| CPU load | `opns.cpu.load` | Dependent | – | System load average (1 min). |
+| System Uptime | `opns.system.uptime` | Dependent | – | Uptime converted to seconds. Displayed in Zabbix uptime format. |
+| Total Memory | `opns.memory.total` | Dependent | – | Total physical memory in bytes. |
+| Used Memory | `opns.memory.used` | Dependent | – | Used memory in bytes. |
+| ARC Memory | `opns.memory.arc` | Dependent | – | ZFS ARC memory usage in bytes. |
+| Memory utilization in % | `opns.memory.util` | Calculated | – | Percentage of used memory relative to total memory. |
+| Licensed until | `opns.product.licenseuntil` | Dependent | – | OPNsense Business Edition license expiry (Unix timestamp). Returns `0` if not present. |
+| Firmware update status | `opns.firmware.update.status` | Dependent | – | Firmware update status (`none`, `update`, `upgrade`, or `error`). |
+| Firmware update status message | `opns.firmware.update.status_msg` | Dependent | – | Human-readable firmware update status message. |
+| Firmware update count | `opns.firmware.update.count` | Dependent | – | Number of available firmware package or set updates. |
+| Firmware update packages | `opns.firmware.update.packages` | Dependent | – | List of available package or set updates. |
+| Firmware update requires reboot | `opns.firmware.update.reboot` | Dependent | – | Returns `1` when the available firmware update requires a reboot. |
 
 ### Firewall Items
 
-| Name                          | Key                      | Type       | Description                                     |
-| ----------------------------- | ------------------------ | ---------- | ----------------------------------------------- |
-| Firewall states current       | `opns.fw.states.current` | Dependent  | Current number of active firewall states.       |
-| Firewall states max           | `opns.fw.states.max`     | Dependent  | Maximum number of allowed firewall states.      |
-| States table utilization in % | `opns.states.util`       | Calculated | Percentage of the state table currently in use. |
+| Name | Key | Type | Description |
+|------|-----|------|-------------|
+| Firewall states current | `opns.fw.states.current` | Dependent | Current number of active firewall states. |
+| Firewall states max | `opns.fw.states.max` | Dependent | Maximum number of allowed firewall states. |
+| States table utilization in % | `opns.states.util` | Calculated | Percentage of the state table currently in use. |
+
+### Processor Items
+
+| Name | Key | Type | Unit | Description |
+|------|-----|------|------|-------------|
+| CPU: Utilization | `opns.cpu.util` | Dependent | % | Processor utilization, derived from the idle share reported by the process listing header. |
+| CPU: User time | `opns.cpu.user` | Dependent | % | Share spent in user space. |
+| CPU: System time | `opns.cpu.system` | Dependent | % | Share spent in the kernel. |
+| CPU: Interrupt time | `opns.cpu.interrupt` | Dependent | % | Share spent servicing interrupts. On a firewall this is mostly the network cards, and it rises well before the total looks alarming. |
+| CPU: Cores | `opns.cpu.cores` | Dependent | – | Number of processor cores. |
+| Load average (5 min) | `opns.system.load.avg5` | Dependent | – | Five minute load average. |
+| Load average (15 min) | `opns.system.load.avg15` | Dependent | – | Fifteen minute load average. |
+| Load average per core (5 min) | `opns.system.load.percore` | Calculated | – | Five minute load divided by the core count, so the threshold does not depend on the hardware. |
+
+### Packet Filter Items
+
+pf reports its counters as rates already, so none of these need rate preprocessing.
+
+| Name | Key | Type | Unit | Description |
+|------|-----|------|------|-------------|
+| pf: Rule matches per second | `opns.pf.counter.match.rate` | Dependent | p/s | Packets matching a rule. |
+| pf: Packets dropped for memory per second | `opns.pf.counter.memdrop.rate` | Dependent | p/s | Packets dropped because pf could not allocate memory. |
+| pf: State limit hits per second | `opns.pf.counter.statelimit.rate` | Dependent | p/s | Packets refused because the state table is full. |
+| pf: Source limit hits per second | `opns.pf.counter.srclimit.rate` | Dependent | p/s | Packets refused by a source tracking limit. |
+| pf: State mismatches per second | `opns.pf.counter.statemismatch.rate` | Dependent | p/s | Packets that did not match the state they claimed. |
+| pf: Bad offset packets per second | `opns.pf.counter.badoffset.rate` | Dependent | p/s | Malformed packets with an invalid header offset. |
+| pf: Short packets per second | `opns.pf.counter.short.rate` | Dependent | p/s | Packets shorter than their header claims. |
+| pf: Fragmented packets per second | `opns.pf.counter.fragment.rate` | Dependent | p/s | Fragmented packets seen by pf. |
+| pf: Normalized packets per second | `opns.pf.counter.normalize.rate` | Dependent | p/s | Packets rewritten by scrub rules. |
+| pf: SYN floods detected per second | `opns.pf.synfloods.rate` | Dependent | /s | SYN floods detected by pf. |
+| pf: Overload table insertions per second | `opns.pf.overload.rate` | Dependent | /s | Addresses added to an overload table by a rule limit. |
+| pf: State table inserts per second | `opns.pf.states.inserts.rate` | Dependent | /s | New states created. |
+| pf: State table removals per second | `opns.pf.states.removals.rate` | Dependent | /s | States expired or removed. |
+| pf: State table searches per second | `opns.pf.states.searches.rate` | Dependent | /s | State table lookups. |
+| pf: Source nodes | `opns.pf.srcnodes.current` | Dependent | – | Entries in the source tracking table. |
+| pf: Source node limit | `opns.pf.srcnodes.limit` | Dependent | – | Configured source tracking limit. |
+| pf: Source tracking table utilization | `opns.pf.srcnodes.pused` | Calculated | % | Source tracking table fill level. |
+| pf: Table entries in use | `opns.pf.tables.entries.used` | Dependent | – | Entries held by all pf tables together. Block lists and GeoIP aliases live here. |
+| pf: Table entry limit | `opns.pf.tables.entries.limit` | Dependent | – | Configured ceiling for pf table entries. |
+| pf: Table entry utilization | `opns.pf.tables.entries.pused` | Calculated | % | Share of the pf table entry budget in use. |
+| pf: Filter rules loaded | `opns.pf.rules.filter.count` | Dependent | – | Number of filter rules currently loaded. |
+| pf: NAT rules loaded | `opns.pf.rules.nat.count` | Dependent | – | Number of NAT rules currently loaded. |
+| pf: Rules never matched | `opns.pf.rules.unused` | Dependent | – | Rules that have never matched a packet since the ruleset was loaded. |
+| pf: Rule evaluations per second | `opns.pf.rules.evaluations.rate` | Dependent | /s | How often rules are evaluated, a measure of ruleset cost. |
+| pf: Ruleset fingerprint | `opns.pf.rules.fingerprint` | Dependent | – | Checksum over the loaded ruleset. Changes when the ruleset changes, which is what the ruleset trigger watches. |
+| Firewall log: Blocked share | `opns.fwlog.block.pct` | Dependent | % | Share of blocked entries among the most recent logged packets. |
+
+### Kernel Network Memory and Protocol Items
+
+When either the mbuf pool or a netisr queue runs dry, the firewall still answers ping and
+still reports free memory and a normal state table, while throughput collapses and packets
+are dropped before reaching any rule. Both counters are cumulative and should stay at zero
+for the entire uptime, which is why their triggers fire on any increase rather than on a
+threshold.
+
+| Name | Key | Type | Unit | Description |
+|------|-----|------|------|-------------|
+| mbuf: Clusters in use | `opns.mbuf.cluster.current` | Dependent | – | mbuf clusters currently allocated. |
+| mbuf: Cluster limit | `opns.mbuf.cluster.max` | Dependent | – | Configured cluster limit (`kern.ipc.nmbclusters`). |
+| mbuf: Cluster utilization | `opns.mbuf.cluster.pused` | Calculated | % | Share of the cluster limit in use. |
+| mbuf: Denied requests | `opns.mbuf.denied` | Dependent | – | Requests for network memory the kernel could not satisfy. |
+| netisr: Queue drops | `opns.netisr.queue.drops` | Dependent | /s | Packets dropped by the network interrupt queues, all protocols together. |
+| IP: Packets with a bad checksum per second | `opns.proto.ip.badsum.rate` | Dependent | p/s | Usually a cable, an optic or an offloading problem. |
+| IP: Fragments dropped per second | `opns.proto.ip.fragdrop.rate` | Dependent | p/s | Fragments discarded before reassembly. |
+| IP: Packets discarded for lack of a route | `opns.proto.ip.noroute.rate` | Dependent | p/s | No route to the destination, often a missing return route. |
+| IP: Packets that cannot be forwarded | `opns.proto.ip.nofwd.rate` | Dependent | p/s | Packets the kernel refused to forward. |
+| TCP: Segments with a bad checksum per second | `opns.proto.tcp.badsum.rate` | Dependent | p/s | Corrupted segments. |
+| TCP: Retransmitted segments per second | `opns.proto.tcp.retrans.rate` | Dependent | p/s | Retransmissions, a measure of path quality. |
+
+### Time Synchronization Items
+
+| Name | Key | Type | Unit | Description |
+|------|-----|------|------|-------------|
+| NTP: Synchronised | `opns.ntp.synced` | Dependent | – | Whether the clock is disciplined by a peer. |
+| NTP: Offset of the selected peer | `opns.ntp.offset` | Dependent | ms | Offset against the selected peer. |
+| NTP: Stratum of the selected peer | `opns.ntp.stratum` | Dependent | – | Stratum of the selected peer. |
+| NTP: Reachable peers | `opns.ntp.peers.reachable` | Dependent | – | Number of peers currently reachable. |
+
+### CARP and Configuration Items
+
+| Name | Key | Type | Unit | Description |
+|------|-----|------|------|-------------|
+| CARP: Demotion factor | `opns.carp.demotion` | Dependent | – | How strongly this node holds itself back from becoming master. Anything above zero is the usual reason a node refuses to take over when the peer fails. |
+| CARP: Maintenance mode | `opns.carp.maintenance` | Dependent | – | Maintenance mode hands every virtual address to the peer. Easy to switch on for a planned change and just as easy to forget afterwards. |
+| OPNsense: Version | `opns.version` | Dependent | – | Product version string. |
+| OPNsense: Configuration last changed | `opns.config.changed` | Dependent | unixtime | Timestamp OPNsense records when the configuration is written. Covers every change, not only firewall rules, and needs no extra request. |
 
 ### UPS Items (NUT)
 
 > These items are only active when `RAW UPS` is enabled on the host.
 
-| Name                | Key                   | Unit | Description                                                              |
-| ------------------- | --------------------- | ---- | ------------------------------------------------------------------------ |
-| UPS Battery Charge  | `nut.battery.charge`  | %    | Current battery charge level.                                            |
-| UPS Battery Runtime | `nut.battery.runtime` | s    | Estimated remaining battery runtime in seconds.                          |
-| UPS Battery Load    | `nut.battery.load`    | %    | Current load on the UPS in percent.                                      |
-| UPS Input Voltage   | `nut.input.voltage`   | V    | Input (mains) voltage.                                                   |
-| UPS Input Frequency | `nut.input.frequency` | Hz   | Input (mains) frequency.                                                 |
-| UPS Output Voltage  | `nut.output.voltage`  | V    | Output voltage supplied to connected devices.                            |
-| UPS Status          | `nut.status`          | Text | Current UPS status code (e.g. `OL`, `OB`, `LB`). See status codes below. |
-| UPS Model           | `nut.model`           | Text | UPS model name as reported by NUT.                                       |
+| Name | Key | Unit | Description |
+|------|-----|------|-------------|
+| UPS Battery Charge | `nut.battery.charge` | % | Current battery charge level. |
+| UPS Battery Runtime | `nut.battery.runtime` | s | Estimated remaining battery runtime in seconds. |
+| UPS Battery Load | `nut.battery.load` | % | Current load on the UPS in percent. |
+| UPS Input Voltage | `nut.input.voltage` | V | Input (mains) voltage. |
+| UPS Input Frequency | `nut.input.frequency` | Hz | Input (mains) frequency. |
+| UPS Output Voltage | `nut.output.voltage` | V | Output voltage supplied to connected devices. |
+| UPS Status | `nut.status` | Text | Current UPS status code (e.g. `OL`, `OB`, `LB`). See status codes below. |
+| UPS Model | `nut.model` | Text | UPS model name as reported by NUT. |
 
 #### UPS Status Codes
 
-| Code       | Meaning            | Description                                                                |
-| ---------- | ------------------ | -------------------------------------------------------------------------- |
-| `OL`       | On Line            | UPS is powered by mains electricity, supplying power to connected devices. |
-| `OB`       | On Battery         | UPS is running on battery power due to a mains failure.                    |
-| `LB`       | Low Battery        | Battery charge is critically low. UPS will shut down soon.                 |
-| `RB`       | Replace Battery    | Battery needs replacement due to age or health issues.                     |
-| `HB`       | High Battery       | Battery is fully charged (rare).                                           |
-| `CHRG`     | Charging           | Battery is currently being charged.                                        |
-| `DISCHRG`  | Discharging        | Battery is actively discharging (more specific than `OB`).                 |
-| `OVER`     | Overload           | UPS load exceeds its rated capacity.                                       |
-| `ALARM`    | Alarm Active       | UPS has triggered an internal alarm (e.g. overload or battery fault).      |
-| `CAL`      | Calibrating        | UPS is performing a battery runtime calibration.                           |
-| `COMMLOST` | Communication Lost | Communication between NUT and the UPS device is lost.                      |
-| `OFF`      | Off                | UPS output is turned off.                                                  |
-| `TRIM`     | Trim               | Input voltage is too high; UPS is stepping it down (buck).                 |
-| `BOOST`    | Boost              | Input voltage is too low; UPS is stepping it up.                           |
-| `TEST`     | Self-Test          | UPS is performing an automatic self-test.                                  |
-| `SYNC`     | Synchronizing      | UPS is synchronizing with the mains frequency (rare).                      |
+| Code | Meaning | Description |
+|------|---------|-------------|
+| `OL` | On Line | UPS is powered by mains electricity, supplying power to connected devices. |
+| `OB` | On Battery | UPS is running on battery power due to a mains failure. |
+| `LB` | Low Battery | Battery charge is critically low. UPS will shut down soon. |
+| `RB` | Replace Battery | Battery needs replacement due to age or health issues. |
+| `HB` | High Battery | Battery is fully charged (rare). |
+| `CHRG` | Charging | Battery is currently being charged. |
+| `DISCHRG` | Discharging | Battery is actively discharging (more specific than `OB`). |
+| `OVER` | Overload | UPS load exceeds its rated capacity. |
+| `ALARM` | Alarm Active | UPS has triggered an internal alarm (e.g. overload or battery fault). |
+| `CAL` | Calibrating | UPS is performing a battery runtime calibration. |
+| `COMMLOST` | Communication Lost | Communication between NUT and the UPS device is lost. |
+| `OFF` | Off | UPS output is turned off. |
+| `TRIM` | Trim | Input voltage is too high; UPS is stepping it down (buck). |
+| `BOOST` | Boost | Input voltage is too low; UPS is stepping it up. |
+| `TEST` | Self-Test | UPS is performing an automatic self-test. |
+| `SYNC` | Synchronizing | UPS is synchronizing with the mains frequency (rare). |
 
 ### Raw Data Items
 
 These items fetch raw JSON from the OPNsense API and serve as master items for dependent
 items and discovery rules.
 
-| Name                     | Key                           | Update Interval | API Endpoint                                                                   |
-| ------------------------ | ----------------------------- | --------------- | ------------------------------------------------------------------------------ |
-| RAW Load                 | `opns.raw.load`               | 5m              | `/api/diagnostics/system/system_time`                                          |
-| RAW Memorystatus         | `opns.raw.memory.status`      | 5m              | `/api/diagnostics/system/systemResources`                                      |
-| RAW Disk                 | `opns.raw.disk`               | 5m              | `/api/diagnostics/system/system_disk`                                          |
-| RAW Gatewaystatus        | `opns.raw.gateway.status`     | 1m              | `/api/routes/gateway/status`                                                   |
-| RAW Firewall States      | `opns.raw.fw.states`          | 1m              | `/api/diagnostics/firewall/pfStates`                                           |
-| RAW Firewallaction       | `opns.raw.fw.action`          | 1m              | `/api/diagnostics/firewall/stats?group_by=action`                              |
-| RAW Firewall Interfaces  | `opns.raw.fw.interface.stat`  | 1m              | `/api/diagnostics/firewall/pf_statistics/interfaces`                           |
-| RAW Interfaces           | `opns.raw.interfaces.stat`    | 1m              | `/api/diagnostics/traffic/_interface`                                          |
-| RAW Carp Interfaces      | `opns.raw.interfaces.carp`    | 1m              | `/api/diagnostics/interface/get_vip_status`                                    |
-| RAW Product Info         | `opns.raw.product.info`       | 30m             | `/api/core/firmware/info`                                                      |
-| RAW Firmware Status      | `opns.raw.firmware.status`    | 1d              | `/api/core/firmware/status` *(POST; runs update probe before fetching status)* |
-| RAW UPS                  | `opns.ups.raw`                | 5m              | `/api/nut/diagnostics/upsstatus` *(disabled by default)*                       |
-| RAW WireGuard            | `opns.wireguard.raw`          | 1m              | `/api/wireguard/service/show`                                                  |
-| RAW Trust - Certificates | `opns.raw.trust.certificates` | 5m              | `/api/trust/cert/search/`                                                      |
+| Name | Key | Update Interval | API Endpoint |
+|------|-----|-----------------|--------------|
+| RAW Load | `opns.raw.load` | 5m | `/api/diagnostics/system/system_time` |
+| RAW Memorystatus | `opns.raw.memory.status` | 5m | `/api/diagnostics/system/systemResources` |
+| RAW Disk | `opns.raw.disk` | 5m | `/api/diagnostics/system/system_disk` |
+| RAW Gatewaystatus | `opns.raw.gateway.status` | 1m | `/api/routes/gateway/status` |
+| RAW Firewall States | `opns.raw.fw.states` | 1m | `/api/diagnostics/firewall/pfStates` |
+| RAW Firewallaction | `opns.raw.fw.action` | 1m | `/api/diagnostics/firewall/stats?group_by=action` |
+| RAW Firewall Interfaces | `opns.raw.fw.interface.stat` | 1m | `/api/diagnostics/firewall/pf_statistics/interfaces` |
+| RAW Interfaces | `opns.raw.interfaces.stat` | 1m | `/api/diagnostics/traffic/_interface` |
+| RAW Carp Interfaces | `opns.raw.interfaces.carp` | 1m | `/api/diagnostics/interface/get_vip_status` |
+| RAW Product Info | `opns.raw.product.info` | 30m | `/api/core/firmware/info` |
+| RAW Firmware Status | `opns.raw.firmware.status` | 1d | `/api/core/firmware/status` *(POST; runs update probe before fetching status)* |
+| RAW UPS | `opns.ups.raw` | 5m | `/api/nut/diagnostics/upsstatus` *(disabled by default)* |
+| RAW WireGuard | `opns.wireguard.raw` | 1m | `/api/wireguard/service/show` |
+| OPNsense: System activity (raw) | `opns.activity.raw` | 1m | `/api/diagnostics/activity/get_activity` |
+| OPNsense: CPU type (raw) | `opns.cpu.raw` | 1m | `/api/diagnostics/cpu_usage/getCPUType` |
+| OPNsense: pf statistics (raw) | `opns.pfinfo.raw` | 1m | `/api/diagnostics/firewall/pf_statistics/info` |
+| OPNsense: pf limits (raw) | `opns.pfmem.raw` | 1m | `/api/diagnostics/firewall/pf_statistics/memory` |
+| OPNsense: pf ruleset (raw) | `opns.pf.rules.raw` | 10m | `/api/diagnostics/firewall/pf_statistics/rules` |
+| OPNsense: Alias tables (raw) | `opns.alias.raw` | 10m | `/api/firewall/alias/get_table_size` |
+| OPNsense: mbuf statistics (raw) | `opns.mbuf.raw` | 1m | `/api/diagnostics/interface/get_memory_statistics` |
+| OPNsense: netisr statistics (raw) | `opns.netisr.raw` | 1m | `/api/diagnostics/interface/get_netisr_statistics` |
+| OPNsense: Protocol statistics (raw) | `opns.proto.raw` | 1m | `/api/diagnostics/interface/get_protocol_statistics` |
+| OPNsense: Interface statistics (raw) | `opns.ifstats.raw` | 1m | `/api/diagnostics/interface/get_interface_statistics` |
+| OPNsense: NTP peers (raw) | `opns.ntp.raw` | 5m | `/api/ntpd/service/status` |
+| OPNsense: Services (raw) | `opns.services.raw` | 5m | `/api/core/service/search` |
+| OPNsense: Swap (raw) | `opns.swap.raw` | 5m | `/api/diagnostics/system/system_swap` |
+| OPNsense: Temperature sensors (raw) | `opns.temperature.raw` | 1m | `/api/diagnostics/system/system_temperature` |
+| RAW IPsec Phase1 | `opns.ipsec.phase1.raw` | 5m | `/api/ipsec/sessions/searchPhase1` |
+
+Seven items need no request of their own because they hang off masters that were already
+being polled: the configuration change timestamp and both load averages come from
+`opns.raw.load`, the blocked share of the firewall log from `opns.raw.fw.action`, the CARP
+demotion factor and maintenance mode from `opns.raw.interfaces.carp`, and the version from
+`opns.raw.product.info`.
 
 ## Triggers
 
 ### System Triggers
 
-| Name                                    | Severity    | Description                                                                                          |
-| --------------------------------------- | ----------- | ---------------------------------------------------------------------------------------------------- |
-| No data from OPNsense                   | **High**    | No data received from `opns.raw.gateway.status` for 5 minutes – API is unreachable.                  |
-| CPU load is high                        | **Warning** | CPU load exceeds `{$OPNS.CPU.LOAD.MAX}` for 5 minutes.                                               |
-| Memory utilization is high              | **Average** | Memory utilization exceeds `{$OPNS.MEMORY.UTIL.MAX}` % for 5 minutes.                                |
-| OPNSense Business License expires soon  | **Average** | License expires in less than `{$OPNS.LICENSE.EXPIRY.WARN}` days. Only relevant for Business Edition. |
-| OPNsense firmware updates are available | **Info**    | Firmware update status is `update` or `upgrade` and at least one update is available.                |
-| OPNsense firmware update check failed   | **Warning** | Firmware update check returned `error`.                                                              |
-| State table usage is high               | **Warning** | State table utilization exceeds `{$OPNS.STATE.TABLE.UTIL.MAX}` % for the last 3 values.              |
-| {HOST.NAME} has been restarted          | **Info**    | System uptime is less than 600 seconds (10 minutes).                                                 |
+| Name | Severity | Description |
+|------|----------|-------------|
+| No data from OPNsense | **High** | No data received from `opns.raw.gateway.status` for 5 minutes – API is unreachable. |
+| CPU load is high | **Warning** | CPU load exceeds `{$OPNS.CPU.LOAD.MAX}` for 5 minutes. |
+| Memory utilization is high | **Average** | Memory utilization exceeds `{$OPNS.MEMORY.UTIL.MAX}` % for 5 minutes. |
+| OPNSense Business License expires soon | **Average** | License expires in less than `{$OPNS.LICENSE.EXPIRY.WARN}` days. Only relevant for Business Edition. |
+| OPNsense firmware updates are available | **Info** | Firmware update status is `update` or `upgrade` and at least one update is available. |
+| OPNsense firmware update check failed | **Warning** | Firmware update check returned `error`. |
+| State table usage is high | **Warning** | State table utilization exceeds `{$OPNS.STATE.TABLE.UTIL.MAX}` % for the last 3 values. |
+| {HOST.NAME} has been restarted | **Info** | System uptime is less than 600 seconds (10 minutes). |
 
 ### UPS Triggers
 
-| Name                                        | Severity     | Description                                                                            |
-| ------------------------------------------- | ------------ | -------------------------------------------------------------------------------------- |
-| UPS on Battery                              | **High**     | UPS status contains `OB` – mains power has failed.                                     |
-| Battery low                                 | **Disaster** | UPS status contains `LB` – battery is critically low and shutdown is imminent.         |
-| High Load on UPS Battery                    | **Average**  | UPS load exceeds `{$OPNS.NUT.HIGH.LOAD}` % (default: 80%).                             |
-| Battery charge is below {$OPNS.NUT.BAT.LOW} | **Warning**  | Battery charge is below `{$OPNS.NUT.BAT.LOW}` % (default: 30%).                        |
-| Remaining battery runtime is low            | **High**     | Estimated runtime is below `{$OPNS.NUT.BAT.RUNTIME}` seconds (default: 600s / 10 min). |
+| Name | Severity | Description |
+|------|----------|-------------|
+| UPS on Battery | **High** | UPS status contains `OB` – mains power has failed. |
+| Battery low | **Disaster** | UPS status contains `LB` – battery is critically low and shutdown is imminent. |
+| High Load on UPS Battery | **Average** | UPS load exceeds `{$OPNS.NUT.HIGH.LOAD}` % (default: 80%). |
+| Battery charge is below {$OPNS.NUT.BAT.LOW} | **Warning** | Battery charge is below `{$OPNS.NUT.BAT.LOW}` % (default: 30%). |
+| Remaining battery runtime is low | **High** | Estimated runtime is below `{$OPNS.NUT.BAT.RUNTIME}` seconds (default: 600s / 10 min). |
 
 ### WireGuard Triggers
 
-| Name                                      | Severity | Description                                                                                                                           |
-| ----------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| WireGuard instance {#WG.INSTANCE} is down | **High** | Instance status has not been `up` for 5 minutes.                                                                                      |
-| WireGuard peer {#WG.NAME} is not online   | **High** | Peer status has not been `online` for 5 minutes. OPNsense marks peers online when the latest handshake is not older than 300 seconds. |
+| Name | Severity | Description |
+|------|----------|-------------|
+| WireGuard instance {#WG.INSTANCE} is down | **High** | Instance status has not been `up` for 5 minutes. |
+| WireGuard peer {#WG.NAME} is not online | **High** | Peer status has not been `online` for 5 minutes. OPNsense marks peers online when the latest handshake is not older than 300 seconds. |
+
+### Packet Filter Triggers
+
+| Name | Severity | Description |
+|------|----------|-------------|
+| OPNsense: pf is dropping packets due to memory | **High** | `opns.pf.counter.memdrop.rate` above zero. Traffic is being lost, not merely delayed. |
+| OPNsense: pf state limit is being hit | **High** | `opns.pf.counter.statelimit.rate` above zero. New connections are being refused. |
+| OPNsense: pf source tracking table is filling up | **High** | Source tracking above `{$OPNS.PF.SRCNODES.UTIL.CRIT}` % for 5 minutes. Depends on the source limit trigger, so only the more specific one alerts. |
+| OPNsense: SYN flood detected | **Average** | `opns.pf.synfloods.rate` above zero. |
+| OPNsense: pf source limit is being hit | **Warning** | `opns.pf.counter.srclimit.rate` above zero. |
+| OPNsense: pf is seeing malformed packets | **Warning** | `opns.pf.counter.badoffset.rate` above zero. |
+| OPNsense: pf table entries are filling up | **Warning** | Table entries above `{$OPNS.PF.TABLES.UTIL.WARN}` % of the configured ceiling. |
+| OPNsense: Ruleset has changed | **Info** | The ruleset fingerprint differs from the previous value. |
+| OPNsense: Number of filter rules has changed | **Info** | The filter rule count changed. |
+| OPNsense: Number of NAT rules has changed | **Info** | The NAT rule count changed. |
+
+### Kernel, Protocol and Processor Triggers
+
+| Name | Severity | Description |
+|------|----------|-------------|
+| OPNsense: Kernel denied network memory requests | **High** | `opns.mbuf.denied` increased. The counter is cumulative and should stay at zero. |
+| OPNsense: mbuf cluster pool is filling up | **Average** | Cluster utilization above `{$OPNS.MBUF.UTIL.WARN}` % for 5 minutes. Depends on the trigger above. |
+| OPNsense: netisr queue is dropping packets | **Average** | `opns.netisr.queue.drops` increased. |
+| OPNsense: Receiving IP packets with bad checksums | **Warning** | Bad checksums for 10 minutes straight. |
+| OPNsense: Packets discarded for lack of a route | **Warning** | No route for 10 minutes straight. |
+| OPNsense: CPU utilization is high | **Warning** | Utilization above `{$OPNS.CPU.UTIL.WARN}` % averaged over 10 minutes. |
+| OPNsense: Load average is high | **Warning** | Five minute load above `{$OPNS.LOAD.AVG5.WARN}` averaged over 10 minutes. |
+| OPNsense: Load per core is high | **Warning** | Load per core above `{$OPNS.LOAD.PERCORE.WARN}` averaged over 15 minutes. |
+
+### Clock, CARP and Configuration Triggers
+
+| Name | Severity | Description |
+|------|----------|-------------|
+| OPNsense: Clock is not synchronised | **Warning** | Unsynchronised for 30 minutes. |
+| OPNsense: Clock offset is high | **Warning** | Absolute offset above `{$OPNS.NTP.OFFSET.WARN}` ms. |
+| OPNsense: CARP maintenance mode has been on for 30 minutes | **Warning** | Maintenance mode was probably left on after a planned change. |
+| OPNsense: Configuration has been changed | **Info** | The configuration change timestamp moved. |
+| OPNsense: Version has changed | **Info** | An update was most likely applied. |
 
 ## Discovery Rules
 
 ### 1. Disk Discovery
 
-| Property            | Value                                               |
-| ------------------- | --------------------------------------------------- |
-| Key                 | `opns.disk.discovery`                               |
-| Type                | Dependent (master: `opns.raw.disk`)                 |
-| Filters             | `{#FSNAME}` and `{#FSTYPE}` configurable via macros |
-| Keep lost resources | 1h                                                  |
+| Property | Value |
+|----------|-------|
+| Key | `opns.disk.discovery` |
+| Type | Dependent (master: `opns.raw.disk`) |
+| Filters | `{#FSNAME}` and `{#FSTYPE}` configurable via macros |
+| Keep lost resources | 1h |
 
 **Item Prototypes:**
 
-| Name                              | Key                                   | Unit | Description                                      |
-| --------------------------------- | ------------------------------------- | ---- | ------------------------------------------------ |
-| FS [{#FSNAME}]: Get data          | `opns.disk.data[{#FSNAME},data]`      | –    | Raw JSON for the filesystem (intermediate item). |
-| FS [{#FSNAME}]: Space: Total      | `opns.disk.size[{#FSNAME},total]`     | B    | Total filesystem size in bytes.                  |
-| FS [{#FSNAME}]: Space: Used       | `opns.disk.size[{#FSNAME},used]`      | B    | Used space in bytes.                             |
-| FS [{#FSNAME}]: Space: Available  | `opns.disk.size[{#FSNAME},available]` | B    | Available space in bytes.                        |
-| FS [{#FSNAME}]: Space: Used, in % | `opns.disk.size[{#FSNAME},pused]`     | %    | Used space as a percentage.                      |
+| Name | Key | Unit | Description |
+|------|-----|------|-------------|
+| FS [{#FSNAME}]: Get data | `opns.disk.data[{#FSNAME},data]` | – | Raw JSON for the filesystem (intermediate item). |
+| FS [{#FSNAME}]: Space: Total | `opns.disk.size[{#FSNAME},total]` | B | Total filesystem size in bytes. |
+| FS [{#FSNAME}]: Space: Used | `opns.disk.size[{#FSNAME},used]` | B | Used space in bytes. |
+| FS [{#FSNAME}]: Space: Available | `opns.disk.size[{#FSNAME},available]` | B | Available space in bytes. |
+| FS [{#FSNAME}]: Space: Used, in % | `opns.disk.size[{#FSNAME},pused]` | % | Used space as a percentage. |
 
 **Trigger Prototypes:**
 
-| Name                                              | Severity    | Description                                                      |
-| ------------------------------------------------- | ----------- | ---------------------------------------------------------------- |
-| OPNsense: FS [{#FSNAME}]: Space is low            | **Warning** | Used space exceeds `{$OPNS.FS.PUSED.MAX.WARN}` % (default: 90%). |
+| Name | Severity | Description |
+|------|----------|-------------|
+| OPNsense: FS [{#FSNAME}]: Space is low | **Warning** | Used space exceeds `{$OPNS.FS.PUSED.MAX.WARN}` % (default: 90%). |
 | OPNsense: FS [{#FSNAME}]: Space is critically low | **Average** | Used space exceeds `{$OPNS.FS.PUSED.MAX.CRIT}` % (default: 95%). |
 
 ---
 
 ### 2. Gateway Discovery
 
-| Property            | Value                                         |
-| ------------------- | --------------------------------------------- |
-| Key                 | `opns.gateway.discovery`                      |
-| Type                | Dependent (master: `opns.raw.gateway.status`) |
-| LLD Macro           | `{#GWSTATUSNAME}` → `$.name`                 |
-| Keep lost resources | 1h                                            |
+| Property | Value |
+|----------|-------|
+| Key | `opns.gateway.discovery` |
+| Type | Dependent (master: `opns.raw.gateway.status`) |
+| LLD Macro | `{#GWSTATUSNAME}` → `$.name` |
+| Keep lost resources | 1h |
 
 **Item Prototypes:**
 
-| Name                            | Key                                       | Unit | Description                                                     |
-| ------------------------------- | ----------------------------------------- | ---- | --------------------------------------------------------------- |
-| Gateway Address {#GWSTATUSNAME} | `opns.gw.status.address[{#GWSTATUSNAME}]` | –    | Gateway IP address.                                             |
-| Gateway Status {#GWSTATUSNAME}  | `opns.gw.status.status[{#GWSTATUSNAME}]`  | –    | Translated status string (e.g. "Online").                       |
-| Gateway RTT {#GWSTATUSNAME}     | `opns.gw.status.delay[{#GWSTATUSNAME}]`   | ms   | Round-trip time. Returns 9999 if monitoring is disabled.        |
-| Gateway RTTd {#GWSTATUSNAME}    | `opns.gw.status.stddev[{#GWSTATUSNAME}]`  | ms   | RTT standard deviation. Returns 9999 if monitoring is disabled. |
-| Gateway loss {#GWSTATUSNAME}    | `opns.gw.status.loss[{#GWSTATUSNAME}]`    | %    | Packet loss percentage. Returns 9999 if monitoring is disabled. |
+| Name | Key | Unit | Description |
+|------|-----|------|-------------|
+| Gateway Address {#GWSTATUSNAME} | `opns.gw.status.address[{#GWSTATUSNAME}]` | – | Gateway IP address. |
+| Gateway Status {#GWSTATUSNAME} | `opns.gw.status.status[{#GWSTATUSNAME}]` | – | Translated status string (e.g. "Online"). |
+| Gateway RTT {#GWSTATUSNAME} | `opns.gw.status.delay[{#GWSTATUSNAME}]` | ms | Round-trip time. Returns 9999 if monitoring is disabled. |
+| Gateway RTTd {#GWSTATUSNAME} | `opns.gw.status.stddev[{#GWSTATUSNAME}]` | ms | RTT standard deviation. Returns 9999 if monitoring is disabled. |
+| Gateway loss {#GWSTATUSNAME} | `opns.gw.status.loss[{#GWSTATUSNAME}]` | % | Packet loss percentage. Returns 9999 if monitoring is disabled. |
 
 **Trigger Prototypes:**
 
-| Name                                              | Severity     | Description                                                                                                            |
-| ------------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| Gateway {#GWSTATUSNAME} Packet loss               | **Average**  | Packet loss > `{$OPNS.GW.MIN.PACKET.LOSS}` % for 5 min. Ignores the `9999` sentinel used when monitoring is disabled.  |
-| Gateway {#GWSTATUSNAME} High packet loss          | **High**     | Packet loss > `{$OPNS.GW.HIGH.PACKET.LOSS}` % for 5 min. Ignores the `9999` sentinel used when monitoring is disabled. |
-| Gateway {#GWSTATUSNAME} is down                   | **Disaster** | Packet loss > 99% for 5 min. Ignores the `9999` sentinel used when monitoring is disabled.                             |
-| Gateway Monitoring on {#GWSTATUSNAME} is disabled | **Average**  | All monitoring values return 9999 – gateway monitoring is not enabled in OPNsense.                                     |
+| Name | Severity | Description |
+|------|----------|-------------|
+| Gateway {#GWSTATUSNAME} Packet loss | **Average** | Packet loss > `{$OPNS.GW.MIN.PACKET.LOSS}` % for 5 min. Ignores the `9999` sentinel used when monitoring is disabled. |
+| Gateway {#GWSTATUSNAME} High packet loss | **High** | Packet loss > `{$OPNS.GW.HIGH.PACKET.LOSS}` % for 5 min. Ignores the `9999` sentinel used when monitoring is disabled. |
+| Gateway {#GWSTATUSNAME} is down | **Disaster** | Packet loss > 99% for 5 min. Ignores the `9999` sentinel used when monitoring is disabled. |
+| Gateway Monitoring on {#GWSTATUSNAME} is disabled | **Average** | All monitoring values return 9999 – gateway monitoring is not enabled in OPNsense. |
 
 ---
 
 ### 3. FW Action Discovery
 
-| Property            | Value                                    |
-| ------------------- | ---------------------------------------- |
-| Key                 | `opns.fw.action.discovery`               |
-| Type                | Dependent (master: `opns.raw.fw.action`) |
-| LLD Macro           | `{#FWACTION}` → `$.label`               |
-| Keep lost resources | 1h                                       |
+| Property | Value |
+|----------|-------|
+| Key | `opns.fw.action.discovery` |
+| Type | Dependent (master: `opns.raw.fw.action`) |
+| LLD Macro | `{#FWACTION}` → `$.label` |
+| Keep lost resources | 1h |
 
 **Item Prototypes:**
 
-| Name                        | Key                           | Description                                                           |
-| --------------------------- | ----------------------------- | --------------------------------------------------------------------- |
+| Name | Key | Description |
+|------|-----|-------------|
 | Firewall action {#FWACTION} | `opns.fw.action[{#FWACTION}]` | Counter for the discovered firewall action (e.g. pass, block, match). |
 
 **Graph Prototypes:**
 
-| Name                              | Description                                                      |
-| --------------------------------- | ---------------------------------------------------------------- |
+| Name | Description |
+|------|-------------|
 | OPNSense Action Graph {#FWACTION} | Graph showing firewall action counts per discovered action type. |
 
 ---
 
 ### 4. Interface CARP Discovery
 
-| Property            | Value                                          |
-| ------------------- | ---------------------------------------------- |
-| Key                 | `opns.interface.carp.discovery`                |
-| Type                | Dependent (master: `opns.raw.interfaces.carp`) |
-| LLD Macro           | `{#OPNS.INTERFACE.NAME}` → `$.interface`      |
-| Keep lost resources | 1d                                             |
+| Property | Value |
+|----------|-------|
+| Key | `opns.interface.carp.discovery` |
+| Type | Dependent (master: `opns.raw.interfaces.carp`) |
+| LLD Macro | `{#OPNS.INTERFACE.NAME}` → `$.interface` |
+| Keep lost resources | 1d |
 
 **Item Prototypes:**
 
-| Name                                  | Key                                        | Description                                                                           |
-| ------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------- |
+| Name | Key | Description |
+|------|-----|-------------|
 | Carp Status of {#OPNS.INTERFACE.NAME} | `opns.carp.status[{#OPNS.INTERFACE.NAME}]` | CARP status of the VIP (MASTER, BACKUP, INIT). Uses discard unchanged heartbeat (2h). |
 
 **Trigger Prototypes:**
 
-| Name                                          | Severity | Description                                       |
-| --------------------------------------------- | -------- | ------------------------------------------------- |
+| Name | Severity | Description |
+|------|----------|-------------|
 | Carp Status Changed on {#OPNS.INTERFACE.NAME} | **High** | CARP status changed – indicates a failover event. |
 
 > **Note:** If no CARP interfaces are configured, the discovery returns a custom error and
@@ -332,100 +521,242 @@ items and discovery rules.
 
 ### 5. Interface Stats Discovery
 
-| Property   | Value                                                                          |
-| ---------- | ------------------------------------------------------------------------------ |
-| Key        | `opns.interface.stats.discovery`                                               |
-| Type       | Dependent (master: `opns.raw.interfaces.stat`)                                 |
+| Property | Value |
+|----------|-------|
+| Key | `opns.interface.stats.discovery` |
+| Type | Dependent (master: `opns.raw.interfaces.stat`) |
 | LLD Macros | `{#OPNS.INTERFACE.DEVICE}` → `$.device`, `{#OPNS.INTERFACE.NAME}` → `$.name` |
 
 **Item Prototypes – Traffic:**
 
-| Name                 | Key                                                            | Unit |
-| -------------------- | -------------------------------------------------------------- | ---- |
-| …Bytes received      | `opns.interface.bytes.received[{#OPNS.INTERFACE.DEVICE}]`      | Bps  |
-| …Bytes transmitted   | `opns.interface.bytes.transmitted[{#OPNS.INTERFACE.DEVICE}]`   | Bps  |
-| …packets received    | `opns.interface.packets.received[{#OPNS.INTERFACE.DEVICE}]`    | –    |
-| …packets transmitted | `opns.interface.packets.transmitted[{#OPNS.INTERFACE.DEVICE}]` | –    |
-| …multicasts received | `opns.interface.multicast.received[{#OPNS.INTERFACE.DEVICE}]`  | –    |
+| Name | Key | Unit |
+|------|-----|------|
+| …Bytes received | `opns.interface.bytes.received[{#OPNS.INTERFACE.DEVICE}]` | Bps |
+| …Bytes transmitted | `opns.interface.bytes.transmitted[{#OPNS.INTERFACE.DEVICE}]` | Bps |
+| …packets received | `opns.interface.packets.received[{#OPNS.INTERFACE.DEVICE}]` | – |
+| …packets transmitted | `opns.interface.packets.transmitted[{#OPNS.INTERFACE.DEVICE}]` | – |
+| …multicasts received | `opns.interface.multicast.received[{#OPNS.INTERFACE.DEVICE}]` | – |
 
 **Item Prototypes – Errors & Drops:**
 
-| Name                          | Key                                                                 |
-| ----------------------------- | ------------------------------------------------------------------- |
-| …collisions                   | `opns.interface.collisions[{#OPNS.INTERFACE.DEVICE}]`               |
-| …input queue drops            | `opns.interface.input.queue.drops[{#OPNS.INTERFACE.DEVICE}]`        |
-| …output errors                | `opns.interface.output.errors[{#OPNS.INTERFACE.DEVICE}]`            |
+| Name | Key |
+|------|-----|
+| …collisions | `opns.interface.collisions[{#OPNS.INTERFACE.DEVICE}]` |
+| …input queue drops | `opns.interface.input.queue.drops[{#OPNS.INTERFACE.DEVICE}]` |
+| …output errors | `opns.interface.output.errors[{#OPNS.INTERFACE.DEVICE}]` |
 | …packets for unknown protocol | `opns.interface.packets.unknown.protocol[{#OPNS.INTERFACE.DEVICE}]` |
 
 **Item Prototypes – Firewall per Interface (IPv4):**
 
-| Name                   | Key                                                               | Unit |
-| ---------------------- | ----------------------------------------------------------------- | ---- |
-| …blocked bytes INv4    | `opns.interface.fw.bytes.blockin.v4[{#OPNS.INTERFACE.DEVICE}]`    | Bps  |
-| …blocked bytes OUTv4   | `opns.interface.fw.bytes.blockout.v4[{#OPNS.INTERFACE.DEVICE}]`   | Bps  |
-| …passed bytes INv4     | `opns.interface.fw.bytes.passin.v4[{#OPNS.INTERFACE.DEVICE}]`     | Bps  |
-| …passed bytes OUTv4    | `opns.interface.fw.bytes.passout.v4[{#OPNS.INTERFACE.DEVICE}]`    | Bps  |
-| …blocked packets INv4  | `opns.interface.fw.packets.blockin.v4[{#OPNS.INTERFACE.DEVICE}]`  | –    |
-| …blocked packets OUTv4 | `opns.interface.fw.packets.blockout.v4[{#OPNS.INTERFACE.DEVICE}]` | –    |
-| …passed packets INv4   | `opns.interface.fw.packets.passin.v4[{#OPNS.INTERFACE.DEVICE}]`   | –    |
-| …passed packets OUTv4  | `opns.interface.fw.packets.passout.v4[{#OPNS.INTERFACE.DEVICE}]`  | –    |
+| Name | Key | Unit |
+|------|-----|------|
+| …blocked bytes INv4 | `opns.interface.fw.bytes.blockin.v4[{#OPNS.INTERFACE.DEVICE}]` | Bps |
+| …blocked bytes OUTv4 | `opns.interface.fw.bytes.blockout.v4[{#OPNS.INTERFACE.DEVICE}]` | Bps |
+| …passed bytes INv4 | `opns.interface.fw.bytes.passin.v4[{#OPNS.INTERFACE.DEVICE}]` | Bps |
+| …passed bytes OUTv4 | `opns.interface.fw.bytes.passout.v4[{#OPNS.INTERFACE.DEVICE}]` | Bps |
+| …blocked packets INv4 | `opns.interface.fw.packets.blockin.v4[{#OPNS.INTERFACE.DEVICE}]` | – |
+| …blocked packets OUTv4 | `opns.interface.fw.packets.blockout.v4[{#OPNS.INTERFACE.DEVICE}]` | – |
+| …passed packets INv4 | `opns.interface.fw.packets.passin.v4[{#OPNS.INTERFACE.DEVICE}]` | – |
+| …passed packets OUTv4 | `opns.interface.fw.packets.passout.v4[{#OPNS.INTERFACE.DEVICE}]` | – |
 
 ---
 
 ### 6. WireGuard Instance Discovery
 
-| Property            | Value                                                                                                 |
-| ------------------- | ----------------------------------------------------------------------------------------------------- |
-| Key                 | `opns.wireguard.instance.discovery`                                                                   |
-| Type                | Dependent (master: `opns.wireguard.raw`)                                                              |
-| LLD Macros          | `{#WG.IF}` → `$.if`, `{#WG.INSTANCE}` → `$.name`                                                    |
-| Filters             | `{#WG.INSTANCE}` configurable via `{$OPNS.WG.INSTANCE.MATCHES}` and `{$OPNS.WG.INSTANCE.NOT_MATCHES}` |
-| Keep lost resources | 1h                                                                                                    |
+| Property | Value |
+|----------|-------|
+| Key | `opns.wireguard.instance.discovery` |
+| Type | Dependent (master: `opns.wireguard.raw`) |
+| LLD Macros | `{#WG.IF}` → `$.if`, `{#WG.INSTANCE}` → `$.name` |
+| Filters | `{#WG.INSTANCE}` configurable via `{$OPNS.WG.INSTANCE.MATCHES}` and `{$OPNS.WG.INSTANCE.NOT_MATCHES}` |
+| Keep lost resources | 1h |
 
 **Item Prototypes:**
 
-| Name                                           | Key                                             | Unit | Description                                             |
-| ---------------------------------------------- | ----------------------------------------------- | ---- | ------------------------------------------------------- |
-| WireGuard instance {#WG.INSTANCE}: status      | `opns.wireguard.instance.status[{#WG.IF}]`      | –    | Interface status reported by OPNsense (`up` or `down`). |
-| WireGuard instance {#WG.INSTANCE}: listen port | `opns.wireguard.instance.listen_port[{#WG.IF}]` | –    | WireGuard listen port.                                  |
-| WireGuard instance {#WG.INSTANCE}: public key  | `opns.wireguard.instance.public_key[{#WG.IF}]`  | –    | Instance public key.                                    |
+| Name | Key | Unit | Description |
+|------|-----|------|-------------|
+| WireGuard instance {#WG.INSTANCE}: status | `opns.wireguard.instance.status[{#WG.IF}]` | – | Interface status reported by OPNsense (`up` or `down`). |
+| WireGuard instance {#WG.INSTANCE}: listen port | `opns.wireguard.instance.listen_port[{#WG.IF}]` | – | WireGuard listen port. |
+| WireGuard instance {#WG.INSTANCE}: public key | `opns.wireguard.instance.public_key[{#WG.IF}]` | – | Instance public key. |
 
 **Trigger Prototypes:**
 
-| Name                                      | Severity | Description                                      |
-| ----------------------------------------- | -------- | ------------------------------------------------ |
+| Name | Severity | Description |
+|------|----------|-------------|
 | WireGuard instance {#WG.INSTANCE} is down | **High** | Instance status has not been `up` for 5 minutes. |
 
 ---
 
 ### 7. WireGuard Peer Discovery
 
-| Property            | Value                                                                                                                                                                                          |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Key                 | `opns.wireguard.peer.discovery`                                                                                                                                                                |
-| Type                | Dependent (master: `opns.wireguard.raw`)                                                                                                                                                       |
-| LLD Macros          | `{#WG.PUBKEY}` → `$.public_key`, `{#WG.NAME}` → `$.name`, `{#WG.IF}` → `$.if`, `{#WG.IFNAME}` → `$.ifname`                                                                                 |
-| Filters             | `{#WG.NAME}` configurable via `{$OPNS.WG.PEER.MATCHES}` and `{$OPNS.WG.PEER.NOT_MATCHES}`; `{#WG.IFNAME}` configurable via `{$OPNS.WG.INSTANCE.MATCHES}` and `{$OPNS.WG.INSTANCE.NOT_MATCHES}` |
-| Keep lost resources | 1h                                                                                                                                                                                             |
+| Property | Value |
+|----------|-------|
+| Key | `opns.wireguard.peer.discovery` |
+| Type | Dependent (master: `opns.wireguard.raw`) |
+| LLD Macros | `{#WG.PUBKEY}` → `$.public_key`, `{#WG.NAME}` → `$.name`, `{#WG.IF}` → `$.if`, `{#WG.IFNAME}` → `$.ifname` |
+| Filters | `{#WG.NAME}` configurable via `{$OPNS.WG.PEER.MATCHES}` and `{$OPNS.WG.PEER.NOT_MATCHES}`; `{#WG.IFNAME}` configurable via `{$OPNS.WG.INSTANCE.MATCHES}` and `{$OPNS.WG.INSTANCE.NOT_MATCHES}` |
+| Keep lost resources | 1h |
 
 **Item Prototypes:**
 
-| Name                                                 | Key                                                        | Unit     | Description                                                                 |
-| ---------------------------------------------------- | ---------------------------------------------------------- | -------- | --------------------------------------------------------------------------- |
-| WireGuard peer {#WG.NAME}: status                    | `opns.wireguard.peer.status["{#WG.PUBKEY}"]`               | –        | Peer status reported by OPNsense (`online`, `stale`, or `offline`).         |
-| WireGuard peer {#WG.NAME}: latest handshake          | `opns.wireguard.peer.latest_handshake["{#WG.PUBKEY}"]`     | unixtime | Latest WireGuard handshake timestamp. Returns `0` if no handshake exists.   |
-| WireGuard peer {#WG.NAME}: latest handshake age      | `opns.wireguard.peer.latest_handshake_age["{#WG.PUBKEY}"]` | s        | Age of the latest handshake in seconds. Returns `0` if no handshake exists. |
-| WireGuard peer {#WG.NAME}: endpoint                  | `opns.wireguard.peer.endpoint["{#WG.PUBKEY}"]`             | –        | Current peer endpoint.                                                      |
-| WireGuard peer {#WG.NAME}: bytes received            | `opns.wireguard.peer.transfer_rx["{#WG.PUBKEY}"]`          | B        | Total bytes received from the peer.                                         |
-| WireGuard peer {#WG.NAME}: bytes received per second | `opns.wireguard.peer.transfer_rx.rate["{#WG.PUBKEY}"]`     | Bps      | Receive rate calculated from total received bytes.                          |
-| WireGuard peer {#WG.NAME}: bytes sent                | `opns.wireguard.peer.transfer_tx["{#WG.PUBKEY}"]`          | B        | Total bytes sent to the peer.                                               |
-| WireGuard peer {#WG.NAME}: bytes sent per second     | `opns.wireguard.peer.transfer_tx.rate["{#WG.PUBKEY}"]`     | Bps      | Send rate calculated from total sent bytes.                                 |
+| Name | Key | Unit | Description |
+|------|-----|------|-------------|
+| WireGuard peer {#WG.NAME}: status | `opns.wireguard.peer.status["{#WG.PUBKEY}"]` | – | Peer status reported by OPNsense (`online`, `stale`, or `offline`). |
+| WireGuard peer {#WG.NAME}: latest handshake | `opns.wireguard.peer.latest_handshake["{#WG.PUBKEY}"]` | unixtime | Latest WireGuard handshake timestamp. Returns `0` if no handshake exists. |
+| WireGuard peer {#WG.NAME}: latest handshake age | `opns.wireguard.peer.latest_handshake_age["{#WG.PUBKEY}"]` | s | Age of the latest handshake in seconds. Returns `0` if no handshake exists. |
+| WireGuard peer {#WG.NAME}: endpoint | `opns.wireguard.peer.endpoint["{#WG.PUBKEY}"]` | – | Current peer endpoint. |
+| WireGuard peer {#WG.NAME}: bytes received | `opns.wireguard.peer.transfer_rx["{#WG.PUBKEY}"]` | B | Total bytes received from the peer. |
+| WireGuard peer {#WG.NAME}: bytes received per second | `opns.wireguard.peer.transfer_rx.rate["{#WG.PUBKEY}"]` | Bps | Receive rate calculated from total received bytes. |
+| WireGuard peer {#WG.NAME}: bytes sent | `opns.wireguard.peer.transfer_tx["{#WG.PUBKEY}"]` | B | Total bytes sent to the peer. |
+| WireGuard peer {#WG.NAME}: bytes sent per second | `opns.wireguard.peer.transfer_tx.rate["{#WG.PUBKEY}"]` | Bps | Send rate calculated from total sent bytes. |
 
 **Trigger Prototypes:**
 
-| Name                                    | Severity | Description                                      |
-| --------------------------------------- | -------- | ------------------------------------------------ |
+| Name | Severity | Description |
+|------|----------|-------------|
 | WireGuard peer {#WG.NAME} is not online | **High** | Peer status has not been `online` for 5 minutes. |
+
+### 8. Services Discovery
+
+| Property | Value |
+|----------|-------|
+| Key | `opns.services.discovery` |
+| Type | Dependent (master: `opns.services.raw`) |
+| LLD Macros | `{#SERVICE.ID}` → `$.id`, `{#SERVICE.NAME}` → `$.name`, `{#SERVICE.DESCRIPTION}` → `$.description` |
+| Filters | `{#SERVICE.ID}` configurable via `{$OPNS.SERVICE.ID.NOT_MATCHES}` |
+
+**Item Prototypes:**
+
+| Name | Key | Description |
+|------|-----|-------------|
+| Service {#SERVICE.DESCRIPTION}: Running | `opns.service.running[{#SERVICE.ID}]` | Run state of the service, the packet filter included. |
+
+**Trigger Prototypes:**
+
+| Name | Severity | Description |
+|------|----------|-------------|
+| OPNsense: Service {#SERVICE.DESCRIPTION} is not running | **Average** | Service has been down for 5 minutes. |
+
+---
+
+### 9. Swap Discovery
+
+| Property | Value |
+|----------|-------|
+| Key | `opns.swap.discovery` |
+| Type | Dependent (master: `opns.swap.raw`) |
+| LLD Macro | `{#SWAPDEV}` → `$.device` |
+
+**Item Prototypes:**
+
+| Name | Key | Unit | Description |
+|------|-----|------|-------------|
+| Swap {#SWAPDEV}: total | `opns.swap.total[{#SWAPDEV}]` | B | Size of the swap device. |
+| Swap {#SWAPDEV}: used | `opns.swap.used[{#SWAPDEV}]` | B | Used swap in bytes. |
+| Swap {#SWAPDEV}: utilization | `opns.swap.pused[{#SWAPDEV}]` | % | Used swap as a percentage. |
+
+**Trigger Prototypes:**
+
+| Name | Severity | Description |
+|------|----------|-------------|
+| OPNsense: Swap {#SWAPDEV} is in use | **Warning** | Above `{$OPNS.SWAP.UTIL.WARN}` % for 10 minutes. A firewall should not swap, so the default threshold is deliberately low. Overridable per device via macro context. |
+
+---
+
+### 10. Temperature Discovery
+
+| Property | Value |
+|----------|-------|
+| Key | `opns.temperature.discovery` |
+| Type | Dependent (master: `opns.temperature.raw`) |
+| LLD Macros | `{#DEVICE}` → `$.device`, `{#TYPE}` → `$.type` |
+
+**Item Prototypes:**
+
+| Name | Key | Unit | Description |
+|------|-----|------|-------------|
+| Temperature {#DEVICE} | `opns.temperature[{#DEVICE}]` | °C | Sensor reading. |
+
+**Trigger Prototypes:**
+
+| Name | Severity | Description |
+|------|----------|-------------|
+| OPNsense: Sensor {#DEVICE} is running hot | **High** | Above `{$OPNS.TEMP.CRIT}` °C averaged over 5 minutes. Overridable per sensor via macro context, so a single hot sensor does not force the threshold up everywhere. |
+
+**Graph Prototypes:**
+
+| Name | Description |
+|------|-------------|
+| Temperature {#DEVICE} | Sensor reading over time. |
+
+---
+
+### 11. netisr Queue Discovery
+
+| Property | Value |
+|----------|-------|
+| Key | `opns.netisr.discovery` |
+| Type | Dependent (master: `opns.netisr.raw`) |
+| LLD Macro | `{#NETISR.PROTO}`, collected by shape rather than by path because the nesting depth varies between netstat versions |
+
+**Item Prototypes:**
+
+| Name | Key | Unit | Description |
+|------|-----|------|-------------|
+| netisr {#NETISR.PROTO}: Queue drops | `opns.netisr.queue.drops[{#NETISR.PROTO}]` | /s | Queue drops for the individual protocol. |
+
+---
+
+### 12. Network Interface Discovery (link state and inbound errors)
+
+Deliberately separate from *Interface Stats Discovery*: it adds the two metrics that
+discovery does not provide, out of a different endpoint, and leaves the existing rule
+untouched. Both rules discover the same interfaces, but no metric exists twice.
+
+| Property | Value |
+|----------|-------|
+| Key | `opns.net.if.discovery` |
+| Type | Dependent (master: `opns.ifstats.raw`) |
+| LLD Macros | `{#IFNAME}`, `{#IFALIAS}` |
+| Filters | `{#IFNAME}` configurable via `{$OPNS.IF.NAME.NOT_MATCHES}` |
+
+**Item Prototypes:**
+
+| Name | Key | Description |
+|------|-----|-------------|
+| Interface {#IFALIAS} ({#IFNAME}): Link status | `opns.net.if.status[{#IFNAME}]` | Link up or down, read from the interface flags. |
+| Interface {#IFALIAS} ({#IFNAME}): Inbound errors | `opns.net.if.in.errors[{#IFNAME}]` | Receive errors per second. |
+
+**Trigger Prototypes:**
+
+| Name | Severity | Description |
+|------|----------|-------------|
+| OPNsense: Interface {#IFALIAS} ({#IFNAME}) is down | **Average** | Link is gone or the interface was shut down. Set `{$OPNS.IF.CONTROL:"{#IFNAME}"}` to `0` for interfaces that are allowed to be down, such as a cold standby uplink. |
+
+---
+
+### 13. IPsec Phase 1 Discovery
+
+Was not described here before. Phase 2 no longer has a rule of its own, see below.
+
+| Property | Value |
+|----------|-------|
+| Key | `opns.ipsec.phase1.discovery` |
+| Type | Dependent (master: `opns.ipsec.phase1.raw`) |
+| LLD Macros | `{#IPSECDESC}` -> `$.phase1desc`, `{#IPSECNAME}` -> `$.name` |
+
+**Item Prototypes, phase 1:** connection state, local address, and bytes in and out both as a
+total and as a rate. The API aggregates these counters over all child SAs of the connection
+itself.
+
+**Item Prototypes, phase 2:** `IPsec {#IPSECDESC}: phase 2 (raw)`
+(`opns.ipsec.phase2.raw[{#IPSECNAME}]`) is an HTTP agent prototype that posts
+`id={#IPSECNAME}` to `/api/ipsec/sessions/search_phase2`, one request per connection, and
+serves the ten phase 2 values below it: bytes and packets in and out as totals and rates,
+plus mode and state. Values are summed over the child SAs of the connection, and a tunnel that
+is down simply reports nothing rather than turning the items unsupported.
+
+---
 
 ## UPS Monitoring (NUT)
 
@@ -447,47 +778,98 @@ from this JSON using standard JSONPath preprocessing – no external scripts req
 3. In Zabbix, navigate to the host and **enable the item** `RAW UPS` (`opns.ups.raw`)
 4. All dependent UPS items and triggers will start collecting data automatically
 
----
-
-### 8. Certificates Discovery
-
-| Property            | Value                                             |
-| ------------------- | ------------------------------------------------- |
-| Key                 | `opns.trust.certificates.discovery`               |
-| Type                | Dependent (master: `opns.raw.trust.certificates`) |
-| LLD Macros          | `{#DESCRIPTION}` → `$..descr.first()`            |
-
-**Item Prototypes:**
-
-| Name                      | Key                                                            | Unit      | Description                                                                    |
-| ------------------------- | -------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------ |
-| {#DESCRIPTION} commonname | `opns.trust.certificates.discovery.commonname[{#DESCRIPTION}]` | -         | Certificate CN (common name)                                                   |
-| {#DESCRIPTION} is in use  | `opns.trust.certificates.discovery.in_use[{#DESCRIPTION}]`     | (Boolean) | Shows if certificate is used / assigned                                        |
-| {#DESCRIPTION} is user    | `opns.trust.certificates.discovery.is_user[{#DESCRIPTION}]`    | (Boolean) | User certificate (User VPN) or system certificate (e. g. for Site-to-Site VPN) |
-| {#DESCRIPTION} valid from | `opns.trust.certificates.discovery.valid_from[{#DESCRIPTION}]` | unixtime  | Certificate valid from                                                         |
-| {#DESCRIPTION} valid to   | `opns.trust.certificates.discovery.valid_to[{#DESCRIPTION}]`   | unixtime  | Certificate valid to                                                           |
-
----
-
-## Value mapping
-
-
-| Name    | Raw value | Mapped value |
-| ------- | --------- | ------------ |
-| Boolean | `1`       | `Yes`        |
-| Boolean | `0`       | `No`         |
-
----
 
 ## Dashboards
 
-The template includes a built-in dashboard **"OPNsense Info"** with three pages:
+The template includes a built-in dashboard **"OPNsense Info"** with eight pages:
 
-1. **OPNSense Info** – CPU load widget, memory usage pie chart, firewall states pie chart,
-   firewall action SVG graph, and CARP status honeycomb overview.
-2. **Gateway Info** – SVG graphs for gateway round-trip time and packet loss across all
-   discovered gateways.
-3. **Interfaces** – SVG graph showing blocked and passed bytes (IPv4) per interface.
+1. **Overview** – memory, state table, processor and load per core as gauges, tiles for CPU
+   load, uptime, version, firmware status and the state table, firewall actions over time,
+   CARP status, and every filesystem as a honeycomb.
+2. **Packet filter** – state table, source tracking and pf table utilization, tiles from
+   states in use to source limit hits, state table churn and searches, rule matches against
+   evaluations, drops and limit hits, and malformed packets.
+3. **Interfaces** – link state per interface, traffic, blocked and passed bytes (IPv4) side
+   by side, and inbound errors, output errors, queue drops and collisions in one graph.
+4. **Gateways** – status honeycomb, round-trip time and packet loss side by side, and the
+   round-trip deviation below.
+5. **VPN** – WireGuard peers and instances, peer traffic, IPsec phase 1 tunnels and phase 2
+   traffic.
+6. **System** – processor, memory and load per core, uptime, version, cores, configuration
+   change timestamp, both load averages, processor utilization split into user, system and
+   interrupt, load average over time, and temperature and swap honeycombs.
+7. **Kernel and protocols** – mbuf utilization, clusters in use, denied requests, netisr
+   drops, kernel network memory and netisr drops per protocol, IP and TCP error rates.
+8. **Services, clock and power** – every service as a honeycomb, clock synchronization,
+   offset, stratum and reachable peers, CARP demotion and maintenance, UPS battery, status,
+   load and runtime, and clock offset and UPS voltage over time.
+
+The previous three pages were rebuilt for three reasons. The CPU load widget set `Show=5`,
+which Zabbix 7.0 refuses with `Invalid parameter "Show/5": value must be one of 1, 2, 3, 4`.
+Both pie charts plotted a total against a part of that same total, so the slice for used
+memory was drawn against total plus used and always read about half its real size. And the
+pages occupied 41, 45 and 55 of the 72 grid columns, leaving the right third empty, while
+`Gateway RTT*` also matched `Gateway RTTd` and mixed round-trip time into one graph with its
+own standard deviation. Everything the old pages showed is still shown, and the UPS,
+WireGuard and IPsec items that ship with the template but appeared on no page now have one.
+
+## Corrected API URLs
+
+Two master items called their endpoint in camelCase while the OPNsense privilege pattern is
+exact snake_case. OPNsense routes both spellings to the same controller action, so an
+administrator API key never sees a problem, but the ACL is a different code path: it matches
+the raw URL with `preg_match` and no `i` modifier against `api/diagnostics/firewall/pf_states`
+and `api/diagnostics/system/system_resources`, both exact rather than wildcards.
+
+Measured against OPNsense 26.7 with a monitoring user holding only Lobby: Dashboard:
+
+```
+403  diagnostics/firewall/pfStates        200  diagnostics/firewall/pf_states
+403  diagnostics/system/systemResources   200  diagnostics/system/system_resources
+```
+
+For anyone following least privilege this took out `opns.fw.states.current`,
+`opns.fw.states.max`, `opns.states.util` and all four memory items. Both URLs now use the
+snake_case spelling.
+
+The IPsec phase 1 master was also one of two items ignoring `{$OPNS.PORT}` and pinned to 443.
+It now uses the macro like everything else.
+
+## Repaired IPsec monitoring
+
+Three defects, none of them visible without a tunnel to test against.
+
+**The masters shipped disabled.** Both IPsec raw items carried `status: DISABLED`. For the UPS
+master that is deliberate and documented; for IPsec neither the README nor the Raw Data Items
+table mentioned the items at all, so a user with working tunnels saw nothing and had no hint
+why. The same confusion already played out for UPS in issue #706. Phase 1 is enabled now;
+`ipsec/sessions/search_phase1` answers HTTP 200 with an empty row set on a firewall without
+tunnels, so this costs nothing for anyone else.
+
+**Tunnels without a description were dropped.** `searchPhase1Action` leaves `phase1desc` at
+`null` when the connection carries no description, and legacy tunnels can miss the ikeid
+lookup as well. The discovery used that field as the entity identity and put it into every
+prototype key, so several such tunnels collapsed into identical keys and the rule failed as a
+whole. A JavaScript step now fills `phase1desc` from `name`, which the API always sets. Item
+keys of anybody who does have descriptions are unchanged.
+
+**Phase 2 could never return anything.** `searchPhase2Action` reads its connection from
+`getPost('id')` and returns an empty set without it, while the template asked for it with a
+plain GET and no parameters. Measured against OPNsense 26.7 with a monitoring key, echoing
+`current` back proves that POST parameters arrive:
+
+```
+GET  (no parameters)         -> {"current":1,...}
+POST form-encoded current=3  -> {"current":3,...}
+```
+
+The web interface does the same: `sessions.volt` sends `request['id']` taken from the selected
+phase 1 row, whose identifier is the `name` column. Phase 2 therefore needs one request per
+connection, which is an item prototype inside the phase 1 rule rather than a standalone
+master, because a discovery rule cannot depend on an item another rule created. The ten phase 2
+prototypes moved accordingly and now aggregate over the child SAs of their connection.
+
+The privilege set does not change, `page-status-ipsec` covers `api/ipsec/sessions/*`.
 
 ## Feedback
 

--- a/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_http_json/7.4/template_opnsense_by_http_json.yaml
@@ -159,6 +159,177 @@ zabbix_export:
               expression: 'find(/OPNsense by HTTP-JSON/nut.status,#1,"like","OB")=1'
               name: 'UPS on Battery'
               priority: HIGH
+        - uuid: d097f8214e134bd6a95b1036d0df71e5
+          name: 'OPNsense: System activity (raw)'
+          type: HTTP_AGENT
+          key: opns.activity.raw
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Header block of the process listing, which is the only place the API states how busy the processor actually is. The bulk of the response is the process table itself and is not evaluated, so nothing is stored from it.'
+          timeout: 15s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/activity/get_activity'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 2ec4a8e2b6194cd4b5f64760ef978014
+          name: 'OPNsense: Alias tables (raw)'
+          type: HTTP_AGENT
+          key: opns.alias.raw
+          delay: 10m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Entries held by all pf tables together with the configured ceiling. Polled every ten minutes because block lists and GeoIP feeds move on that scale, not by the second.'
+          timeout: 10s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/firewall/alias/get_table_size'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: a058e380463444e5bb8d071da8eecae1
+          name: 'CARP: Demotion factor'
+          type: DEPENDENT
+          key: opns.carp.demotion
+          delay: '0'
+          description: 'How strongly this node is holding itself back from becoming master. Zero means it is willing; anything above means a subsystem has demoted it, which is the usual reason a node refuses to take over when the peer fails.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.carp.demotion
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 3m
+          master_item:
+            key: opns.raw.interfaces.carp
+          tags:
+            - tag: component
+              value: carp
+        - uuid: 4093a54af2c442f9ad0694842db3a69b
+          name: 'CARP: Maintenance mode'
+          type: DEPENDENT
+          key: opns.carp.maintenance
+          delay: '0'
+          description: 'Maintenance mode hands every virtual address to the peer and keeps it there. Worth watching because it is easy to switch on for a planned change and just as easy to forget afterwards, leaving the pair permanently one sided.'
+          valuemap:
+            name: 'Enabled state'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.carp.maintenancemode
+              error_handler: DISCARD_VALUE
+            - type: BOOL_TO_DECIMAL
+              parameters:
+                - ''
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 3m
+          master_item:
+            key: opns.raw.interfaces.carp
+          tags:
+            - tag: component
+              value: carp
+          triggers:
+            - uuid: 7f942fe661d445b6ae7e984f26c52a66
+              expression: 'min(/OPNsense by HTTP-JSON/opns.carp.maintenance,30m)=1'
+              name: 'OPNsense: CARP maintenance mode has been on for 30 minutes'
+              priority: WARNING
+              description: 'Long enough to suggest it was left on rather than switched on for a change in progress. While it is on there is no redundancy.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: 1bdadcfead32450bbde183b2535b2afb
+          name: 'OPNsense: Configuration last changed'
+          type: DEPENDENT
+          key: opns.config.changed
+          delay: '0'
+          units: unixtime
+          description: 'Timestamp OPNsense records when the configuration is written. Covers every change, not only firewall rules, and needs no extra request because it rides along with the system time that is already polled. The reading is what the firewall itself reports, so a clock that is off shifts it accordingly.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // "Thu Aug 13 12:03:17 UTC 2026". Date.parse is unreliable with this
+                  // format, so it is taken apart by position.
+                  var m = JSON.parse(value).config.match(
+                      /^\w{3}\s+(\w{3})\s+(\d{1,2})\s+(\d{1,2}):(\d{2}):(\d{2})\s+\S+\s+(\d{4})$/);
+                  if (m === null) { throw 'cannot read config timestamp: ' + value; }
+                  var months = {Jan:0,Feb:1,Mar:2,Apr:3,May:4,Jun:5,Jul:6,Aug:7,Sep:8,Oct:9,Nov:10,Dec:11};
+                  return Math.round(Date.UTC(+m[6], months[m[1]], +m[2], +m[3], +m[4], +m[5]) / 1000);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.raw.load
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 88a455eab1884b0389fbef53a5a047d2
+              expression: 'change(/OPNsense by HTTP-JSON/opns.config.changed)<>0 and last(/OPNsense by HTTP-JSON/opns.config.changed,#2)>0'
+              name: 'OPNsense: Configuration has been changed'
+              priority: INFO
+              description: 'Someone wrote a new configuration. Broader than the ruleset fingerprint, which reacts to rules only, and the two together tell whether a change touched the firewall rules or something else. The second condition suppresses the jump out of a zero, which is what an item reports after a gap in collection rather than a real change.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 86f2155b4dd74f4d911d642ddb131800
+          name: 'CPU: Cores'
+          type: DEPENDENT
+          key: opns.cpu.cores
+          delay: '0'
+          description: 'Physical core count, needed to put the load average into proportion. Parsed by position rather than by wording, because the source string is translated on a localised firewall.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // "Intel(R) Xeon(R) ... (4 cores, 8 threads)". The words are translated,
+                  // the two numbers in the trailing parenthesis are not, so take those.
+                  var m = String(JSON.parse(value)[0]).match(/\((\d+)\D+(\d+)\D*\)\s*$/);
+                  if (m === null) { throw 'cannot read core count from: ' + value; }
+                  return parseInt(m[1], 10);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: opns.cpu.raw
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: 2b59ce99a7c443f7976adb5bb5d3555f
+          name: 'CPU: Interrupt time'
+          type: DEPENDENT
+          key: opns.cpu.interrupt
+          delay: '0'
+          value_type: FLOAT
+          units: '%'
+          description: 'Share spent servicing hardware interrupts. On a firewall this is largely network cards, and a high figure means the packet rate is close to what the hardware can take, well before the total utilisation looks alarming.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var h = JSON.parse(value).headers || [];
+                  for (var i = 0; i < h.length; i++) {
+                      var m = h[i].match(/([0-9.]+)%\s+interrupt/);
+                      if (m !== null) { return parseFloat(m[1]); }
+                  }
+                  throw 'no CPU line in the activity header';
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.activity.raw
+          tags:
+            - tag: component
+              value: cpu
         - uuid: bf7c17f8b2094ec391ae4c4f58f45be3
           name: 'CPU load'
           type: DEPENDENT
@@ -182,6 +353,111 @@ zabbix_export:
               name: 'CPU load is high'
               opdata: '{ITEM.LASTVALUE}'
               priority: WARNING
+        - uuid: f86c006020ba4fe0bc3ba0b6cbe904aa
+          name: 'OPNsense: CPU type (raw)'
+          type: HTTP_AGENT
+          key: opns.cpu.raw
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Processor model with core and thread count. Static inventory, but polled at the same interval as the load average it is divided into, because a calculated item goes unsupported while a referenced item has no data yet. The dependent item discards unchanged values, so this costs a request rather than history. This is also the only endpoint addressed in camelCase, because the action name carries consecutive capitals that the snake_case spelling does not reproduce; its privilege matches by wildcard, so the spelling raises no access problem.'
+          timeout: 10s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/cpu_usage/getCPUType'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: c5dd65f882254f909f6d679b8ed7c640
+          name: 'CPU: System time'
+          type: DEPENDENT
+          key: opns.cpu.system
+          delay: '0'
+          value_type: FLOAT
+          units: '%'
+          description: 'Share spent in the kernel, which on a firewall is mostly packet forwarding and rule evaluation.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var h = JSON.parse(value).headers || [];
+                  for (var i = 0; i < h.length; i++) {
+                      var m = h[i].match(/([0-9.]+)%\s+system/);
+                      if (m !== null) { return parseFloat(m[1]); }
+                  }
+                  throw 'no CPU line in the activity header';
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.activity.raw
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: b56c1b2ab9a8418db1ce35aff171f66b
+          name: 'CPU: User time'
+          type: DEPENDENT
+          key: opns.cpu.user
+          delay: '0'
+          value_type: FLOAT
+          units: '%'
+          description: 'Share spent in user space, which covers the web interface, the configuration daemon and plugins such as an IDS.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var h = JSON.parse(value).headers || [];
+                  for (var i = 0; i < h.length; i++) {
+                      var m = h[i].match(/([0-9.]+)%\s+user/);
+                      if (m !== null) { return parseFloat(m[1]); }
+                  }
+                  throw 'no CPU line in the activity header';
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.activity.raw
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: d2bdc7e7aab340d8a1fd88ef23d5a5e6
+          name: 'CPU: Utilization'
+          type: DEPENDENT
+          key: opns.cpu.util
+          delay: '0'
+          value_type: FLOAT
+          units: '%'
+          description: 'Everything that is not idle. Derived from the idle share the firewall reports, because that is the one figure the API states directly and the rest have to be added up otherwise.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // "CPU:  1.8% user,  0.0% nice,  2.0% system,  0.2% interrupt, 96.1% idle"
+                  var h = JSON.parse(value).headers || [];
+                  for (var i = 0; i < h.length; i++) {
+                      var m = h[i].match(/([0-9.]+)%\s+idle/);
+                      if (m !== null) { return 100 - parseFloat(m[1]); }
+                  }
+                  throw 'no CPU line in the activity header';
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 5m
+          master_item:
+            key: opns.activity.raw
+          tags:
+            - tag: component
+              value: cpu
+          triggers:
+            - uuid: c662f82953b3403db90bb60287cb90f9
+              expression: 'avg(/OPNsense by HTTP-JSON/opns.cpu.util,10m)>{$OPNS.CPU.UTIL.WARN}'
+              name: 'OPNsense: CPU utilization is high'
+              priority: WARNING
+              description: 'Sustained load on the processor. Read alongside the interrupt share: if that dominates, the limit is packet handling rather than anything running on the box.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: performance
         - uuid: 6ebbcee115654039a5735c835bbdaa78
           name: 'Firmware update count'
           type: DEPENDENT
@@ -321,6 +597,50 @@ zabbix_export:
           tags:
             - tag: component
               value: firewall
+        - uuid: c3397fb562cc4a15b5779ed7d7ac741d
+          name: 'Firewall log: Blocked share'
+          type: DEPENDENT
+          key: opns.fwlog.block.pct
+          delay: '0'
+          value_type: FLOAT
+          units: '%'
+          description: 'Share of blocked entries among the most recent logged packets. Deliberately a share and not a count: the endpoint returns a fixed window of the last log entries, so the counts always add up to that window size and say nothing on their own. The span of time covered therefore varies with how much the firewall logs, and only rules with logging enabled appear at all. What a normal share looks like differs per site, so this ships without a trigger.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // [{"label":"pass","value":4323},{"label":"block","value":677}]
+                  var rows = JSON.parse(value), total = 0, block = 0;
+                  for (var i = 0; i < rows.length; i++) {
+                      total += Number(rows[i].value) || 0;
+                      if (rows[i].label === 'block') { block += Number(rows[i].value) || 0; }
+                  }
+                  if (!total) { throw 'firewall log is empty'; }
+                  return block / total * 100;
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.raw.fw.action
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 1e23fcd943034d9d9670bd97eda62da7
+          name: 'OPNsense: Interface statistics (raw)'
+          type: HTTP_AGENT
+          key: opns.ifstats.raw
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Counters per interface and address.'
+          timeout: 10s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/interface/get_interface_statistics'
+          tags:
+            - tag: component
+              value: raw
         - uuid: f6fab497a5734651a596ef0752999120
           name: 'RAW IPsec Phase1'
           type: HTTP_AGENT
@@ -329,7 +649,6 @@ zabbix_export:
           history: 1d
           value_type: TEXT
           trends: '0'
-          status: DISABLED
           authtype: BASIC
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
@@ -337,27 +656,139 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.rows
-          url: 'https://{HOST.IP}/api/ipsec/sessions/searchPhase1'
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // searchPhase1 leaves phase1desc null when the connection carries no description, and the
+                  // discovery uses that field as the entity identity in every prototype key. name is always
+                  // set, so it stands in. Anyone who does have descriptions keeps the keys they already have.
+                  var rows = JSON.parse(value);
+                  for (var i = 0; i < rows.length; i++) {
+                      var desc = rows[i]['phase1desc'];
+                      if (desc === null || desc === undefined || String(desc).trim() === '') {
+                          rows[i]['phase1desc'] = rows[i]['name'];
+                      }
+                  }
+                  return JSON.stringify(rows);
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/ipsec/sessions/searchPhase1'
           tags:
             - tag: component
               value: raw
-        - uuid: 863da87dd15b47e98e34ee5cb0ecefc0
-          name: 'RAW IPsec Phase2'
-          type: HTTP_AGENT
-          key: opns.ipsec.phase2.raw
-          delay: 5m
-          history: 1d
-          value_type: TEXT
-          trends: '0'
-          status: DISABLED
-          authtype: BASIC
-          username: '{$OPNS.KEY}'
-          password: '{$OPNS.SECRET}'
+        - uuid: a799adbd842945c393c662dabd60c7bf
+          name: 'mbuf: Clusters in use'
+          type: DEPENDENT
+          key: opns.mbuf.cluster.current
+          delay: '0'
+          description: 'mbuf clusters currently taken from the fixed kernel pool. Grows with the number of packets in flight, not with configured memory.'
           preprocessing:
             - type: JSONPATH
               parameters:
-                - $.rows
-          url: 'https://{HOST.IP}/api/ipsec/sessions/searchPhase2'
+                - '$[''mbuf-statistics''][''cluster-current'']'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.mbuf.raw
+          tags:
+            - tag: component
+              value: memory
+        - uuid: caed05b0ee824b9197520f92a6080157
+          name: 'mbuf: Cluster limit'
+          type: DEPENDENT
+          key: opns.mbuf.cluster.max
+          delay: '0'
+          description: 'Upper bound of the cluster pool, set by kern.ipc.nmbclusters. Raising that sysctl is the remedy when the pool runs dry.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[''mbuf-statistics''][''cluster-max'']'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.mbuf.raw
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 3970a817b5844dc49e8612b688ffeb57
+          name: 'mbuf: Cluster utilization'
+          type: CALCULATED
+          key: opns.mbuf.cluster.pused
+          value_type: FLOAT
+          units: '%'
+          params: 'last(/{HOST.HOST}/opns.mbuf.cluster.current) / last(/{HOST.HOST}/opns.mbuf.cluster.max) * 100'
+          description: 'mbuf clusters are a fixed kernel pool. Once it is exhausted the firewall stops forwarding traffic while still answering ping and reporting free system memory, which makes this failure hard to recognise from the outside.'
+          tags:
+            - tag: component
+              value: memory
+          triggers:
+            - uuid: 05374d2308424522b850a3f997765671
+              expression: 'min(/OPNsense by HTTP-JSON/opns.mbuf.cluster.pused,5m)>{$OPNS.MBUF.UTIL.WARN}'
+              name: 'OPNsense: mbuf cluster pool is filling up'
+              priority: AVERAGE
+              description: 'Approaching the cluster limit. Raise kern.ipc.nmbclusters before it is reached, because exhaustion costs traffic, not just performance.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'OPNsense: Kernel denied network memory requests'
+                  expression: 'change(/OPNsense by HTTP-JSON/opns.mbuf.denied)>0'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: bb6b88bb2ef749828609f1141e5b7f04
+          name: 'mbuf: Denied requests'
+          type: DEPENDENT
+          key: opns.mbuf.denied
+          delay: '0'
+          description: 'Sum of the mbuf, cluster and packet allocation failures reported by the kernel. A cumulative counter since boot that should stay at zero for the entire uptime, so the trigger fires on any increase rather than on a threshold.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // netstat reports denials per pool. Any of them being non zero means the
+                  // kernel could not hand out network memory, so they are summed into one
+                  // figure. The jumbo pools are included because a firewall using jumbo
+                  // frames exhausts those first, while the regular counters stay at zero.
+                  var s = JSON.parse(value)['mbuf-statistics'];
+                  var fields = ['mbuf-failures', 'cluster-failures', 'packet-failures',
+                                'jumbop-failures', 'jumbo9-failures', 'jumbo16-failures'];
+                  var total = 0;
+                  for (var i = 0; i < fields.length; i++) {
+                      total += Number(s[fields[i]] || 0);
+                  }
+                  return total;
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.mbuf.raw
+          tags:
+            - tag: component
+              value: memory
+          triggers:
+            - uuid: 24bbc30008034ca78809fb34138c6880
+              expression: 'change(/OPNsense by HTTP-JSON/opns.mbuf.denied)>0'
+              name: 'OPNsense: Kernel denied network memory requests'
+              priority: HIGH
+              description: 'The kernel ran out of mbufs or clusters and dropped traffic. Raise kern.ipc.nmbclusters. The counter never decreases, so this fires once per new occurrence.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: 2d46d51f51e24538a58804d1060bbe0c
+          name: 'OPNsense: mbuf statistics (raw)'
+          type: HTTP_AGENT
+          key: opns.mbuf.raw
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Kernel network memory pool, the libxo output of netstat -m.'
+          timeout: 10s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/interface/get_memory_statistics'
           tags:
             - tag: component
               value: raw
@@ -415,6 +846,862 @@ zabbix_export:
               name: 'Memory utilization is high'
               opdata: '{ITEM.LASTVALUE}'
               priority: AVERAGE
+        - uuid: 9fd390edb9d442368ec9dd4619462559
+          name: 'netisr: Queue drops'
+          type: DEPENDENT
+          key: opns.netisr.queue.drops
+          delay: '0'
+          description: 'Packets discarded because a netisr queue was full, summed over all protocols and worker streams. This is the symptom of a firewall that cannot keep up with its offered load, and it is invisible in interface counters.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // netstat nests the per protocol work entries differently depending on
+                  // version, so walk the whole structure and add up every queue-drops
+                  // field found rather than relying on one fixed path.
+                  var total = 0;
+                  (function walk(node) {
+                      if (node === null || typeof node !== 'object') { return; }
+                      for (var k in node) {
+                          if (k === 'queue-drops') { total += Number(node[k]) || 0; }
+                          else { walk(node[k]); }
+                      }
+                  })(JSON.parse(value));
+                  return total;
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.netisr.raw
+          tags:
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 157bc55253b643dfac6468a383eb64aa
+              expression: 'change(/OPNsense by HTTP-JSON/opns.netisr.queue.drops)>0'
+              name: 'OPNsense: netisr queue is dropping packets'
+              priority: AVERAGE
+              description: 'The kernel discarded packets before they reached the firewall rules. Check load, interface queue lengths and net.isr tuning. The counter never decreases, so this fires once per new occurrence.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: cc982c2da6e84b499a00bcf229b9f14b
+          name: 'OPNsense: netisr statistics (raw)'
+          type: HTTP_AGENT
+          key: opns.netisr.raw
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Network dispatch queues, the libxo output of netstat -Q.'
+          timeout: 10s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/interface/get_netisr_statistics'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: e315b3130e6a49e0a0987a5cf3825f47
+          name: 'NTP: Offset of the selected peer'
+          type: DEPENDENT
+          key: opns.ntp.offset
+          delay: '0'
+          value_type: FLOAT
+          units: ms
+          description: 'How far the local clock sits from the peer it is currently steering by. A drifting firewall clock breaks IPsec, certificate validation and the correlation of its own logs, and it does so without any other symptom.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // ntpq marks the selected peer with * and a PPS reference with o.
+                  var rows = JSON.parse(value).rows || [];
+                  for (var i = 0; i < rows.length; i++) {
+                      if (rows[i].status === '*' || rows[i].status === 'o') {
+                          return parseFloat(rows[i].offset);
+                      }
+                  }
+                  throw 'no peer selected';
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.ntp.raw
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: caedb1b696a2448e8edba335e96c21cb
+              expression: 'abs(last(/OPNsense by HTTP-JSON/opns.ntp.offset))>{$OPNS.NTP.OFFSET.WARN}'
+              name: 'OPNsense: Clock offset is high'
+              priority: WARNING
+              description: 'The local clock has drifted away from its time source. Check reachability of the configured servers.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: e514dd4a3c714ec481903d904a4b8e37
+          name: 'NTP: Reachable peers'
+          type: DEPENDENT
+          key: opns.ntp.peers.reachable
+          delay: '0'
+          description: 'Configured time sources that have answered recently. Pool placeholders are excluded, they are not servers but slots the daemon still has to fill.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var rows = JSON.parse(value).rows || [];
+                  var n = 0;
+                  for (var i = 0; i < rows.length; i++) {
+                      if (rows[i].status !== '__pool' && Number(rows[i].reach) > 0) { n++; }
+                  }
+                  return n;
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.ntp.raw
+          tags:
+            - tag: component
+              value: system
+        - uuid: bbc5c47252694848928d86b23da16bb7
+          name: 'OPNsense: NTP peers (raw)'
+          type: HTTP_AGENT
+          key: opns.ntp.raw
+          delay: 5m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Peer list of the time daemon with selection state, stratum, reach, offset and jitter.'
+          timeout: 10s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/ntpd/service/status'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 3b86f0cbe51e48d09ec58454b58a58a5
+          name: 'NTP: Stratum of the selected peer'
+          type: DEPENDENT
+          key: opns.ntp.stratum
+          delay: '0'
+          description: 'Distance of the chosen source from a reference clock. A stratum of 16 means the daemon is not synchronised at all.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var rows = JSON.parse(value).rows || [];
+                  for (var i = 0; i < rows.length; i++) {
+                      if (rows[i].status === '*' || rows[i].status === 'o') {
+                          return parseInt(rows[i].stratum, 10);
+                      }
+                  }
+                  throw 'no peer selected';
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.ntp.raw
+          tags:
+            - tag: component
+              value: system
+        - uuid: f6c3f7bc06d54d118909a91bba02ab24
+          name: 'NTP: Synchronised'
+          type: DEPENDENT
+          key: opns.ntp.synced
+          delay: '0'
+          description: 'Whether the daemon has settled on a time source. Unsynchronised is the state that matters: the clock then follows nothing and drifts freely.'
+          valuemap:
+            name: 'NTP sync state'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var rows = JSON.parse(value).rows || [];
+                  for (var i = 0; i < rows.length; i++) {
+                      if (rows[i].status === '*' || rows[i].status === 'o') { return 1; }
+                  }
+                  return 0;
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 15m
+          master_item:
+            key: opns.ntp.raw
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: aca51d62c8d041678618bb662cb20ab8
+              expression: 'min(/OPNsense by HTTP-JSON/opns.ntp.synced,30m)=0'
+              name: 'OPNsense: Clock is not synchronised'
+              priority: WARNING
+              description: 'No time source has been selected for half an hour. Right after a boot this is normal for a few minutes, beyond that the configured servers are unreachable or refusing.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: dc3b29d8d01342c89e93624a219c6461
+          name: 'pf: Bad offset packets per second'
+          type: DEPENDENT
+          key: opns.pf.counter.badoffset.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Packets whose header offset field was invalid. Normally zero for the whole uptime.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.info.counters[''bad-offset''].rate'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: 2f21c1d3de1f4b04963b0ce7d89efd43
+              expression: 'last(/OPNsense by HTTP-JSON/opns.pf.counter.badoffset.rate)>0'
+              name: 'OPNsense: pf is seeing malformed packets'
+              priority: WARNING
+              description: 'Packets with a bad offset are normally zero. A sustained rate points at a broken sender or an attack.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: security
+        - uuid: ba3ac35e39ce46f9ba30c01ef9f25a6c
+          name: 'pf: Fragmented packets per second'
+          type: DEPENDENT
+          key: opns.pf.counter.fragment.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Fragmented packets seen by pf. Some fragmentation is normal, a rising rate usually means an MTU mismatch somewhere on the path.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters.fragment.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: e93c1b8370e24feaa04d70d2d197ca16
+          name: 'pf: Rule matches per second'
+          type: DEPENDENT
+          key: opns.pf.counter.match.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Packets that matched a filter rule. The general throughput measure of the ruleset.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters.match.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 8941892bb97a4a5e9b9a7ea4cc3012ba
+          name: 'pf: Packets dropped for memory per second'
+          type: DEPENDENT
+          key: opns.pf.counter.memdrop.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Packets dropped because pf could not allocate memory for a state or a fragment. Traffic is lost when this is non zero.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters.memory.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: b72715f8f5e04129b3b23d704bce2916
+              expression: 'last(/OPNsense by HTTP-JSON/opns.pf.counter.memdrop.rate)>0'
+              name: 'OPNsense: pf is dropping packets due to memory'
+              priority: HIGH
+              description: 'pf ran out of memory for states or fragments. Traffic is being lost. Check the state and table limits.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: 612c264c082548098cacbac4677fbef3
+          name: 'pf: Normalized packets per second'
+          type: DEPENDENT
+          key: opns.pf.counter.normalize.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Packets rewritten by scrub rules, most often reassembled fragments.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters.normalize.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 7a7f3d2546ba4e62b8166b65c4bcd9a2
+          name: 'pf: Short packets per second'
+          type: DEPENDENT
+          key: opns.pf.counter.short.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Packets shorter than their own header claimed. Normally zero, and malformed by definition.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters.short.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: b080b4750573457baa85f5bf028e0a66
+          name: 'pf: Source limit hits per second'
+          type: DEPENDENT
+          key: opns.pf.counter.srclimit.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Connections refused because one source exceeded the number of states its rule allows it.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.info.counters[''src-limit''].rate'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: 8a18a6c047454f8c923832a9c0a1f525
+              expression: 'last(/OPNsense by HTTP-JSON/opns.pf.counter.srclimit.rate)>0'
+              name: 'OPNsense: pf source limit is being hit'
+              priority: WARNING
+              description: 'A single source exceeded its allowed number of states.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: security
+        - uuid: 13efaaefa3984abf8686c6bda0d44544
+          name: 'pf: State limit hits per second'
+          type: DEPENDENT
+          key: opns.pf.counter.statelimit.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Connections refused because the state table is at its limit. Every one of these is a connection that did not happen.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.info.counters[''state-limit''].rate'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: ae286e3f31d242bcbdea99e5ee342b84
+              expression: 'last(/OPNsense by HTTP-JSON/opns.pf.counter.statelimit.rate)>0'
+              name: 'OPNsense: pf state limit is being hit'
+              priority: HIGH
+              description: 'New connections are refused because the state limit is reached. Raise the limit or find the source.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: de9bad9a394741fc98eb4853e8aac2b5
+          name: 'pf: State mismatches per second'
+          type: DEPENDENT
+          key: opns.pf.counter.statemismatch.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Packets that did not fit the state they were matched against. Isolated ones are normal on an asymmetric path, a sustained rate is not.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.info.counters[''state-mismatch''].rate'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 7ecd4704316c4aaeaac08f6dbec6e8a2
+          name: 'pf: Overload table insertions per second'
+          type: DEPENDENT
+          key: opns.pf.overload.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!/s'
+          description: 'Entries added to the overload table, where pf collects sources that tripped a connection rate limit. Rises during brute force attempts against an exposed service.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.info[''limit-counters''][''overload-table-insertion''].rate'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 2dd100eda96b468c9b9cfca66394c8ea
+          name: 'pf: Rule evaluations per second'
+          type: DEPENDENT
+          key: opns.pf.rules.evaluations.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!/s'
+          description: 'How many rule tests pf performs per second across the whole ruleset. Rises with traffic and with ruleset length, and shows what a reordering or a large alias table costs. The counters reset when the ruleset is reloaded, which the rate calculation absorbs by discarding the decrease.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // The backend nests every section under its own name, so the two
+                  // rule tables sit below "rules".
+                  var d = JSON.parse(value).rules;
+                  var total = 0;
+                  for (var section in d) {
+                      for (var rule in d[section]) {
+                          total += Number(d[section][rule].evaluations) || 0;
+                      }
+                  }
+                  return total;
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.pf.rules.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 31a2ced7cdc94f578a4aa83dd6608b29
+          name: 'pf: Filter rules loaded'
+          type: DEPENDENT
+          key: opns.pf.rules.filter.count
+          delay: '0'
+          description: 'Number of filter rules in the running ruleset. Counting instead of tracking the rules themselves keeps this to one item and survives a changing WAN address, which rewrites rule text without changing the rule count.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var d = JSON.parse(value).rules['filter rules'];
+                  return d === undefined ? 0 : Object.keys(d).length;
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.pf.rules.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: 8c8c0713140849af8eb358f145eeb262
+              expression: 'change(/OPNsense by HTTP-JSON/opns.pf.rules.filter.count)<>0 and last(/OPNsense by HTTP-JSON/opns.pf.rules.filter.count,#2)>0'
+              name: 'OPNsense: Number of filter rules has changed'
+              priority: INFO
+              description: 'Rules were added or removed. Useful for correlating a fault with a change to the ruleset. Edits to an existing rule do not change the count and are not detected. The second condition suppresses the jump out of a zero, which is what an item reports after a gap in collection rather than a real change.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 89d0bf73374049db98070a8a20d68bea
+          name: 'pf: Ruleset fingerprint'
+          type: DEPENDENT
+          key: opns.pf.rules.fingerprint
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Hash over the text of every filter and NAT rule, sorted so that reordering alone does not register. Catches what the rule counts cannot, namely an edit to an existing rule, which leaves the number of rules untouched. Counters are excluded from the hash, otherwise it would change with every packet. On a firewall whose WAN address changes, expect this to move with it. Rules written against an interface keep a symbolic form such as (vtnet0:1), but the generated anti-spoofing rules and every route-to statement embed the address literally; on the firewall this was measured against, 22 of 176 rules did so. The trigger is INFO for that reason, and a changed address is in fairness a changed ruleset.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Only the rule texts, which are the keys, never the counter values.
+                  var d = JSON.parse(value).rules;
+                  var rules = [];
+                  for (var section in d) {
+                      for (var rule in d[section]) { rules.push(section + '|' + rule); }
+                  }
+                  rules.sort();
+                  var s = rules.join('\n');
+                  // FNV-1a, 32 bit. No cryptography needed, only a stable fingerprint.
+                  var h = 0x811c9dc5;
+                  for (var i = 0; i < s.length; i++) {
+                      h ^= s.charCodeAt(i);
+                      h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+                  }
+                  return ('0000000' + h.toString(16)).slice(-8);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.pf.rules.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: 0f3795eef800436c9608e18941c5af2f
+              expression: 'last(/OPNsense by HTTP-JSON/opns.pf.rules.fingerprint,#1)<>last(/OPNsense by HTTP-JSON/opns.pf.rules.fingerprint,#2)'
+              name: 'OPNsense: Ruleset has changed'
+              priority: INFO
+              description: 'A rule was added, removed, edited or reworded. Together with the rule counts this separates the cases: if the counts moved as well, rules were added or removed, if they did not, an existing rule was edited.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 85865a270ab14c5594f455bf815a21db
+          name: 'pf: NAT rules loaded'
+          type: DEPENDENT
+          key: opns.pf.rules.nat.count
+          delay: '0'
+          description: 'Number of NAT rules in the running ruleset. Changes when the configuration is applied, so it works as a change signal.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var d = JSON.parse(value).rules['nat rules'];
+                  return d === undefined ? 0 : Object.keys(d).length;
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.pf.rules.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: 71eaa9231fc74ba4ba6bf67d3784e4fd
+              expression: 'change(/OPNsense by HTTP-JSON/opns.pf.rules.nat.count)<>0 and last(/OPNsense by HTTP-JSON/opns.pf.rules.nat.count,#2)>0'
+              name: 'OPNsense: Number of NAT rules has changed'
+              priority: INFO
+              description: 'NAT rules were added or removed. Edits to an existing rule leave the count unchanged and are not detected. The second condition suppresses the jump out of a zero, which is what an item reports after a gap in collection rather than a real change.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 23254b2fdf714394929fa2e0ab7c7f13
+          name: 'OPNsense: pf ruleset (raw)'
+          type: HTTP_AGENT
+          key: opns.pf.rules.raw
+          delay: 10m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Running filter and NAT ruleset with per rule counters. Polled every ten minutes because the response carries the full text of every rule and rule changes are not a per minute concern.'
+          timeout: 30s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/pf_statistics/rules'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 27c780cd0ab143f581931e5eb094a003
+          name: 'pf: Rules never matched'
+          type: DEPENDENT
+          key: opns.pf.rules.unused
+          delay: '0'
+          description: 'Rules with no evaluation since the ruleset was last loaded. Useful for spotting rules that no longer do anything, but only meaningful after a decent uptime: a reload resets every counter, so right after a configuration change this equals the total rule count. Deliberately has no trigger for that reason.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var d = JSON.parse(value).rules;
+                  var unused = 0;
+                  for (var section in d) {
+                      for (var rule in d[section]) {
+                          if (!Number(d[section][rule].evaluations)) { unused++; }
+                      }
+                  }
+                  return unused;
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.pf.rules.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: c52be2bd0cd34b0ba0bd44bb68f9d0c4
+          name: 'pf: Source nodes'
+          type: DEPENDENT
+          key: opns.pf.srcnodes.current
+          delay: '0'
+          description: 'Source tracking entries in use. One per client for rules using sticky-address or a source limit, so this grows with the number of distinct clients rather than with connections.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.info[''source-tracking-table''][''current-entries''].total'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: de50ef4f4a0f485591a701bade338961
+          name: 'pf: Source node limit'
+          type: DEPENDENT
+          key: opns.pf.srcnodes.limit
+          delay: '0'
+          description: 'Maximum number of source tracking entries pf will hold.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.memory[''src-nodes'']'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.pfmem.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 98c9265b96fa492d980e84732091c5ae
+          name: 'pf: Source tracking table utilization'
+          type: CALCULATED
+          key: opns.pf.srcnodes.pused
+          value_type: FLOAT
+          units: '%'
+          params: 'last(/{HOST.HOST}/opns.pf.srcnodes.current) / last(/{HOST.HOST}/opns.pf.srcnodes.limit) * 100'
+          description: 'Source tracking holds one entry per client for rules using sticky-address or source limits. Exhausting it rejects new connections from new clients while the state table still looks healthy.'
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: f7dfc74c0a6e4cc2a643884dca1c86c1
+              expression: 'min(/OPNsense by HTTP-JSON/opns.pf.srcnodes.pused,5m)>{$OPNS.PF.SRCNODES.UTIL.CRIT}'
+              name: 'OPNsense: pf source tracking table is filling up'
+              priority: HIGH
+              description: 'Once the limit is reached pf refuses connections from clients it has no entry for.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'OPNsense: pf source limit is being hit'
+                  expression: 'last(/OPNsense by HTTP-JSON/opns.pf.counter.srclimit.rate)>0'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: 322fda1a93024091927dba654a506c6f
+          name: 'pf: State table inserts per second'
+          type: DEPENDENT
+          key: opns.pf.states.inserts.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!/s'
+          description: 'New connections entering the state table per second.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.info[''state-table''].inserts.rate'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: b77df993555d44db8d33f491967fa1dd
+          name: 'pf: State table removals per second'
+          type: DEPENDENT
+          key: opns.pf.states.removals.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!/s'
+          description: 'Connections leaving the state table per second, through closure or timeout. Should roughly track the insert rate in steady state.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.info[''state-table''].removals.rate'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 0bf92a6230494f68ac64f20ea644325d
+          name: 'pf: State table searches per second'
+          type: DEPENDENT
+          key: opns.pf.states.searches.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!/s'
+          description: 'State table lookups per second, one or more per forwarded packet. The busiest counter on a loaded firewall.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.info[''state-table''].searches.rate'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: feb9ad9ec7594e228d7c7c4926537fd5
+          name: 'pf: SYN floods detected per second'
+          type: DEPENDENT
+          key: opns.pf.synfloods.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!/s'
+          description: 'Destinations for which pf switched to syncookies because half open connections piled up.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.info[''limit-counters''][''synfloods-detected''].rate'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: e84bd18ddd59451ca91b522233248f49
+              expression: 'last(/OPNsense by HTTP-JSON/opns.pf.synfloods.rate)>0'
+              name: 'OPNsense: SYN flood detected'
+              priority: AVERAGE
+              description: 'pf activated syncookies for at least one destination.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: security
+        - uuid: 8f5c2c83660f45e0925d42c0611cfb1e
+          name: 'pf: Table entry limit'
+          type: DEPENDENT
+          key: opns.pf.tables.entries.limit
+          delay: '0'
+          description: 'Ceiling for all pf table entries combined, from the firewall maximum table entries setting.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.size
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.alias.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: fd134ce22f674283905b771aceb76e85
+          name: 'pf: Table entry utilization'
+          type: CALCULATED
+          key: opns.pf.tables.entries.pused
+          delay: 10m
+          value_type: FLOAT
+          units: '%'
+          params: 'last(/{HOST.HOST}/opns.pf.tables.entries.used) / last(/{HOST.HOST}/opns.pf.tables.entries.limit) * 100'
+          description: 'How much of the table entry budget the aliases consume. Exceeding it is not a slow degradation: pf refuses to load a ruleset whose tables do not fit, so the firewall keeps running on the previous one and quietly ignores the change that was just applied.'
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: 6b24d27baf1b46039e265fbcaaf81692
+              expression: 'last(/OPNsense by HTTP-JSON/opns.pf.tables.entries.pused)>{$OPNS.PF.TABLES.UTIL.WARN}'
+              name: 'OPNsense: pf table entries are filling up'
+              priority: WARNING
+              description: 'Raise the maximum table entries setting before a block list update pushes the ruleset over the limit.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: 3bfe09a5c7c2487a9279b090a2c92a89
+          name: 'pf: Table entries in use'
+          type: DEPENDENT
+          key: opns.pf.tables.entries.used
+          delay: '0'
+          description: 'Addresses currently held across all pf tables, which is what aliases, block lists and GeoIP feeds fill.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.used
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.alias.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 6c3f7c1727c842429988d8e73ea9fbbb
+          name: 'OPNsense: pf statistics (raw)'
+          type: HTTP_AGENT
+          key: opns.pfinfo.raw
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Full pfctl -si output: state table, source tracking, counters and limit counters. Rates are already computed by pf.'
+          timeout: 10s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/pf_statistics/info'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: e4388324b7e849f7bc525378899ab118
+          name: 'OPNsense: pf limits (raw)'
+          type: HTTP_AGENT
+          key: opns.pfmem.raw
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Hard limits for states, source nodes, fragments and table entries. These change only with the configuration, but are polled at the same interval as the counters they are compared against: a calculated item goes unsupported while a referenced item has no data yet, so a slower interval here would leave the source tracking utilisation unsupported after every template link.'
+          timeout: 10s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/pf_statistics/memory'
+          tags:
+            - tag: component
+              value: raw
         - uuid: 90c1c7dd19ed45038ec9281727d8a32b
           name: 'Licensed until'
           type: DEPENDENT
@@ -451,6 +1738,168 @@ zabbix_export:
               name: 'OPNSense Business License expires soon'
               event_name: 'OPNSense Business License expires soon (less than {$OPNS.LICENSE.EXPIRY.WARN} days)'
               priority: AVERAGE
+        - uuid: 63f0a90248bd4b3eb3d35bb0f8fa39d7
+          name: 'IP: Packets with a bad checksum per second'
+          type: DEPENDENT
+          key: opns.proto.ip.badsum.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'IP packets discarded because the header checksum did not match. Steady non zero values point at a hardware or cabling fault rather than at an attack.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.statistics.ip[''dropped-bad-checksum'']'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.proto.raw
+          tags:
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 619e45fa09a84d97ab1e69be64aa5d4e
+              expression: 'min(/OPNsense by HTTP-JSON/opns.proto.ip.badsum.rate,10m)>0'
+              name: 'OPNsense: Receiving IP packets with bad checksums'
+              priority: WARNING
+              description: 'A sustained rate points at faulty cabling, a failing NIC or a broken device upstream. Occasional single packets are normal.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: hardware
+        - uuid: c2fd59cb775849c0b21a528fd92fab5c
+          name: 'IP: Fragments dropped per second'
+          type: DEPENDENT
+          key: opns.proto.ip.fragdrop.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Fragments the kernel could not reassemble. Typically an MTU problem, often on a tunnel.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.statistics.ip[''dropped-fragments'']'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.proto.raw
+          tags:
+            - tag: component
+              value: network
+        - uuid: 6a76597cb55b4b4c9cd0c34ba6481e9b
+          name: 'IP: Packets that cannot be forwarded per second'
+          type: DEPENDENT
+          key: opns.proto.ip.nofwd.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Packets the firewall was asked to route onward but could not, for instance because forwarding is disabled for that address family.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.statistics.ip[''packets-cannot-forward'']'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.proto.raw
+          tags:
+            - tag: component
+              value: network
+        - uuid: 3a72c3bfbda74d1f976290b89b7bd264
+          name: 'IP: Packets discarded for lack of a route per second'
+          type: DEPENDENT
+          key: opns.proto.ip.noroute.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Packets discarded because no route matched their destination. Rises when a gateway or a tunnel disappears while traffic for it keeps arriving.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.statistics.ip[''discard-no-route'']'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.proto.raw
+          tags:
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 95c5390a20834a1485d10045dcff43db
+              expression: 'min(/OPNsense by HTTP-JSON/opns.proto.ip.noroute.rate,10m)>0'
+              name: 'OPNsense: Packets discarded for lack of a route'
+              priority: WARNING
+              description: 'Traffic arrives for destinations the firewall has no route to. Check the routing table and whether a gateway or a tunnel went down.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: 46060d2fd9fa40d683d6b84b6282e3a3
+          name: 'OPNsense: Protocol statistics (raw)'
+          type: HTTP_AGENT
+          key: opns.proto.raw
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Per protocol kernel counters, the libxo output of netstat -s.'
+          timeout: 10s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/interface/get_protocol_statistics'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: a42cc0fb101b4e29a7ac1923b5cf4510
+          name: 'TCP: Segments with a bad checksum per second'
+          type: DEPENDENT
+          key: opns.proto.tcp.badsum.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'TCP segments discarded on a checksum mismatch, counted separately from the IP layer.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.statistics.tcp[''discard-bad-checksum'']'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.proto.raw
+          tags:
+            - tag: component
+              value: network
+        - uuid: 3a21c334425a4d09bf6ebedf6c402736
+          name: 'TCP: Retransmitted segments per second'
+          type: DEPENDENT
+          key: opns.proto.tcp.retrans.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: 'Retransmissions sent by the firewall itself, so this reflects the quality of its own connections rather than of forwarded traffic.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.statistics.tcp[''sent-retransmitted-packets'']'
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.proto.raw
+          tags:
+            - tag: component
+              value: network
         - uuid: 164f961df24a445aa57872068e5a1f99
           name: 'RAW Disk'
           type: HTTP_AGENT
@@ -566,7 +2015,7 @@ zabbix_export:
           authtype: BASIC
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
-          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/pfStates'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/pf_states'
           tags:
             - tag: component
               value: raw
@@ -655,7 +2104,7 @@ zabbix_export:
           authtype: BASIC
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
-          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/system/systemResources'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/system/system_resources'
           tags:
             - tag: component
               value: raw
@@ -674,80 +2123,20 @@ zabbix_export:
           tags:
             - tag: component
               value: raw
-        - uuid: e905ad319c8a402aaef8097eb2b6d5f3
-          name: 'RAW Trust - Certificates'
+        - uuid: 7e1830fb13344f22bff9b5c48d8ea779
+          name: 'OPNsense: Services (raw)'
           type: HTTP_AGENT
-          key: opns.raw.trust.certificates
+          key: opns.services.raw
           delay: 5m
-          history: 1d
+          history: '0'
           value_type: TEXT
           trends: '0'
           authtype: BASIC
           username: '{$OPNS.KEY}'
           password: '{$OPNS.SECRET}'
-          description: |
-            Needs permission:
-            System: Certificate Manager
-            
-            Warning:
-            This permission also allows retrieval of key material!
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$[*].*'
-            - type: JAVASCRIPT
-              parameters:
-                - |
-                  // The API doesn't allow filtering for fields.
-                  // To avoid saving key material we only return fields we want.
-                  // This also means if the API may return problematic fields in the future we still filter it.
-                  var certificateList = JSON.parse(value);
-                  
-                  var allowedFieldsArray = [
-                      "descr",
-                      "%caref",
-                      "key_type",
-                      "%key_type",
-                      "digest",
-                      "%digest",
-                      "cert_type",
-                      "%cert_type",
-                      "lifetime",
-                      "city",
-                      "state",
-                      "organization",
-                      "organizationalunit",
-                      "country",
-                      "email",
-                      "commonname",
-                      "ocsp_uri",
-                      "altnames_dns",
-                      "altnames_ip",
-                      "altnames_uri",
-                      "altnames_email",
-                      "rfc3280_purpose",
-                      "in_use",
-                      "is_user",
-                      "name",
-                      "valid_from",
-                      "valid_to"
-                  ];
-                  
-                  var filteredCertificateList = certificateList.map(function(singleCert) {
-                  
-                      var filteredCert = {};
-                  
-                      allowedFieldsArray.forEach(function(allowedField) {
-                          if (singleCert.hasOwnProperty(allowedField)) {
-                              filteredCert[allowedField] = singleCert[allowedField];
-                          }
-                      });
-                  
-                      return filteredCert;
-                  });
-                  
-                  return JSON.stringify(filteredCertificateList);
-          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/trust/cert/search/'
+          description: 'Run state of every service the firewall knows about, including the packet filter itself.'
+          timeout: 10s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/core/service/search'
           tags:
             - tag: component
               value: raw
@@ -770,6 +2159,95 @@ zabbix_export:
               opdata: 'Current utilization: {ITEM.LASTVALUE}'
               priority: WARNING
               description: 'Please check the number of connections.'
+        - uuid: b5d0b62b2cfb463d9f06e2d55beaeff7
+          name: 'OPNsense: Swap (raw)'
+          type: HTTP_AGENT
+          key: opns.swap.raw
+          delay: 5m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Swap devices with total and used, in KB. The list is empty on installations without swap, which is why the items below are discovered rather than static.'
+          timeout: 10s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/system/system_swap'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: cd32f2c3f23044d4bb622894333faef1
+          name: 'Load average (5 min)'
+          type: DEPENDENT
+          key: opns.system.load.avg5
+          delay: '0'
+          value_type: FLOAT
+          description: 'Run queue length averaged over five minutes. The value to alert on, since it ignores brief spikes.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var v = JSON.parse(value).loadavg.split(',');
+                  return parseFloat(v[1]);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 5m
+          master_item:
+            key: opns.raw.load
+          tags:
+            - tag: component
+              value: cpu
+          triggers:
+            - uuid: e99c64770ee94ec3855bcf85e1751f00
+              expression: 'avg(/OPNsense by HTTP-JSON/opns.system.load.avg5,10m)>{$OPNS.LOAD.AVG5.WARN}'
+              name: 'OPNsense: Load average is high'
+              priority: WARNING
+              description: 'The 5 minute average has been above the threshold for 10 minutes.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: performance
+        - uuid: 51cb5bcf0d00447f90e8ff439e8b24b3
+          name: 'Load average (15 min)'
+          type: DEPENDENT
+          key: opns.system.load.avg15
+          delay: '0'
+          value_type: FLOAT
+          description: 'Run queue length averaged over fifteen minutes. Shows whether a load is sustained or passing.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var v = JSON.parse(value).loadavg.split(',');
+                  return parseFloat(v[2]);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.raw.load
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: 957a08c26cc4473c99394ad6d0f3f269
+          name: 'Load average per core (5 min)'
+          type: CALCULATED
+          key: opns.system.load.percore
+          value_type: FLOAT
+          params: 'last(/{HOST.HOST}/opns.system.load.avg5) / last(/{HOST.HOST}/opns.cpu.cores)'
+          description: 'Five minute load divided by the number of cores. A load of 4 means saturation on a two core appliance and idling on a sixteen core one, so this is the figure that is comparable between firewalls. The API offers no true CPU utilisation, which makes this the closest available measure of saturation.'
+          tags:
+            - tag: component
+              value: cpu
+          triggers:
+            - uuid: 166479b7b0e140efb346fbb244fa7809
+              expression: 'avg(/OPNsense by HTTP-JSON/opns.system.load.percore,15m)>{$OPNS.LOAD.PERCORE.WARN}'
+              name: 'OPNsense: Load per core is high'
+              priority: WARNING
+              description: 'Sustained demand above what the cores can serve. Unlike the raw load average this does not need a per host threshold.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: performance
         - uuid: f58b046d6e554f129272472d79f00389
           name: 'System Uptime'
           type: DEPENDENT
@@ -813,6 +2291,22 @@ zabbix_export:
               expression: 'last(/OPNsense by HTTP-JSON/opns.system.uptime)<600'
               name: '{HOST.NAME} has been restarted'
               priority: INFO
+        - uuid: 484bc3e86f734ff291418e0664a021d5
+          name: 'OPNsense: Temperature sensors (raw)'
+          type: HTTP_AGENT
+          key: opns.temperature.raw
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Sensor readings as a JSON array. Hardware without sensors, notably virtual machines, returns an empty array, so nothing is discovered and no item goes unsupported.'
+          timeout: 10s
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/system/system_temperature'
+          tags:
+            - tag: component
+              value: raw
         - uuid: 4dee0747d2ef4530999ae8535d8aba49
           name: 'RAW UPS'
           type: HTTP_AGENT
@@ -848,6 +2342,36 @@ zabbix_export:
           tags:
             - tag: component
               value: raw
+        - uuid: 7a9c72c0889042908e5a708ff03e456d
+          name: 'OPNsense: Version'
+          type: DEPENDENT
+          key: opns.version
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Product name, version and architecture as one string. Changes after an update was applied.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.product_version
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.raw.product.info
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 2c12511453b041a58e641bebd5efa0f6
+              expression: 'last(/OPNsense by HTTP-JSON/opns.version,#1)<>last(/OPNsense by HTTP-JSON/opns.version,#2)'
+              name: 'OPNsense: Version has changed'
+              priority: INFO
+              description: 'An update was most likely applied.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
         - uuid: 7945ce5b7e174b9e8f6ea6da6dd64060
           name: 'RAW WireGuard'
           type: HTTP_AGENT
@@ -1809,6 +3333,355 @@ zabbix_export:
                   value: '{#IPSECNAME}'
                 - tag: 'IPSEC Phase1'
                   value: '{#IPSECNAME}'
+            - uuid: bd094323b26645a4952de246b3ff4912
+              name: '{#IPSECDESC} bytes-in per second'
+              type: DEPENDENT
+              key: 'opn.ipsecph2.bytes.in.second[{#IPSECDESC}]'
+              delay: '0'
+              trends: '0'
+              units: Bps
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      // One request per connection, so every row is a child SA of this tunnel. searchPhase1
+                      // aggregates its own counters the same way. A missing field is reported rather than
+                      // silently summed as zero, which would look like an idle tunnel.
+                      var rows = JSON.parse(value), total = 0, seen = 0;
+                      if (rows.length === 0) { throw 'connection has no child SA'; }
+                      for (var i = 0; i < rows.length; i++) {
+                          var v = rows[i]['bytes-in'];
+                          if (v === null || v === undefined) { continue; }
+                          total += Number(v) || 0;
+                          seen++;
+                      }
+                      if (seen === 0) { throw 'no child SA reports bytes-in'; }
+                      return total;
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              master_item:
+                key: 'opns.ipsec.phase2.raw[{#IPSECNAME}]'
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase2'
+                  value: '{#IPSECNAME}'
+            - uuid: 87d602f4b186490db33bde839ba155d1
+              name: '{#IPSECDESC} bytes-in'
+              type: DEPENDENT
+              key: 'opn.ipsecph2.bytes.in[{#IPSECDESC}]'
+              delay: '0'
+              trends: '0'
+              units: B
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      // One request per connection, so every row is a child SA of this tunnel. searchPhase1
+                      // aggregates its own counters the same way. A missing field is reported rather than
+                      // silently summed as zero, which would look like an idle tunnel.
+                      var rows = JSON.parse(value), total = 0, seen = 0;
+                      if (rows.length === 0) { throw 'connection has no child SA'; }
+                      for (var i = 0; i < rows.length; i++) {
+                          var v = rows[i]['bytes-in'];
+                          if (v === null || v === undefined) { continue; }
+                          total += Number(v) || 0;
+                          seen++;
+                      }
+                      if (seen === 0) { throw 'no child SA reports bytes-in'; }
+                      return total;
+              master_item:
+                key: 'opns.ipsec.phase2.raw[{#IPSECNAME}]'
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase2'
+                  value: '{#IPSECNAME}'
+            - uuid: bdf51a903bfd4fe1b82e633005ce68ab
+              name: '{#IPSECDESC} bytes-out per second'
+              type: DEPENDENT
+              key: 'opn.ipsecph2.bytes.out.second[{#IPSECDESC}]'
+              delay: '0'
+              trends: '0'
+              units: Bps
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      // One request per connection, so every row is a child SA of this tunnel. searchPhase1
+                      // aggregates its own counters the same way. A missing field is reported rather than
+                      // silently summed as zero, which would look like an idle tunnel.
+                      var rows = JSON.parse(value), total = 0, seen = 0;
+                      if (rows.length === 0) { throw 'connection has no child SA'; }
+                      for (var i = 0; i < rows.length; i++) {
+                          var v = rows[i]['bytes-out'];
+                          if (v === null || v === undefined) { continue; }
+                          total += Number(v) || 0;
+                          seen++;
+                      }
+                      if (seen === 0) { throw 'no child SA reports bytes-out'; }
+                      return total;
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              master_item:
+                key: 'opns.ipsec.phase2.raw[{#IPSECNAME}]'
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase2'
+                  value: '{#IPSECNAME}'
+            - uuid: 03157dc913264295a572ca7173111976
+              name: '{#IPSECDESC} bytes-out'
+              type: DEPENDENT
+              key: 'opn.ipsecph2.bytes.out[{#IPSECDESC}]'
+              delay: '0'
+              trends: '0'
+              units: B
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      // One request per connection, so every row is a child SA of this tunnel. searchPhase1
+                      // aggregates its own counters the same way. A missing field is reported rather than
+                      // silently summed as zero, which would look like an idle tunnel.
+                      var rows = JSON.parse(value), total = 0, seen = 0;
+                      if (rows.length === 0) { throw 'connection has no child SA'; }
+                      for (var i = 0; i < rows.length; i++) {
+                          var v = rows[i]['bytes-out'];
+                          if (v === null || v === undefined) { continue; }
+                          total += Number(v) || 0;
+                          seen++;
+                      }
+                      if (seen === 0) { throw 'no child SA reports bytes-out'; }
+                      return total;
+              master_item:
+                key: 'opns.ipsec.phase2.raw[{#IPSECNAME}]'
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase2'
+                  value: '{#IPSECNAME}'
+            - uuid: 2a092b018aa144aca810863f3db76906
+              name: '{#IPSECDESC} mode'
+              type: DEPENDENT
+              key: 'opn.ipsecph2.mode[{#IPSECDESC}]'
+              delay: '0'
+              value_type: TEXT
+              trends: '0'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      var rows = JSON.parse(value);
+                      if (rows.length === 0) { throw 'connection has no child SA'; }
+                      var v = rows[0]['mode'];
+                      if (v === null || v === undefined) { throw 'child SA does not report mode'; }
+                      return v;
+              master_item:
+                key: 'opns.ipsec.phase2.raw[{#IPSECNAME}]'
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase2'
+                  value: '{#IPSECNAME}'
+            - uuid: 413359f74125473b9016a77062d25a6f
+              name: '{#IPSECDESC} packets-in per second'
+              type: DEPENDENT
+              key: 'opn.ipsecph2.packets.in.second[{#IPSECDESC}]'
+              delay: '0'
+              trends: '0'
+              units: P/s
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      // One request per connection, so every row is a child SA of this tunnel. searchPhase1
+                      // aggregates its own counters the same way. A missing field is reported rather than
+                      // silently summed as zero, which would look like an idle tunnel.
+                      var rows = JSON.parse(value), total = 0, seen = 0;
+                      if (rows.length === 0) { throw 'connection has no child SA'; }
+                      for (var i = 0; i < rows.length; i++) {
+                          var v = rows[i]['packets-in'];
+                          if (v === null || v === undefined) { continue; }
+                          total += Number(v) || 0;
+                          seen++;
+                      }
+                      if (seen === 0) { throw 'no child SA reports packets-in'; }
+                      return total;
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              master_item:
+                key: 'opns.ipsec.phase2.raw[{#IPSECNAME}]'
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase2'
+                  value: '{#IPSECNAME}'
+            - uuid: f6a1a0e363fc484c94a962827e4f8dfa
+              name: '{#IPSECDESC} packets-in'
+              type: DEPENDENT
+              key: 'opn.ipsecph2.packets.in[{#IPSECDESC}]'
+              delay: '0'
+              trends: '0'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      // One request per connection, so every row is a child SA of this tunnel. searchPhase1
+                      // aggregates its own counters the same way. A missing field is reported rather than
+                      // silently summed as zero, which would look like an idle tunnel.
+                      var rows = JSON.parse(value), total = 0, seen = 0;
+                      if (rows.length === 0) { throw 'connection has no child SA'; }
+                      for (var i = 0; i < rows.length; i++) {
+                          var v = rows[i]['packets-in'];
+                          if (v === null || v === undefined) { continue; }
+                          total += Number(v) || 0;
+                          seen++;
+                      }
+                      if (seen === 0) { throw 'no child SA reports packets-in'; }
+                      return total;
+              master_item:
+                key: 'opns.ipsec.phase2.raw[{#IPSECNAME}]'
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase2'
+                  value: '{#IPSECNAME}'
+            - uuid: ec29b5514f084eaabdf307268f69157e
+              name: '{#IPSECDESC} packets-out per second'
+              type: DEPENDENT
+              key: 'opn.ipsecph2.packets.out.second[{#IPSECDESC}]'
+              delay: '0'
+              trends: '0'
+              units: P/s
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      // One request per connection, so every row is a child SA of this tunnel. searchPhase1
+                      // aggregates its own counters the same way. A missing field is reported rather than
+                      // silently summed as zero, which would look like an idle tunnel.
+                      var rows = JSON.parse(value), total = 0, seen = 0;
+                      if (rows.length === 0) { throw 'connection has no child SA'; }
+                      for (var i = 0; i < rows.length; i++) {
+                          var v = rows[i]['packets-out'];
+                          if (v === null || v === undefined) { continue; }
+                          total += Number(v) || 0;
+                          seen++;
+                      }
+                      if (seen === 0) { throw 'no child SA reports packets-out'; }
+                      return total;
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              master_item:
+                key: 'opns.ipsec.phase2.raw[{#IPSECNAME}]'
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase2'
+                  value: '{#IPSECNAME}'
+            - uuid: c680fb86f53f41639ee5a921c9b0a159
+              name: '{#IPSECDESC} packets-out'
+              type: DEPENDENT
+              key: 'opn.ipsecph2.packets.out[{#IPSECDESC}]'
+              delay: '0'
+              trends: '0'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      // One request per connection, so every row is a child SA of this tunnel. searchPhase1
+                      // aggregates its own counters the same way. A missing field is reported rather than
+                      // silently summed as zero, which would look like an idle tunnel.
+                      var rows = JSON.parse(value), total = 0, seen = 0;
+                      if (rows.length === 0) { throw 'connection has no child SA'; }
+                      for (var i = 0; i < rows.length; i++) {
+                          var v = rows[i]['packets-out'];
+                          if (v === null || v === undefined) { continue; }
+                          total += Number(v) || 0;
+                          seen++;
+                      }
+                      if (seen === 0) { throw 'no child SA reports packets-out'; }
+                      return total;
+              master_item:
+                key: 'opns.ipsec.phase2.raw[{#IPSECNAME}]'
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase2'
+                  value: '{#IPSECNAME}'
+            - uuid: 187a9213483e4ed2bef55c1464c9d2cf
+              name: '{#IPSECDESC} state'
+              type: DEPENDENT
+              key: 'opn.ipsecph2.state[{#IPSECDESC}]'
+              delay: '0'
+              value_type: TEXT
+              trends: '0'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      var rows = JSON.parse(value);
+                      if (rows.length === 0) { throw 'connection has no child SA'; }
+                      var v = rows[0]['state'];
+                      if (v === null || v === undefined) { throw 'child SA does not report state'; }
+                      return v;
+              master_item:
+                key: 'opns.ipsec.phase2.raw[{#IPSECNAME}]'
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase2'
+                  value: '{#IPSECNAME}'
+            - uuid: 3b4c41e92a0e48ebb97dfa5be3efb113
+              name: 'IPsec {#IPSECDESC}: phase 2 (raw)'
+              type: HTTP_AGENT
+              key: 'opns.ipsec.phase2.raw[{#IPSECNAME}]'
+              delay: 5m
+              history: '0'
+              value_type: TEXT
+              trends: '0'
+              authtype: BASIC
+              username: '{$OPNS.KEY}'
+              password: '{$OPNS.SECRET}'
+              description: 'Child SAs of this connection. The endpoint takes the connection through a POST parameter and returns an empty set without it, which is why this is one request per tunnel rather than a single master item. The identifier is the name field of the phase 1 row, the same value the web interface sends.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.rows
+              timeout: 15s
+              url: 'https://{HOST.IP}:{$OPNS.PORT}/api/ipsec/sessions/search_phase2'
+              posts: 'id={#IPSECNAME}'
+              headers:
+                - name: Content-Type
+                  value: application/x-www-form-urlencoded
+              tags:
+                - tag: component
+                  value: raw
           trigger_prototypes:
             - uuid: 5d24b625aaa3450bbce7da3fd28f14aa
               expression: '(change(/OPNsense by HTTP-JSON/opn.ipsecph1.bytes.out.total[{#IPSECDESC}])=0 or change(/OPNsense by HTTP-JSON/opn.ipsecph1.bytes.in.total[{#IPSECDESC}])=0) and find(/OPNsense by HTTP-JSON/opn.ipsecph1.connected[{#IPSECDESC}],,"like","connected")=1'
@@ -1821,331 +3694,396 @@ zabbix_export:
               path: $.phase1desc
             - lld_macro: '{#IPSECNAME}'
               path: $.name
-        - uuid: 2b2e4dd4b2184511b0e2c230d26ded95
-          name: 'IPsec Phase2 Discovery'
+        - uuid: 97b7888c8a29465cb6a2aae5b64ca451
+          name: 'Network interfaces (link state and inbound errors)'
           type: DEPENDENT
-          key: opns.ipsec.phase2.discovery
+          key: opns.net.if.discovery
           delay: '0'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#IFNAME}'
+                value: '{$OPNS.IF.NAME.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: A
+          description: 'One entry per physical and virtual interface. Only link level rows are used, because the per address rows count traffic per IP rather than per interface. Interfaces matching the exclusion macro are skipped.'
           item_prototypes:
-            - uuid: d97aa8c0e15040c584585e005c00b554
-              name: '{#IPSECDESC} bytes-in per second'
+            - uuid: d93fd3588dfd4321bd68f575de0bdfec
+              name: 'Interface {#IFALIAS} ({#IFNAME}): Inbound errors'
               type: DEPENDENT
-              key: 'opn.ipsecph2.bytes.in.second[{#IPSECDESC}]'
+              key: 'opns.net.if.in.errors[{#IFNAME}]'
               delay: '0'
-              trends: '0'
-              units: Bps
+              value_type: FLOAT
+              description: 'Receive errors on this interface. Points at cabling, an optic or the link partner.'
               preprocessing:
-                - type: JSONPATH
+                - type: JAVASCRIPT
                   parameters:
-                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["bytes-in"].first()'
+                    - |
+                      var d = JSON.parse(value).statistics;
+                      for (var k in d) {
+                          var e = d[k];
+                          if (e.name === '{#IFNAME}' && String(e.network).indexOf('<Link') === 0) {
+                              return e['received-errors'];
+                          }
+                      }
+                      throw 'interface {#IFNAME} not found';
                 - type: CHANGE_PER_SECOND
                   parameters:
                     - ''
               master_item:
-                key: opns.ipsec.phase2.raw
+                key: opns.ifstats.raw
               tags:
-                - tag: IPSEC
-                  value: '{#IPSECDESC}'
-                - tag: IPSEC
-                  value: '{#IPSECNAME}'
-                - tag: 'IPSEC Phase2'
-                  value: '{#IPSECNAME}'
-            - uuid: df38a66c1aef47eb983908c2e0d866e9
-              name: '{#IPSECDESC} bytes-in'
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: a05161181dd248f48ef81aa075502177
+              name: 'Interface {#IFALIAS} ({#IFNAME}): Link status'
               type: DEPENDENT
-              key: 'opn.ipsecph2.bytes.in[{#IPSECDESC}]'
+              key: 'opns.net.if.status[{#IFNAME}]'
               delay: '0'
-              trends: '0'
-              units: B
+              description: 'Derived from the BSD interface flags: bit 0 is UP, the administrative state, and bit 6 is RUNNING, which is set once the interface has a usable link. Both must be set for the interface to count as up.'
+              valuemap:
+                name: 'Link status'
               preprocessing:
-                - type: JSONPATH
+                - type: JAVASCRIPT
                   parameters:
-                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["bytes-in"].first()'
+                    - |
+                      var d = JSON.parse(value).statistics;
+                      for (var k in d) {
+                          var e = d[k];
+                          if (e.name === '{#IFNAME}' && String(e.network).indexOf('<Link') === 0) {
+                              // flags arrive as a hex string such as "0x8843"
+                              var f = parseInt(e.flags, 16);
+                              return (f & 0x1) && (f & 0x40) ? 1 : 0;
+                          }
+                      }
+                      throw 'interface {#IFNAME} not found';
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
-                key: opns.ipsec.phase2.raw
+                key: opns.ifstats.raw
               tags:
-                - tag: IPSEC
-                  value: '{#IPSECDESC}'
-                - tag: IPSEC
-                  value: '{#IPSECNAME}'
-                - tag: 'IPSEC Phase2'
-                  value: '{#IPSECNAME}'
-            - uuid: 10458f1b234e4bca98560bf4a8277bbd
-              name: '{#IPSECDESC} bytes-out per second'
-              type: DEPENDENT
-              key: 'opn.ipsecph2.bytes.out.second[{#IPSECDESC}]'
-              delay: '0'
-              trends: '0'
-              units: Bps
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["bytes-out"].first()'
-                - type: CHANGE_PER_SECOND
-                  parameters:
-                    - ''
-              master_item:
-                key: opns.ipsec.phase2.raw
-              tags:
-                - tag: IPSEC
-                  value: '{#IPSECDESC}'
-                - tag: IPSEC
-                  value: '{#IPSECNAME}'
-                - tag: 'IPSEC Phase2'
-                  value: '{#IPSECNAME}'
-            - uuid: 518f612b8fe94fd78167023f218ae02d
-              name: '{#IPSECDESC} bytes-out'
-              type: DEPENDENT
-              key: 'opn.ipsecph2.bytes.out[{#IPSECDESC}]'
-              delay: '0'
-              trends: '0'
-              units: B
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["bytes-out"].first()'
-              master_item:
-                key: opns.ipsec.phase2.raw
-              tags:
-                - tag: IPSEC
-                  value: '{#IPSECDESC}'
-                - tag: IPSEC
-                  value: '{#IPSECNAME}'
-                - tag: 'IPSEC Phase2'
-                  value: '{#IPSECNAME}'
-            - uuid: 4597e12f5486417b97bafaf81c82e37b
-              name: '{#IPSECDESC} mode'
-              type: DEPENDENT
-              key: 'opn.ipsecph2.mode[{#IPSECDESC}]'
-              delay: '0'
-              value_type: TEXT
-              trends: '0'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["mode"].first()'
-              master_item:
-                key: opns.ipsec.phase2.raw
-              tags:
-                - tag: IPSEC
-                  value: '{#IPSECDESC}'
-                - tag: IPSEC
-                  value: '{#IPSECNAME}'
-                - tag: 'IPSEC Phase2'
-                  value: '{#IPSECNAME}'
-            - uuid: 839c225230c945a1b0c26c22bbae0714
-              name: '{#IPSECDESC} packets-in per second'
-              type: DEPENDENT
-              key: 'opn.ipsecph2.packets.in.second[{#IPSECDESC}]'
-              delay: '0'
-              trends: '0'
-              units: P/s
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["packets-in"].first()'
-                - type: CHANGE_PER_SECOND
-                  parameters:
-                    - ''
-              master_item:
-                key: opns.ipsec.phase2.raw
-              tags:
-                - tag: IPSEC
-                  value: '{#IPSECDESC}'
-                - tag: IPSEC
-                  value: '{#IPSECNAME}'
-                - tag: 'IPSEC Phase2'
-                  value: '{#IPSECNAME}'
-            - uuid: 9792202103774e50878da59c99d77f67
-              name: '{#IPSECDESC} packets-in'
-              type: DEPENDENT
-              key: 'opn.ipsecph2.packets.in[{#IPSECDESC}]'
-              delay: '0'
-              trends: '0'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["packets-in"].first()'
-              master_item:
-                key: opns.ipsec.phase2.raw
-              tags:
-                - tag: IPSEC
-                  value: '{#IPSECDESC}'
-                - tag: IPSEC
-                  value: '{#IPSECNAME}'
-                - tag: 'IPSEC Phase2'
-                  value: '{#IPSECNAME}'
-            - uuid: eb2bcadcdc914f97a93092466b127612
-              name: '{#IPSECDESC} packets-out per second'
-              type: DEPENDENT
-              key: 'opn.ipsecph2.packets.out.second[{#IPSECDESC}]'
-              delay: '0'
-              trends: '0'
-              units: P/s
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["packets-out"].first()'
-                - type: CHANGE_PER_SECOND
-                  parameters:
-                    - ''
-              master_item:
-                key: opns.ipsec.phase2.raw
-              tags:
-                - tag: IPSEC
-                  value: '{#IPSECDESC}'
-                - tag: IPSEC
-                  value: '{#IPSECNAME}'
-                - tag: 'IPSEC Phase2'
-                  value: '{#IPSECNAME}'
-            - uuid: 2e9be92ccd6b42caa2db637e65671d0b
-              name: '{#IPSECDESC} packets-out'
-              type: DEPENDENT
-              key: 'opn.ipsecph2.packets.out[{#IPSECDESC}]'
-              delay: '0'
-              trends: '0'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["packets-out"].first()'
-              master_item:
-                key: opns.ipsec.phase2.raw
-              tags:
-                - tag: IPSEC
-                  value: '{#IPSECDESC}'
-                - tag: IPSEC
-                  value: '{#IPSECNAME}'
-                - tag: 'IPSEC Phase2'
-                  value: '{#IPSECNAME}'
-            - uuid: 08b982f6f1d64a50bd45359386b7d8bf
-              name: '{#IPSECDESC} state'
-              type: DEPENDENT
-              key: 'opn.ipsecph2.state[{#IPSECDESC}]'
-              delay: '0'
-              value_type: TEXT
-              trends: '0'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["state"].first()'
-              master_item:
-                key: opns.ipsec.phase2.raw
-              tags:
-                - tag: IPSEC
-                  value: '{#IPSECDESC}'
-                - tag: IPSEC
-                  value: '{#IPSECNAME}'
-                - tag: 'IPSEC Phase2'
-                  value: '{#IPSECNAME}'
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+              trigger_prototypes:
+                - uuid: 99f06b8dbc2d42dca9be0aa9b2cf6692
+                  expression: 'last(/OPNsense by HTTP-JSON/opns.net.if.status[{#IFNAME}])=0 and {$OPNS.IF.CONTROL:"{#IFNAME}"}=1'
+                  name: 'OPNsense: Interface {#IFALIAS} ({#IFNAME}) is down'
+                  priority: AVERAGE
+                  description: 'The link is gone or the interface was shut down. Set {$OPNS.IF.CONTROL:"{#IFNAME}"} to 0 for interfaces that are allowed to be down, such as a cold standby uplink.'
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: availability
           master_item:
-            key: opns.ipsec.phase2.raw
+            key: opns.ifstats.raw
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var d = JSON.parse(value).statistics;
+                  var seen = {};
+                  var out = [];
+                  for (var k in d) {
+                      var e = d[k];
+                      // Only the link level carries the interface counters, the IP rows count per address.
+                      if (String(e.network).indexOf('<Link') !== 0) { continue; }
+                      if (seen[e.name]) { continue; }
+                      seen[e.name] = true;
+                      out.push({'{#IFNAME}': e.name, '{#IFALIAS}': k.replace(/^\[([^\]]*)\].*$/, '$1')});
+                  }
+                  return JSON.stringify(out);
+        - uuid: 9274632975e543eeb768432cf34229d1
+          name: 'netisr queues'
+          type: DEPENDENT
+          key: opns.netisr.discovery
+          delay: '0'
+          description: 'One entry per protocol queue. The summed counter alerts, these tell you which queue is the one overflowing.'
+          item_prototypes:
+            - uuid: 7d4bda8e53b24a30b3a05c93967ba2b2
+              name: 'netisr {#NETISR.PROTO}: Queue drops'
+              type: DEPENDENT
+              key: 'opns.netisr.queue.drops[{#NETISR.PROTO}]'
+              delay: '0'
+              value_type: FLOAT
+              units: '!/s'
+              description: 'Packets discarded from this protocol queue before reaching the firewall rules. Identifies which queue the summed counter is reacting to.'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      // Entries for one protocol exist once per worker stream, so the
+                      // drops of this protocol are summed across all of them.
+                      var total = null;
+                      (function walk(node) {
+                          if (node === null || typeof node !== 'object') { return; }
+                          if (node.name === '{#NETISR.PROTO}' && node['queue-drops'] !== undefined) {
+                              total = (total || 0) + (Number(node['queue-drops']) || 0);
+                              return;
+                          }
+                          for (var k in node) { walk(node[k]); }
+                      })(JSON.parse(value));
+                      if (total === null) { throw 'netisr protocol {#NETISR.PROTO} not found'; }
+                      return total;
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              master_item:
+                key: opns.netisr.raw
+              tags:
+                - tag: component
+                  value: network
+                - tag: protocol
+                  value: '{#NETISR.PROTO}'
+          master_item:
+            key: opns.netisr.raw
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // The per protocol entries sit at a nesting depth that varies between
+                  // netstat versions, so collect them by shape rather than by path.
+                  var seen = {};
+                  (function walk(node) {
+                      if (node === null || typeof node !== 'object') { return; }
+                      if (node.name !== undefined && node['queue-drops'] !== undefined) {
+                          seen[node.name] = true;
+                          return;
+                      }
+                      for (var k in node) { walk(node[k]); }
+                  })(JSON.parse(value));
+                  var out = [];
+                  for (var p in seen) { out.push({'{#NETISR.PROTO}': p}); }
+                  return JSON.stringify(out);
+        - uuid: a2223a933a864f468e3d949dff5b2ffe
+          name: Services
+          type: DEPENDENT
+          key: opns.services.discovery
+          delay: '0'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#SERVICE.ID}'
+                value: '{$OPNS.SERVICE.ID.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: A
+          description: 'One entry per known service. Discovery keys on the identifier rather than the name, because a name can appear twice: the DHCP server registers once for IPv4 and once for IPv6 under the same name but distinct identifiers.'
+          item_prototypes:
+            - uuid: 20e7948537fb4044b37ae8e752d72239
+              name: 'Service {#SERVICE.DESCRIPTION}: Running'
+              type: DEPENDENT
+              key: 'opns.service.running[{#SERVICE.ID}]'
+              delay: '0'
+              description: 'Whether this service is running. The packet filter itself appears here, so a firewall that has been disabled while staying reachable becomes visible.'
+              valuemap:
+                name: 'Service state'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      var rows = JSON.parse(value).rows || [];
+                      for (var i = 0; i < rows.length; i++) {
+                          if (rows[i].id === '{#SERVICE.ID}') { return Number(rows[i].running) ? 1 : 0; }
+                      }
+                      throw 'service {#SERVICE.ID} not found';
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 3m
+              master_item:
+                key: opns.services.raw
+              tags:
+                - tag: component
+                  value: service
+                - tag: service
+                  value: '{#SERVICE.ID}'
+              trigger_prototypes:
+                - uuid: c30ad696fb574fc184b0da9ce93d274b
+                  expression: 'min(/OPNsense by HTTP-JSON/opns.service.running[{#SERVICE.ID}],5m)=0'
+                  name: 'OPNsense: Service {#SERVICE.DESCRIPTION} is not running'
+                  priority: AVERAGE
+                  description: 'The service has been down for five minutes. Add it to {$OPNS.SERVICE.ID.NOT_MATCHES} if it is not supposed to run on this firewall.'
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: availability
+          master_item:
+            key: opns.services.raw
           lld_macro_paths:
-            - lld_macro: '{#IPSECDESC}'
-              path: $.phase2desc
-            - lld_macro: '{#IPSECNAME}'
+            - lld_macro: '{#SERVICE.DESCRIPTION}'
+              path: $.description
+            - lld_macro: '{#SERVICE.ID}'
+              path: $.id
+            - lld_macro: '{#SERVICE.NAME}'
               path: $.name
-        - uuid: fc1eb6072f754528829cad74ae0e3df3
-          name: 'Certificates discovery'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows
+        - uuid: 2a93a8c702dc4c1ea109451af490c6ec
+          name: 'Swap devices'
           type: DEPENDENT
-          key: opns.trust.certificates.discovery
+          key: opns.swap.discovery
           delay: '0'
+          description: 'Discovers nothing on installations without swap, which keeps the template free of unsupported items there.'
           item_prototypes:
-            - uuid: 1024f69ff1984a4abbdba3855e44ac63
-              name: '{#DESCRIPTION} commonname'
+            - uuid: 1166d726f308446e9d7180ec1a082abc
+              name: 'Swap {#SWAPDEV}: utilization'
               type: DEPENDENT
-              key: 'opns.trust.certificates.discovery.commonname[{#DESCRIPTION}]'
+              key: 'opns.swap.pused[{#SWAPDEV}]'
               delay: '0'
-              value_type: TEXT
-              trends: '0'
+              value_type: FLOAT
+              units: '%'
+              description: 'Fill level of this swap device. A firewall that swaps at all is short on memory.'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      var d = JSON.parse(value).swap;
+                      for (var i = 0; i < d.length; i++) {
+                          if (d[i].device === '{#SWAPDEV}') {
+                              var total = Number(d[i].total);
+                              if (!total) { return 0; }
+                              return Number(d[i].used) / total * 100;
+                          }
+                      }
+                      throw 'swap device {#SWAPDEV} not found';
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 5m
+              master_item:
+                key: opns.swap.raw
+              tags:
+                - tag: component
+                  value: memory
+                - tag: swapdev
+                  value: '{#SWAPDEV}'
+              trigger_prototypes:
+                - uuid: 1b9f813cf6d4447192279e316ce1a033
+                  expression: 'min(/OPNsense by HTTP-JSON/opns.swap.pused[{#SWAPDEV}],10m)>{$OPNS.SWAP.UTIL.WARN:"{#SWAPDEV}"}'
+                  name: 'OPNsense: Swap {#SWAPDEV} is in use'
+                  priority: WARNING
+                  description: 'A firewall that swaps is short on memory. Sustained swap usage costs throughput.'
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: performance
+            - uuid: 0b0420a64b184b9f9074fb5a49feea25
+              name: 'Swap {#SWAPDEV}: total'
+              type: DEPENDENT
+              key: 'opns.swap.total[{#SWAPDEV}]'
+              delay: '0'
+              value_type: FLOAT
+              units: B
+              description: 'Size of this swap device.'
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$..[?(@.descr=="{#DESCRIPTION}" && @["commonname"] != "")].[''commonname''].first()'
-                  error_handler: DISCARD_VALUE
+                    - '$.swap[?(@.device == "{#SWAPDEV}")].total.first()'
+                - type: MULTIPLIER
+                  parameters:
+                    - '1024'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
-                key: opns.raw.trust.certificates
+                key: opns.swap.raw
               tags:
                 - tag: component
-                  value: trust_certificates
-            - uuid: 6c965a3e5798479ba84bbcef2911c9a4
-              name: '{#DESCRIPTION} is in use'
+                  value: memory
+                - tag: swapdev
+                  value: '{#SWAPDEV}'
+            - uuid: b93738cf3f6a4b7395f688ba7deda853
+              name: 'Swap {#SWAPDEV}: used'
               type: DEPENDENT
-              key: 'opns.trust.certificates.discovery.in_use[{#DESCRIPTION}]'
+              key: 'opns.swap.used[{#SWAPDEV}]'
               delay: '0'
-              trends: '0'
-              valuemap:
-                name: Boolean
+              value_type: FLOAT
+              units: B
+              description: 'Swap in use on this device.'
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$..[?(@.descr=="{#DESCRIPTION}" && @["in_use"] != "")].[''in_use''].first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: opns.raw.trust.certificates
-              tags:
-                - tag: component
-                  value: trust_certificates
-            - uuid: f0cfc3507b084a17913126513b35101d
-              name: '{#DESCRIPTION} is user'
-              type: DEPENDENT
-              key: 'opns.trust.certificates.discovery.is_user[{#DESCRIPTION}]'
-              delay: '0'
-              trends: '0'
-              valuemap:
-                name: Boolean
-              preprocessing:
-                - type: JSONPATH
+                    - '$.swap[?(@.device == "{#SWAPDEV}")].used.first()'
+                - type: MULTIPLIER
                   parameters:
-                    - '$..[?(@.descr=="{#DESCRIPTION}" && @["is_user"] != "")].[''is_user''].first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: opns.raw.trust.certificates
-              tags:
-                - tag: component
-                  value: trust_certificates
-            - uuid: cc1f7e709919445387fe995d0a5e560e
-              name: '{#DESCRIPTION} valid from'
-              type: DEPENDENT
-              key: 'opns.trust.certificates.discovery.valid_from[{#DESCRIPTION}]'
-              delay: '0'
-              trends: '0'
-              units: unixtime
-              preprocessing:
-                - type: JSONPATH
+                    - '1024'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
                   parameters:
-                    - '$..[?(@.descr=="{#DESCRIPTION}" && @["valid_from"] != "")].[''valid_from''].first()'
-                  error_handler: DISCARD_VALUE
+                    - 1h
               master_item:
-                key: opns.raw.trust.certificates
+                key: opns.swap.raw
               tags:
                 - tag: component
-                  value: trust_certificates
-            - uuid: 704c9c4b132244c49a78988d314413b3
-              name: '{#DESCRIPTION} valid to'
-              type: DEPENDENT
-              key: 'opns.trust.certificates.discovery.valid_to[{#DESCRIPTION}]'
-              delay: '0'
-              trends: '0'
-              units: unixtime
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$..[?(@.descr=="{#DESCRIPTION}" && @["valid_to"] != "")].[''valid_to''].first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: opns.raw.trust.certificates
-              tags:
-                - tag: component
-                  value: trust_certificates
+                  value: memory
+                - tag: swapdev
+                  value: '{#SWAPDEV}'
           master_item:
-            key: opns.raw.trust.certificates
+            key: opns.swap.raw
           lld_macro_paths:
-            - lld_macro: '{#DESCRIPTION}'
-              path: $..descr.first()
-            - lld_macro: '{#OPNS.INTERFACE.DEVICE}'
+            - lld_macro: '{#SWAPDEV}'
               path: $.device
-            - lld_macro: '{#OPNS.INTERFACE.NAME}'
-              path: $.name
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.swap
+        - uuid: 0f55bff2400e4eb4b77a30a3099e0882
+          name: 'Temperature sensors'
+          type: DEPENDENT
+          key: opns.temperature.discovery
+          delay: '0'
+          description: 'The endpoint returns a JSON array at the root. Virtual machines report no sensors, so nothing is discovered and nothing goes unsupported.'
+          item_prototypes:
+            - uuid: ebff261699b04ee29c455ded77a586c7
+              name: 'Temperature {#DEVICE}'
+              type: DEPENDENT
+              key: 'opns.temperature[{#DEVICE}]'
+              delay: '0'
+              value_type: FLOAT
+              units: °C
+              description: 'Reading of one hardware sensor. Which physical component it describes depends on the platform, the sensor name carries that.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$[?(@.device == "{#DEVICE}")].temperature.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 3m
+              master_item:
+                key: opns.temperature.raw
+              tags:
+                - tag: component
+                  value: temperature
+                - tag: sensor
+                  value: '{#DEVICE}'
+              trigger_prototypes:
+                - uuid: 5976a7eda70140f59309a801ff5b28bc
+                  expression: 'avg(/OPNsense by HTTP-JSON/opns.temperature[{#DEVICE}],5m)>{$OPNS.TEMP.CRIT:"{#DEVICE}"}'
+                  name: 'OPNsense: Sensor {#DEVICE} is running hot'
+                  priority: HIGH
+                  description: 'Sustained high temperature. Check fans, filters and ambient temperature. Adjust {$OPNS.TEMP.CRIT} per hardware, the default suits most x86 appliances.'
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: hardware
+          graph_prototypes:
+            - uuid: f64239b29cce452e9104d5496d032527
+              name: 'Temperature {#DEVICE}'
+              graph_items:
+                - color: E53935
+                  item:
+                    host: 'OPNsense by HTTP-JSON'
+                    key: 'opns.temperature[{#DEVICE}]'
+          master_item:
+            key: opns.temperature.raw
+          lld_macro_paths:
+            - lld_macro: '{#DEVICE}'
+              path: $.device
+            - lld_macro: '{#TYPE}'
+              path: $.type
         - uuid: 36c000378e754ccb9475fa047160fd8f
           name: 'WireGuard Instance Discovery'
           type: DEPENDENT
@@ -2463,6 +4401,9 @@ zabbix_export:
       macros:
         - macro: '{$OPNS.CPU.LOAD.MAX}'
           value: '2'
+        - macro: '{$OPNS.CPU.UTIL.WARN}'
+          value: '85'
+          description: 'Processor utilisation that counts as high, averaged over ten minutes.'
         - macro: '{$OPNS.FS.FSNAME.MATCHES}'
           value: .+
           description: 'Used for filesystem discovery. Can be overridden on the host or linked template level.'
@@ -2485,11 +4426,29 @@ zabbix_export:
           value: '50'
         - macro: '{$OPNS.GW.MIN.PACKET.LOSS}'
           value: '10'
+        - macro: '{$OPNS.IF.CONTROL}'
+          value: '1'
+          description: 'Set to 0, optionally per interface as {$OPNS.IF.CONTROL:"vtnet3"}, to stop the down trigger for interfaces that are allowed to have no link.'
+        - macro: '{$OPNS.IF.NAME.NOT_MATCHES}'
+          value: '^(pflog|pfsync|enc|lo)\d*$'
+          description: 'Interfaces that should not be discovered.'
         - macro: '{$OPNS.KEY}'
         - macro: '{$OPNS.LICENSE.EXPIRY.WARN}'
           value: '30'
+        - macro: '{$OPNS.LOAD.AVG5.WARN}'
+          value: '4'
+          description: 'Absolute five minute load average that counts as high. Depends on the core count, which is why the per core trigger is usually the better one.'
+        - macro: '{$OPNS.LOAD.PERCORE.WARN}'
+          value: '1'
+          description: 'Five minute load per core that counts as high. A value of 1 means the cores are exactly saturated.'
+        - macro: '{$OPNS.MBUF.UTIL.WARN}'
+          value: '80'
+          description: 'Percentage of the mbuf cluster limit in use that counts as filling up.'
         - macro: '{$OPNS.MEMORY.UTIL.MAX}'
           value: '90'
+        - macro: '{$OPNS.NTP.OFFSET.WARN}'
+          value: '100'
+          description: 'Clock offset in milliseconds that counts as high. 100 is generous for a LAN time source and still far below what breaks Kerberos or IPsec.'
         - macro: '{$OPNS.NUT.BAT.LOW}'
           value: '30'
         - macro: '{$OPNS.NUT.BAT.RUNTIME}'
@@ -2497,12 +4456,27 @@ zabbix_export:
           description: 'Remaining battery runtime in seconds'
         - macro: '{$OPNS.NUT.HIGH.LOAD}'
           value: '80'
+        - macro: '{$OPNS.PF.SRCNODES.UTIL.CRIT}'
+          value: '90'
+          description: 'Fill level of the source tracking table that counts as critical.'
+        - macro: '{$OPNS.PF.TABLES.UTIL.WARN}'
+          value: '80'
+          description: 'Share of the pf table entry budget that counts as filling up. Relevant where block lists or GeoIP aliases are in use.'
         - macro: '{$OPNS.PORT}'
           value: '443'
           description: 'HTTPS API Port'
         - macro: '{$OPNS.SECRET}'
+        - macro: '{$OPNS.SERVICE.ID.NOT_MATCHES}'
+          value: ^$
+          description: 'Services excluded from discovery, as a regular expression over the service identifier. The default excludes nothing.'
         - macro: '{$OPNS.STATE.TABLE.UTIL.MAX}'
           value: '90'
+        - macro: '{$OPNS.SWAP.UTIL.WARN}'
+          value: '5'
+          description: 'A firewall should not swap at all, so the default is deliberately low. Can be overridden per device with the device path as context.'
+        - macro: '{$OPNS.TEMP.CRIT}'
+          value: '80'
+          description: 'Temperature threshold in degrees Celsius. Sensors on one board tolerate very different values, so this can be overridden per sensor with the sensor name as context, for example {$OPNS.TEMP.CRIT:"dev.cpu.0.temperature"}.'
         - macro: '{$OPNS.WG.INSTANCE.MATCHES}'
           value: .+
           description: 'Regex filter for WireGuard instance discovery. Can be overridden on the host or linked template level.'
@@ -2519,12 +4493,47 @@ zabbix_export:
         - uuid: 7a4b378cb31c4d6fb3c4c69731653336
           name: 'OPNsense Info'
           pages:
-            - name: 'OPNSense Info'
+            - name: Overview
               widgets:
+                - type: gauge
+                  name: Memory
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: STRING
+                      name: description
+                      value: 'Memory utilization'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.memory.util
+                    - type: STRING
+                      name: max
+                      value: '100'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
                 - type: item
-                  name: 'CPU Load'
+                  name: 'CPU load'
+                  'y': '3'
                   width: '12'
-                  height: '4'
+                  height: '3'
                   fields:
                     - type: ITEM
                       name: itemid.0
@@ -2533,40 +4542,205 @@ zabbix_export:
                         key: opns.cpu.load
                     - type: INTEGER
                       name: show.0
-                      value: '1'
-                    - type: INTEGER
-                      name: show.1
                       value: '2'
                     - type: INTEGER
-                      name: show.2
+                      name: show.1
                       value: '3'
-                    - type: INTEGER
-                      name: show.3
-                      value: '4'
-                    - type: INTEGER
-                      name: show.4
-                      value: '5'
                 - type: svggraph
-                  'y': '4'
-                  width: '41'
-                  height: '4'
+                  name: 'Firewall actions'
+                  'y': '6'
+                  width: '36'
+                  height: '5'
                   fields:
-                    - type: INTEGER
-                      name: ds.0.color_palette
-                      value: '0'
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
                     - type: STRING
                       name: ds.0.items.0
                       value: 'Firewall action*'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
                     - type: STRING
                       name: reference
-                      value: GNQTN
-                    - type: INTEGER
-                      name: righty
-                      value: '0'
+                      value: FWACT
                 - type: honeycomb
-                  name: 'Carp Status'
-                  'y': '8'
-                  width: '41'
+                  name: Filesystems
+                  'y': '11'
+                  width: '72'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'FS *: Space: Used, in %'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("FS \[(.*)\]: Space", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: FSHNY
+                    - type: STRING
+                      name: secondary_label_units
+                      value: '%'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '90'
+                - type: item
+                  name: Uptime
+                  x: '12'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.system.uptime
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: gauge
+                  name: 'State table'
+                  x: '18'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: STRING
+                      name: description
+                      value: 'pf states'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.states.util
+                    - type: STRING
+                      name: max
+                      value: '100'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: item
+                  name: Version
+                  x: '24'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.version
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: gauge
+                  name: Processor
+                  x: '36'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: STRING
+                      name: description
+                      value: 'CPU utilization'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.cpu.util
+                    - type: STRING
+                      name: max
+                      value: '100'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: item
+                  name: Firmware
+                  x: '36'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.firmware.update.status
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: honeycomb
+                  name: CARP
+                  x: '36'
+                  'y': '6'
+                  width: '36'
                   height: '5'
                   fields:
                     - type: STRING
@@ -2574,125 +4748,2149 @@ zabbix_export:
                       value: 'Carp Status of *'
                     - type: STRING
                       name: primary_label
-                      value: '{ITEM.NAME}'
+                      value: '{{ITEM.NAME}.regsub("Carp Status of (.*)", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
                     - type: STRING
                       name: reference
-                      value: RDXXH
-                - type: piechart
-                  name: 'Memory Usage'
-                  x: '12'
-                  width: '14'
-                  height: '4'
+                      value: CARPH
+                - type: item
+                  name: 'States in use'
+                  x: '48'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
                   fields:
-                    - type: STRING
-                      name: ds.0.color
-                      value: 00FF00
-                    - type: STRING
-                      name: ds.0.items.0
-                      value: 'Total Memory'
-                    - type: STRING
-                      name: ds.1.color
-                      value: FF4000
-                    - type: STRING
-                      name: ds.1.items.0
-                      value: 'Used Memory'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.fw.states.current
                     - type: INTEGER
-                      name: space
+                      name: show.0
                       value: '2'
-                - type: piechart
-                  name: 'FW States'
-                  x: '26'
-                  width: '15'
-                  height: '4'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: gauge
+                  name: 'Load per core'
+                  x: '54'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: STRING
+                      name: description
+                      value: 'Load per core'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.system.load.percore
+                    - type: STRING
+                      name: max
+                      value: '4'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '1'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '2'
+                - type: item
+                  name: 'State limit'
+                  x: '60'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.fw.states.max
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+            - name: 'Packet filter'
+              widgets:
+                - type: gauge
+                  name: 'State table'
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: STRING
+                      name: description
+                      value: 'State table'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.states.util
+                    - type: STRING
+                      name: max
+                      value: '100'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: item
+                  name: 'States in use'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.fw.states.current
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'Ruleset fingerprint'
+                  'y': '6'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.pf.rules.fingerprint
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: svggraph
+                  name: 'State table churn'
+                  'y': '9'
+                  width: '36'
+                  height: '6'
                   fields:
                     - type: STRING
                       name: ds.0.color
-                      value: 00FF00
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '2'
                     - type: STRING
                       name: ds.0.items.0
-                      value: 'Firewall states max'
+                      value: 'pf: State table inserts per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
                     - type: STRING
                       name: ds.1.color
-                      value: FF4000
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
                     - type: STRING
                       name: ds.1.items.0
-                      value: 'Firewall states current'
-            - name: 'Gateway Info'
-              widgets:
+                      value: 'pf: State table removals per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: PFCHU
                 - type: svggraph
-                  name: RoundTripTime
-                  width: '45'
+                  name: 'Rule matches and evaluations'
+                  'y': '15'
+                  width: '36'
                   height: '6'
                   fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
                     - type: INTEGER
-                      name: ds.0.color_palette
+                      name: ds.0.fill
+                      value: '2'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'pf: Rule matches per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'pf: Rule evaluations per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: PFMAT
+                - type: svggraph
+                  name: 'Malformed packets'
+                  'y': '21'
+                  width: '72'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
                       value: '0'
                     - type: STRING
                       name: ds.0.items.0
-                      value: 'Gateway RTT*'
+                      value: 'pf: Bad offset packets per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'pf: Short packets per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.2.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: 'pf: Fragmented packets per second'
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.3.color
+                      value: 00897B
+                    - type: INTEGER
+                      name: ds.3.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.3.items.0
+                      value: 'pf: Normalized packets per second'
+                    - type: INTEGER
+                      name: ds.3.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
                     - type: STRING
                       name: reference
-                      value: JRMUO
+                      value: PFMAL
+                - type: item
+                  name: 'Source nodes'
+                  x: '12'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.pf.srcnodes.current
                     - type: INTEGER
-                      name: righty
-                      value: '0'
-                - type: svggraph
-                  name: 'Gateway lost packages in %'
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'Rule evaluations/s'
+                  x: '12'
                   'y': '6'
-                  width: '45'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.pf.rules.evaluations.rate
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: gauge
+                  name: 'Source tracking'
+                  x: '24'
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: STRING
+                      name: description
+                      value: 'Source tracking'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.pf.srcnodes.pused
+                    - type: STRING
+                      name: max
+                      value: '100'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: item
+                  name: 'Table entries'
+                  x: '24'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.pf.tables.entries.used
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'Blocked share of log'
+                  x: '24'
+                  'y': '6'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.fwlog.block.pct
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'Filter rules'
+                  x: '36'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.pf.rules.filter.count
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'SYN floods/s'
+                  x: '36'
+                  'y': '6'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.pf.synfloods.rate
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: svggraph
+                  name: 'State table searches'
+                  x: '36'
+                  'y': '9'
+                  width: '36'
                   height: '6'
                   fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 8E24AA
                     - type: INTEGER
-                      name: ds.0.color_palette
+                      name: ds.0.fill
+                      value: '2'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'pf: State table searches per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: PFSEA
+                - type: svggraph
+                  name: 'Drops and limit hits'
+                  x: '36'
+                  'y': '15'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
                       value: '0'
                     - type: STRING
                       name: ds.0.items.0
-                      value: 'Gateway loss*'
+                      value: 'pf: Packets dropped for memory per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'pf: State limit hits per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: FFD54F
+                    - type: INTEGER
+                      name: ds.2.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: 'pf: Source limit hits per second'
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.3.color
+                      value: 8E24AA
+                    - type: INTEGER
+                      name: ds.3.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.3.items.0
+                      value: 'pf: State mismatches per second'
+                    - type: INTEGER
+                      name: ds.3.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.4.color
+                      value: 00897B
+                    - type: INTEGER
+                      name: ds.4.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.4.items.0
+                      value: 'pf: SYN floods detected per second'
+                    - type: INTEGER
+                      name: ds.4.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.5.color
+                      value: '757575'
+                    - type: INTEGER
+                      name: ds.5.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.5.items.0
+                      value: 'pf: Overload table insertions per second'
+                    - type: INTEGER
+                      name: ds.5.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
                     - type: STRING
                       name: reference
-                      value: XALVE
-                    - type: INTEGER
-                      name: righty
-                      value: '0'
-            - name: Inerfaces
-              widgets:
-                - type: svggraph
-                  name: 'Bytes v4'
-                  width: '55'
-                  height: '10'
+                      value: PFDRP
+                - type: gauge
+                  name: 'Table entries'
+                  x: '48'
+                  width: '24'
+                  height: '3'
                   fields:
+                    - type: STRING
+                      name: description
+                      value: 'Table entries'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.pf.tables.entries.pused
+                    - type: STRING
+                      name: max
+                      value: '100'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: item
+                  name: 'NAT rules'
+                  x: '48'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.pf.rules.nat.count
                     - type: INTEGER
-                      name: ds.0.color_palette
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'State limit hits/s'
+                  x: '48'
+                  'y': '6'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.pf.counter.statelimit.rate
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'Rules never matched'
+                  x: '60'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.pf.rules.unused
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'Source limit hits/s'
+                  x: '60'
+                  'y': '6'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.pf.counter.srclimit.rate
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+            - name: Interfaces
+              widgets:
+                - type: honeycomb
+                  name: 'Link state'
+                  width: '72'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Interface *: Link status'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("Interface (.*): Link status", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IFLNK
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: svggraph
+                  name: Traffic
+                  'y': '4'
+                  width: '72'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'Interface *: Bytes received'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'Interface *: Bytes transmitted'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IFTRF
+                - type: svggraph
+                  name: 'Blocked bytes IPv4'
+                  'y': '10'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
                       value: '0'
                     - type: STRING
                       name: ds.0.items.0
                       value: '*blocked bytes INv4'
                     - type: INTEGER
-                      name: ds.1.color_palette
-                      value: '1'
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
                     - type: STRING
                       name: ds.1.items.0
-                      value: '*passed bytes INv4'
+                      value: '*blocked bytes OUTv4'
                     - type: INTEGER
-                      name: lefty_scale
-                      value: '1'
+                      name: ds.1.width
+                      value: '2'
                     - type: INTEGER
                       name: legend_lines
-                      value: '4'
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
                     - type: STRING
                       name: reference
-                      value: MARXC
+                      value: IFBLK
+                - type: svggraph
+                  name: 'Errors and drops'
+                  'y': '16'
+                  width: '72'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
                     - type: INTEGER
-                      name: righty
+                      name: ds.0.fill
                       value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'Interface *: Inbound errors'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'Interface *: output errors'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: FFD54F
+                    - type: INTEGER
+                      name: ds.2.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: 'Interface *: input queue drops'
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.3.color
+                      value: 8E24AA
+                    - type: INTEGER
+                      name: ds.3.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.3.items.0
+                      value: 'Interface *: collisions'
+                    - type: INTEGER
+                      name: ds.3.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IFERR
+                - type: svggraph
+                  name: 'Passed bytes IPv4'
+                  x: '36'
+                  'y': '10'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: '*passed bytes INv4'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: '*passed bytes OUTv4'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IFPAS
+            - name: Gateways
+              widgets:
+                - type: honeycomb
+                  name: 'Gateway status'
+                  width: '72'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Gateway Status *'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("Gateway Status (.*)", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: GWYHC
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '4'
+                - type: svggraph
+                  name: 'Round trip time'
+                  'y': '4'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'Gateway RTT *'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: GWRTT
+                - type: svggraph
+                  name: 'Round trip time deviation'
+                  'y': '10'
+                  width: '72'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 8E24AA
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'Gateway RTTd *'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: GWDEV
+                - type: svggraph
+                  name: 'Packet loss'
+                  x: '36'
+                  'y': '4'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'Gateway loss *'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: GWLOS
+            - name: VPN
+              widgets:
+                - type: honeycomb
+                  name: 'WireGuard peers'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'WireGuard peer *: status'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("WireGuard peer (.*): status", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: WGPHC
+                - type: svggraph
+                  name: 'WireGuard peer traffic'
+                  'y': '4'
+                  width: '72'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'WireGuard peer *: bytes received per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'WireGuard peer *: bytes sent per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: WGTRF
+                - type: honeycomb
+                  name: 'IPsec phase 1'
+                  'y': '10'
+                  width: '72'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: '* connected'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("(.*) connected", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IPSHC
+                - type: svggraph
+                  name: 'IPsec phase 1 traffic'
+                  'y': '14'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: '* bytes per second in'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: '* bytes per second out'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IPS1T
+                - type: honeycomb
+                  name: 'WireGuard instances'
+                  x: '36'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'WireGuard instance *: status'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("WireGuard instance (.*): status", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: WGIHC
+                - type: svggraph
+                  name: 'IPsec phase 2 traffic'
+                  x: '36'
+                  'y': '14'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: '* bytes-in per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: '* bytes-out per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IPSTR
+            - name: System
+              widgets:
+                - type: gauge
+                  name: Processor
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: STRING
+                      name: description
+                      value: 'CPU utilization'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.cpu.util
+                    - type: STRING
+                      name: max
+                      value: '100'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: item
+                  name: Uptime
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.system.uptime
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: svggraph
+                  name: 'Processor utilization'
+                  'y': '6'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'CPU: User time'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'CPU: System time'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: E53935
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: 'CPU: Interrupt time'
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.3.color
+                      value: '757575'
+                    - type: INTEGER
+                      name: ds.3.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.3.items.0
+                      value: 'CPU: Utilization'
+                    - type: INTEGER
+                      name: ds.3.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: CPUUT
+                - type: honeycomb
+                  name: 'Temperature sensors'
+                  'y': '12'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Temperature *'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("Temperature (.*)", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: TEMPH
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '65'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '80'
+                - type: item
+                  name: Version
+                  x: '12'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.version
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: gauge
+                  name: Memory
+                  x: '24'
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: STRING
+                      name: description
+                      value: 'Memory utilization'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.memory.util
+                    - type: STRING
+                      name: max
+                      value: '100'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: item
+                  name: Cores
+                  x: '24'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.cpu.cores
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'Configuration changed'
+                  x: '36'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.config.changed
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: svggraph
+                  name: 'Load average'
+                  x: '36'
+                  'y': '6'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'CPU load'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'Load average (5 min)'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: 8E24AA
+                    - type: INTEGER
+                      name: ds.2.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: 'Load average (15 min)'
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: LOADA
+                - type: honeycomb
+                  name: 'Swap devices'
+                  x: '36'
+                  'y': '12'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Swap *: utilization'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("Swap (.*): utilization", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: SWAPH
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '5'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '30'
+                - type: gauge
+                  name: 'Load per core'
+                  x: '48'
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: STRING
+                      name: description
+                      value: 'Load per core'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.system.load.percore
+                    - type: STRING
+                      name: max
+                      value: '4'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '1'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '2'
+                - type: item
+                  name: 'Load average 5 min'
+                  x: '48'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.system.load.avg5
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'Load average 15 min'
+                  x: '60'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.system.load.avg15
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+            - name: 'Kernel and protocols'
+              widgets:
+                - type: gauge
+                  name: 'mbuf clusters'
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: STRING
+                      name: description
+                      value: 'mbuf clusters'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.mbuf.cluster.pused
+                    - type: STRING
+                      name: max
+                      value: '100'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '60'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '80'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: svggraph
+                  name: 'Kernel network memory'
+                  'y': '3'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'mbuf: Clusters in use'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'mbuf: Denied requests'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: MBUFG
+                - type: svggraph
+                  name: 'IP errors'
+                  'y': '9'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'IP: Packets with a bad checksum per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'IP: Fragments dropped per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: FFD54F
+                    - type: INTEGER
+                      name: ds.2.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: 'IP: Packets discarded for lack of a route per second'
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.3.color
+                      value: 8E24AA
+                    - type: INTEGER
+                      name: ds.3.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.3.items.0
+                      value: 'IP: Packets that cannot be forwarded per second'
+                    - type: INTEGER
+                      name: ds.3.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IPERR
+                - type: item
+                  name: 'Clusters in use'
+                  x: '24'
+                  width: '16'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.mbuf.cluster.current
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: svggraph
+                  name: 'netisr queue drops per protocol'
+                  x: '36'
+                  'y': '3'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'netisr *: Queue drops'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: NETIS
+                - type: svggraph
+                  name: 'TCP errors'
+                  x: '36'
+                  'y': '9'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'TCP: Segments with a bad checksum per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'TCP: Retransmitted segments per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: TCPER
+                - type: item
+                  name: 'Denied requests'
+                  x: '40'
+                  width: '16'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.mbuf.denied
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'netisr queue drops'
+                  x: '56'
+                  width: '16'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.netisr.queue.drops
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+            - name: 'Services, clock and power'
+              widgets:
+                - type: honeycomb
+                  name: Services
+                  width: '72'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Service *: Running'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("Service (.*): Running", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '11'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: SVCHC
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: item
+                  name: 'Clock synchronised'
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.ntp.synced
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: gauge
+                  name: 'UPS battery'
+                  'y': '8'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: STRING
+                      name: description
+                      value: 'UPS battery'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: nut.battery.charge
+                    - type: STRING
+                      name: max
+                      value: '100'
+                    - type: STRING
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '20'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '50'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: svggraph
+                  name: 'Clock offset'
+                  'y': '11'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'NTP: Offset of the selected peer'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: NTPOF
+                - type: item
+                  name: 'Clock offset'
+                  x: '12'
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.ntp.offset
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'UPS status'
+                  x: '18'
+                  'y': '8'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: nut.status
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: Stratum
+                  x: '24'
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.ntp.stratum
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'Reachable peers'
+                  x: '36'
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.ntp.peers.reachable
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'UPS load'
+                  x: '36'
+                  'y': '8'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: nut.battery.load
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: svggraph
+                  name: 'UPS voltage'
+                  x: '36'
+                  'y': '11'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'UPS Input Voltage'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'UPS Output Voltage'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: UPSVO
+                - type: item
+                  name: 'CARP demotion'
+                  x: '48'
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.carp.demotion
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'UPS runtime'
+                  x: '54'
+                  'y': '8'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: nut.battery.runtime
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
+                - type: item
+                  name: 'CARP maintenance'
+                  x: '60'
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'OPNsense by HTTP-JSON'
+                        key: opns.carp.maintenance
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: show.1
+                      value: '3'
       valuemaps:
-        - uuid: d8cb56d6bfd24ad4a5b7837a74b5cf21
-          name: Boolean
+        - uuid: c7611ec793464de48d316d672127f43c
+          name: 'Enabled state'
           mappings:
-            - value: '1'
-              newvalue: 'Yes'
             - value: '0'
               newvalue: 'No'
+            - value: '1'
+              newvalue: 'Yes'
+        - uuid: ddf684d6eac14d5a9205faabf9f3adab
+          name: 'Link status'
+          mappings:
+            - value: '0'
+              newvalue: Down
+            - value: '1'
+              newvalue: Up
+        - uuid: 586b4c1f36cc4372a999693e99278974
+          name: 'NTP sync state'
+          mappings:
+            - value: '0'
+              newvalue: 'Not synchronised'
+            - value: '1'
+              newvalue: Synchronised
+        - uuid: 9b854528a2314ac2a7db744216908730
+          name: 'Service state'
+          mappings:
+            - value: '0'
+              newvalue: Stopped
+            - value: '1'
+              newvalue: Running
   triggers:
     - uuid: 6003bfd5a8f44a6d9a04f08de932fef1
       expression: 'find(/OPNsense by HTTP-JSON/opns.firmware.update.status,#1,"regexp","^(update|upgrade)$")=1 and last(/OPNsense by HTTP-JSON/opns.firmware.update.count)>0'


### PR DESCRIPTION
  Two items call their endpoint in camelCase where the OPNsense privilege
  pattern is exact snake_case. OPNsense routes both spellings to the same
  controller action, so an administrator API key never notices, but ACL.php
  matches the raw URL with preg_match and no /i modifier against the exact
  patterns api/diagnostics/firewall/pf_states and
  api/diagnostics/system/system_resources. Verified against OPNsense 26.7
  with a monitoring key holding only Lobby: Dashboard:
  
    403 diagnostics/firewall/pfStates       200 diagnostics/firewall/pf_states
    403 diagnostics/system/systemResources  200 diagnostics/system/system_resources
  
  That takes out the firewall state items, the state table utilization and
  every memory item for anyone following least privilege. The IPsec phase 1
  and phase 2 masters were the only two items ignoring {$OPNS.PORT} and are
  now consistent with the rest.
  
  The additions cover what the template did not reach yet, all of it through
  endpoints it was not already polling: the pf counters and both limit
  tables, the ruleset with change detection, kernel network memory, netisr
  queues, IP and TCP protocol errors, NTP synchronization, service state,
  swap, temperature, processor utilization split into user, system and
  interrupt, and the core count with load per core. Seven further items ride
  along on masters the template already polls and cost no extra request: the
  configuration change timestamp, load average over 5 and 15 minutes, the
  blocked share of the firewall log, the CARP demotion factor and
  maintenance mode, and the OPNsense version.
  
  67 items, 5 discovery rules with 8 prototypes, 23 triggers, 4 trigger
  prototypes, 12 macros and 4 value maps, all in the existing opns namespace.
  Every threshold is a macro with a default, four of them accept context so a
  single sensor, filesystem, swap device or interface can differ. Nothing
  existing was renamed, removed or re-tuned.
 