### PR TITLE
Add ADVA FSP 150-XG108 template for Zabbix 7.4

### DIFF
--- a/Network_Devices/Adva/template_adva_fsp150_xg108_by_snmp/7.4/README.md
+++ b/Network_Devices/Adva/template_adva_fsp150_xg108_by_snmp/7.4/README.md
@@ -1,0 +1,304 @@
+# ADVA FSP 150-XG108 Monitoring Template for Zabbix 7.4
+
+[![Zabbix Version](https://img.shields.io/badge/Zabbix-7.4-red.svg)](https://www.zabbix.com/)
+[![Protocol](https://img.shields.io/badge/SNMP-v2c%20%2B%20traps-blue.svg)](https://www.zabbix.com/documentation/7.4/en/manual/config/items/itemtypes/snmp)
+[![License](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
+
+**Author:** `://echo@dla.network [oZark oRChes✝ra✝'d]` | [![GitHub](https://img.shields.io/badge/GitHub-DLA--neTWorK-blue?logo=github)](https://github.com/DLA-neTWorK)
+
+**Version:** 1.0.0
+
+## Overview
+
+Standalone monitoring template for the **ADVA FSP 150-XG108** carrier Ethernet demarcation device, built for Zabbix 7.4. It combines SNMPv2c polling with SNMP trap reception to cover device reachability, chassis card health, physical service-port state and traffic, and dying-gasp/power-failure notifications.
+
+The template is **self-contained**: ICMP availability, standard SNMP system polling, SNMP availability, trap collection, triggers, dependencies, macros, value maps, and dashboards are all included. It does not link `Generic SNMP` or any other baseline template.
+
+Verified against a device reporting sysObjectID `1.3.6.1.4.1.2544.1.12.1.1.50`.
+
+### Key Features
+
+- ✅ **Self-contained baseline** - ICMP, SNMP system tree, and SNMP availability included; no template linkage required
+- ✅ **Chassis card discovery** - Per-card administrative state, operational state, temperature, voltage, and dying-gasp configuration from the ADVA enterprise MIB
+- ✅ **Filtered service-port discovery** - Macro-driven IF-MIB/IF-X-MIB discovery scoped to real customer/network ports, not DCN or placeholder interfaces
+- ✅ **64-bit traffic counters** - `ifHCInOctets`/`ifHCOutOctets` with per-interface error, discard, speed, and utilization telemetry
+- ✅ **Dying-gasp trap capture** - Text-matched power-event notifications plus a fallback stream for unmatched traps
+- ✅ **Conservative alerting posture** - Only reachability and SNMP-collection triggers are enabled by default; device-specific triggers ship disabled for operator review
+- ✅ **Dependency-aware triggers** - SNMP and interface alarms are suppressed by the ICMP root-cause trigger
+- ✅ **Ready-made dashboards** - Two template dashboards covering general health and interface/card statistics
+
+---
+
+## Monitoring Capabilities
+
+### Device-level polling
+
+| Metric | Item key | Source OID |
+|--------|----------|------------|
+| ICMP ping | `icmpping` | Simple check |
+| ICMP loss | `icmppingloss` | Simple check |
+| ICMP response time | `icmppingsec` | Simple check |
+| System description | `system.descr[sysDescr.0]` | `1.3.6.1.2.1.1.1.0` |
+| System name | `system.name` | `1.3.6.1.2.1.1.5.0` |
+| System object ID | `system.objectid[sysObjectID.0]` | `1.3.6.1.2.1.1.2.0` |
+| Uptime | `system.net.uptime[sysUpTime.0]` | `1.3.6.1.2.1.1.3.0` |
+| SNMP agent availability | `zabbix[host,snmp,available]` | Zabbix internal |
+| Dying gasp / power failure trap | `snmptrap["(?i)(dying[ -]?gasp\|power[ -]?(fail\|loss))"]` | SNMP trap |
+| SNMP traps (fallback) | `snmptrap.fallback` | SNMP trap |
+
+### Physical service interface discovery
+
+LLD rule `adva.net.if.discovery` (every 1h) walks IF-MIB/IF-X-MIB and creates **8 item prototypes** plus a traffic graph per discovered port:
+
+| Metric | Item key | OID |
+|--------|----------|-----|
+| Administrative status | `adva.net.if.admin[ifAdminStatus.{#SNMPINDEX}]` | `1.3.6.1.2.1.2.2.1.7` |
+| Operational status | `adva.net.if.oper[ifOperStatus.{#SNMPINDEX}]` | `1.3.6.1.2.1.2.2.1.8` |
+| Bits received | `adva.net.if.in[ifHCInOctets.{#SNMPINDEX}]` | `1.3.6.1.2.1.31.1.1.1.6` |
+| Bits sent | `adva.net.if.out[ifHCOutOctets.{#SNMPINDEX}]` | `1.3.6.1.2.1.31.1.1.1.10` |
+| Inbound errors | `adva.net.if.in.errors[ifInErrors.{#SNMPINDEX}]` | `1.3.6.1.2.1.2.2.1.14` |
+| Inbound discards | `adva.net.if.in.discards[ifInDiscards.{#SNMPINDEX}]` | `1.3.6.1.2.1.2.2.1.13` |
+| Outbound discards | `adva.net.if.out.discards[ifOutDiscards.{#SNMPINDEX}]` | `1.3.6.1.2.1.2.2.1.19` |
+| Speed | `adva.net.if.speed[ifHighSpeed.{#SNMPINDEX}]` | `1.3.6.1.2.1.31.1.1.1.15` |
+
+Discovery defaults select administratively up Ethernet (`ifType` 6) ports whose name and description match ADVA NETWORK/ACCESS service-port patterns. Operationally down ports are deliberately retained so link failures stay visible.
+
+### XG108 card discovery
+
+LLD rule `adva.xg108.card.discovery` (every 1h) walks the ADVA enterprise entity table `1.3.6.1.4.1.2544.1.12.3.1.106.1` and creates **5 item prototypes** plus temperature and voltage graphs per card:
+
+| Metric | Item key | OID suffix |
+|--------|----------|------------|
+| Administrative state | `adva.xg108.card.admin_state[{#SNMPINDEX}]` | `.2` |
+| Operational state | `adva.xg108.card.operational_state[{#SNMPINDEX}]` | `.3` |
+| Voltage | `adva.xg108.card.voltage[{#SNMPINDEX}]` | `.5` |
+| Temperature | `adva.xg108.card.temperature[{#SNMPINDEX}]` | `.6` |
+| Dying-gasp notification state | `adva.xg108.dying_gasp.enabled[{#SNMPINDEX}]` | `.7` |
+
+Card rows are discovered dynamically rather than assuming a fixed network-element, shelf, or slot suffix, so the template follows XG108 variants and inventory layouts.
+
+---
+
+## Trigger Summary
+
+**10 triggers total. 4 are enabled by default; 6 ship disabled** so the template is safe to link before device-specific behaviour has been proven in your environment.
+
+### Enabled by default
+
+| Severity | Trigger | Recovery | Dependency |
+|----------|---------|----------|------------|
+| **HIGH** | `ADVA CPE: Unavailable by ICMP` | 3 successful ICMP checks | Root cause |
+| **WARNING** | `ADVA CPE: High ICMP packet loss` | 5-minute loss below threshold | ICMP unavailable |
+| **WARNING** | `ADVA CPE: High ICMP response time` | 5-minute average below threshold | ICMP loss, ICMP unavailable |
+| **WARNING** | `ADVA CPE: No SNMP data collection` | SNMP polling resumes | ICMP unavailable |
+
+### Disabled by default — enable after review
+
+| Severity | Trigger | Why it ships disabled |
+|----------|---------|-----------------------|
+| **DISASTER** | `ADVA CPE: Dying gasp or power failure notification received` | Enable once the notification OID and trap routing are proven in your environment |
+| **HIGH** | `ADVA CPE: Interface {#IFNAME} is down` | Enable after confirming discovery scope matches your service ports |
+| **HIGH** | `ADVA CPE: XG108 card {#ADVA.CARD.ENTITYINDEX} is in outage state` | Evaluates only when administrative state is `in-service(1)` |
+| **WARNING** | `ADVA CPE: Device has restarted` | Enable when uptime-based alerting is wanted |
+| **WARNING** | `ADVA CPE: Interface {#IFNAME} inbound error rate is high` | Tune `{$IF.ERRORS.WARN}` to the circuit first |
+| **WARNING** | `ADVA CPE: Interface {#IFNAME} utilization is high` | Tune `{$IF.UTIL.MAX}` to the service profile first |
+
+The dying-gasp trigger is intentionally **independent of ICMP**, because the trap is often the last evidence received before polling stops. It recovers after ten minutes without another matching trap and allows manual close.
+
+---
+
+## Installation Guide
+
+### Prerequisites
+
+- ✅ Zabbix server/proxy and frontend **7.4** or later
+- ✅ SNMPv2c enabled on the FSP 150-XG108
+- ✅ One SNMP host interface reaching the device on **UDP 161**
+- ✅ A working Zabbix SNMP trap receiver on **UDP 162**, with the device configured to send notifications to it
+- ✅ ICMP echo permitted from the Zabbix server/proxy (`fping`)
+
+### Step 1: Import the template
+
+1. Download `template_adva_fsp150_xg108_by_snmp.yaml`
+2. Zabbix web interface -> **Data collection** -> **Templates** -> **Import**
+3. Select the YAML file and complete import
+4. Verify template name: **ADVA FSP 150-XG108 by SNMP** in group **Templates/Network devices**
+
+### Step 2: Create the host
+
+1. **Data collection** -> **Hosts** -> **Create host**
+2. **Interfaces:** add an **SNMP** interface with the device management address on UDP 161, SNMP version **v2c**
+3. **Templates:** link `ADVA FSP 150-XG108 by SNMP`
+
+### Step 3: Set the SNMP community
+
+The template deliberately **does not define a community value**. Set `{$SNMP_COMMUNITY}` as a **secret** host or host-group macro on your own installation.
+
+> Never commit a real SNMP community to a template export, a README, or an issue report.
+
+### Step 4: Configure trap forwarding
+
+1. Point the device's SNMPv2c notification target at the Zabbix trap receiver on UDP 162
+2. Confirm the receiver is listening and Zabbix trap processing is enabled
+3. Verify firewall policy permits UDP 162 from the device management network
+
+### Step 5: Validate and enable
+
+1. **Monitoring** -> **Latest data**: confirm ICMP and SNMP system items populate
+2. Confirm both discovery rules create the expected ports and cards
+3. Confirm unmatched notifications land in `snmptrap.fallback`
+4. Review thresholds, then enable the disabled triggers you want
+
+---
+
+## Zabbix Configuration
+
+### Discovery filter macros
+
+| Macro | Default | Purpose |
+|-------|---------|---------|
+| `{$ADVA.IFADMINSTATUS.MATCHES}` | `^1$` | Discover administratively up ports |
+| `{$ADVA.IFADMINSTATUS.NOT_MATCHES}` | `^$` | Optional admin-state exclusion |
+| `{$ADVA.IFDESCR.MATCHES}` | `^ETHERNET (NETWORK\|ACCESS) PORT$` | ADVA service-port descriptions |
+| `{$ADVA.IFDESCR.NOT_MATCHES}` | `^$` | Optional description exclusion |
+| `{$ADVA.IFNAME.MATCHES}` | `^(NETWORK\|ACCESS) PORT-` | Physical service-port names |
+| `{$ADVA.IFNAME.NOT_MATCHES}` | `^$` | Optional name exclusion |
+| `{$ADVA.IFOPERSTATUS.MATCHES}` | `^.*$` | Keep down ports discoverable |
+| `{$ADVA.IFOPERSTATUS.NOT_MATCHES}` | `^6$` | Exclude `notPresent(6)` |
+| `{$ADVA.IFTYPE.MATCHES}` | `^6$` | Ethernet CSMA/CD only |
+| `{$ADVA.IFTYPE.NOT_MATCHES}` | `^$` | Optional type exclusion |
+
+### Threshold macros
+
+| Macro | Default | Purpose |
+|-------|---------|---------|
+| `{$ICMP_LOSS_WARN}` | `20` | Sustained ICMP loss warning, percent over 5 minutes |
+| `{$ICMP_RESPONSE_TIME_WARN}` | `0.15` | 5-minute average response-time warning, seconds |
+| `{$IF.ERRORS.WARN}` | `1` | Inbound error rate warning, errors/second over 5 minutes |
+| `{$IF.UTIL.MAX}` | `90` | Interface utilization warning, percent over 15 minutes |
+| `{$IFCONTROL}` | `1` | Set to `0` (with interface context) to except a port from link alerting |
+| `{$SNMP.TIMEOUT}` | `5m` | How long SNMP must be unavailable before alerting |
+
+`{$IF.ERRORS.WARN}`, `{$IF.UTIL.MAX}`, and `{$IFCONTROL}` accept a **macro context** of `{#IFNAME}` for per-interface exceptions, for example `{$IFCONTROL:"NETWORK PORT-1-1-1-1"}`.
+
+### Value maps
+
+`ADVA administrative state`, `ADVA operational state`, `IF-MIB interface status`, `Service state`, `SNMP availability`, and `SNMP TruthValue`.
+
+### Dashboards
+
+| Dashboard | Pages | Content |
+|-----------|-------|---------|
+| `ADVA CPE: General` | 1 | Availability, ICMP loss, response time, device identity |
+| `ADVA CPE: Statistics` | 2 | Interface traffic/errors and card temperature/voltage |
+
+### Object counts
+
+| Object type | Count |
+|-------------|-------|
+| Items | 10 |
+| Discovery rules | 2 |
+| Item prototypes | 13 |
+| Graph prototypes | 3 |
+| Triggers and trigger prototypes | 10 (4 enabled) |
+| Value maps | 6 |
+| Dashboards | 2 |
+| Macros | 16 |
+
+---
+
+## Troubleshooting
+
+### Standard SNMP data is unavailable
+
+1. Confirm the SNMP interface address and UDP 161 reachability
+2. Verify SNMPv2c is enabled on the device
+3. Confirm `{$SNMP_COMMUNITY}` is set at host or host-group level
+4. Review the SNMP error text on the item and the Zabbix server/proxy log
+
+### No interfaces discovered
+
+**Symptom:** `adva.net.if.discovery` returns nothing, or the wrong ports appear.
+
+The default filters are tuned to ADVA `NETWORK PORT-` / `ACCESS PORT-` naming. Check the raw values of `ifName`, `ifDescr`, and `ifType` on the device with `snmpwalk`, then relax `{$ADVA.IFNAME.MATCHES}` and `{$ADVA.IFDESCR.MATCHES}` accordingly.
+
+### No cards discovered
+
+**Symptom:** `adva.xg108.card.discovery` returns nothing.
+
+Walk `1.3.6.1.4.1.2544.1.12.3.1.106.1.1` directly. If the table is empty, the firmware exposes a different entity layout and the OID branch needs adjusting for that variant.
+
+### Traps are unavailable
+
+1. Confirm the device trap target uses the receiver address and UDP 162
+2. Confirm the trap receiver is listening and Zabbix trap processing is enabled
+3. Review `snmptrap.fallback` for unmatched ADVA notifications
+4. Verify firewall policy permits UDP 162 from the device management network
+
+### False positive power-trap match
+
+Review the complete formatted notification in item history. Tighten the regular expression using the confirmed enterprise notification OID rather than adding site-specific text.
+
+---
+
+## Known Limitations
+
+- The exact enterprise notification OID for an XG108 dying-gasp event has not been captured from a controlled or real event. The trap item currently matches **formatted notification text**. Before treating this as OID-validated, capture a representative trap from `snmptrap.fallback`, confirm the enterprise OID and varbinds, and add the OID to the item expression.
+- Routing-protocol monitoring (OSPF, BGP) is intentionally out of scope.
+- Discovery filter defaults reflect one verified XG108 naming layout; other firmware revisions may need filter changes.
+
+---
+
+## Version History
+
+### v1.0.0 - Initial release
+
+- ✅ Standalone Zabbix 7.4 template with no external template linkage
+- ✅ ICMP, SNMP system tree, SNMP availability, and trap collection
+- ✅ Physical service-interface discovery with 64-bit traffic counters
+- ✅ XG108 card discovery with temperature, voltage, and state telemetry
+- ✅ Dying-gasp and power-failure trap matching with timed recovery and manual close
+- ✅ Two dashboards, six value maps, and dependency-aware triggers
+- ✅ Verified device identity and SNMPv2c polling against sysObjectID `1.3.6.1.4.1.2544.1.12.1.1.50`
+
+---
+
+## Support & Resources
+
+### Template Maintainer
+
+**Author:** `://echo@dla.network [oZark oRChes✝ra✝'d]` | [![GitHub](https://img.shields.io/badge/GitHub-DLA--neTWorK-blue?logo=github)](https://github.com/DLA-neTWorK)
+
+When reporting an issue, include the Zabbix version, ADVA firmware version, sanitized item error, and a redacted trap sample. **Remove communities, addresses, customer names, and device identifiers before sharing.**
+
+### Zabbix Resources
+
+- [Zabbix 7.4 Documentation](https://www.zabbix.com/documentation/7.4/)
+- [SNMP agent items](https://www.zabbix.com/documentation/7.4/en/manual/config/items/itemtypes/snmp)
+- [SNMP trap monitoring](https://www.zabbix.com/documentation/7.4/en/manual/config/items/itemtypes/snmptrap)
+- [Low-level discovery](https://www.zabbix.com/documentation/7.4/en/manual/discovery/low_level_discovery)
+- [Zabbix template guidelines](https://www.zabbix.com/documentation/guidelines/en/template_guidelines)
+
+---
+
+## Quick Reference
+
+| Property | Value |
+|----------|-------|
+| **Template Name** | ADVA FSP 150-XG108 by SNMP |
+| **Template Group** | Templates/Network devices |
+| **Zabbix Version** | 7.4+ |
+| **Monitoring Type** | SNMPv2c polling + SNMP traps |
+| **Device sysObjectID** | `1.3.6.1.4.1.2544.1.12.1.1.50` |
+| **Required host macro** | `{$SNMP_COMMUNITY}` (secret) |
+| **Template linkage** | None - standalone |
+
+---
+
+## License & Attribution
+
+**License:** MIT
+
+**Attribution:** Please retain author attribution when sharing or modifying.
+
+This template contains no ADVA firmware, MIB source, third-party code, credentials, management addresses, proxy names, SNMP communities, or customer identifiers.

--- a/Network_Devices/Adva/template_adva_fsp150_xg108_by_snmp/7.4/template_adva_fsp150_xg108_by_snmp.yaml
+++ b/Network_Devices/Adva/template_adva_fsp150_xg108_by_snmp/7.4/template_adva_fsp150_xg108_by_snmp.yaml
@@ -1,0 +1,1247 @@
+zabbix_export:
+  version: '7.4'
+  template_groups:
+    - uuid: 36bff6c29af64692839d077febfc7079
+      name: 'Templates/Network devices'
+  templates:
+    - uuid: 5dfbf270558b4d01a9e24d95215b5e8f
+      template: 'ADVA FSP 150-XG108 by SNMP'
+      name: 'ADVA FSP 150-XG108 by SNMP'
+      description: |
+        Enterprise CPE monitoring for the ADVA FSP 150-XG108 through SNMPv2c and SNMP traps.
+        
+        Collects device availability, ICMP loss and response time, identity, uptime, XG108 card operational state, temperature, voltage, dying-gasp configuration, focused physical service-interface state, 64-bit traffic, errors, discards, speed, and dying-gasp/power-failure notifications. Routing-protocol monitoring such as OSPF and BGP is intentionally excluded. Only ICMP reachability/performance and Zabbix SNMP-availability triggers are enabled by default. Restart, LLD-derived card/interface, and event-driven trap triggers remain disabled for operator review.
+        
+        Verified device sysObjectID: 1.3.6.1.4.1.2544.1.12.1.1.50.
+      groups:
+        - name: 'Templates/Network devices'
+      items:
+        - uuid: 46d53acaefcc42039f116db1505e2756
+          name: 'ICMP ping'
+          type: SIMPLE
+          key: icmpping
+          history: 7d
+          description: 'Tests management-plane reachability with ICMP echo. The NOC uses this as the primary device-reachability signal and as the root-cause dependency for SNMP collection failures. A value of 1 is reachable and 0 is unreachable.'
+          valuemap:
+            name: 'Service state'
+          tags:
+            - tag: component
+              value: availability
+            - tag: scope
+              value: availability
+          triggers:
+            - uuid: 5d12d89964a144fc8d5d81a124715e27
+              expression: 'max(/ADVA FSP 150-XG108 by SNMP/icmpping,#3)=0'
+              name: 'ADVA CPE: Unavailable by ICMP'
+              priority: HIGH
+              description: 'Condition: the last three ICMP checks returned no response. NOC impact: management reachability is lost and downstream SNMP alarms may be symptoms. Dependency behavior: root-cause trigger with no dependency. Recovery: closes automatically when ICMP succeeds. First actions: confirm the management path, upstream reachability, and site impact before dispatch.'
+              tags:
+                - tag: component
+                  value: availability
+                - tag: scope
+                  value: availability
+        - uuid: 30ee39cc0e684b18bf006b7456945b17
+          name: 'ICMP loss'
+          type: SIMPLE
+          key: icmppingloss
+          history: 14d
+          value_type: FLOAT
+          units: '%'
+          description: 'Measures management-plane ICMP packet loss as a percentage each minute. The NOC uses the trend to distinguish intermittent transport degradation from a hard outage and to correlate customer-impact reports. The enabled threshold trigger uses {$ICMP_LOSS_WARN} over a five-minute window.'
+          tags:
+            - tag: component
+              value: availability
+            - tag: scope
+              value: performance
+          triggers:
+            - uuid: d7188be68b87453c9b22258e334447eb
+              expression: 'min(/ADVA FSP 150-XG108 by SNMP/icmppingloss,5m)>{$ICMP_LOSS_WARN} and min(/ADVA FSP 150-XG108 by SNMP/icmppingloss,5m)<100'
+              name: 'ADVA CPE: High ICMP packet loss'
+              event_name: 'ADVA CPE: ICMP packet loss is above {$ICMP_LOSS_WARN}%'
+              opdata: 'Loss: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'Condition: every ICMP loss sample in the last five minutes is above {$ICMP_LOSS_WARN}, while loss remains below 100 percent. NOC impact: sustained management-path loss may indicate transport degradation and can affect enterprise applications before a hard outage. Dependency behavior: suppressed by the ICMP-unavailable trigger because total reachability loss is the stronger root cause. Recovery: closes automatically when the five-minute condition clears. First actions: correlate response time, interface errors/discards/utilization, upstream path health, and customer reports.'
+              dependencies:
+                - name: 'ADVA CPE: Unavailable by ICMP'
+                  expression: 'max(/ADVA FSP 150-XG108 by SNMP/icmpping,#3)=0'
+              tags:
+                - tag: component
+                  value: availability
+                - tag: scope
+                  value: performance
+        - uuid: 0b31172901c84f4dbd648ed4411b89b9
+          name: 'ICMP response time'
+          type: SIMPLE
+          key: icmppingsec
+          history: 14d
+          value_type: FLOAT
+          units: s
+          description: 'Measures management-plane ICMP round-trip time in seconds each minute. The NOC uses the trend to identify latency changes and correlate them with loss or interface congestion. The enabled threshold trigger averages five minutes and uses {$ICMP_RESPONSE_TIME_WARN}.'
+          tags:
+            - tag: component
+              value: availability
+            - tag: scope
+              value: performance
+          triggers:
+            - uuid: c2be7d52c1294e8abb8ad835e5228d71
+              expression: 'avg(/ADVA FSP 150-XG108 by SNMP/icmppingsec,5m)>{$ICMP_RESPONSE_TIME_WARN}'
+              name: 'ADVA CPE: High ICMP response time'
+              event_name: 'ADVA CPE: ICMP response time is above {$ICMP_RESPONSE_TIME_WARN}s'
+              opdata: 'Response time: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'Condition: the five-minute average ICMP round-trip time is above {$ICMP_RESPONSE_TIME_WARN} seconds. NOC impact: sustained latency may degrade interactive enterprise applications and can precede loss or congestion. Dependency behavior: suppressed by both the high-ICMP-loss and ICMP-unavailable triggers because loss or total reachability failure is the stronger root cause. Recovery: closes automatically when the five-minute average returns below threshold. First actions: correlate packet loss, interface utilization/errors/discards, upstream path latency, and customer reports.'
+              dependencies:
+                - name: 'ADVA CPE: High ICMP packet loss'
+                  expression: 'min(/ADVA FSP 150-XG108 by SNMP/icmppingloss,5m)>{$ICMP_LOSS_WARN} and min(/ADVA FSP 150-XG108 by SNMP/icmppingloss,5m)<100'
+                - name: 'ADVA CPE: Unavailable by ICMP'
+                  expression: 'max(/ADVA FSP 150-XG108 by SNMP/icmpping,#3)=0'
+              tags:
+                - tag: component
+                  value: availability
+                - tag: scope
+                  value: performance
+        - uuid: 7324a0e9d8144fbd926b68e69e27927d
+          name: 'SNMP traps (fallback)'
+          type: SNMP_TRAP
+          key: snmptrap.fallback
+          history: 14d
+          value_type: LOG
+          description: 'Stores SNMP traps that do not match a dedicated trap item. The NOC uses this diagnostic stream to identify uncategorized device events and capture the exact ADVA notification OID and varbind layout. This is event-driven data, not a heartbeat.'
+          logtimefmt: 'hh:mm:sszyyyy/MM/dd'
+          tags:
+            - tag: component
+              value: snmp
+            - tag: scope
+              value: diagnostics
+            - tag: source
+              value: snmp-trap
+        - uuid: 003a2ea903ea46a984b5351dccd278ba
+          name: 'ADVA: Dying gasp or power failure trap'
+          type: SNMP_TRAP
+          key: 'snmptrap["(?i)(dying[ -]?gasp|power[ -]?(fail|loss))"]'
+          history: 90d
+          value_type: LOG
+          description: 'Stores ADVA SNMP notifications whose formatted text identifies dying gasp, power failure, or power loss. The NOC uses this as direct evidence of a CPE power event when polling may stop immediately afterward. The fallback item retains unmatched traps until the exact enterprise notification OID is verified.'
+          logtimefmt: 'hh:mm:sszyyyy/MM/dd'
+          tags:
+            - tag: component
+              value: power
+            - tag: scope
+              value: availability
+            - tag: source
+              value: snmp-trap
+          triggers:
+            - uuid: 640672f1e93044cf82ab2d826aa0f444
+              expression: 'nodata(/ADVA FSP 150-XG108 by SNMP/snmptrap["(?i)(dying[ -]?gasp|power[ -]?(fail|loss))"],10m)=0'
+              name: 'ADVA CPE: Dying gasp or power failure notification received'
+              opdata: '{ITEM.LASTVALUE1}'
+              status: DISABLED
+              priority: DISASTER
+              description: 'Condition: a matching dying-gasp, power-failure, or power-loss SNMP trap was received within ten minutes. NOC impact: probable loss of CPE power and enterprise service. Dependency behavior: intentionally independent because this trap can be the root-cause evidence after ICMP and SNMP polling stop. Recovery: closes after ten minutes without another matching trap; manual close is also allowed. First actions: verify site power, device reachability, and customer impact. Disabled by default until the notification OID and routing are proven.'
+              manual_close: 'YES'
+              tags:
+                - tag: component
+                  value: power
+                - tag: scope
+                  value: availability
+                - tag: source
+                  value: snmp-trap
+        - uuid: de0f17bd9e394dddb82388acccbc776c
+          name: 'System description'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.1.0
+          key: 'system.descr[sysDescr.0]'
+          delay: 1h
+          history: 14d
+          value_type: CHAR
+          description: 'Polls SNMPv2-MIB sysDescr.0 for the device software and platform identity string. The NOC uses it to verify the expected model/firmware context during triage and after maintenance; unchanged values are retained by heartbeat.'
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+            - tag: scope
+              value: inventory
+        - uuid: 3f9e265fd37a4df1bc12288535c35e8d
+          name: 'System name'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.5.0
+          key: system.name
+          delay: 15m
+          history: 14d
+          value_type: CHAR
+          description: 'Polls SNMPv2-MIB sysName.0 for the device-configured hostname. The NOC uses it to detect naming drift and confirm the intended CPE during incident response; unchanged values are retained by heartbeat.'
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 12h
+          tags:
+            - tag: component
+              value: system
+            - tag: scope
+              value: inventory
+        - uuid: d122642d39c547d2890e38c83e0854b6
+          name: Uptime
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.3.0
+          key: 'system.net.uptime[sysUpTime.0]'
+          history: 14d
+          trends: '0'
+          units: uptime
+          description: 'Polls SNMPv2-MIB sysUpTime.0 and converts hundredths of a second to seconds. The NOC uses it to confirm restarts and correlate outages with device boot time.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.01'
+          tags:
+            - tag: component
+              value: system
+            - tag: scope
+              value: availability
+          triggers:
+            - uuid: 0554f792cf6b410db2e2d4f6bda74a3f
+              expression: 'last(/ADVA FSP 150-XG108 by SNMP/system.net.uptime[sysUpTime.0])<10m'
+              name: 'ADVA CPE: Device has restarted'
+              status: DISABLED
+              priority: WARNING
+              description: 'Policy: disabled by default because this is a polled event inference, not baseline ICMP/SNMP availability. Condition: SNMP-reported uptime is less than ten minutes. NOC impact: the CPE recently restarted and service may have briefly interrupted. Dependency behavior: suppressed by the SNMP-collection trigger because stale or unavailable uptime is not reliable restart evidence. Recovery: closes automatically when uptime reaches ten minutes; manual close is allowed. First actions after operator enablement: correlate the boot time with reachability, power, traps, maintenance, and customer reports.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'ADVA CPE: No SNMP data collection'
+                  expression: 'max(/ADVA FSP 150-XG108 by SNMP/zabbix[host,snmp,available],{$SNMP.TIMEOUT})=0'
+              tags:
+                - tag: component
+                  value: system
+                - tag: scope
+                  value: notice
+        - uuid: e7e951d4fbc44eb79c9d0e20509d2df2
+          name: 'System object ID'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.2.0
+          key: 'system.objectid[sysObjectID.0]'
+          delay: 1h
+          history: 14d
+          value_type: CHAR
+          description: 'Polls SNMPv2-MIB sysObjectID.0 for the vendor product identifier. The NOC uses it to confirm that the host is an expected ADVA FSP 150-XG108 and to prevent template/model mismatch.'
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+            - tag: scope
+              value: inventory
+        - uuid: ff4b8519ebc542f0a2e5554e15004d33
+          name: 'SNMP agent availability'
+          type: INTERNAL
+          key: 'zabbix[host,snmp,available]'
+          history: 7d
+          description: 'Reports Zabbix''s internal availability state for the host SNMP interface. The NOC uses it to distinguish an SNMP polling/configuration failure from general ICMP reachability loss.'
+          valuemap:
+            name: 'SNMP availability'
+          tags:
+            - tag: component
+              value: availability
+            - tag: scope
+              value: availability
+          triggers:
+            - uuid: 887b9863f4de4e02a3ea1d9cfc3c2f68
+              expression: 'max(/ADVA FSP 150-XG108 by SNMP/zabbix[host,snmp,available],{$SNMP.TIMEOUT})=0'
+              name: 'ADVA CPE: No SNMP data collection'
+              opdata: 'Current state: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'Condition: Zabbix reports the SNMP interface unavailable for {$SNMP.TIMEOUT}. NOC impact: interface and system telemetry may be stale even if the CPE still answers ICMP. Dependency behavior: suppressed by the ICMP-unavailable trigger to avoid duplicate alarms during a reachability outage. Recovery: closes automatically when SNMP polling resumes. First actions: verify SNMP credentials, ACLs, UDP/161 path, and proxy collection.'
+              dependencies:
+                - name: 'ADVA CPE: Unavailable by ICMP'
+                  expression: 'max(/ADVA FSP 150-XG108 by SNMP/icmpping,#3)=0'
+              tags:
+                - tag: component
+                  value: snmp
+                - tag: scope
+                  value: availability
+      discovery_rules:
+        - uuid: 306e558dead2446ca1666fb64082da15
+          name: 'ADVA physical service interfaces discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#IFNAME},1.3.6.1.2.1.31.1.1.1.1,{#IFDESCR},1.3.6.1.2.1.2.2.1.2,{#IFADMINSTATUS},1.3.6.1.2.1.2.2.1.7,{#IFOPERSTATUS},1.3.6.1.2.1.2.2.1.8,{#IFTYPE},1.3.6.1.2.1.2.2.1.3]'
+          key: adva.net.if.discovery
+          delay: 1h
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#IFADMINSTATUS}'
+                value: '{$ADVA.IFADMINSTATUS.MATCHES}'
+              - macro: '{#IFADMINSTATUS}'
+                value: '{$ADVA.IFADMINSTATUS.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFDESCR}'
+                value: '{$ADVA.IFDESCR.MATCHES}'
+              - macro: '{#IFDESCR}'
+                value: '{$ADVA.IFDESCR.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFNAME}'
+                value: '{$ADVA.IFNAME.MATCHES}'
+              - macro: '{#IFNAME}'
+                value: '{$ADVA.IFNAME.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFOPERSTATUS}'
+                value: '{$ADVA.IFOPERSTATUS.MATCHES}'
+              - macro: '{#IFOPERSTATUS}'
+                value: '{$ADVA.IFOPERSTATUS.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#IFTYPE}'
+                value: '{$ADVA.IFTYPE.MATCHES}'
+              - macro: '{#IFTYPE}'
+                value: '{$ADVA.IFTYPE.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+          lifetime: 30d
+          enabled_lifetime_type: DISABLE_AFTER
+          enabled_lifetime: 1h
+          description: 'Discovers configured IF-MIB/IF-X-MIB physical service interfaces every hour using host-overridable filters for administrative state, description, name, operational state, and interface type. Defaults select administratively up Ethernet NETWORK/ACCESS ports, retain operationally down ports so link failures remain visible, and exclude DCN/placeholder interfaces. Resources no longer matching the host configuration are disabled after one hour and retained for 30 days before deletion.'
+          item_prototypes:
+            - uuid: 39bf4a367c97478ead07b08d14270311
+              name: 'Interface {#IFNAME}: Administrative status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.7.{#SNMPINDEX}'
+              key: 'adva.net.if.admin[ifAdminStatus.{#SNMPINDEX}]'
+              delay: 5m
+              history: 14d
+              trends: '0'
+              description: 'Polls IF-MIB ifAdminStatus for the configured administrative state. The NOC uses it to distinguish an intentionally shut interface from an unexpected operational failure.'
+              valuemap:
+                name: 'IF-MIB interface status'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: metric
+                  value: admin-status
+                - tag: scope
+                  value: availability
+            - uuid: 64a2e04913f44cf89766707a8391494a
+              name: 'Interface {#IFNAME}: Inbound discards'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.13.{#SNMPINDEX}'
+              key: 'adva.net.if.in.discards[ifInDiscards.{#SNMPINDEX}]'
+              delay: 3m
+              history: 14d
+              description: 'Polls IF-MIB ifInDiscards and calculates inbound discarded packets per second. The NOC uses it to identify local resource pressure or policy drops even when packets contain no detectable errors.'
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+              tags:
+                - tag: component
+                  value: interface
+                - tag: direction
+                  value: in
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: metric
+                  value: discards
+                - tag: scope
+                  value: performance
+            - uuid: d2ec73c30b93404f882e43043e3f9dc6
+              name: 'Interface {#IFNAME}: Inbound errors'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.14.{#SNMPINDEX}'
+              key: 'adva.net.if.in.errors[ifInErrors.{#SNMPINDEX}]'
+              delay: 3m
+              history: 14d
+              description: 'Polls IF-MIB ifInErrors and calculates inbound errored packets per second. The NOC uses sustained increases to identify physical-layer, framing, or handoff-quality problems. This model did not expose usable per-interface ifOutErrors during validation.'
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+              tags:
+                - tag: component
+                  value: interface
+                - tag: direction
+                  value: in
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: metric
+                  value: errors
+                - tag: scope
+                  value: performance
+              trigger_prototypes:
+                - uuid: 0e0aeab650c043dc8978862bbdfe3361
+                  expression: 'avg(/ADVA FSP 150-XG108 by SNMP/adva.net.if.in.errors[ifInErrors.{#SNMPINDEX}],5m)>{$IF.ERRORS.WARN:"{#IFNAME}"}'
+                  name: 'ADVA CPE: Interface {#IFNAME} inbound error rate is high'
+                  status: DISABLED
+                  priority: WARNING
+                  description: 'Policy: disabled by default because this is an LLD-derived polled threshold, not baseline ICMP/SNMP availability. Condition: the five-minute average inbound error rate exceeds {$IF.ERRORS.WARN:"{#IFNAME}"}. NOC impact: sustained receive errors may indicate physical-layer, framing, or handoff degradation. Dependency behavior: suppressed while the same interface link-down trigger is active; enable the complete interface dependency chain together. Recovery: closes automatically after the rolling average falls below threshold. First actions after operator enablement: compare traffic and discards, inspect optics/cabling and far-end counters, and confirm customer impact. This XG108 did not expose usable per-interface ifOutErrors.'
+                  dependencies:
+                    - name: 'ADVA CPE: Interface {#IFNAME} is down'
+                      expression: '{$IFCONTROL:"{#IFNAME}"}=1 and last(/ADVA FSP 150-XG108 by SNMP/adva.net.if.admin[ifAdminStatus.{#SNMPINDEX}])=1 and last(/ADVA FSP 150-XG108 by SNMP/adva.net.if.oper[ifOperStatus.{#SNMPINDEX}])=2'
+                      recovery_expression: 'last(/ADVA FSP 150-XG108 by SNMP/adva.net.if.oper[ifOperStatus.{#SNMPINDEX}])=1 or {$IFCONTROL:"{#IFNAME}"}=0'
+                  tags:
+                    - tag: component
+                      value: interface
+                    - tag: interface
+                      value: '{#IFNAME}'
+                    - tag: scope
+                      value: performance
+            - uuid: 38b6c689aaf049a68b26b63e16e8d254
+              name: 'Interface {#IFNAME}: Bits received'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.31.1.1.1.6.{#SNMPINDEX}'
+              key: 'adva.net.if.in[ifHCInOctets.{#SNMPINDEX}]'
+              delay: 3m
+              history: 14d
+              units: bps
+              description: 'Polls IF-MIB ifHCInOctets for the interface, calculates the per-second change, and converts octets to inbound bits per second. The NOC uses this 64-bit rate to baseline customer traffic and investigate congestion without counter-wrap distortion.'
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: direction
+                  value: in
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: metric
+                  value: traffic
+                - tag: scope
+                  value: performance
+            - uuid: 37c83f5a1a064ca2ac302614cd1934a4
+              name: 'Interface {#IFNAME}: Operational status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.8.{#SNMPINDEX}'
+              key: 'adva.net.if.oper[ifOperStatus.{#SNMPINDEX}]'
+              history: 14d
+              trends: '0'
+              description: 'Polls IF-MIB ifOperStatus for the current operational state. The NOC uses it with administrative state to identify service-facing links that are unexpectedly down.'
+              valuemap:
+                name: 'IF-MIB interface status'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: metric
+                  value: oper-status
+                - tag: scope
+                  value: availability
+            - uuid: 2a59126abb7b4a8d8a8a4abe6fde9090
+              name: 'Interface {#IFNAME}: Outbound discards'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.19.{#SNMPINDEX}'
+              key: 'adva.net.if.out.discards[ifOutDiscards.{#SNMPINDEX}]'
+              delay: 3m
+              history: 14d
+              description: 'Polls IF-MIB ifOutDiscards and calculates outbound discarded packets per second. The NOC uses it to identify egress resource pressure or policy drops that may affect enterprise traffic.'
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+              tags:
+                - tag: component
+                  value: interface
+                - tag: direction
+                  value: out
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: metric
+                  value: discards
+                - tag: scope
+                  value: performance
+            - uuid: 9d32d2d8a6474c849cc8dc017034e3f4
+              name: 'Interface {#IFNAME}: Bits sent'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.31.1.1.1.10.{#SNMPINDEX}'
+              key: 'adva.net.if.out[ifHCOutOctets.{#SNMPINDEX}]'
+              delay: 3m
+              history: 14d
+              units: bps
+              description: 'Polls IF-MIB ifHCOutOctets for the interface, calculates the per-second change, and converts octets to outbound bits per second. The NOC uses this 64-bit rate to baseline customer traffic and investigate congestion without counter-wrap distortion.'
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: direction
+                  value: out
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: metric
+                  value: traffic
+                - tag: scope
+                  value: performance
+            - uuid: 167327505d8f47008a64333694ada1b9
+              name: 'Interface {#IFNAME}: Speed'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.31.1.1.1.15.{#SNMPINDEX}'
+              key: 'adva.net.if.speed[ifHighSpeed.{#SNMPINDEX}]'
+              delay: 5m
+              history: 14d
+              trends: '0'
+              units: bps
+              description: 'Polls IF-MIB ifHighSpeed, reported in Mbit/s, and converts it to bit/s. The NOC uses the negotiated/reported capacity to interpret traffic rates and calculate interface utilization.'
+              preprocessing:
+                - type: MULTIPLIER
+                  parameters:
+                    - '1000000'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: metric
+                  value: speed
+                - tag: scope
+                  value: capacity
+          trigger_prototypes:
+            - uuid: 3640ff4b22844910b25610d9a08cdb99
+              expression: '{$IFCONTROL:"{#IFNAME}"}=1 and last(/ADVA FSP 150-XG108 by SNMP/adva.net.if.admin[ifAdminStatus.{#SNMPINDEX}])=1 and last(/ADVA FSP 150-XG108 by SNMP/adva.net.if.oper[ifOperStatus.{#SNMPINDEX}])=2'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'last(/ADVA FSP 150-XG108 by SNMP/adva.net.if.oper[ifOperStatus.{#SNMPINDEX}])=1 or {$IFCONTROL:"{#IFNAME}"}=0'
+              name: 'ADVA CPE: Interface {#IFNAME} is down'
+              status: DISABLED
+              priority: HIGH
+              description: 'Policy: disabled by default because this is an LLD-derived polled condition, not baseline ICMP/SNMP availability. Condition: {$IFCONTROL:"{#IFNAME}"}=1, the interface is administratively up, and its operational state is down. NOC impact: probable loss of the enterprise handoff or network-side service path. Dependency behavior: suppressed by the SNMP-collection trigger so stale polling does not create a link alarm. Recovery: closes when the link returns or per-interface control is set to 0; manual close is allowed. First actions after operator enablement: identify the port role, check optics/cabling and the far-end device, then correlate customer impact. {$IFCONTROL} defaults to 1; set a per-interface context to 0 only for a reviewed exception.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'ADVA CPE: No SNMP data collection'
+                  expression: 'max(/ADVA FSP 150-XG108 by SNMP/zabbix[host,snmp,available],{$SNMP.TIMEOUT})=0'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: scope
+                  value: availability
+            - uuid: 2faae04a38324dad805eb26e97ca8e7d
+              expression: '(avg(/ADVA FSP 150-XG108 by SNMP/adva.net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/ADVA FSP 150-XG108 by SNMP/adva.net.if.speed[ifHighSpeed.{#SNMPINDEX}]) or avg(/ADVA FSP 150-XG108 by SNMP/adva.net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/ADVA FSP 150-XG108 by SNMP/adva.net.if.speed[ifHighSpeed.{#SNMPINDEX}])) and last(/ADVA FSP 150-XG108 by SNMP/adva.net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0'
+              name: 'ADVA CPE: Interface {#IFNAME} utilization is high'
+              status: DISABLED
+              priority: WARNING
+              description: 'Policy: disabled by default because this is an LLD-derived polled threshold, not baseline ICMP/SNMP availability. Condition: the 15-minute average inbound or outbound bit rate exceeds {$IF.UTIL.MAX:"{#IFNAME}"} percent of reported interface speed. NOC impact: sustained utilization may cause latency, loss, or customer throughput complaints. Dependency behavior: suppressed while the same interface link-down trigger is active; enable the complete interface dependency chain together. Recovery: closes automatically when utilization no longer meets the condition. First actions after operator enablement: confirm interface speed, review both traffic directions and ICMP trends, and identify whether demand is expected.'
+              dependencies:
+                - name: 'ADVA CPE: Interface {#IFNAME} is down'
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and last(/ADVA FSP 150-XG108 by SNMP/adva.net.if.admin[ifAdminStatus.{#SNMPINDEX}])=1 and last(/ADVA FSP 150-XG108 by SNMP/adva.net.if.oper[ifOperStatus.{#SNMPINDEX}])=2'
+                  recovery_expression: 'last(/ADVA FSP 150-XG108 by SNMP/adva.net.if.oper[ifOperStatus.{#SNMPINDEX}])=1 or {$IFCONTROL:"{#IFNAME}"}=0'
+              tags:
+                - tag: component
+                  value: interface
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: scope
+                  value: performance
+          graph_prototypes:
+            - uuid: 9f7bc6f0289d4ec594e9108fcb94ef8c
+              name: 'ADVA interface {#IFNAME}: Traffic'
+              graph_items:
+                - color: 199C0D
+                  item:
+                    host: 'ADVA FSP 150-XG108 by SNMP'
+                    key: 'adva.net.if.in[ifHCInOctets.{#SNMPINDEX}]'
+                - sortorder: '1'
+                  color: F63100
+                  item:
+                    host: 'ADVA FSP 150-XG108 by SNMP'
+                    key: 'adva.net.if.out[ifHCOutOctets.{#SNMPINDEX}]'
+        - uuid: 03a8b16239fe4819acc546493dea47f1
+          name: 'ADVA XG108 card discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#ADVA.CARD.ENTITYINDEX},1.3.6.1.4.1.2544.1.12.3.1.106.1.1,{#ADVA.CARD.ADMINSTATE},1.3.6.1.4.1.2544.1.12.3.1.106.1.2,{#ADVA.CARD.OPERSTATE},1.3.6.1.4.1.2544.1.12.3.1.106.1.3,{#ADVA.CARD.VOLTAGE},1.3.6.1.4.1.2544.1.12.3.1.106.1.5,{#ADVA.CARD.TEMPERATURE},1.3.6.1.4.1.2544.1.12.3.1.106.1.6,{#ADVA.CARD.DYINGGASP},1.3.6.1.4.1.2544.1.12.3.1.106.1.7]'
+          key: adva.xg108.card.discovery
+          delay: 1h
+          lifetime: 30d
+          enabled_lifetime_type: DISABLE_AFTER
+          enabled_lifetime: 1h
+          description: 'Discovers each live XG108 Ethernet-card row from the ADVA CM-ENTITY-MIB instead of assuming a fixed network-element, shelf, or slot suffix. This allows the same template to follow XG108 variants and inventory layouts dynamically. A card row no longer returned by the device is disabled after one hour and retained for 30 days before deletion.'
+          item_prototypes:
+            - uuid: 50710bc8be1e4036bfb8f043421e1ed4
+              name: 'ADVA XG108 card {#ADVA.CARD.ENTITYINDEX}: Administrative state'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.2544.1.12.3.1.106.1.2.{#SNMPINDEX}'
+              key: 'adva.xg108.card.admin_state[{#SNMPINDEX}]'
+              delay: 5m
+              history: 90d
+              trends: '0'
+              description: 'Polls the CM-ENTITY-MIB administrative state for the discovered XG108 Ethernet card. The NOC uses this value to distinguish an intentionally managed, maintained, disabled, or unassigned card from an unexpected operational outage. The card-outage trigger evaluates only when this state is in-service(1).'
+              valuemap:
+                name: 'ADVA administrative state'
+              tags:
+                - tag: component
+                  value: hardware
+                - tag: entity
+                  value: 'XG108 card {#ADVA.CARD.ENTITYINDEX}'
+                - tag: metric
+                  value: administrative-state
+                - tag: scope
+                  value: configuration
+                - tag: source
+                  value: snmp-poll
+            - uuid: ea7d46a6dbca4e939daed33af651f37f
+              name: 'ADVA XG108 card {#ADVA.CARD.ENTITYINDEX}: Operational state'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.2544.1.12.3.1.106.1.3.{#SNMPINDEX}'
+              key: 'adva.xg108.card.operational_state[{#SNMPINDEX}]'
+              delay: 3m
+              history: 90d
+              trends: '0'
+              description: 'Polls the CM-ENTITY-MIB operational state for the discovered XG108 Ethernet card. The NOC uses this chassis-level health signal with administrative state to distinguish a card outage from planned maintenance and individual service-port faults. The verified values are normal(1) and outage(2).'
+              valuemap:
+                name: 'ADVA operational state'
+              tags:
+                - tag: component
+                  value: hardware
+                - tag: entity
+                  value: 'XG108 card {#ADVA.CARD.ENTITYINDEX}'
+                - tag: metric
+                  value: operational-state
+                - tag: scope
+                  value: availability
+                - tag: source
+                  value: snmp-poll
+            - uuid: 8b6a5deb3164453a85db21e07728918c
+              name: 'ADVA XG108 card {#ADVA.CARD.ENTITYINDEX}: Temperature'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.2544.1.12.3.1.106.1.6.{#SNMPINDEX}'
+              key: 'adva.xg108.card.temperature[{#SNMPINDEX}]'
+              delay: 5m
+              history: 90d
+              value_type: FLOAT
+              units: °C
+              description: 'Polls the CM-ENTITY-MIB temperature reported by the discovered XG108 Ethernet card in degrees Celsius. The NOC should trend this value against site temperature and active over-temperature alarms. No threshold trigger is defined until representative fleet baselines or an ADVA internal-card threshold are available; the published -40 to +65 degrees Celsius rating is an ambient operating range, not a safe substitute for the internal sensor threshold.'
+              tags:
+                - tag: component
+                  value: temperature
+                - tag: entity
+                  value: 'XG108 card {#ADVA.CARD.ENTITYINDEX}'
+                - tag: metric
+                  value: temperature
+                - tag: scope
+                  value: health
+                - tag: source
+                  value: snmp-poll
+            - uuid: 7cf7952c64e340dab5b35cbe703ebfe6
+              name: 'ADVA XG108 card {#ADVA.CARD.ENTITYINDEX}: Voltage'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.2544.1.12.3.1.106.1.5.{#SNMPINDEX}'
+              key: 'adva.xg108.card.voltage[{#SNMPINDEX}]'
+              delay: 5m
+              history: 90d
+              value_type: FLOAT
+              units: V
+              description: 'Polls the CM-ENTITY-MIB voltage reported by the discovered XG108 Ethernet card and converts millivolts to volts. The NOC uses the trend with dying-gasp, restart, and ADVA power alarms to investigate unstable site power. No voltage threshold trigger is defined until the deployed AC/DC variant and vendor limits are confirmed.'
+              preprocessing:
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.001'
+              tags:
+                - tag: component
+                  value: power
+                - tag: entity
+                  value: 'XG108 card {#ADVA.CARD.ENTITYINDEX}'
+                - tag: metric
+                  value: voltage
+                - tag: scope
+                  value: health
+                - tag: source
+                  value: snmp-poll
+            - uuid: 9ee4c03b146f4ac2baa785942f9d7353
+              name: 'ADVA XG108 card {#ADVA.CARD.ENTITYINDEX}: Dying-gasp notification state'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.2544.1.12.3.1.106.1.7.{#SNMPINDEX}'
+              key: 'adva.xg108.dying_gasp.enabled[{#SNMPINDEX}]'
+              delay: 15m
+              history: 90d
+              trends: '0'
+              description: 'Polls the CM-ENTITY-MIB TruthValue controlling whether the discovered XG108 card can emit dying-gasp notifications. The NOC uses this configuration-health item to explain missing last-gasp traps independently of receiver routing. A value of true(1) is enabled and false(2) is disabled.'
+              valuemap:
+                name: 'SNMP TruthValue'
+              tags:
+                - tag: component
+                  value: power
+                - tag: entity
+                  value: 'XG108 card {#ADVA.CARD.ENTITYINDEX}'
+                - tag: metric
+                  value: dying-gasp-enabled
+                - tag: scope
+                  value: configuration
+                - tag: source
+                  value: snmp-poll
+          trigger_prototypes:
+            - uuid: aa3d3be9fa6540bca92b47c20f827719
+              expression: 'last(/ADVA FSP 150-XG108 by SNMP/adva.xg108.card.admin_state[{#SNMPINDEX}])=1 and last(/ADVA FSP 150-XG108 by SNMP/adva.xg108.card.operational_state[{#SNMPINDEX}])=2'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'last(/ADVA FSP 150-XG108 by SNMP/adva.xg108.card.operational_state[{#SNMPINDEX}])=1 or last(/ADVA FSP 150-XG108 by SNMP/adva.xg108.card.admin_state[{#SNMPINDEX}])<>1'
+              name: 'ADVA CPE: XG108 card {#ADVA.CARD.ENTITYINDEX} is in outage state'
+              opdata: 'Administrative state: {ITEM.LASTVALUE1}; operational state: {ITEM.LASTVALUE2}'
+              status: DISABLED
+              priority: HIGH
+              description: 'Policy: disabled by default because this is an LLD-derived polled condition, not baseline ICMP/SNMP availability. Condition: the discovered XG108 card is administratively in-service(1) and operationally outage(2). NOC impact: chassis-level packet processing or all enterprise service interfaces may be impaired. Dependency behavior: suppressed by the SNMP-collection trigger because stale card state is not reliable outage evidence; the expression also prevents alerts during management, maintenance, disabled, or unassigned states. Recovery: closes when the card returns to normal(1) or leaves in-service administration. First actions after operator enablement: correlate ICMP/SNMP reachability, active ADVA alarms, uptime, temperature, voltage, and all service-port states before considering a dispatch or restart.'
+              dependencies:
+                - name: 'ADVA CPE: No SNMP data collection'
+                  expression: 'max(/ADVA FSP 150-XG108 by SNMP/zabbix[host,snmp,available],{$SNMP.TIMEOUT})=0'
+              tags:
+                - tag: component
+                  value: hardware
+                - tag: entity
+                  value: 'XG108 card {#ADVA.CARD.ENTITYINDEX}'
+                - tag: scope
+                  value: availability
+                - tag: source
+                  value: snmp-poll
+          graph_prototypes:
+            - uuid: 0d35200b73bc4299ac6bda489b8cfdbf
+              name: 'ADVA XG108 card {#ADVA.CARD.ENTITYINDEX}: Temperature'
+              graph_items:
+                - color: FFCA28
+                  item:
+                    host: 'ADVA FSP 150-XG108 by SNMP'
+                    key: 'adva.xg108.card.temperature[{#SNMPINDEX}]'
+            - uuid: e37f70a0f00a4414b2562c2a5d42286f
+              name: 'ADVA XG108 card {#ADVA.CARD.ENTITYINDEX}: Voltage'
+              graph_items:
+                - color: 1E88E5
+                  item:
+                    host: 'ADVA FSP 150-XG108 by SNMP'
+                    key: 'adva.xg108.card.voltage[{#SNMPINDEX}]'
+      tags:
+        - tag: class
+          value: network
+        - tag: target
+          value: adva
+        - tag: target
+          value: 'ADVA FSP 150-XG108'
+      macros:
+        - macro: '{$ADVA.IFADMINSTATUS.MATCHES}'
+          value: ^1$
+          description: 'Discover administratively up service interfaces by default. Override per host when disabled-port telemetry is intentionally required.'
+        - macro: '{$ADVA.IFADMINSTATUS.NOT_MATCHES}'
+          value: ^$
+          description: 'Optional host-specific exclusion regex for IF-MIB ifAdminStatus values.'
+        - macro: '{$ADVA.IFDESCR.MATCHES}'
+          value: '^ETHERNET (NETWORK|ACCESS) PORT$'
+          description: 'Discover ADVA Ethernet network/access service-port descriptions by default.'
+        - macro: '{$ADVA.IFDESCR.NOT_MATCHES}'
+          value: ^$
+          description: 'Optional host-specific exclusion regex for IF-MIB interface descriptions.'
+        - macro: '{$ADVA.IFNAME.MATCHES}'
+          value: '^(NETWORK|ACCESS) PORT-'
+          description: 'Discover physical customer/network service ports by default.'
+        - macro: '{$ADVA.IFNAME.NOT_MATCHES}'
+          value: ^$
+          description: 'Optional exclusion regex for physical service ports.'
+        - macro: '{$ADVA.IFOPERSTATUS.MATCHES}'
+          value: '^.*$'
+          description: 'Include every operational state so an administratively up but operationally down service port is discovered and can alert.'
+        - macro: '{$ADVA.IFOPERSTATUS.NOT_MATCHES}'
+          value: ^6$
+          description: 'Exclude IF-MIB notPresent(6) interfaces by default.'
+        - macro: '{$ADVA.IFTYPE.MATCHES}'
+          value: ^6$
+          description: 'Discover Ethernet CSMACD ifType(6) service interfaces by default.'
+        - macro: '{$ADVA.IFTYPE.NOT_MATCHES}'
+          value: ^$
+          description: 'Optional host-specific exclusion regex for IF-MIB interface type values.'
+        - macro: '{$ICMP_LOSS_WARN}'
+          value: '20'
+          description: 'Sustained ICMP packet-loss warning threshold in percent over five minutes.'
+        - macro: '{$ICMP_RESPONSE_TIME_WARN}'
+          value: '0.15'
+          description: 'Five-minute average ICMP response-time warning threshold in seconds (0.15 seconds equals 150 milliseconds).'
+        - macro: '{$IF.ERRORS.WARN}'
+          value: '1'
+          description: 'Five-minute average inbound interface error-rate threshold in errors per second.'
+        - macro: '{$IF.UTIL.MAX}'
+          value: '90'
+          description: 'Fifteen-minute average interface utilization threshold percentage.'
+        - macro: '{$IFCONTROL}'
+          value: '1'
+          description: 'Enable link-state alerting on administratively up service interfaces. Set a context value of 0 only for a reviewed per-interface exception.'
+        - macro: '{$SNMP.TIMEOUT}'
+          value: 5m
+          description: 'Time SNMP must remain unavailable before the enabled SNMP collection trigger enters problem state.'
+      dashboards:
+        - uuid: 0c485b047fb746f3bc74bc8df6b421a9
+          name: 'ADVA CPE: General'
+          pages:
+            - name: Overview
+              widgets:
+                - type: problems
+                  width: '72'
+                  height: '3'
+                  fields:
+                    - type: INTEGER
+                      name: acknowledgement_status
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: ADVAC
+                    - type: INTEGER
+                      name: show
+                      value: '3'
+                    - type: INTEGER
+                      name: show_opdata
+                      value: '2'
+                    - type: INTEGER
+                      name: show_tags
+                      value: '1'
+                    - type: STRING
+                      name: tag_priority
+                      value: 'scope,component,interface,entity'
+                - type: item
+                  name: 'ICMP availability'
+                  'y': '3'
+                  width: '12'
+                  hide_header: 'YES'
+                  fields:
+                    - type: STRING
+                      name: bg_color
+                      value: FFCA28
+                    - type: STRING
+                      name: description
+                      value: ICMP
+                    - type: INTEGER
+                      name: desc_bold
+                      value: '1'
+                    - type: STRING
+                      name: desc_color
+                      value: FFFFFF
+                    - type: INTEGER
+                      name: desc_v_pos
+                      value: '0'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        key: icmpping
+                    - type: INTEGER
+                      name: show.0
+                      value: '1'
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FF465C
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 0EC9AC
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                    - type: STRING
+                      name: value_color
+                      value: FFFFFF
+                    - type: INTEGER
+                      name: value_size
+                      value: '35'
+                - type: item
+                  name: 'ICMP packet loss'
+                  'y': '5'
+                  width: '18'
+                  fields:
+                    - type: INTEGER
+                      name: decimal_places
+                      value: '1'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        key: icmppingloss
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: STRING
+                      name: value_color
+                      value: 1E88E5
+                    - type: INTEGER
+                      name: value_size
+                      value: '42'
+                - type: svggraph
+                  name: 'ICMP packet loss history'
+                  'y': '7'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color.0
+                      value: FFCA28
+                    - type: INTEGER
+                      name: ds.0.dataset_type
+                      value: '0'
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '5'
+                    - type: ITEM
+                      name: ds.0.itemids.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        key: icmppingloss
+                    - type: INTEGER
+                      name: ds.0.missingdatafunc
+                      value: '1'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '3'
+                    - type: STRING
+                      name: lefty_max
+                      value: '100'
+                    - type: STRING
+                      name: lefty_min
+                      value: '0'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: ADVAA
+                    - type: INTEGER
+                      name: righty
+                      value: '0'
+                - type: item
+                  name: 'SNMP availability'
+                  x: '12'
+                  'y': '3'
+                  width: '12'
+                  hide_header: 'YES'
+                  fields:
+                    - type: STRING
+                      name: bg_color
+                      value: FFCA28
+                    - type: STRING
+                      name: description
+                      value: SNMP
+                    - type: INTEGER
+                      name: desc_bold
+                      value: '1'
+                    - type: STRING
+                      name: desc_color
+                      value: FFFFFF
+                    - type: INTEGER
+                      name: desc_v_pos
+                      value: '0'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        key: 'zabbix[host,snmp,available]'
+                    - type: INTEGER
+                      name: show.0
+                      value: '1'
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FF465C
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 0EC9AC
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: FFCA28
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '2'
+                    - type: STRING
+                      name: value_color
+                      value: FFFFFF
+                    - type: INTEGER
+                      name: value_size
+                      value: '35'
+                - type: item
+                  name: 'ICMP response time'
+                  x: '18'
+                  'y': '5'
+                  width: '18'
+                  fields:
+                    - type: INTEGER
+                      name: decimal_places
+                      value: '3'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        key: icmppingsec
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: STRING
+                      name: value_color
+                      value: 1E88E5
+                    - type: INTEGER
+                      name: value_size
+                      value: '42'
+                - type: item
+                  name: Uptime
+                  x: '24'
+                  'y': '3'
+                  width: '12'
+                  hide_header: 'YES'
+                  fields:
+                    - type: STRING
+                      name: bg_color
+                      value: 1E88E5
+                    - type: STRING
+                      name: description
+                      value: Uptime
+                    - type: INTEGER
+                      name: desc_bold
+                      value: '1'
+                    - type: STRING
+                      name: desc_color
+                      value: FFFFFF
+                    - type: INTEGER
+                      name: desc_v_pos
+                      value: '0'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        key: 'system.net.uptime[sysUpTime.0]'
+                    - type: INTEGER
+                      name: show.0
+                      value: '1'
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: STRING
+                      name: value_color
+                      value: FFFFFF
+                    - type: INTEGER
+                      name: value_size
+                      value: '35'
+                - type: item
+                  name: 'System name'
+                  x: '36'
+                  'y': '3'
+                  width: '18'
+                  fields:
+                    - type: INTEGER
+                      name: decimal_size
+                      value: '20'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        key: system.name
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: units_show
+                      value: '0'
+                    - type: INTEGER
+                      name: value_size
+                      value: '32'
+                - type: item
+                  name: 'System description'
+                  x: '36'
+                  'y': '5'
+                  width: '36'
+                  fields:
+                    - type: INTEGER
+                      name: decimal_size
+                      value: '20'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        key: 'system.descr[sysDescr.0]'
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: units_show
+                      value: '0'
+                    - type: INTEGER
+                      name: value_size
+                      value: '28'
+                - type: svggraph
+                  name: 'ICMP response time history'
+                  x: '36'
+                  'y': '7'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color.0
+                      value: 1E88E5
+                    - type: INTEGER
+                      name: ds.0.dataset_type
+                      value: '0'
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '5'
+                    - type: ITEM
+                      name: ds.0.itemids.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        key: icmppingsec
+                    - type: INTEGER
+                      name: ds.0.missingdatafunc
+                      value: '1'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '3'
+                    - type: STRING
+                      name: lefty_min
+                      value: '0'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: ADVAB
+                    - type: INTEGER
+                      name: righty
+                      value: '0'
+                - type: item
+                  name: 'System object ID'
+                  x: '54'
+                  'y': '3'
+                  width: '18'
+                  fields:
+                    - type: INTEGER
+                      name: decimal_size
+                      value: '20'
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        key: 'system.objectid[sysObjectID.0]'
+                    - type: INTEGER
+                      name: show.0
+                      value: '2'
+                    - type: INTEGER
+                      name: units_show
+                      value: '0'
+                    - type: INTEGER
+                      name: value_size
+                      value: '24'
+        - uuid: bb2cba388645447b8d05ec4a10900642
+          name: 'ADVA CPE: Statistics'
+          pages:
+            - name: 'Service interfaces'
+              widgets:
+                - type: graphprototype
+                  width: '72'
+                  height: '7'
+                  fields:
+                    - type: INTEGER
+                      name: columns
+                      value: '1'
+                    - type: GRAPH_PROTOTYPE
+                      name: graphid.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        name: 'ADVA interface {#IFNAME}: Traffic'
+                    - type: STRING
+                      name: reference
+                      value: ADVAD
+            - name: 'Card health'
+              widgets:
+                - type: graphprototype
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: INTEGER
+                      name: columns
+                      value: '1'
+                    - type: GRAPH_PROTOTYPE
+                      name: graphid.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        name: 'ADVA XG108 card {#ADVA.CARD.ENTITYINDEX}: Temperature'
+                    - type: STRING
+                      name: reference
+                      value: ADVAE
+                - type: graphprototype
+                  x: '36'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: INTEGER
+                      name: columns
+                      value: '1'
+                    - type: GRAPH_PROTOTYPE
+                      name: graphid.0
+                      value:
+                        host: 'ADVA FSP 150-XG108 by SNMP'
+                        name: 'ADVA XG108 card {#ADVA.CARD.ENTITYINDEX}: Voltage'
+                    - type: STRING
+                      name: reference
+                      value: ADVAF
+      valuemaps:
+        - uuid: 7bc20a569cd74ccbade9fcd6116fbb04
+          name: 'ADVA administrative state'
+          mappings:
+            - value: '1'
+              newvalue: in-service
+            - value: '2'
+              newvalue: management
+            - value: '3'
+              newvalue: maintenance
+            - value: '4'
+              newvalue: disabled
+            - value: '5'
+              newvalue: unassigned
+            - value: '6'
+              newvalue: monitored
+        - uuid: 4c30c6144c2c4571879b6f85a1798027
+          name: 'ADVA operational state'
+          mappings:
+            - value: '1'
+              newvalue: normal
+            - value: '2'
+              newvalue: outage
+        - uuid: 0428b1de53994f789f8087a3362a1f5e
+          name: 'IF-MIB interface status'
+          mappings:
+            - value: '1'
+              newvalue: up
+            - value: '2'
+              newvalue: down
+            - value: '3'
+              newvalue: testing
+            - value: '4'
+              newvalue: unknown
+            - value: '5'
+              newvalue: dormant
+            - value: '6'
+              newvalue: notPresent
+            - value: '7'
+              newvalue: lowerLayerDown
+        - uuid: b2d0d45ed038425585e28a790a81f9c4
+          name: 'Service state'
+          mappings:
+            - value: '0'
+              newvalue: Down
+            - value: '1'
+              newvalue: Up
+        - uuid: 97da013138dd446f8929f043af3aa691
+          name: 'SNMP availability'
+          mappings:
+            - value: '0'
+              newvalue: 'not available'
+            - value: '1'
+              newvalue: available
+            - value: '2'
+              newvalue: unknown
+        - uuid: 205427b9fe784f25b388e6b373efcbec
+          name: 'SNMP TruthValue'
+          mappings:
+            - value: '1'
+              newvalue: 'true'
+            - value: '2'
+              newvalue: 'false'


### PR DESCRIPTION
## Summary

Adds a standalone SNMPv2c and SNMP trap monitoring template for the
**ADVA FSP 150-XG108** carrier Ethernet demarcation device.

Path: `Network_Devices/Adva/template_adva_fsp150_xg108_by_snmp/7.4/`

Placed under a vendor directory, consistent with the other network-device vendors in
this repository and with the `Network_Devices/Adva/` path proposed in open PR #779.
Note that the older `template_adva_fsp3000` currently sits in `Network_Devices/Other/`;
this PR does not relocate it, to avoid touching unrelated files. Happy to move this
template to `Network_Devices/Other/` instead if maintainers prefer to keep ADVA
consolidated there.

## What it monitors

| Area | Coverage |
|---|---|
| Availability | ICMP ping, loss, response time; Zabbix SNMP availability |
| Identity | sysDescr, sysName, sysObjectID, sysUpTime |
| Chassis cards | Per-card administrative state, operational state, temperature, voltage, dying-gasp configuration |
| Service interfaces | Admin/oper status, 64-bit in/out traffic, inbound errors, in/out discards, speed |
| Power events | Dying-gasp / power-failure trap matching, plus `snmptrap.fallback` for unmatched traps |

**Objects:** 10 items, 2 discovery rules, 13 item prototypes, 3 graph prototypes,
10 triggers, 6 value maps, 2 dashboards, 16 macros.

## Design notes

- **Self-contained, no template linkage.** ICMP availability, the standard SNMP system
  tree, SNMP availability, and trap collection are included directly rather than linking
  `Generic SNMP`. Item keys intentionally match the generic baseline, so the two should
  not be linked to the same host simultaneously.
- **Filtered interface discovery.** `adva.net.if.discovery` walks IF-MIB/IF-X-MIB and is
  scoped by host-overridable macros for admin state, description, name, oper state, and
  type. Defaults select administratively up Ethernet (`ifType` 6) NETWORK/ACCESS service
  ports and exclude DCN/placeholder interfaces. Operationally down ports are deliberately
  retained so link failures stay visible.
- **Dynamic card discovery.** `adva.xg108.card.discovery` walks the ADVA enterprise entity
  table `1.3.6.1.4.1.2544.1.12.3.1.106.1` rather than assuming a fixed network-element,
  shelf, or slot suffix, so the template follows XG108 variants and inventory layouts.
- **Conservative alerting posture.** Only the four reachability and SNMP-collection
  triggers are enabled by default. The six device-specific triggers (dying gasp, device
  restarted, interface down, interface errors, interface utilization, card outage) ship
  **disabled** so the template is safe to link before thresholds and trap routing have
  been proven in the target environment.
- **Dependency-aware triggers.** SNMP and interface alarms are suppressed by the ICMP
  root-cause trigger. The dying-gasp trigger is intentionally independent of ICMP, because
  the trap is often the last evidence received before polling stops; it recovers after ten
  minutes without another matching trap and allows manual close.
- **Per-interface exceptions.** `{$IF.ERRORS.WARN}`, `{$IF.UTIL.MAX}`, and `{$IFCONTROL}`
  accept a `{#IFNAME}` macro context.

## Known limitation, stated up front

The exact enterprise notification OID for an XG108 dying-gasp event has not yet been
captured from a controlled or real event. The trap item currently matches **formatted
notification text** (`dying gasp`, `power fail`, `power failure`, `power loss`), and the
fallback item retains unmatched traps so the OID and varbind layout can be confirmed from
a real event. This is documented in the README, and the corresponding trigger ships
disabled for exactly this reason. Happy to revise the item to an OID match if reviewers
would prefer to wait for that evidence.

Routing-protocol monitoring (OSPF, BGP) is intentionally out of scope.

## Notes for reviewers

- The template **does not define a community value**. `{$SNMP_COMMUNITY}` must be set as a
  secret host or host-group macro; this is stated in the README setup steps.
- Contains no SNMP communities, management addresses, proxy names, device serials, or
  customer identifiers.
- Template group is `Templates/Network devices`.
- Discovery filter defaults reflect one verified XG108 naming layout; the README explains
  how to relax them with `snmpwalk` output for other firmware revisions.

## Validation

- Verified against a device reporting sysObjectID `1.3.6.1.4.1.2544.1.12.1.1.50`.
- SNMPv2c system-tree polling verified; all trigger expressions, dependencies, value maps,
  graph prototypes, and dashboard widget references resolve to items defined in the export.
- Directory layout, template folder/file naming, and folder-version-to-export-version
  match were checked against the repository rules.

## License

MIT.
