### PR TITLE
Add Duo Authentication Proxy template for Zabbix 7.4

### DIFF
--- a/Applications/Security/template_duo_authentication_proxy_by_zabbix_agent2/7.4/README.md
+++ b/Applications/Security/template_duo_authentication_proxy_by_zabbix_agent2/7.4/README.md
@@ -1,0 +1,290 @@
+# Duo Authentication Proxy Monitoring Template for Zabbix 7.4
+
+[![Zabbix Version](https://img.shields.io/badge/Zabbix-7.4-red.svg)](https://www.zabbix.com/)
+[![Agent](https://img.shields.io/badge/Zabbix%20agent%202-systemd-blue.svg)](https://www.zabbix.com/documentation/7.4/en/manual/config/items/itemtypes/zabbix_agent)
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+
+**Author:** `://echo@dla.network [oZark oRChes✝ra✝'d]` | [![GitHub](https://img.shields.io/badge/GitHub-DLA--neTWorK-blue?logo=github)](https://github.com/DLA-neTWorK)
+
+**Version:** 1.0.0
+
+## Overview
+
+Monitoring template for **Cisco Duo Authentication Proxy** on Linux, built for Zabbix 7.4 using **native Zabbix agent 2 keys only**. It covers systemd service state, service resource consumption, the Duo process itself, configuration-file integrity metadata, and locally listening RADIUS ports.
+
+The template is deliberately **credential-free**. It does not read Duo configuration contents, authentication logs, RADIUS secrets, Duo cloud credentials, or Duo cloud data. No custom UserParameter, sudo rule, log permission, external script, or additional package is required.
+
+Validated on Zabbix server and agent 2 **7.4.13**, with a systemd unit named `duoauthproxy.service`, the standard `/opt/duoauthproxy` installation path, and the Duo process running as `duo_authproxy_svc`.
+
+### Key Features
+
+- ✅ **Native systemd collection** - Two raw `systemd.unit.get` master items feed every service metric
+- ✅ **Service state coverage** - Active state, substate, boot-enabled state, uptime, restart counter, and main PID
+- ✅ **Resource trends** - Service cgroup CPU utilization, memory usage, and task count
+- ✅ **Independent process checks** - Process count and RSS memory matched by executable, service account, and command line
+- ✅ **Configuration integrity without exposure** - Existence and modification-time metadata only; file contents are never read
+- ✅ **Macro-driven RADIUS listener LLD** - One item and trigger per UDP port, with strict port validation
+- ✅ **Noise-controlled alerting** - Three-check confirmation for availability, ten-minute persistence for resource warnings
+- ✅ **Dependency suppression** - Process, resource, restart, and listener alerts are suppressed while the parent service is down
+
+---
+
+## Monitoring Capabilities
+
+### Raw master items
+
+| Item | Key | History |
+|------|-----|---------|
+| Get systemd unit state | `systemd.unit.get[{$DUO.SERVICE.NAME},Unit]` | `0` |
+| Get systemd service metrics | `systemd.unit.get[{$DUO.SERVICE.NAME},Service]` | `0` |
+
+Both master items intentionally use `history=0`. Their JSON is processed into dependent metrics but is not stored, matching the official Zabbix systemd template pattern. Seeing no history on these two items is expected, not a fault.
+
+### Service metrics (dependent on the `Unit` master)
+
+| Metric | Item key | Notes |
+|--------|----------|-------|
+| Service active state | `duo.service.active` | Numeric systemd state, displayed via the `Unit Active State` value map |
+| Service substate | `duo.service.substate` | Text, normally `running` |
+| Service enabled state | `duo.service.enabled` | Numeric, displayed via the `Unit File State` value map |
+| Service uptime | `duo.service.uptime` | Seconds since the unit last entered the active state |
+
+### Service resources (dependent on the `Service` master)
+
+| Metric | Item key | Units |
+|--------|----------|-------|
+| Service CPU utilization | `duo.service.cpu.util` | `%` |
+| Service memory usage | `duo.service.memory` | `B` |
+| Service tasks | `duo.service.tasks` | count |
+| Service restart count | `duo.service.restarts` | count |
+| Service main PID | `duo.service.main_pid` | PID |
+
+### Process, configuration, and application checks
+
+| Metric | Item key |
+|--------|----------|
+| Process count | `proc.num[{$DUO.PROCESS.NAME},{$DUO.PROCESS.USER},,{$DUO.PROCESS.CMDLINE}]` |
+| Process RSS memory | `proc.mem[{$DUO.PROCESS.NAME},{$DUO.PROCESS.USER},,{$DUO.PROCESS.CMDLINE},rss]` |
+| Configuration file exists | `vfs.file.exists[{$DUO.CONFIG.PATH}]` |
+| Configuration modification time | `vfs.file.time[{$DUO.CONFIG.PATH},modify]` |
+| Control executable exists | `vfs.file.exists[{$DUO.BINARY.PATH}]` |
+
+### RADIUS listener discovery
+
+| Rule | Key | Interval |
+|------|-----|----------|
+| Duo: RADIUS listener discovery | `duo.radius.listener.discovery` | 1h |
+
+A script-type LLD rule converts the comma-separated `{$DUO.RADIUS.PORTS}` macro into one item and one trigger per UDP listener. The script validates each port is an integer in the range 1-65535, removes duplicates, and rejects an empty list.
+
+| Item prototype | Key | Interval |
+|----------------|-----|----------|
+| Duo: UDP `{#DUO.PORT}` listener status | `net.udp.listen[{#DUO.PORT}]` | 1m |
+
+---
+
+## Trigger Summary
+
+**13 triggers total**, all enabled by default.
+
+| Severity | Trigger | Persistence | Parent dependency |
+|----------|---------|-------------|-------------------|
+| **HIGH** | Service is not active | 3 checks | Root cause |
+| **HIGH** | Service has no main process | 3 checks | Service not active |
+| **HIGH** | Process is not running | 3 checks | Service not active |
+| **HIGH** | UDP `{#DUO.PORT}` listener is not available | 3 checks | Service not active |
+| **HIGH** | Configuration file is missing | 3 checks | None |
+| **HIGH** | Executable is missing | 3 checks | None |
+| **WARNING** | Service is not enabled at boot | Current state | None |
+| **WARNING** | Service was automatically restarted | Counter increase | Service not active |
+| **WARNING** | Memory usage is high | 10 minutes | Service not active |
+| **WARNING** | CPU utilization is high | 10 minutes | Service not active |
+| **WARNING** | Task count is high | 10 minutes | Service not active |
+| **INFO** | Service has been restarted | Uptime below 10 minutes | Service not active |
+| **INFO** | Configuration was modified | On change | None |
+
+Restart and configuration-change events allow **manual close**. Every trigger description states the condition, its operational meaning, and initial investigation guidance. The configuration-change trigger reports only that the modification timestamp changed — it never exposes configuration contents.
+
+---
+
+## Installation Guide
+
+### Prerequisites
+
+- ✅ Zabbix server and frontend **7.4** or later
+- ✅ **Zabbix agent 2** installed on the monitored Linux host (the classic agent does not provide `systemd.unit.get`)
+- ✅ A systemd-managed Duo Authentication Proxy installation
+- ✅ Agent 2 permitted to query systemd over D-Bus and to stat the configured executable and configuration paths
+
+### Step 1: Import the template
+
+1. Download `template_duo_authentication_proxy_by_zabbix_agent2.yaml`
+2. Zabbix web interface -> **Data collection** -> **Templates** -> **Import**
+3. Select the YAML file and complete import
+4. Verify template name: **Duo Authentication Proxy by Zabbix agent 2** in group **Templates/Applications**
+
+### Step 2: Link to the host
+
+Link `Duo Authentication Proxy by Zabbix agent 2` to the Linux host running the Duo proxy. The host needs a Zabbix agent interface.
+
+### Step 3: Set the listener ports
+
+Set `{$DUO.RADIUS.PORTS}` to the comma-separated UDP ports owned by that Duo instance, for example `18120,18121`.
+
+> The default `18121` is a **tested deployment value, not a universal Duo default**. Set this macro to the listener ports actually configured on each target host.
+
+### Step 4: Override paths only if needed
+
+Override the service, process, user, and path macros only when the local installation differs from the defaults.
+
+### Step 5: Validate
+
+1. Confirm both raw systemd master items are **supported** (they will show no stored history — this is by design)
+2. Confirm the dependent service, resource, and process metrics populate
+3. Confirm the expected UDP listeners are discovered
+4. Review thresholds before enabling notifications
+
+---
+
+## Zabbix Configuration
+
+### Macros
+
+| Macro | Default | Purpose |
+|-------|---------|---------|
+| `{$DUO.SERVICE.NAME}` | `duoauthproxy.service` | systemd unit name |
+| `{$DUO.RADIUS.PORTS}` | `18121` | Comma-separated UDP listener ports |
+| `{$DUO.PROCESS.NAME}` | `python3` | Process executable name |
+| `{$DUO.PROCESS.USER}` | `duo_authproxy_svc` | Operating-system service account |
+| `{$DUO.PROCESS.CMDLINE}` | `duoauthproxy` | Process command-line regular expression |
+| `{$DUO.CONFIG.PATH}` | `/opt/duoauthproxy/conf/authproxy.cfg` | Configuration path; **metadata only** |
+| `{$DUO.BINARY.PATH}` | `/opt/duoauthproxy/bin/authproxyctl` | Control executable path |
+| `{$DUO.CPU.UTIL.MAX.WARN}` | `80` | Sustained CPU warning, percent |
+| `{$DUO.MEMORY.MAX.WARN}` | `512M` | Sustained service memory warning |
+| `{$DUO.TASKS.MAX.WARN}` | `50` | Sustained service task warning |
+
+### Value maps
+
+`Unit Active State` and `Unit File State`, using the same numeric state codes as the official Zabbix systemd template.
+
+### Template links
+
+**None.** The export is self-contained and uses only native Zabbix agent 2 keys.
+
+### Object counts
+
+| Object type | Count |
+|-------------|-------|
+| Items | 16 |
+| Discovery rules | 1 |
+| Item prototypes | 1 |
+| Triggers and trigger prototypes | 13 |
+| Value maps | 2 |
+| Macros | 10 |
+
+---
+
+## Troubleshooting
+
+### Raw systemd master items appear empty
+
+**This is expected.** The two `systemd.unit.get` items use `history=0` and exist only to feed dependent metrics. Check the dependent service values and the master item's supported/error state instead.
+
+### Systemd items are unsupported
+
+1. Confirm **Zabbix agent 2** is installed, not the classic agent
+2. Confirm `{$DUO.SERVICE.NAME}` matches the local systemd unit name
+3. Test directly: `zabbix_get -s <host> -k 'systemd.unit.get[duoauthproxy.service,Unit]'`
+4. Check D-Bus access and the agent 2 log
+
+### Process item reports zero
+
+Check `{$DUO.PROCESS.NAME}`, `{$DUO.PROCESS.USER}`, and `{$DUO.PROCESS.CMDLINE}` against the actually running process:
+
+```bash
+ps -eo user,comm,args | grep -i duoauthproxy
+```
+
+Note the default process name is `python3`, because the Duo proxy runs under a bundled Python interpreter.
+
+### Listener item reports zero
+
+Confirm the port is configured in Duo, present in `{$DUO.RADIUS.PORTS}`, and locally bound:
+
+```bash
+ss -lnu | grep 18121
+```
+
+Local listener state does **not** prove network firewall access from RADIUS clients.
+
+### Service uptime shows no value
+
+The uptime item deliberately produces no value while the unit is inactive. An empty uptime alongside an inactive service is correct behaviour, not a collection failure.
+
+---
+
+## Known Limitations
+
+- `net.udp.listen[]` confirms a local UDP socket is bound. It does **not** perform a credentialed RADIUS authentication transaction.
+- Synthetic RADIUS testing would require extra software and a protected test secret, and is outside the scope of this credential-free template.
+- Authentication logs are intentionally excluded because they may contain usernames, source addresses, and other sensitive operational data.
+- The installed Duo version is not collected, because the vendor control command may require elevated execution on some installations.
+
+---
+
+## Version History
+
+### v1.0.0 - Initial release
+
+- ✅ Initial Zabbix 7.4 community release
+- ✅ systemd, process, resource, configuration, and listener monitoring via native agent 2 keys
+- ✅ Macro-driven RADIUS listener LLD with strict port validation
+- ✅ Dependency-based suppression and operational trigger descriptions
+- ✅ Value maps aligned with the official Zabbix systemd template
+- ✅ Validated on Zabbix server and agent 2 version 7.4.13
+
+---
+
+## Support & Resources
+
+### Template Maintainer
+
+**Author:** `://echo@dla.network [oZark oRChes✝ra✝'d]` | [![GitHub](https://img.shields.io/badge/GitHub-DLA--neTWorK-blue?logo=github)](https://github.com/DLA-neTWorK)
+
+When reporting an issue, include the Zabbix version, operating system, Duo version, macro overrides, and sanitized item errors.
+
+> **Never attach `authproxy.cfg`, RADIUS secrets, Duo integration keys, or authentication logs.**
+
+### Cisco Duo Resources
+
+- [Duo Authentication Proxy reference](https://duo.com/docs/authproxy-reference)
+
+### Zabbix Resources
+
+- [Zabbix 7.4 Documentation](https://www.zabbix.com/documentation/7.4/)
+- [Zabbix agent 2 item reference](https://www.zabbix.com/documentation/7.4/en/manual/config/items/itemtypes/zabbix_agent)
+- [Low-level discovery](https://www.zabbix.com/documentation/7.4/en/manual/discovery/low_level_discovery)
+- [Zabbix template guidelines](https://www.zabbix.com/documentation/guidelines/en/template_guidelines)
+
+---
+
+## Quick Reference
+
+| Property | Value |
+|----------|-------|
+| **Template Name** | Duo Authentication Proxy by Zabbix agent 2 |
+| **Template Group** | Templates/Applications |
+| **Zabbix Version** | 7.4+ |
+| **Monitoring Type** | Zabbix agent 2 (systemd, proc, vfs, net) |
+| **Credentials required** | None |
+| **Template linkage** | None - standalone |
+
+---
+
+## License & Attribution
+
+**License:** MIT
+
+**Attribution:** Please retain author attribution when sharing or modifying.
+
+This template contains no Cisco Duo software, configuration, credentials, logs, or other third-party source code.

--- a/Applications/Security/template_duo_authentication_proxy_by_zabbix_agent2/7.4/template_duo_authentication_proxy_by_zabbix_agent2.yaml
+++ b/Applications/Security/template_duo_authentication_proxy_by_zabbix_agent2/7.4/template_duo_authentication_proxy_by_zabbix_agent2.yaml
@@ -1,0 +1,559 @@
+zabbix_export:
+  version: '7.4'
+  template_groups:
+    - uuid: a571c0d144b14fd4a87a9d9b2aa9fcd6
+      name: Templates/Applications
+  templates:
+    - uuid: 26976b67a34b4b62bcac9cc4991052bd
+      template: 'Duo Authentication Proxy by Zabbix agent 2'
+      name: 'Duo Authentication Proxy by Zabbix agent 2'
+      description: |
+        Monitors Cisco Duo Authentication Proxy on Linux using native Zabbix agent 2 keys.
+        
+        The template monitors systemd state, service resources, the Duo process, configuration-file integrity metadata, and locally listening RADIUS ports. It does not read Duo configuration or authentication logs and requires no credentials or custom UserParameters.
+        
+        Set {$DUO.RADIUS.PORTS} to a comma-separated list of UDP listener ports. The default is 18121. Override other macros only when the installation paths, service name, service account, or process command line differ.
+      groups:
+        - name: Templates/Applications
+      items:
+        - uuid: 35c0290434ae40288c37680f943d1b14
+          name: 'Duo: Service active state'
+          type: DEPENDENT
+          key: duo.service.active
+          history: 7d
+          description: 'Whether the Duo Authentication Proxy systemd unit is active. Reported as the numeric systemd state code and displayed through the "Unit Active State" value map.'
+          valuemap:
+            name: 'Unit Active State'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.ActiveState.state
+          master_item:
+            key: 'systemd.unit.get[{$DUO.SERVICE.NAME},Unit]'
+          tags:
+            - tag: component
+              value: service
+          triggers:
+            - uuid: 37f8b21a820d4fd98e2357b85d9a7c28
+              expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/duo.service.active,#3)<>1'
+              name: 'Duo: Authentication Proxy service is not active'
+              event_name: 'Duo: Authentication Proxy service is not active on {HOST.NAME}'
+              opdata: 'Systemd active state: {ITEM.LASTVALUE1}'
+              priority: HIGH
+              description: |
+                The systemd unit has not reported the active state for three consecutive checks.
+                
+                Confirm the unit state with systemctl status, then review the Duo startup diagnostics and configuration validation. This is the parent availability problem; process and listener problems depend on it to prevent duplicate alerts.
+              tags:
+                - tag: component
+                  value: service
+                - tag: scope
+                  value: availability
+        - uuid: 1e61e5fc82334034bef52cda8aa0a5e7
+          name: 'Duo: Service CPU utilization'
+          type: DEPENDENT
+          key: duo.service.cpu.util
+          history: 30d
+          value_type: FLOAT
+          units: '%'
+          description: 'CPU utilization calculated from the change in systemd service CPU time.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.CPUUsageNSec
+            - type: CHANGE_PER_SECOND
+            - type: MULTIPLIER
+              parameters:
+                - '1.0E-7'
+          master_item:
+            key: 'systemd.unit.get[{$DUO.SERVICE.NAME},Service]'
+          tags:
+            - tag: component
+              value: cpu
+          triggers:
+            - uuid: a25c14793592493280d5a8fddfdd1686
+              expression: 'min(/Duo Authentication Proxy by Zabbix agent 2/duo.service.cpu.util,10m)>{$DUO.CPU.UTIL.MAX.WARN}'
+              name: 'Duo: Authentication Proxy CPU utilization is high'
+              event_name: 'Duo: Authentication Proxy CPU utilization exceeds {$DUO.CPU.UTIL.MAX.WARN}% for 10m'
+              opdata: 'Current CPU utilization: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'Sustained CPU utilization exceeds the configurable threshold. Review authentication volume and service health before taking corrective action.'
+              dependencies:
+                - name: 'Duo: Authentication Proxy service is not active'
+                  expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/duo.service.active,#3)<>1'
+              tags:
+                - tag: component
+                  value: cpu
+                - tag: scope
+                  value: performance
+        - uuid: 052d75bb732e4bf797126607f10b77fa
+          name: 'Duo: Service enabled state'
+          type: DEPENDENT
+          key: duo.service.enabled
+          history: 7d
+          description: 'Whether the Duo Authentication Proxy systemd unit is enabled to start automatically. Reported as the numeric systemd unit-file state code and displayed through the "Unit File State" value map.'
+          valuemap:
+            name: 'Unit File State'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.UnitFileState.state
+          master_item:
+            key: 'systemd.unit.get[{$DUO.SERVICE.NAME},Unit]'
+          tags:
+            - tag: component
+              value: service
+          triggers:
+            - uuid: 62652ddc8ac54244a813c751b1c16240
+              expression: 'last(/Duo Authentication Proxy by Zabbix agent 2/duo.service.enabled)<>1'
+              name: 'Duo: Authentication Proxy service is not enabled at boot'
+              opdata: 'Systemd enabled state: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'The service is not enabled for automatic startup. Authentication may remain unavailable after a server reboot even if the service is currently running.'
+              tags:
+                - tag: component
+                  value: service
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: configuration
+        - uuid: d4bb85db0fd54cc781b9d10611bf6258
+          name: 'Duo: Service main PID'
+          type: DEPENDENT
+          key: duo.service.main_pid
+          history: 7d
+          description: 'Main process identifier reported by systemd.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.MainPID
+          master_item:
+            key: 'systemd.unit.get[{$DUO.SERVICE.NAME},Service]'
+          tags:
+            - tag: component
+              value: process
+          triggers:
+            - uuid: ede46c3b03784326a7db0ffd053f747b
+              expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/duo.service.main_pid,#3)=0'
+              name: 'Duo: Authentication Proxy has no main process'
+              opdata: 'Main PID: {ITEM.LASTVALUE1}'
+              priority: HIGH
+              description: 'Systemd reports no main PID for three consecutive checks even though the parent service-state problem is not active.'
+              dependencies:
+                - name: 'Duo: Authentication Proxy service is not active'
+                  expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/duo.service.active,#3)<>1'
+              tags:
+                - tag: component
+                  value: process
+                - tag: scope
+                  value: availability
+        - uuid: 3e91da01169d4929bbebdac4761189d8
+          name: 'Duo: Service memory usage'
+          type: DEPENDENT
+          key: duo.service.memory
+          history: 30d
+          units: B
+          description: 'Current memory attributed to the Duo systemd service cgroup.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.MemoryCurrent
+          master_item:
+            key: 'systemd.unit.get[{$DUO.SERVICE.NAME},Service]'
+          tags:
+            - tag: component
+              value: memory
+          triggers:
+            - uuid: 30271ffdab8c48ee84af075d262d87db
+              expression: 'min(/Duo Authentication Proxy by Zabbix agent 2/duo.service.memory,10m)>{$DUO.MEMORY.MAX.WARN}'
+              name: 'Duo: Authentication Proxy memory usage is high'
+              event_name: 'Duo: Authentication Proxy memory usage exceeds {$DUO.MEMORY.MAX.WARN} for 10m'
+              opdata: 'Current memory: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'Sustained service-cgroup memory usage exceeds the configurable warning threshold. Confirm whether traffic or worker counts changed before restarting the service.'
+              dependencies:
+                - name: 'Duo: Authentication Proxy service is not active'
+                  expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/duo.service.active,#3)<>1'
+              tags:
+                - tag: component
+                  value: memory
+                - tag: scope
+                  value: performance
+        - uuid: feecf696b3c2406f95a91c66fe34db0f
+          name: 'Duo: Service restart count'
+          type: DEPENDENT
+          key: duo.service.restarts
+          history: 30d
+          description: 'Number of automatic service restarts reported by systemd.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.NRestarts
+          master_item:
+            key: 'systemd.unit.get[{$DUO.SERVICE.NAME},Service]'
+          tags:
+            - tag: component
+              value: service
+          triggers:
+            - uuid: 5a1fba9c029a4694b2f2e79abcaad4e2
+              expression: 'change(/Duo Authentication Proxy by Zabbix agent 2/duo.service.restarts)>0'
+              name: 'Duo: Authentication Proxy was automatically restarted'
+              opdata: 'Restart counter: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'The systemd automatic-restart counter increased. Investigate the service journal and Duo startup diagnostics for a crash or failed health condition.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'Duo: Authentication Proxy service is not active'
+                  expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/duo.service.active,#3)<>1'
+              tags:
+                - tag: component
+                  value: service
+                - tag: scope
+                  value: notice
+        - uuid: e97562aeb2e448968dfe18cad7e12e27
+          name: 'Duo: Service substate'
+          type: DEPENDENT
+          key: duo.service.substate
+          history: 7d
+          value_type: CHAR
+          description: 'Detailed systemd unit substate, normally running.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.SubState
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: 'systemd.unit.get[{$DUO.SERVICE.NAME},Unit]'
+          tags:
+            - tag: component
+              value: service
+        - uuid: 9b672c417b5a4f0b8c4ec4ce7ee9dbce
+          name: 'Duo: Service tasks'
+          type: DEPENDENT
+          key: duo.service.tasks
+          history: 30d
+          description: 'Current number of tasks in the Duo systemd service cgroup.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.TasksCurrent
+          master_item:
+            key: 'systemd.unit.get[{$DUO.SERVICE.NAME},Service]'
+          tags:
+            - tag: component
+              value: process
+          triggers:
+            - uuid: 576b5e9958c248bdb4db3813950c1415
+              expression: 'min(/Duo Authentication Proxy by Zabbix agent 2/duo.service.tasks,10m)>{$DUO.TASKS.MAX.WARN}'
+              name: 'Duo: Authentication Proxy task count is high'
+              event_name: 'Duo: Authentication Proxy task count exceeds {$DUO.TASKS.MAX.WARN} for 10m'
+              opdata: 'Current tasks: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'The number of service-cgroup tasks has remained above the configured threshold. Review authentication demand and look for stuck or accumulating workers.'
+              dependencies:
+                - name: 'Duo: Authentication Proxy service is not active'
+                  expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/duo.service.active,#3)<>1'
+              tags:
+                - tag: component
+                  value: process
+                - tag: scope
+                  value: performance
+        - uuid: 9a75d237c64c4e64ad8388d558d35bce
+          name: 'Duo: Service uptime'
+          type: DEPENDENT
+          key: duo.service.uptime
+          history: 7d
+          trends: '0'
+          value_type: FLOAT
+          units: uptime
+          description: 'Number of seconds since systemd most recently placed the Duo service in the active state. No value is produced while the unit is inactive.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  data = JSON.parse(value);
+                  if (data.ActiveEnterTimestamp > data.ActiveExitTimestamp) {
+                    return Math.floor(Date.now() / 1000) - Number(data.ActiveEnterTimestamp) / 1000000;
+                  }
+                  return null;
+          master_item:
+            key: 'systemd.unit.get[{$DUO.SERVICE.NAME},Unit]'
+          tags:
+            - tag: component
+              value: service
+          triggers:
+            - uuid: c632483035f3475ba7f87d53c19f4fd3
+              expression: 'last(/Duo Authentication Proxy by Zabbix agent 2/duo.service.uptime)<10m'
+              name: 'Duo: Authentication Proxy has been restarted'
+              event_name: 'Duo: Authentication Proxy has been restarted on {HOST.NAME}'
+              opdata: 'Service uptime: {ITEM.LASTVALUE1}'
+              priority: INFO
+              description: 'The service uptime is below ten minutes, indicating a recent manual or automatic restart. Confirm that the restart was expected and that the service and listener recovered normally.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'Duo: Authentication Proxy service is not active'
+                  expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/duo.service.active,#3)<>1'
+              tags:
+                - tag: component
+                  value: service
+                - tag: scope
+                  value: notice
+        - uuid: fcce6e8f9d2f4566a55b0a779b1c6c89
+          name: 'Duo: Process RSS memory'
+          key: 'proc.mem[{$DUO.PROCESS.NAME},{$DUO.PROCESS.USER},,{$DUO.PROCESS.CMDLINE},rss]'
+          history: 30d
+          units: B
+          description: 'Resident memory used by Duo Authentication Proxy processes matching the configured filters.'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 24ca3ff9193943c38a51e60793b7d765
+          name: 'Duo: Process count'
+          key: 'proc.num[{$DUO.PROCESS.NAME},{$DUO.PROCESS.USER},,{$DUO.PROCESS.CMDLINE}]'
+          history: 7d
+          description: 'Number of Duo Authentication Proxy processes matching the configured executable name, service account, and command-line pattern.'
+          tags:
+            - tag: component
+              value: process
+          triggers:
+            - uuid: 0c2d9f924c81494eab30624df20ca25b
+              expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/proc.num[{$DUO.PROCESS.NAME},{$DUO.PROCESS.USER},,{$DUO.PROCESS.CMDLINE}],#3)=0'
+              name: 'Duo: Authentication Proxy process is not running'
+              opdata: 'Matching processes: {ITEM.LASTVALUE1}'
+              priority: HIGH
+              description: 'No process matching the configured Duo executable, service account, and command line was found for three consecutive checks.'
+              dependencies:
+                - name: 'Duo: Authentication Proxy service is not active'
+                  expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/duo.service.active,#3)<>1'
+              tags:
+                - tag: component
+                  value: process
+                - tag: scope
+                  value: availability
+        - uuid: 9c874216129446ec93ab78794a722040
+          name: 'Duo: Get systemd service metrics'
+          key: 'systemd.unit.get[{$DUO.SERVICE.NAME},Service]'
+          history: '0'
+          value_type: TEXT
+          description: 'Raw systemd Service-interface properties used by dependent resource and restart items.'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 79f1d77bf8ff419e82db12d349cda213
+          name: 'Duo: Get systemd unit state'
+          key: 'systemd.unit.get[{$DUO.SERVICE.NAME},Unit]'
+          history: '0'
+          value_type: TEXT
+          description: 'Raw systemd Unit-interface properties. Dependent items extract service availability and configuration state.'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 3a754676aa4345a5b6a4948a3ca3ca48
+          name: 'Duo: Executable exists'
+          key: 'vfs.file.exists[{$DUO.BINARY.PATH}]'
+          delay: 15m
+          history: 7d
+          description: 'Whether the Duo Authentication Proxy control executable exists.'
+          tags:
+            - tag: component
+              value: application
+          triggers:
+            - uuid: 671d8ce992c34c3688d4c602e762814d
+              expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/vfs.file.exists[{$DUO.BINARY.PATH}],#3)=0'
+              name: 'Duo: Authentication Proxy executable is missing'
+              priority: HIGH
+              description: 'The configured Duo Authentication Proxy executable path did not exist for three consecutive checks. Verify installation integrity and the {$DUO.BINARY.PATH} macro.'
+              tags:
+                - tag: component
+                  value: application
+                - tag: scope
+                  value: availability
+        - uuid: d446460ccd4e46dc8cb45089cb27ed4d
+          name: 'Duo: Configuration file exists'
+          key: 'vfs.file.exists[{$DUO.CONFIG.PATH}]'
+          delay: 5m
+          history: 7d
+          description: 'Whether the Duo Authentication Proxy configuration file exists. The file contents are never collected.'
+          tags:
+            - tag: component
+              value: configuration
+          triggers:
+            - uuid: 6dd8ea3d601b4058acdaa17b7eca4993
+              expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/vfs.file.exists[{$DUO.CONFIG.PATH}],#3)=0'
+              name: 'Duo: Authentication Proxy configuration file is missing'
+              priority: HIGH
+              description: 'The configured Duo Authentication Proxy configuration path did not exist for three consecutive checks. The item collects existence metadata only and never reads configuration contents.'
+              tags:
+                - tag: component
+                  value: configuration
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: configuration
+        - uuid: b313fd4a863a424c84aab679d47b2ed9
+          name: 'Duo: Configuration modification time'
+          key: 'vfs.file.time[{$DUO.CONFIG.PATH},modify]'
+          delay: 5m
+          history: 30d
+          units: unixtime
+          description: 'Last modification time of the Duo configuration file. Configuration contents are not collected.'
+          tags:
+            - tag: component
+              value: configuration
+          triggers:
+            - uuid: a9b0c592741a4f1ead42239511b1e8d5
+              expression: 'change(/Duo Authentication Proxy by Zabbix agent 2/vfs.file.time[{$DUO.CONFIG.PATH},modify])<>0'
+              name: 'Duo: Authentication Proxy configuration was modified'
+              opdata: 'Modification time: {ITEM.LASTVALUE1}'
+              priority: INFO
+              description: 'The configuration-file modification timestamp changed. Confirm that the change was authorized and that the service remains healthy. This trigger does not expose configuration contents.'
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: configuration
+                - tag: scope
+                  value: configuration
+                - tag: scope
+                  value: notice
+      discovery_rules:
+        - uuid: 65b58ee20156461dac53dc44248b80bf
+          name: 'Duo: RADIUS listener discovery'
+          type: SCRIPT
+          key: duo.radius.listener.discovery
+          delay: 1h
+          params: |
+            var input = JSON.parse(value),
+                ports = String(input.ports || '').split(','),
+                seen = {},
+                result = [];
+            
+            ports.forEach(function (entry) {
+                var port = entry.trim();
+                if (!/^\d+$/.test(port) || Number(port) < 1 || Number(port) > 65535) {
+                    throw 'Invalid UDP port in {$DUO.RADIUS.PORTS}: ' + port;
+                }
+                if (!seen[port]) {
+                    result.push({'{#DUO.PORT}': port});
+                    seen[port] = true;
+                }
+            });
+            
+            if (result.length === 0) {
+                throw '{$DUO.RADIUS.PORTS} must contain at least one UDP port.';
+            }
+            return JSON.stringify(result);
+          enabled_lifetime_type: DISABLE_NEVER
+          description: 'Discovers one or more locally monitored UDP RADIUS listeners from the comma-separated {$DUO.RADIUS.PORTS} macro.'
+          item_prototypes:
+            - uuid: 59ff86e99b28433aa0ff33fc6610eefb
+              name: 'Duo: UDP {#DUO.PORT} listener status'
+              key: 'net.udp.listen[{#DUO.PORT}]'
+              history: 7d
+              description: 'Whether a process is listening locally on discovered UDP port {#DUO.PORT}. Combined with the systemd and process checks, this verifies that the Duo service and its expected listener are present.'
+              tags:
+                - tag: component
+                  value: network
+                - tag: port
+                  value: '{#DUO.PORT}'
+              trigger_prototypes:
+                - uuid: 4689cb075bd84ba494c674c8ae59faae
+                  expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/net.udp.listen[{#DUO.PORT}],#3)=0'
+                  name: 'Duo: UDP {#DUO.PORT} listener is not available'
+                  event_name: 'Duo: Expected UDP listener {#DUO.PORT} is not available on {HOST.NAME}'
+                  opdata: 'Listener state: {ITEM.LASTVALUE1}'
+                  priority: HIGH
+                  description: 'No local UDP listener was detected on the discovered Duo RADIUS port for three consecutive checks. Verify the configured Duo server section and listening port. This problem depends on the parent service-down trigger to prevent duplicate outage alerts.'
+                  dependencies:
+                    - name: 'Duo: Authentication Proxy service is not active'
+                      expression: 'max(/Duo Authentication Proxy by Zabbix agent 2/duo.service.active,#3)<>1'
+                  tags:
+                    - tag: component
+                      value: network
+                    - tag: port
+                      value: '{#DUO.PORT}'
+                    - tag: scope
+                      value: availability
+          parameters:
+            - name: ports
+              value: '{$DUO.RADIUS.PORTS}'
+      tags:
+        - tag: class
+          value: application
+        - tag: target
+          value: authentication-proxy
+        - tag: target
+          value: duo
+      macros:
+        - macro: '{$DUO.BINARY.PATH}'
+          value: /opt/duoauthproxy/bin/authproxyctl
+          description: 'Path to the Duo Authentication Proxy control executable.'
+        - macro: '{$DUO.CONFIG.PATH}'
+          value: /opt/duoauthproxy/conf/authproxy.cfg
+          description: 'Path to the Duo Authentication Proxy configuration file. Only file metadata is monitored.'
+        - macro: '{$DUO.CPU.UTIL.MAX.WARN}'
+          value: '80'
+          description: 'Maximum sustained Duo service CPU utilization percentage before a warning.'
+        - macro: '{$DUO.MEMORY.MAX.WARN}'
+          value: 512M
+          description: 'Maximum sustained Duo service-cgroup memory usage before a warning.'
+        - macro: '{$DUO.PROCESS.CMDLINE}'
+          value: duoauthproxy
+          description: 'Regular expression used to identify the Duo process command line.'
+        - macro: '{$DUO.PROCESS.NAME}'
+          value: python3
+          description: 'Process executable name used by proc.num and proc.mem.'
+        - macro: '{$DUO.PROCESS.USER}'
+          value: duo_authproxy_svc
+          description: 'Operating-system account that runs Duo Authentication Proxy.'
+        - macro: '{$DUO.RADIUS.PORTS}'
+          value: '18121'
+          description: 'Comma-separated UDP listener ports discovered and monitored as Duo RADIUS listeners.'
+        - macro: '{$DUO.SERVICE.NAME}'
+          value: duoauthproxy.service
+          description: 'Duo Authentication Proxy systemd unit name.'
+        - macro: '{$DUO.TASKS.MAX.WARN}'
+          value: '50'
+          description: 'Maximum sustained number of tasks in the Duo service cgroup before a warning.'
+      valuemaps:
+        - uuid: 8f2b1d6c4a7e4c92b0d31e5a7c9f4b28
+          name: 'Unit Active State'
+          mappings:
+            - value: '0'
+              newvalue: unknown
+            - value: '1'
+              newvalue: active
+            - value: '2'
+              newvalue: reloading
+            - value: '3'
+              newvalue: inactive
+            - value: '4'
+              newvalue: failed
+            - value: '5'
+              newvalue: activating
+            - value: '6'
+              newvalue: deactivating
+        - uuid: 3c7a95e21b8d4f60ae42c8d1f36b7e04
+          name: 'Unit File State'
+          mappings:
+            - value: '0'
+              newvalue: unknown
+            - value: '1'
+              newvalue: enabled
+            - value: '2'
+              newvalue: enabled-runtime
+            - value: '3'
+              newvalue: linked
+            - value: '4'
+              newvalue: linked-runtime
+            - value: '5'
+              newvalue: masked
+            - value: '6'
+              newvalue: masked-runtime
+            - value: '7'
+              newvalue: static
+            - value: '8'
+              newvalue: disabled
+            - value: '9'
+              newvalue: invalid

--- a/Applications/Security/template_duo_authentication_proxy_by_zabbix_agent2/7.4/template_duo_authentication_proxy_by_zabbix_agent2.yaml
+++ b/Applications/Security/template_duo_authentication_proxy_by_zabbix_agent2/7.4/template_duo_authentication_proxy_by_zabbix_agent2.yaml
@@ -273,11 +273,15 @@ zabbix_export:
             - type: JAVASCRIPT
               parameters:
                 - |
-                  data = JSON.parse(value);
-                  if (data.ActiveEnterTimestamp > data.ActiveExitTimestamp) {
-                    return Math.floor(Date.now() / 1000) - Number(data.ActiveEnterTimestamp) / 1000000;
+                  var data = JSON.parse(value),
+                      enter = Number(data.ActiveEnterTimestamp),
+                      exit = Number(data.ActiveExitTimestamp);
+
+                  if (!isFinite(enter) || !isFinite(exit) || enter <= exit) {
+                    return null;
                   }
-                  return null;
+
+                  return Math.floor(Date.now() / 1000) - enter / 1000000;
           master_item:
             key: 'systemd.unit.get[{$DUO.SERVICE.NAME},Unit]'
           tags:
@@ -431,6 +435,9 @@ zabbix_export:
             
             ports.forEach(function (entry) {
                 var port = entry.trim();
+                if (port === '') {
+                    return;
+                }
                 if (!/^\d+$/.test(port) || Number(port) < 1 || Number(port) > 65535) {
                     throw 'Invalid UDP port in {$DUO.RADIUS.PORTS}: ' + port;
                 }


### PR DESCRIPTION
## Summary

Adds a monitoring template for **Cisco Duo Authentication Proxy** on Linux, using
native Zabbix agent 2 keys only.

Path: `Applications/Security/template_duo_authentication_proxy_by_zabbix_agent2/7.4/`

## What it monitors

| Area | Coverage |
|---|---|
| Service | systemd active state, substate, boot-enabled state, uptime, restart counter, main PID |
| Resources | Service cgroup CPU utilization, memory usage, task count |
| Process | Process count and RSS memory, matched by executable, service account, and command line |
| Configuration | Configuration-file existence and modification-time metadata |
| Application | Control executable existence |
| Network | Discovered local UDP RADIUS listener status |

**Objects:** 16 items, 1 discovery rule, 1 item prototype, 13 triggers, 2 value maps, 10 macros.

## Design notes

- **Credential-free by design.** The template never reads Duo configuration contents,
  authentication logs, RADIUS secrets, or Duo cloud credentials. Configuration monitoring
  is limited to existence and modification-time metadata. Authentication logs are
  intentionally excluded because they may contain usernames and source addresses.
- **No host-side setup.** No UserParameter, sudo rule, log permission, external script,
  or additional package is required.
- **Two raw `systemd.unit.get` master items** (`Unit` and `Service` interfaces) with
  `history=0` feed every dependent metric, following the official Zabbix systemd
  template pattern. Their empty history is expected and is documented in the README.
- **Value maps** `Unit Active State` and `Unit File State` use the same numeric state
  codes as the official Zabbix systemd template, so `$.ActiveState.state` and
  `$.UnitFileState.state` render as text rather than integers.
- **Service uptime** returns no value while the unit is inactive, using the official
  `ActiveEnterTimestamp > ActiveExitTimestamp` guard rather than subtracting a zero
  timestamp from the current epoch.
- **Macro-driven RADIUS listener LLD.** A script-type rule converts the comma-separated
  `{$DUO.RADIUS.PORTS}` macro into one item and trigger per UDP listener, validating each
  port is an integer in 1-65535, removing duplicates, and rejecting an empty list.
- **Alert noise control.** Availability triggers require three consecutive checks;
  resource warnings require ten minutes of persistence. Process, resource, restart, and
  listener triggers depend on the parent service-down trigger so a single service outage
  does not fan out into duplicate alerts.

## Notes for reviewers

- `{$DUO.RADIUS.PORTS}` defaults to `18121`, which is a **tested deployment value, not a
  universal Duo default**. This is called out in both the macro description and the README.
- `{$DUO.PROCESS.NAME}` defaults to `python3` because the Duo proxy runs under a bundled
  Python interpreter; the command-line and user macros narrow the match.
- `net.udp.listen[]` confirms a local UDP socket is bound. It does not perform a
  credentialed RADIUS transaction, and the README states this limitation explicitly.
- No template linkage. The export is self-contained.

## Validation

- Validated on Zabbix server and agent 2 **7.4.13**, with unit `duoauthproxy.service`,
  install path `/opt/duoauthproxy`, and the process running as `duo_authproxy_svc`.
- All 16 static items supported, listener discovery successful, dependencies and tags
  retained after import. No host-side change was required.
- Directory layout, template folder/file naming, and folder-version-to-export-version
  match were checked against the repository rules.
- Contains no credentials, secrets, addresses, or customer identifiers.

## License

MIT.
