### PR TITLE
Add OPNsense by REST API

### DIFF
--- a/Network_Devices/OPNsense/template_opnsense_by_rest_api/7.0/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_rest_api/7.0/README.md
@@ -1,0 +1,246 @@
+# OPNsense by REST API
+
+Zabbix template that monitors an OPNsense firewall over its own REST API. No SNMP, no Zabbix
+agent on the firewall, one API key with read privileges.
+
+Import into **Zabbix 7.0 or later**. The export declares format 7.0, which every later
+release accepts.
+
+Everything in here was measured against a live OPNsense 26.7 with a restricted monitoring
+key, not read off the documentation. Where the API turned out to behave differently than
+expected, that is written down in [Notes](#notes) rather than smoothed over.
+
+## Contents
+
+- [What it monitors](#what-it-monitors)
+- [Setup](#setup)
+- [Privileges](#privileges)
+- [Macros](#macros)
+- [Discovery](#discovery)
+- [Triggers](#triggers)
+- [Dashboard](#dashboard)
+- [Notes](#notes)
+- [License](#license)
+
+## What it monitors
+
+107 items, 14 discovery rules with 70 item prototypes, 52 triggers, 36 macros and a dashboard
+with 8 pages.
+
+| Area | Source endpoint |
+|------|-----------------|
+| Processor utilisation, split into user, system and interrupt | `diagnostics/activity/get_activity` |
+| Core count, load average over 1, 5 and 15 minutes, load per core | `diagnostics/cpu_usage/get_c_p_u_type`, `diagnostics/system/system_time` |
+| Memory, swap per device, filesystems | `diagnostics/system/system_resources`, `system_swap`, `system_disk` |
+| Temperature per sensor | `diagnostics/system/system_temperature` |
+| Kernel network memory, mbuf clusters, denied requests | `diagnostics/interface/get_memory_statistics` |
+| netisr queue drops, total and per protocol | `diagnostics/interface/get_netisr_statistics` |
+| IP and TCP protocol error rates | `diagnostics/interface/get_protocol_statistics` |
+| Interface traffic, errors, link state, per interface blocks | `diagnostics/traffic/_interface`, `diagnostics/firewall/pf_statistics/interfaces` |
+| pf state table and source tracking, with their limits | `diagnostics/firewall/pf_states`, `pf_statistics/info`, `pf_statistics/memory` |
+| pf counters, SYN floods, malformed packets | `diagnostics/firewall/pf_statistics/info` |
+| Ruleset size, fingerprint, evaluation rate, unmatched rules | `diagnostics/firewall/pf_statistics/rules` |
+| pf table entries against the configured ceiling | `firewall/alias/get_table_size` |
+| Blocked share of the firewall log | `diagnostics/firewall/stats?group_by=action` |
+| Gateways, address, status, round trip time, loss, deviation | `routes/gateway/status` |
+| CARP status per address, demotion factor, maintenance mode | `diagnostics/interface/get_vip_status` |
+| IPsec phase 1 and phase 2, per connection | `ipsec/sessions/searchPhase1`, `search_phase2` |
+| WireGuard instances and peers | `wireguard/service/show` |
+| OpenVPN instances and clients | `openvpn/service/search_sessions` |
+| Services, discovered and checked | `core/service/search` |
+| Clock synchronisation, offset, stratum, reachable peers | `ntpd/service/status` |
+| Firmware state, pending updates, business license, version | `core/firmware/status`, `core/firmware/info` |
+| Configuration change timestamp, uptime | `diagnostics/system/system_time` |
+| UPS, battery, load, runtime, voltage | `nut/diagnostics/upsstatus` |
+
+## Setup
+
+### 1. Create the API key
+
+In the OPNsense GUI under **System, Access, Users**, create a user without a login shell, for
+example `zabbix`, give it the privileges from the next section, then add an API key. The
+download contains the key and the secret.
+
+### 2. Import the template
+
+**Data collection, Templates, Import**, then select `template_opnsense_by_rest_api.yaml`.
+
+### 3. Create the host
+
+Create a host with an agent interface carrying the firewall address, link the template, and
+set the three connection macros:
+
+| Macro | Value |
+|-------|-------|
+| `{$OPNS.KEY}` | the API key |
+| `{$OPNS.SECRET}` | the API secret |
+| `{$OPNS.PORT}` | the HTTPS port of the web interface, default 443 |
+
+The items address the firewall through `{HOST.IP}`, so the interface address is what counts,
+not the DNS name.
+
+## Privileges
+
+Measured with a restricted key, not taken from the documentation. Ten privileges are needed,
+eight of them read only.
+
+| Privilege in the GUI | Internal ID | Needed for | Read only |
+|----------------------|-------------|------------|-----------|
+| Lobby: Dashboard | `page-system-login-logout` | system resources, time, disks, swap, temperature, core count, pf states | yes |
+| Diagnostics: Netstat | `page-diagnostics-netstat` | interface statistics, mbuf pool, netisr queues, protocol errors | yes |
+| Diagnostics: Firewall statistics | `page-diagnostics-pf-info` | pf counters, source tracking, ruleset | yes |
+| Diagnostics: System Activity | `page-diagnostics-system-activity` | processor utilisation | yes |
+| Status: NTP | `page-status-ntp` | clock synchronisation | yes |
+| Diagnostics: Logs: Firewall: Summary View | `page-diagnostics-logs-firewall-summary` | blocked share of the firewall log | yes |
+| Firewall: Aliases | `page-firewall-aliases` | pf table entry usage, also exposes every alias content | yes |
+| Reporting: Traffic | `page-status-trafficgraph` | interface discovery, traffic and counters | yes |
+| Status: Services | `page-status-services` | service run state | **no**, also permits starting and stopping services |
+| System: Firmware | `page-system-firmware-manualupdate` | firmware state, pending updates, business license, version | **no**, its pattern `api/core/firmware/*` also covers reboot, poweroff, install and remove |
+
+Two of them grant more than reading. Without **Status: Services** the service discovery stays
+empty and nothing else breaks. Without **System: Firmware** the five firmware items, the
+license item and the version item stay unsupported; the version is also available from
+`diagnostics/system/system_information`, which Lobby: Dashboard already covers.
+
+`page-nut` is needed only if a UPS is monitored. It comes with the NUT plugin and covers
+`api/nut/*`. Without it the UPS master returns HTTP 403 even with the item enabled.
+
+## Macros
+
+### Connection
+
+| Macro | Default | Purpose |
+|-------|---------|---------|
+| `{$OPNS.KEY}` | empty | API key |
+| `{$OPNS.SECRET}` | empty | API secret |
+| `{$OPNS.PORT}` | `443` | HTTPS port of the web interface |
+
+### Thresholds
+
+| Macro | Default | Purpose |
+|-------|---------|---------|
+| `{$OPNS.CPU.UTIL.WARN}` | `85` | Processor utilisation counting as high, averaged over ten minutes |
+| `{$OPNS.CPU.LOAD.MAX}` | `2` | Load average counting as high |
+| `{$OPNS.LOAD.AVG5.WARN}` | `4` | Absolute five minute load average counting as high |
+| `{$OPNS.LOAD.PERCORE.WARN}` | `1` | Five minute load per core, 1 means the cores are exactly saturated |
+| `{$OPNS.MEMORY.UTIL.MAX}` | `90` | Memory utilisation counting as high |
+| `{$OPNS.MBUF.UTIL.WARN}` | `80` | Share of the mbuf cluster limit counting as filling up |
+| `{$OPNS.SWAP.UTIL.WARN}` | `5` | Swap in use counting as a problem. A firewall should not swap at all, so this is deliberately low. Per device through macro context |
+| `{$OPNS.TEMP.CRIT}` | `80` | Sensor temperature in degrees Celsius. Per sensor through context, for example `{$OPNS.TEMP.CRIT:"dev.cpu.0.temperature"}` |
+| `{$OPNS.FS.PUSED.MAX.WARN}` | `90` | Filesystem utilisation, warning |
+| `{$OPNS.FS.PUSED.MAX.CRIT}` | `95` | Filesystem utilisation, critical |
+| `{$OPNS.STATE.TABLE.UTIL.MAX}` | `90` | pf state table fill level counting as high |
+| `{$OPNS.PF.SRCNODES.UTIL.CRIT}` | `90` | Source tracking table fill level counting as critical |
+| `{$OPNS.PF.TABLES.UTIL.WARN}` | `80` | Share of the pf table entry budget counting as filling up. Relevant with block lists or GeoIP aliases |
+| `{$OPNS.GW.MIN.PACKET.LOSS}` | `10` | Gateway packet loss counting as a problem |
+| `{$OPNS.GW.HIGH.PACKET.LOSS}` | `50` | Gateway packet loss counting as severe |
+| `{$OPNS.NTP.OFFSET.WARN}` | `100` | Clock offset in milliseconds. Generous for a LAN time source and still far below what breaks Kerberos or IPsec |
+| `{$OPNS.LICENSE.EXPIRY.WARN}` | `30` | Days before the business license expires |
+| `{$OPNS.NUT.BAT.LOW}` | `30` | UPS battery charge counting as low |
+| `{$OPNS.NUT.BAT.RUNTIME}` | `600` | Remaining UPS runtime in seconds |
+| `{$OPNS.NUT.HIGH.LOAD}` | `80` | UPS load counting as high |
+
+### Discovery filters and switches
+
+| Macro | Default | Purpose |
+|-------|---------|---------|
+| `{$OPNS.IF.CONTROL}` | `1` | Set to 0, per interface through context, to silence the interface down trigger |
+| `{$OPNS.IF.NAME.NOT_MATCHES}` | `^(pflog\|pfsync\|enc\|lo)\d*$` | Interfaces excluded from discovery |
+| `{$OPNS.SERVICE.ID.NOT_MATCHES}` | `^$` | Services excluded from discovery, excludes nothing by default |
+| `{$OPNS.OPENVPN.ID.NOT_MATCHES}` | `^$` | OpenVPN instances excluded from discovery |
+| `{$OPNS.OPENVPN.CONTROL}` | `1` | Set to 0, per instance through context, to silence the OpenVPN down trigger |
+| `{$OPNS.WG.INSTANCE.MATCHES}` / `.NOT_MATCHES` | `.+` / `^$` | WireGuard instance discovery filter |
+| `{$OPNS.WG.PEER.MATCHES}` / `.NOT_MATCHES` | `.+` / `^$` | WireGuard peer discovery filter |
+| `{$OPNS.FS.FSNAME.MATCHES}` / `.NOT_MATCHES` | `.+` / `^(/dev\|/sys\|/run\|/proc\|.+/shm$)` | Filesystem discovery filter by mount point |
+| `{$OPNS.FS.FSTYPE.MATCHES}` / `.NOT_MATCHES` | filesystem list / `^\s$` | Filesystem discovery filter by type |
+
+## Discovery
+
+| Rule | Discovers |
+|------|-----------|
+| Interface Stats Discovery | traffic, errors and per interface pf blocks |
+| Network interfaces | link state and inbound errors |
+| Gateway Discovery | address, status, round trip time, loss, deviation |
+| Interface CARP Discovery | CARP status per virtual address |
+| Disk Discovery | filesystems |
+| Swap devices | swap per device |
+| Temperature sensors | one item per sensor |
+| netisr queues | queue drops per protocol |
+| Services | run state per service |
+| FW Action Discovery | firewall log actions |
+| IPsec Phase1 Discovery | tunnels, with phase 2 per connection |
+| WireGuard Instance Discovery | instances |
+| WireGuard Peer Discovery | peers, traffic and handshake age |
+| OpenVPN instances and clients | instances and connected clients |
+
+## Triggers
+
+52 in total: 2 Disaster, 13 High, 11 Average, 18 Warning, 8 Info.
+
+Disaster is reserved for a gateway that is down and for a low UPS battery. High covers the
+cases where the firewall is losing packets or a tunnel is gone: denied kernel network memory,
+pf dropping packets for lack of memory, the state limit being hit, a filling source tracking
+table, a hot sensor, a CARP status change, a dead WireGuard instance or peer, an unconnected
+IPsec tunnel, an unreachable API and the UPS running on battery.
+
+Warning is the working range: utilisation and load, clock offset, swap in use, malformed
+packets, pf table entries filling up, protocol level errors. Info reports facts rather than
+faults: configuration changes, ruleset and rule count changes, a version change, available
+firmware updates, a reboot, and a gateway whose monitoring is switched off.
+
+## Dashboard
+
+Eight pages, 84 widgets. The grid is the full 72 columns wide.
+
+| Page | Shows |
+|------|-------|
+| Overview | memory, state table, processor and load per core as gauges, six tiles, firewall actions over time, CARP status, filesystems as a honeycomb |
+| Packet filter | state table, source tracking and pf table utilisation, twelve tiles, state churn and searches, rule matches against evaluations, drops and limit hits, malformed packets |
+| Interfaces | link state per interface, traffic, blocked and passed bytes side by side, errors, queue drops and collisions |
+| Gateways | status honeycomb, round trip time and packet loss side by side, deviation below |
+| VPN | WireGuard peers and instances, peer traffic, IPsec phase 1 tunnels and phase 2 traffic |
+| System | processor, memory and load per core, uptime, version, cores, configuration change timestamp, both load averages, utilisation split, temperature and swap honeycombs |
+| Kernel and protocols | mbuf utilisation, clusters in use, denied requests, netisr drops per protocol, IP and TCP error rates |
+| Services, clock and power | every service as a honeycomb, clock synchronisation, offset, stratum, reachable peers, CARP demotion and maintenance, UPS battery, status, load and runtime |
+
+## Notes
+
+**snake_case in API paths is not always optional.** OPNsense routes `systemResources` and
+`system_resources` to the same controller action, so an administrator key never notices a
+difference. Some privilege patterns are exact, and `ACL.php` matches them with `preg_match`
+without the `i` modifier, so a monitoring key gets HTTP 403 on the camelCase spelling. That
+is the case for `diagnostics/system/system_resources` and `diagnostics/firewall/pf_states`.
+Other areas carry a wildcard pattern and take either spelling, which is why
+`ipsec/sessions/searchPhase1` works and is left as it is. Test privileges with the restricted
+key, never with an admin key.
+
+**Gateway monitoring switched off.** A gateway without a monitor address reports a tilde for
+round trip time, loss and deviation, and a status of `none` that the API translates to
+`Online`. The three items discard the reading in that case and stay empty instead of
+substituting a number. While monitoring is off, an outage of that gateway raises nothing,
+because the down trigger works on packet loss. That is what the Info trigger is for.
+
+**IPsec phase 2** needs one request per connection. `searchPhase2Action` reads its connection
+from `getPost('id')` and returns an empty set for a plain GET, so phase 2 is an HTTP agent
+prototype inside the phase 1 rule that posts `id={#IPSECNAME}`. Where the API leaves
+`phase1desc` empty, the tunnel name stands in, because the discovery uses that field as the
+entity identity and identical keys would collapse into one.
+
+**Physical interface counters** come from `diagnostics/traffic/_interface`, not from
+`netstat`, whose counters reset on every read.
+
+**JavaScript is kept to a minimum.** Parsing happens once on the master item, dependent items
+read the result with plain JSONPath. A step on a prototype would run per value and per
+discovered instance.
+
+**The pf ruleset item** polls every ten minutes on purpose. The response carries the full text
+of every rule, and rule changes are not a per minute concern.
+
+## License
+
+MIT, like this repository. The template is derived from `OPNsense by HTTP-JSON` in this same
+repository (MIT, Copyright 2021 Zabbix), with the greater part of the current content added on
+top. It carries its own name and its own uuids, so both can be linked to the same host and an
+import of one does not touch the other.
+
+Maintained at https://github.com/Garfieldttt/opnsense-zabbix-template.

--- a/Network_Devices/OPNsense/template_opnsense_by_rest_api/7.0/README.md
+++ b/Network_Devices/OPNsense/template_opnsense_by_rest_api/7.0/README.md
@@ -24,8 +24,8 @@ expected, that is written down in [Notes](#notes) rather than smoothed over.
 
 ## What it monitors
 
-107 items, 14 discovery rules with 70 item prototypes, 52 triggers, 36 macros and a dashboard
-with 8 pages.
+127 items, 15 discovery rules with 71 item prototypes, 58 triggers, 41 macros and a dashboard
+with 9 pages.
 
 | Area | Source endpoint |
 |------|-----------------|
@@ -52,6 +52,10 @@ with 8 pages.
 | Firmware state, pending updates, business license, version | `core/firmware/status`, `core/firmware/info` |
 | Configuration change timestamp, uptime | `diagnostics/system/system_time` |
 | UPS, battery, load, runtime, voltage | `nut/diagnostics/upsstatus` |
+| Resolver: queries, cache hits and misses, prefetches, rate limited queries, recursion time, request queue | `unbound/diagnostics/stats` |
+| Certificate validity, discovered per certificate | `trust/cert/search` |
+| The status panel the firewall shows about itself | `core/system/status` |
+| DHCP leases, active and total, v4 and v6 | `kea/leases4/search`, `kea/leases6/search` |
 
 ## Setup
 
@@ -81,29 +85,50 @@ not the DNS name.
 
 ## Privileges
 
-Measured with a restricted key, not taken from the documentation. Ten privileges are needed,
-eight of them read only.
+Derived from the privilege patterns the firewall itself publishes under `auth/priv/search`,
+not from trying endpoints with a key and reading the HTTP code. Trying tells you what your
+key happens to allow; the patterns tell you what any key needs.
+
+Seventeen endpoints are covered by exactly one privilege each. Three more, the gateway
+status, the WireGuard status and the pf table size, can be covered by either of two, and the
+table names the better choice with the reason. Twenty privileges in total, ten of which only
+read.
 
 | Privilege in the GUI | Internal ID | Needed for | Read only |
 |----------------------|-------------|------------|-----------|
-| Lobby: Dashboard | `page-system-login-logout` | system resources, time, disks, swap, temperature, core count, pf states | yes |
-| Diagnostics: Netstat | `page-diagnostics-netstat` | interface statistics, mbuf pool, netisr queues, protocol errors | yes |
-| Diagnostics: Firewall statistics | `page-diagnostics-pf-info` | pf counters, source tracking, ruleset | yes |
+| Lobby: Dashboard | `page-system-login-logout` | system resources, time, disk, swap, temperature, CPU type, pf states | yes, the pattern names single endpoints |
+| Diagnostics: Netstat | `page-diagnostics-netstat` | mbuf pool, netisr queues, protocol errors | yes |
+| Diagnostics: Firewall statistics | `page-diagnostics-pf-info` | pf counters, memory, ruleset, per interface blocks | yes |
 | Diagnostics: System Activity | `page-diagnostics-system-activity` | processor utilisation | yes |
-| Status: NTP | `page-status-ntp` | clock synchronisation | yes |
 | Diagnostics: Logs: Firewall: Summary View | `page-diagnostics-logs-firewall-summary` | blocked share of the firewall log | yes |
-| Firewall: Aliases | `page-firewall-aliases` | pf table entry usage, also exposes every alias content | yes |
-| Reporting: Traffic | `page-status-trafficgraph` | interface discovery, traffic and counters | yes |
-| Status: Services | `page-status-services` | service run state | **no**, also permits starting and stopping services |
-| System: Firmware | `page-system-firmware-manualupdate` | firmware state, pending updates, business license, version | **no**, its pattern `api/core/firmware/*` also covers reboot, poweroff, install and remove |
+| Firewall: Aliases | `page-firewall-aliases` | pf table entry usage | yes, the pattern is limited to `export`, `search*`, `list*` and `get*`. Do **not** use Firewall: Alias: Edit instead, which covers `api/firewall/alias/*` and therefore writing |
+| Reporting: Traffic | `page-status-trafficgraph` | interface traffic and counters | yes |
+| Interfaces: Virtual IPs: Status | `page-status-carp` | CARP status per address | yes |
+| Status: NTP | `page-status-ntp` | clock synchronisation | yes, the pattern is the single status endpoint |
+| Status: IPsec | `page-status-ipsec` | IPsec phase 1 and phase 2 | yes, `api/ipsec/sessions/*` is a read only controller |
+| System: Status | `page-system-status` | the status panel the firewall shows about itself | almost, it also permits dismissing a message |
+| System: Gateways | `page-system-gateways` | gateway status | **no**, its pattern also covers `api/routing/settings/*`. The alternative, System: Static Routes, covers `api/routes/*` and is no better |
+| Status: OpenVPN | `page-status-openvpn` | OpenVPN instances and clients | **no**, `api/openvpn/service/*` includes service control |
+| VPN: WireGuard: Status | `page-wireguard-diagnostics` | WireGuard instances and peers | **no**, `api/wireguard/service/*` includes service control. Still the narrower of the two: VPN: WireGuard: Configuration also covers servers, clients and general settings |
+| Status: Services | `page-status-services` | service run state | **no**, `api/core/service/*` permits starting and stopping services |
+| System: Firmware | `page-system-firmware-manualupdate` | firmware state, pending updates, business license, version | **no**, `api/core/firmware/*` also covers reboot, poweroff, install and remove |
+| Services: Unbound | `page-services-unbound` | resolver statistics | **no**, `api/unbound/*` covers the whole resolver configuration |
+| System: Certificate Manager | `page-system-certmanager` | certificate validity | **no**, `api/trust/cert/*` covers adding and removing certificates |
+| Services: DHCP: Kea(v4) and Kea(v6) | `page-dhcp-kea-v4`, `page-dhcp-kea-v6` | DHCP lease counters | **no**, the patterns cover the Kea configuration and service control |
 
-Two of them grant more than reading. Without **Status: Services** the service discovery stays
-empty and nothing else breaks. Without **System: Firmware** the five firmware items, the
-license item and the version item stay unsupported; the version is also available from
-`diagnostics/system/system_information`, which Lobby: Dashboard already covers.
+Leaving one out costs exactly the items it feeds, which then stay unsupported, and nothing
+else. That is the way to trade coverage against privilege:
 
-`page-nut` is needed only if a UPS is monitored. It comes with the NUT plugin and covers
-`api/nut/*`. Without it the UPS master returns HTTP 403 even with the item enabled.
+- without **Status: Services** the service discovery stays empty
+- without **System: Firmware** the five firmware items, the license item and the version item
+  stay unsupported. The version is also available from
+  `diagnostics/system/system_information`, which Lobby: Dashboard covers
+- without **Services: Unbound**, **System: Certificate Manager** or the two **Kea** ones the
+  resolver, certificate and lease items stay unsupported. These four areas are the ones to
+  drop first if the account has to stay close to read only
+
+`page-nut` is needed only if a UPS is monitored. It comes from the NUT plugin, covers
+`api/nut/*`, and without it the UPS master returns HTTP 403 even after enabling the item.
 
 ## Macros
 
@@ -139,6 +164,9 @@ license item and the version item stay unsupported; the version is also availabl
 | `{$OPNS.NUT.BAT.LOW}` | `30` | UPS battery charge counting as low |
 | `{$OPNS.NUT.BAT.RUNTIME}` | `600` | Remaining UPS runtime in seconds |
 | `{$OPNS.NUT.HIGH.LOAD}` | `80` | UPS load counting as high |
+| `{$OPNS.DNS.RECURSION.WARN}` | `1` | Average recursion time in seconds counting as slow |
+| `{$OPNS.DNS.HITRATIO.MIN}` | `60` | Cache hit ratio in percent below which the resolver is reported as working harder than it should |
+| `{$OPNS.CERT.EXPIRE.DAYS}` | `21d` | Lead time before a certificate expires |
 
 ### Discovery filters and switches
 
@@ -153,6 +181,8 @@ license item and the version item stay unsupported; the version is also availabl
 | `{$OPNS.WG.PEER.MATCHES}` / `.NOT_MATCHES` | `.+` / `^$` | WireGuard peer discovery filter |
 | `{$OPNS.FS.FSNAME.MATCHES}` / `.NOT_MATCHES` | `.+` / `^(/dev\|/sys\|/run\|/proc\|.+/shm$)` | Filesystem discovery filter by mount point |
 | `{$OPNS.FS.FSTYPE.MATCHES}` / `.NOT_MATCHES` | filesystem list / `^\s$` | Filesystem discovery filter by type |
+| `{$OPNS.CERT.NAME.NOT_MATCHES}` | `^$` | Certificates excluded from discovery, by description |
+| `{$OPNS.CERT.IN_USE.MATCHES}` | `1` | Which certificates are discovered, matched against the in_use flag. Set to `.*` to watch every certificate in the store |
 
 ## Discovery
 
@@ -172,10 +202,14 @@ license item and the version item stay unsupported; the version is also availabl
 | WireGuard Instance Discovery | instances |
 | WireGuard Peer Discovery | peers, traffic and handshake age |
 | OpenVPN instances and clients | instances and connected clients |
+| Certificates | validity per certificate in the trust store |
 
 ## Triggers
 
-52 in total: 2 Disaster, 13 High, 11 Average, 18 Warning, 8 Info.
+58 in total: 2 Disaster, 13 High, 13 Average, 21 Warning, 9 Info.
+
+Trigger names carry no product prefix, following the Zabbix guidelines and the community
+template: Zabbix puts the host name in front of the trigger anyway.
 
 Disaster is reserved for a gateway that is down and for a low UPS battery. High covers the
 cases where the firewall is losing packets or a tunnel is gone: denied kernel network memory,
@@ -190,7 +224,7 @@ firmware updates, a reboot, and a gateway whose monitoring is switched off.
 
 ## Dashboard
 
-Eight pages, 84 widgets. The grid is the full 72 columns wide.
+Nine pages, 96 widgets. The grid is the full 72 columns wide.
 
 | Page | Shows |
 |------|-------|
@@ -202,6 +236,7 @@ Eight pages, 84 widgets. The grid is the full 72 columns wide.
 | System | processor, memory and load per core, uptime, version, cores, configuration change timestamp, both load averages, utilisation split, temperature and swap honeycombs |
 | Kernel and protocols | mbuf utilisation, clusters in use, denied requests, netisr drops per protocol, IP and TCP error rates |
 | Services, clock and power | every service as a honeycomb, clock synchronisation, offset, stratum, reachable peers, CARP demotion and maintenance, UPS battery, status, load and runtime |
+| Resolver, certificates and leases | DNS cache hit ratio, query rate, recursion time and queue, the system status message, query and recursion graphs, DHCP leases, and certificate expiry as a honeycomb |
 
 ## Notes
 
@@ -232,6 +267,27 @@ entity identity and identical keys would collapse into one.
 **JavaScript is kept to a minimum.** Parsing happens once on the master item, dependent items
 read the result with plain JSONPath. A step on a prototype would run per value and per
 discovered instance.
+
+**DHCP leases carry no trigger.** A network that addresses everything statically runs at zero
+leases forever, and a trigger on that would be wrong on exactly the installations that are
+configured most carefully. The meaningful threshold is the size of the pool, which is a local
+decision, so the number is there to be graphed and alerted on where it matters.
+
+**The system status item** reports the code the firewall shows in its own status panel. A
+firewall with nothing pending answers 2 and "No pending messages". The other codes were not
+observed here, so the trigger fires on anything other than 2 rather than claiming to know
+them, and the message is carried next to it as text.
+
+**Raw master items store nothing.** Every master carries `history: 0`. A dependent item is
+fed from the value as it arrives, not from the stored history, so the chain works without it,
+and nothing else reads a raw payload. Measured on one small firewall with this template
+linked, keeping a day of them costs about 20 MiB per host per day. What is given up is
+looking at yesterday's raw response in Latest data.
+
+**A firewall without CARP discovers no CARP addresses** rather than reporting an error.
+`get_vip_status` answers with an empty `rows` list and the message "Could not locate any
+defined CARP interfaces.", which is the normal answer for a single firewall, so the discovery
+rule takes the empty list.
 
 **The pf ruleset item** polls every ten minutes on purpose. The response carries the full text
 of every rule, and rule changes are not a per minute concern.

--- a/Network_Devices/OPNsense/template_opnsense_by_rest_api/7.0/template_opnsense_by_rest_api.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_rest_api/7.0/template_opnsense_by_rest_api.yaml
@@ -166,7 +166,7 @@ zabbix_export:
           triggers:
             - uuid: 61aee5990f854acfb9db63e4c7bffd31
               expression: 'find(/OPNsense by REST API/nut.status,#1,"like","LB")=1'
-              name: 'Battey low'
+              name: 'Battery low'
               priority: DISASTER
             - uuid: 0f77efffd9cc4b1989344c739b2e2274
               expression: 'find(/OPNsense by REST API/nut.status,#1,"like","OB")=1'
@@ -227,7 +227,7 @@ zabbix_export:
           type: HTTP_AGENT
           key: opns.ipsec.phase1.raw
           delay: 5m
-          history: 1d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -259,7 +259,7 @@ zabbix_export:
           type: HTTP_AGENT
           key: opns.wireguard.raw
           delay: 1m
-          history: 1d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -474,7 +474,7 @@ zabbix_export:
           type: HTTP_AGENT
           key: opns.raw.disk
           delay: 5m
-          history: 1d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -533,7 +533,7 @@ zabbix_export:
           name: 'RAW Firewallaction'
           type: HTTP_AGENT
           key: opns.raw.fw.action
-          history: 1d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -546,7 +546,7 @@ zabbix_export:
           name: 'RAW Firewall Interfaces'
           type: HTTP_AGENT
           key: opns.raw.fw.interface.stat
-          history: 1d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -559,7 +559,7 @@ zabbix_export:
           name: 'RAW Firewall States'
           type: HTTP_AGENT
           key: opns.raw.fw.states
-          history: 1d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -572,7 +572,7 @@ zabbix_export:
           name: 'RAW Gatewaystatus'
           type: HTTP_AGENT
           key: opns.raw.gateway.status
-          history: 1d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -595,7 +595,7 @@ zabbix_export:
           name: 'RAW Carp Interfaces'
           type: HTTP_AGENT
           key: opns.raw.interfaces.carp
-          history: 1d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -608,7 +608,7 @@ zabbix_export:
           name: 'RAW Interfaces'
           type: HTTP_AGENT
           key: opns.raw.interfaces.stat
-          history: 1d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -629,7 +629,7 @@ zabbix_export:
           type: HTTP_AGENT
           key: opns.raw.load
           delay: 5m
-          history: 1d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -643,7 +643,7 @@ zabbix_export:
           type: HTTP_AGENT
           key: opns.raw.memory.status
           delay: 5m
-          history: 1d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -657,7 +657,7 @@ zabbix_export:
           type: HTTP_AGENT
           key: opns.raw.product.info
           delay: 30m
-          history: 1d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -671,7 +671,7 @@ zabbix_export:
           type: HTTP_AGENT
           key: opns.raw.firmware.status
           delay: 1d
-          history: 7d
+          history: '0'
           value_type: TEXT
           authtype: BASIC
           username: '{$OPNS.KEY}'
@@ -747,7 +747,7 @@ zabbix_export:
           type: HTTP_AGENT
           key: opns.ups.raw
           delay: 5m
-          history: 1d
+          history: '0'
           value_type: TEXT
           status: DISABLED
           authtype: BASIC
@@ -862,7 +862,7 @@ zabbix_export:
           triggers:
             - uuid: 2382bd0b26b74d9ab79040aff56483a4
               expression: min(/OPNsense by REST API/opns.carp.maintenance,30m)=1
-              name: 'OPNsense: CARP maintenance mode has been on for 30 minutes'
+              name: CARP maintenance mode has been on for 30 minutes
               priority: WARNING
               description: Long enough to suggest it was left on rather than switched on for a change in progress. While it is on there is no redundancy.
               manual_close: 'YES'
@@ -898,7 +898,7 @@ zabbix_export:
           triggers:
             - uuid: 5794a994a35749d48043a0fa73e68ad7
               expression: change(/OPNsense by REST API/opns.config.changed)<>0 and last(/OPNsense by REST API/opns.config.changed,#2)>0
-              name: 'OPNsense: Configuration has been changed'
+              name: Configuration has been changed
               priority: INFO
               description: Someone wrote a new configuration. Broader than the ruleset fingerprint, which reacts to rules only, and the two together tell whether a change touched the firewall rules or something else. The second condition suppresses the jump out of a zero, which is what an item reports after a gap in collection rather than a real change.
               manual_close: 'YES'
@@ -1039,7 +1039,7 @@ zabbix_export:
           triggers:
             - uuid: b8d1df19a30b4748a4d76455246e703a
               expression: avg(/OPNsense by REST API/opns.cpu.util,10m)>{$OPNS.CPU.UTIL.WARN}
-              name: 'OPNsense: CPU utilization is high'
+              name: CPU utilization is high
               priority: WARNING
               description: 'Sustained load on the processor. Read alongside the interrupt share: if that dominates, the limit is packet handling rather than anything running on the box.'
               manual_close: 'YES'
@@ -1089,6 +1089,112 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $[*].value.sum()
+        - uuid: aa4d42ab94934a66af54244959e927b6
+          name: DHCPv4 leases active
+          type: DEPENDENT
+          key: opns.kea.leases4.active
+          delay: '0'
+          description: 'Leases currently handed out by DHCPv4. A network that addresses everything statically stays at zero, which is why no trigger watches this number: the meaningful threshold is the size of the pool, and that is a local decision.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.active
+          master_item:
+            key: opns.kea.leases4.raw
+          tags:
+            - tag: component
+              value: network
+          value_type: UNSIGNED
+        - uuid: 304ccc7b4c1f4c928d6cdf4e6a3fe28b
+          name: RAW Kea DHCPv4 leases
+          type: HTTP_AGENT
+          key: opns.kea.leases4.raw
+          delay: 5m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Master item. Lease table of the Kea DHCPv4 server, reduced to its counters. Returns zeros where Kea is not in use.
+          timeout: 30s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/kea/leases4/search
+          tags:
+            - tag: component
+              value: raw
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.stats
+        - uuid: 64859c82f37f45b59b2a3b200e6bdfe3
+          name: DHCPv4 leases total
+          type: DEPENDENT
+          key: opns.kea.leases4.total
+          delay: '0'
+          description: Entries in the DHCPv4 lease table, active and expired together.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.total
+          master_item:
+            key: opns.kea.leases4.raw
+          tags:
+            - tag: component
+              value: network
+          value_type: UNSIGNED
+        - uuid: 0c4fcddc284e4f968086bee7c435d8ad
+          name: DHCPv6 leases active
+          type: DEPENDENT
+          key: opns.kea.leases6.active
+          delay: '0'
+          description: 'Leases currently handed out by DHCPv6. A network that addresses everything statically stays at zero, which is why no trigger watches this number: the meaningful threshold is the size of the pool, and that is a local decision.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.active
+          master_item:
+            key: opns.kea.leases6.raw
+          tags:
+            - tag: component
+              value: network
+          value_type: UNSIGNED
+        - uuid: 515b2eca849b446680debc2f8686a774
+          name: RAW Kea DHCPv6 leases
+          type: HTTP_AGENT
+          key: opns.kea.leases6.raw
+          delay: 5m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Master item. Lease table of the Kea DHCPv6 server, reduced to its counters. Returns zeros where Kea is not in use.
+          timeout: 30s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/kea/leases6/search
+          tags:
+            - tag: component
+              value: raw
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.stats
+        - uuid: f74de054700841d38278c97ddee7c535
+          name: DHCPv6 leases total
+          type: DEPENDENT
+          key: opns.kea.leases6.total
+          delay: '0'
+          description: Entries in the DHCPv6 lease table, active and expired together.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.total
+          master_item:
+            key: opns.kea.leases6.raw
+          tags:
+            - tag: component
+              value: network
+          value_type: UNSIGNED
         - uuid: 5c46821c5d6a47b8a141619da8310571
           name: 'mbuf: Clusters in use'
           type: DEPENDENT
@@ -1143,9 +1249,9 @@ zabbix_export:
             - uuid: 40f68e99de3b46089f859e114d796c2b
               expression: min(/OPNsense by REST API/opns.mbuf.cluster.pused,5m)>{$OPNS.MBUF.UTIL.WARN}
               dependencies:
-                - name: 'OPNsense: Kernel denied network memory requests'
+                - name: Kernel denied network memory requests
                   expression: change(/OPNsense by REST API/opns.mbuf.denied)>0
-              name: 'OPNsense: mbuf cluster pool is filling up'
+              name: mbuf cluster pool is filling up
               priority: AVERAGE
               description: Approaching the cluster limit. Raise kern.ipc.nmbclusters before it is reached, because exhaustion costs traffic, not just performance.
               manual_close: 'YES'
@@ -1173,7 +1279,7 @@ zabbix_export:
           triggers:
             - uuid: 36f575293b0f46a081c31dcfa5ff33b2
               expression: change(/OPNsense by REST API/opns.mbuf.denied)>0
-              name: 'OPNsense: Kernel denied network memory requests'
+              name: Kernel denied network memory requests
               priority: HIGH
               description: The kernel ran out of mbufs or clusters and dropped traffic. Raise kern.ipc.nmbclusters. The counter never decreases, so this fires once per new occurrence.
               manual_close: 'YES'
@@ -1218,7 +1324,7 @@ zabbix_export:
           triggers:
             - uuid: c1f276eb83d74611ba6fc213555c9a64
               expression: change(/OPNsense by REST API/opns.netisr.queue.drops)>0
-              name: 'OPNsense: netisr queue is dropping packets'
+              name: netisr queue is dropping packets
               priority: AVERAGE
               description: The kernel discarded packets before they reached the firewall rules. Check load, interface queue lengths and net.isr tuning. The counter never decreases, so this fires once per new occurrence.
               manual_close: 'YES'
@@ -1268,7 +1374,7 @@ zabbix_export:
           triggers:
             - uuid: 9cfabe6d7b474088af479d1fcbb399ba
               expression: abs(last(/OPNsense by REST API/opns.ntp.offset))>{$OPNS.NTP.OFFSET.WARN}
-              name: 'OPNsense: Clock offset is high'
+              name: Clock offset is high
               priority: WARNING
               description: The local clock has drifted away from its time source. Check reachability of the configured servers.
               manual_close: 'YES'
@@ -1359,7 +1465,7 @@ zabbix_export:
           triggers:
             - uuid: 1b6f07b78b804b6499745caf77ed0395
               expression: min(/OPNsense by REST API/opns.ntp.synced,30m)=0
-              name: 'OPNsense: Clock is not synchronised'
+              name: Clock is not synchronised
               priority: WARNING
               description: No time source has been selected for half an hour. Right after a boot this is normal for a few minutes, beyond that the configured servers are unreachable or refusing.
               manual_close: 'YES'
@@ -1410,7 +1516,7 @@ zabbix_export:
           triggers:
             - uuid: dc96d30a4f524505a8c1e17e879d2c4c
               expression: last(/OPNsense by REST API/opns.pf.counter.badoffset.rate)>0
-              name: 'OPNsense: pf is seeing malformed packets'
+              name: pf is seeing malformed packets
               priority: WARNING
               description: Packets with a bad offset are normally zero. A sustained rate points at a broken sender or an attack.
               manual_close: 'YES'
@@ -1480,7 +1586,7 @@ zabbix_export:
           triggers:
             - uuid: d2f0c7675f394f17b5f4c726183b3c89
               expression: last(/OPNsense by REST API/opns.pf.counter.memdrop.rate)>0
-              name: 'OPNsense: pf is dropping packets due to memory'
+              name: pf is dropping packets due to memory
               priority: HIGH
               description: pf ran out of memory for states or fragments. Traffic is being lost. Check the state and table limits.
               manual_close: 'YES'
@@ -1550,7 +1656,7 @@ zabbix_export:
           triggers:
             - uuid: 553ec8441b4c402ea0b2f23d2061c0e2
               expression: last(/OPNsense by REST API/opns.pf.counter.srclimit.rate)>0
-              name: 'OPNsense: pf source limit is being hit'
+              name: pf source limit is being hit
               priority: WARNING
               description: A single source exceeded its allowed number of states.
               manual_close: 'YES'
@@ -1580,7 +1686,7 @@ zabbix_export:
           triggers:
             - uuid: 6e26c768a4cd45b2830a1ef34e9e2ce0
               expression: last(/OPNsense by REST API/opns.pf.counter.statelimit.rate)>0
-              name: 'OPNsense: pf state limit is being hit'
+              name: pf state limit is being hit
               priority: HIGH
               description: New connections are refused because the state limit is reached. Raise the limit or find the source.
               manual_close: 'YES'
@@ -1668,7 +1774,7 @@ zabbix_export:
           triggers:
             - uuid: da9efe8816c64b848b45b3bc294f69d7
               expression: change(/OPNsense by REST API/opns.pf.rules.filter.count)<>0 and last(/OPNsense by REST API/opns.pf.rules.filter.count,#2)>0
-              name: 'OPNsense: Number of filter rules has changed'
+              name: Number of filter rules has changed
               priority: INFO
               description: Rules were added or removed. Useful for correlating a fault with a change to the ruleset. Edits to an existing rule do not change the count and are not detected. The second condition suppresses the jump out of a zero, which is what an item reports after a gap in collection rather than a real change.
               manual_close: 'YES'
@@ -1698,7 +1804,7 @@ zabbix_export:
           triggers:
             - uuid: 454dd0be5d8a4d6dab26d3df5217712e
               expression: last(/OPNsense by REST API/opns.pf.rules.fingerprint,#1)<>last(/OPNsense by REST API/opns.pf.rules.fingerprint,#2)
-              name: 'OPNsense: Ruleset has changed'
+              name: Ruleset has changed
               priority: INFO
               description: 'A rule was added, removed, edited or reworded. Together with the rule counts this separates the cases: if the counts moved as well, rules were added or removed, if they did not, an existing rule was edited.'
               manual_close: 'YES'
@@ -1726,7 +1832,7 @@ zabbix_export:
           triggers:
             - uuid: fb0d07ce68cb465f9eae5770b80b4cbe
               expression: change(/OPNsense by REST API/opns.pf.rules.nat.count)<>0 and last(/OPNsense by REST API/opns.pf.rules.nat.count,#2)>0
-              name: 'OPNsense: Number of NAT rules has changed'
+              name: Number of NAT rules has changed
               description: NAT rules were added or removed. Edits to an existing rule leave the count unchanged and are not detected. The second condition suppresses the jump out of a zero, which is what an item reports after a gap in collection rather than a real change.
               priority: INFO
               manual_close: 'YES'
@@ -1851,9 +1957,9 @@ zabbix_export:
             - uuid: c0d1801db6ee4edcb76c70be448e6848
               expression: min(/OPNsense by REST API/opns.pf.srcnodes.pused,5m)>{$OPNS.PF.SRCNODES.UTIL.CRIT}
               dependencies:
-                - name: 'OPNsense: pf source limit is being hit'
+                - name: pf source limit is being hit
                   expression: last(/OPNsense by REST API/opns.pf.counter.srclimit.rate)>0
-              name: 'OPNsense: pf source tracking table is filling up'
+              name: pf source tracking table is filling up
               priority: HIGH
               description: Once the limit is reached pf refuses connections from clients it has no entry for.
               manual_close: 'YES'
@@ -1943,7 +2049,7 @@ zabbix_export:
           triggers:
             - uuid: 54f8ec875d9d4c048144d02233352761
               expression: last(/OPNsense by REST API/opns.pf.synfloods.rate)>0
-              name: 'OPNsense: SYN flood detected'
+              name: SYN flood detected
               priority: AVERAGE
               description: pf activated syncookies for at least one destination.
               manual_close: 'YES'
@@ -1984,7 +2090,7 @@ zabbix_export:
           triggers:
             - uuid: 0e20e54b0f37455d8593c879fa32222a
               expression: last(/OPNsense by REST API/opns.pf.tables.entries.pused)>{$OPNS.PF.TABLES.UTIL.WARN}
-              name: 'OPNsense: pf table entries are filling up'
+              name: pf table entries are filling up
               priority: WARNING
               description: Raise the maximum table entries setting before a block list update pushes the ruleset over the limit.
               manual_close: 'YES'
@@ -2068,7 +2174,7 @@ zabbix_export:
           triggers:
             - uuid: 27d21c533fac4367abb8b00b2a578a30
               expression: min(/OPNsense by REST API/opns.proto.ip.badsum.rate,10m)>0
-              name: 'OPNsense: Receiving IP packets with bad checksums'
+              name: Receiving IP packets with bad checksums
               priority: WARNING
               description: A sustained rate points at faulty cabling, a failing NIC or a broken device upstream. Occasional single packets are normal.
               manual_close: 'YES'
@@ -2141,7 +2247,7 @@ zabbix_export:
           triggers:
             - uuid: d480978e26e7473483a68b45500f3245
               expression: min(/OPNsense by REST API/opns.proto.ip.noroute.rate,10m)>0
-              name: 'OPNsense: Packets discarded for lack of a route'
+              name: Packets discarded for lack of a route
               priority: WARNING
               description: Traffic arrives for destinations the firewall has no route to. Check the routing table and whether a gateway or a tunnel went down.
               manual_close: 'YES'
@@ -2290,7 +2396,7 @@ zabbix_export:
           triggers:
             - uuid: 66d63013d37e4c42a069ee85793475c3
               expression: avg(/OPNsense by REST API/opns.system.load.avg5,10m)>{$OPNS.LOAD.AVG5.WARN}
-              name: 'OPNsense: Load average is high'
+              name: Load average is high
               priority: WARNING
               description: The 5 minute average has been above the threshold for 10 minutes.
               manual_close: 'YES'
@@ -2311,13 +2417,76 @@ zabbix_export:
           triggers:
             - uuid: 4d67083fd891482881629dd8e9f760c9
               expression: avg(/OPNsense by REST API/opns.system.load.percore,15m)>{$OPNS.LOAD.PERCORE.WARN}
-              name: 'OPNsense: Load per core is high'
+              name: Load per core is high
               priority: WARNING
               description: Sustained demand above what the cores can serve. Unlike the raw load average this does not need a per host threshold.
               manual_close: 'YES'
               tags:
                 - tag: scope
                   value: performance
+        - uuid: f4baf02fcfb94f71a15f72f1a79e7c4b
+          name: System status
+          type: DEPENDENT
+          key: opns.system.status
+          delay: '0'
+          description: Overall status the firewall reports about itself. 2 is the healthy state observed on a firewall with nothing pending. The remaining codes were not observed, which is why the trigger fires on anything other than 2 rather than claiming to know them, and why the message is carried as text next to it.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.metadata.system.status
+          master_item:
+            key: opns.system.status.raw
+          tags:
+            - tag: component
+              value: system
+          value_type: UNSIGNED
+          triggers:
+            - uuid: d7b07fe6976f49248dd488535b475f86
+              expression: last(/OPNsense by REST API/opns.system.status)<>2
+              name: System status is not clean
+              opdata: '{ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: The firewall itself reports something pending in its status panel, for example a crash report, a configuration problem or a notice it wants acknowledged. The message item says what it is.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 1e09991029a74925af82412674c78578
+          name: System status message
+          type: DEPENDENT
+          key: opns.system.status.message
+          delay: '0'
+          description: Text the firewall shows next to its status code, for example "No pending messages".
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.metadata.system.message
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.system.status.raw
+          tags:
+            - tag: component
+              value: system
+          value_type: CHAR
+        - uuid: 616043c90d384039a4a5a846ea1d872d
+          name: RAW system status
+          type: HTTP_AGENT
+          key: opns.system.status.raw
+          delay: 5m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Master item. The status panel of the web interface: an overall code and the message that goes with it. A firewall with nothing pending answers 2 and "No pending messages".'
+          timeout: 30s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/core/system/status
+          tags:
+            - tag: component
+              value: raw
         - uuid: 1c669275ef6f41f6b7e255dc838f9b29
           name: 'OPNsense: Temperature sensors (raw)'
           type: HTTP_AGENT
@@ -2335,6 +2504,240 @@ zabbix_export:
           tags:
             - tag: component
               value: raw
+        - uuid: 770d9839028442d8b942a80195fd50c6
+          name: RAW certificates
+          type: HTTP_AGENT
+          key: opns.trust.certs.raw
+          delay: 1h
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Master item. The certificates in the trust store with their validity dates. Requires the Trust privilege, which is read only.
+          timeout: 30s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/trust/cert/search
+          tags:
+            - tag: component
+              value: raw
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows
+        - uuid: c6fe6e714e1344b7a7d437d86a4d06ea
+          name: DNS cache hit ratio
+          type: CALCULATED
+          key: opns.unbound.cache.hitratio
+          delay: 1m
+          value_type: FLOAT
+          units: '%'
+          params: 100*last(//opns.unbound.cachehits.rate)/(last(//opns.unbound.cachehits.rate)+last(//opns.unbound.cachemiss.rate)+0.00001)
+          description: Share of queries answered from the cache. On a resolver for a normal network this settles well above 60 percent once the cache is warm. A ratio that collapses points at a cache that is being flushed or at a client asking for something new every time.
+          tags:
+            - tag: component
+              value: network
+          triggers:
+            - uuid: a9aa0de161fa4606a331529f9025bc79
+              expression: max(/OPNsense by REST API/opns.unbound.cache.hitratio,30m)<{$OPNS.DNS.HITRATIO.MIN} and min(/OPNsense by REST API/opns.unbound.queries.rate,30m)>0
+              name: DNS cache hit ratio is low
+              priority: INFO
+              description: The resolver answered fewer queries from its cache than expected over half an hour, while it was being asked at all. The second condition keeps an idle resolver quiet.
+              tags:
+                - tag: scope
+                  value: performance
+        - uuid: b983cd2f30684b91a7effb452d74f524
+          name: DNS cache hits per second
+          type: DEPENDENT
+          key: opns.unbound.cachehits.rate
+          delay: '0'
+          description: Queries answered from the cache without asking anybody.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.num.cachehits
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.unbound.raw
+          tags:
+            - tag: component
+              value: network
+          value_type: FLOAT
+          units: '!q/s'
+        - uuid: 1aceaccf7a4a49b0b3f0ea65117c41c9
+          name: DNS cache misses per second
+          type: DEPENDENT
+          key: opns.unbound.cachemiss.rate
+          delay: '0'
+          description: Queries the resolver had to recurse or forward. Together with the hit rate this gives the cache hit ratio.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.num.cachemiss
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.unbound.raw
+          tags:
+            - tag: component
+              value: network
+          value_type: FLOAT
+          units: '!q/s'
+        - uuid: 24b3889cd7994de386f948c82f979397
+          name: DNS prefetches per second
+          type: DEPENDENT
+          key: opns.unbound.prefetch.rate
+          delay: '0'
+          description: Entries the resolver refreshed before they expired. Prefetching trades a few extra queries for answers that stay cached.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.num.prefetch
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.unbound.raw
+          tags:
+            - tag: component
+              value: network
+          value_type: FLOAT
+          units: '!q/s'
+        - uuid: e1372b14edc34a7ea6554b17abdeb132
+          name: DNS queries per second
+          type: DEPENDENT
+          key: opns.unbound.queries.rate
+          delay: '0'
+          description: Queries the resolver answered or forwarded, as a rate. A firewall that also serves DNS for the network behind it shows the load of that network here.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.num.queries
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.unbound.raw
+          tags:
+            - tag: component
+              value: network
+          value_type: FLOAT
+          units: '!q/s'
+        - uuid: e6d35da4481f46fda15df55817ac3ffa
+          name: DNS queries rate limited per second
+          type: DEPENDENT
+          key: opns.unbound.ratelimited.rate
+          delay: '0'
+          description: Queries dropped because a client exceeded the per address rate limit. Above zero means either a misbehaving client or a reflection attempt.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.num.queries_ip_ratelimited
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.unbound.raw
+          tags:
+            - tag: component
+              value: network
+          value_type: FLOAT
+          units: '!q/s'
+        - uuid: d3573d25af9a49329edbb9dc1a5f8eea
+          name: RAW Unbound statistics
+          type: HTTP_AGENT
+          key: opns.unbound.raw
+          delay: 1m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Master item. Resolver statistics from unbound/diagnostics/stats, reduced to the total block, which sums the per thread blocks. Counters are absolute since the resolver last started.
+          timeout: 30s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/unbound/diagnostics/stats
+          tags:
+            - tag: component
+              value: raw
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.total
+        - uuid: bc35ecb2fa0a4d3da0e5368af421dc05
+          name: DNS recursion time
+          type: DEPENDENT
+          key: opns.unbound.recursion.time
+          delay: '0'
+          description: Average time an answer took that was not in the cache. This is the number a user feels when a page is slow to start loading.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.recursion.time.avg
+          master_item:
+            key: opns.unbound.raw
+          tags:
+            - tag: component
+              value: network
+          value_type: FLOAT
+          units: s
+          triggers:
+            - uuid: 9c05deacf9eb49eeb19352b868a72138
+              expression: avg(/OPNsense by REST API/opns.unbound.recursion.time,10m)>{$OPNS.DNS.RECURSION.WARN}
+              name: DNS recursion is slow
+              priority: WARNING
+              description: Answers that were not cached took longer than the threshold over ten minutes, so either the upstream resolvers are slow or the link to them is.
+              tags:
+                - tag: scope
+                  value: performance
+        - uuid: 9f4e6995a1184f25b87ae53839431f73
+          name: DNS requests in the queue
+          type: DEPENDENT
+          key: opns.unbound.requestlist.current
+          delay: '0'
+          description: Requests waiting to be resolved. A queue that no longer empties means the resolver is the bottleneck.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.requestlist.current.all
+          master_item:
+            key: opns.unbound.raw
+          tags:
+            - tag: component
+              value: network
+          value_type: FLOAT
+        - uuid: 0797139215f94bcfabcf3b98a3cdd35b
+          name: DNS requests dropped, queue full
+          type: DEPENDENT
+          key: opns.unbound.requestlist.exceeded
+          delay: '0'
+          description: Requests dropped because the queue was full, as a rate. Anything above zero is lost DNS.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.requestlist.exceeded
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.unbound.raw
+          tags:
+            - tag: component
+              value: network
+          value_type: FLOAT
+          units: '!q/s'
+          triggers:
+            - uuid: 4c6080d2e3944d05969c9aa18f2b6420
+              expression: min(/OPNsense by REST API/opns.unbound.requestlist.exceeded,5m)>0
+              name: DNS requests are being dropped
+              priority: AVERAGE
+              description: The request queue of the resolver overflowed, so queries were answered by nobody. Clients see a timeout, not an error.
+              tags:
+                - tag: scope
+                  value: availability
         - uuid: ce65b79664fc47f8a21f7283252af4bf
           name: 'OPNsense: Version'
           type: DEPENDENT
@@ -2358,7 +2761,7 @@ zabbix_export:
           triggers:
             - uuid: 3fab70ab33034cbe8f06e6e5ffae3e9d
               expression: last(/OPNsense by REST API/opns.version,#1)<>last(/OPNsense by REST API/opns.version,#2)
-              name: 'OPNsense: Version has changed'
+              name: Version has changed
               priority: INFO
               description: An update was most likely applied.
               manual_close: 'YES'
@@ -2719,8 +3122,8 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - '$.rows[*]'
-              error_handler: CUSTOM_ERROR
-              error_handler_params: 'Could not locate any defined CARP interfaces.'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
         - uuid: b28e806ede4642a89206e98f06e4ec51
           name: 'Interface Stats Discovery'
           type: DEPENDENT
@@ -3729,6 +4132,72 @@ zabbix_export:
             - lld_macro: '{#IPSECNAME}'
               path: $.name
         # --- added from OPNsense by HTTP API (github.com/Garfieldttt/opnsense-zabbix-api) ---
+        - uuid: afe221e2de304de5a9871374229a6ab3
+          name: Certificates
+          type: DEPENDENT
+          key: opns.cert.discovery
+          delay: '0'
+          description: Discovers the certificates in the trust store, so an expiry is visible before it takes the web interface, a VPN or a captive portal down. Certificates that are not in use are excluded by default.
+          item_prototypes:
+            - uuid: 0b7085d2341a4719a03fde843ee04688
+              name: 'Certificate {#CERT_NAME}: expires'
+              type: DEPENDENT
+              key: opns.cert.validto[{#CERT_UUID}]
+              delay: '0'
+              value_type: FLOAT
+              units: unixtime
+              trends: '0'
+              description: End of the validity period of {#CERT_NAME}, as reported by the trust store. A trend over a timestamp carries no meaning, so trends stay off.
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $[?(@.uuid=="{#CERT_UUID}")].valid_to.first()
+              master_item:
+                key: opns.trust.certs.raw
+              tags:
+                - tag: component
+                  value: security
+                - tag: certificate
+                  value: '{#CERT_NAME}'
+              trigger_prototypes:
+                - uuid: cb1f5b0fc3154ff3a885e8e67362835c
+                  expression: last(/OPNsense by REST API/opns.cert.validto[{#CERT_UUID}])-now()<{$OPNS.CERT.EXPIRE.DAYS}
+                  name: Certificate {#CERT_NAME} expires soon
+                  priority: WARNING
+                  description: Renew it before the date passes. Depends on the expired trigger, so only one of the two is ever open.
+                  dependencies:
+                    - name: Certificate {#CERT_NAME} has expired
+                      expression: last(/OPNsense by REST API/opns.cert.validto[{#CERT_UUID}])-now()<0
+                  tags:
+                    - tag: scope
+                      value: security
+                - uuid: 8102ac279c3349bfae6435bf2a97f81d
+                  expression: last(/OPNsense by REST API/opns.cert.validto[{#CERT_UUID}])-now()<0
+                  name: Certificate {#CERT_NAME} has expired
+                  priority: AVERAGE
+                  description: The certificate is past its validity. Whatever presents it is now refused by clients that check the chain.
+                  tags:
+                    - tag: scope
+                      value: security
+          master_item:
+            key: opns.trust.certs.raw
+          lld_macro_paths:
+            - lld_macro: '{#CERT_UUID}'
+              path: $.uuid
+            - lld_macro: '{#CERT_NAME}'
+              path: $.descr
+            - lld_macro: '{#CERT_IN_USE}'
+              path: $.in_use
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#CERT_NAME}'
+                value: '{$OPNS.CERT.NAME.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: A
+              - macro: '{#CERT_IN_USE}'
+                value: '{$OPNS.CERT.IN_USE.MATCHES}'
+                formulaid: B
         - uuid: f0a8fc199c814bc7b95cc0234b35d825
           name: Network interfaces (link state and inbound errors)
           type: DEPENDENT
@@ -3797,7 +4266,7 @@ zabbix_export:
               trigger_prototypes:
                 - uuid: 110a1532440747e5b4d548420b2053f6
                   expression: last(/OPNsense by REST API/opns.net.if.status[{#IFNAME}])=0 and {$OPNS.IF.CONTROL:"{#IFNAME}"}=1
-                  name: 'OPNsense: Interface {#IFALIAS} ({#IFNAME}) is down'
+                  name: Interface {#IFALIAS} ({#IFNAME}) is down
                   priority: AVERAGE
                   description: The link is gone or the interface was shut down. Set {$OPNS.IF.CONTROL:"{#IFNAME}"} to 0 for interfaces that are allowed to be down, such as a cold standby uplink.
                   manual_close: 'YES'
@@ -4019,7 +4488,7 @@ zabbix_export:
               trigger_prototypes:
                 - uuid: da4a4099f5d24feeaea0a84c3cfd28e5
                   expression: min(/OPNsense by REST API/opns.service.running[{#SERVICE.ID}],5m)=0
-                  name: 'OPNsense: Service {#SERVICE.DESCRIPTION} is not running'
+                  name: Service {#SERVICE.DESCRIPTION} is not running
                   priority: AVERAGE
                   description: The service has been down for five minutes. Add it to {$OPNS.SERVICE.ID.NOT_MATCHES} if it is not supposed to run on this firewall.
                   manual_close: 'YES'
@@ -4062,7 +4531,7 @@ zabbix_export:
               trigger_prototypes:
                 - uuid: 85b857bc0d1a43c4b21b94129f2c83bc
                   expression: min(/OPNsense by REST API/opns.swap.pused[{#SWAPDEV}],10m)>{$OPNS.SWAP.UTIL.WARN:"{#SWAPDEV}"}
-                  name: 'OPNsense: Swap {#SWAPDEV} is in use'
+                  name: Swap {#SWAPDEV} is in use
                   priority: WARNING
                   description: A firewall that swaps is short on memory. Sustained swap usage costs throughput.
                   manual_close: 'YES'
@@ -4161,7 +4630,7 @@ zabbix_export:
               trigger_prototypes:
                 - uuid: 8217649a9ae14ff6be99475632f5c7c9
                   expression: avg(/OPNsense by REST API/opns.temperature[{#DEVICE}],5m)>{$OPNS.TEMP.CRIT:"{#DEVICE}"}
-                  name: 'OPNsense: Sensor {#DEVICE} is running hot'
+                  name: Sensor {#DEVICE} is running hot
                   priority: HIGH
                   description: Sustained high temperature. Check fans, filters and ambient temperature. Adjust {$OPNS.TEMP.CRIT} per hardware, the default suits most x86 appliances.
                   manual_close: 'YES'
@@ -4239,9 +4708,24 @@ zabbix_export:
           value: ^$
           description: 'Regex filter for excluding WireGuard peers from discovery. Can be overridden on the host or linked template level.'
         # --- added from OPNsense by HTTP API (github.com/Garfieldttt/opnsense-zabbix-api) ---
+        - macro: '{$OPNS.CERT.EXPIRE.DAYS}'
+          value: 21d
+          description: Lead time before a certificate expires. Accepts a time unit, for example 21d.
+        - macro: '{$OPNS.CERT.IN_USE.MATCHES}'
+          value: '1'
+          description: Which certificates are discovered, matched against the in_use flag. The default takes only certificates that something actually presents. Set to .* to watch every certificate in the store.
+        - macro: '{$OPNS.CERT.NAME.NOT_MATCHES}'
+          value: ^$
+          description: Certificates excluded from discovery, as a regular expression over the description. The default excludes nothing.
         - macro: '{$OPNS.CPU.UTIL.WARN}'
           value: '85'
           description: Processor utilisation that counts as high, averaged over ten minutes.
+        - macro: '{$OPNS.DNS.HITRATIO.MIN}'
+          value: '60'
+          description: Cache hit ratio in percent below which the resolver is reported as working harder than it should. Informational, not a fault.
+        - macro: '{$OPNS.DNS.RECURSION.WARN}'
+          value: '1'
+          description: Average recursion time in seconds that counts as slow. Uncached answers from a healthy upstream resolver stay well below one second.
         - macro: '{$OPNS.IF.CONTROL}'
           value: '1'
           description: Set to 0, optionally per interface as {$OPNS.IF.CONTROL:"vtnet3"}, to stop the down trigger for interfaces that are allowed to have no link.
@@ -6746,6 +7230,299 @@ zabbix_export:
                     - type: STRING
                       name: reference
                       value: UPSVO
+            - name: Resolver, certificates and leases
+              widgets:
+                - type: gauge
+                  name: DNS cache hit ratio
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.unbound.cache.hitratio
+                    - type: STRING
+                      name: description
+                      value: DNS cache hit ratio
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '40'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '60'
+                - type: item
+                  name: Queries
+                  x: '18'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.unbound.queries.rate
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Recursion time
+                  x: '30'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.unbound.recursion.time
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Queue
+                  x: '42'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.unbound.requestlist.current
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: System status
+                  x: '54'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.system.status.message
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: svggraph
+                  name: DNS queries
+                  'y': '3'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: DNS queries per second
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: DNS cache hits per second
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: FFD54F
+                    - type: INTEGER
+                      name: ds.2.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: DNS cache misses per second
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.3.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.3.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.3.items.0
+                      value: DNS prefetches per second
+                    - type: INTEGER
+                      name: ds.3.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: DNSQR
+                - type: svggraph
+                  name: DNS recursion time
+                  x: '36'
+                  'y': '3'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: DNS recursion time
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: DNSRC
+                - type: item
+                  name: DHCPv4 leases
+                  'y': '8'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.kea.leases4.active
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: DHCPv6 leases
+                  x: '12'
+                  'y': '8'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.kea.leases6.active
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Queries rate limited
+                  x: '24'
+                  'y': '8'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.unbound.ratelimited.rate
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Queue overflows
+                  x: '36'
+                  'y': '8'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.unbound.requestlist.exceeded
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: honeycomb
+                  name: Certificate expiry
+                  'y': '11'
+                  width: '72'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Certificate *: expires'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("Certificate (.*): expires", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '11'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: CERTHC
       # --- added from OPNsense by HTTP API (github.com/Garfieldttt/opnsense-zabbix-api) ---
       valuemaps:
         - uuid: 1454fbfd0a6345b38f4889113c9fde4c

--- a/Network_Devices/OPNsense/template_opnsense_by_rest_api/7.0/template_opnsense_by_rest_api.yaml
+++ b/Network_Devices/OPNsense/template_opnsense_by_rest_api/7.0/template_opnsense_by_rest_api.yaml
@@ -1,0 +1,6778 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 36bff6c29af64692839d077febfc7079
+      name: 'Templates/Network devices'
+    - uuid: 846977d1dfed4968bc5f8bdb363285bc
+      name: 'Templates/Operating systems'
+  templates:
+    - uuid: 895f97c39f4e422cbb7065e8b59fd882
+      template: 'OPNsense by REST API'
+      name: 'OPNsense by REST API'
+      description: |
+        Zabbix template for monitoring OPNsense firewalls using the REST API. No SNMP and no
+        Zabbix agent is required on the firewall.
+
+        Created by Thomas Rzen.
+        For documentation, updates, and source code, visit:
+        https://github.com/Garfieldttt/opnsense-zabbix-template
+
+        Import into Zabbix 7.0 or later.
+
+        Covers processor utilisation split into user, system and interrupt, memory, kernel
+        network memory and mbuf clusters, netisr queues, swap, temperature, load average and
+        core count, the pf state and source tracking tables with their limits, pf counters,
+        table entries and the loaded ruleset with change detection, per interface traffic,
+        errors, link state and blocked packets, protocol level errors, gateways, CARP, IPsec
+        with phase 2 per connection, WireGuard, OpenVPN, services, clock synchronisation,
+        filesystems, firmware state, configuration changes and UPS. Interfaces, gateways,
+        filesystems, swap devices, temperature sensors, netisr protocols, services, CARP
+        addresses, IPsec tunnels, WireGuard peers and OpenVPN instances are discovered.
+
+        The monitoring account needs ten privileges. Eight are read only; the README states
+        what the other two permit and how to do without them.
+
+        Derived from the Zabbix community template "OPNsense by HTTP-JSON", MIT licensed,
+        Copyright (c) 2021 Zabbix, with the greater part of the current content added on
+        top. See LICENSE.
+      groups:
+        - name: 'Templates/Network devices'
+        - name: 'Templates/Operating systems'
+      items:
+        - uuid: 6bb91c79e3ce4cd3ab0a76b80edc1ccd
+          name: 'UPS Battery Charge'
+          type: DEPENDENT
+          key: nut.battery.charge
+          units: '%'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.[''battery.charge'']'
+          master_item:
+            key: opns.ups.raw
+          triggers:
+            - uuid: 0fdb387507f44ebb890174bc36121ad4
+              expression: 'last(/OPNsense by REST API/nut.battery.charge)<{$OPNS.NUT.BAT.LOW}'
+              name: 'Battery charge is below {$OPNS.NUT.BAT.LOW}'
+              opdata: '{ITEM.LASTVALUE}'
+              priority: WARNING
+        - uuid: e4b5141808e8408e8a00efcb479e9cb2
+          name: 'UPS Battery Load'
+          type: DEPENDENT
+          key: nut.battery.load
+          units: '%'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.[''ups.load'']'
+          master_item:
+            key: opns.ups.raw
+          triggers:
+            - uuid: bb0d39e51fa744378fd12e5aab746a24
+              expression: 'last(/OPNsense by REST API/nut.battery.load)>{$OPNS.NUT.HIGH.LOAD}'
+              name: 'High Load on UPS Battery'
+              opdata: '{ITEM.LASTVALUE}'
+              priority: AVERAGE
+        - uuid: 5604961df09b452bb2296d24e1486082
+          name: 'UPS Battery Runtime'
+          type: DEPENDENT
+          key: nut.battery.runtime
+          units: s
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.[''battery.runtime'']'
+          master_item:
+            key: opns.ups.raw
+          triggers:
+            - uuid: 605116b13c4d488398e32e0a6beb93fd
+              expression: 'last(/OPNsense by REST API/nut.battery.runtime)<{$OPNS.NUT.BAT.RUNTIME}'
+              name: 'Remaining battery runtime is low'
+              opdata: '{ITEM.LASTVALUE}'
+              priority: HIGH
+        - uuid: 116b2a83a25e45b8bc50d00b18cf6270
+          name: 'UPS Input Frequency'
+          type: DEPENDENT
+          key: nut.input.frequency
+          units: Hz
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.[''input.frequency'']'
+          master_item:
+            key: opns.ups.raw
+        - uuid: dd7138db48af44e684db3f11d40ac434
+          name: 'UPS Input Voltage'
+          type: DEPENDENT
+          key: nut.input.voltage
+          units: V
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.[''input.voltage'']'
+          master_item:
+            key: opns.ups.raw
+        - uuid: 45fa08b6aec94940bd9942f7d2158578
+          name: 'UPS Model'
+          type: DEPENDENT
+          key: nut.model
+          value_type: TEXT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.[''ups.model'']'
+          master_item:
+            key: opns.ups.raw
+        - uuid: 709e8bb4ff4f4bff843b3fb71adcf853
+          name: 'UPS Output Voltage'
+          type: DEPENDENT
+          key: nut.output.voltage
+          units: V
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.[''output.voltage'']'
+          master_item:
+            key: opns.ups.raw
+        - uuid: 5da24f605c13479f8115d262b0fd8e63
+          name: 'UPS Status'
+          type: DEPENDENT
+          key: nut.status
+          value_type: TEXT
+          description: |
+            OL = On Line = UPS is powered by mains electricity, supplying power to connected devices.
+            OB = On Battery = UPS is running on battery power due to mains failure.
+            LB = Low Battery = Battery charge is critically low. UPS will shut down soon.
+            RB = Replace Battery = Battery needs replacement (age or health issue).
+            HB = High Battery = Battery is fully charged (rare, but possible).
+            CHRG = Charging = Battery is currently being charged.
+            DISCHRG = Discharging = Battery is discharging (same as OB, but more specific).
+            OVER = Overload = UPS is overloaded (load exceeds capacity).
+            ALARM = Alarm Active = UPS has triggered an alarm (e.g., overload, battery fault).
+            CAL = Calibrating = UPS is performing battery calibration.
+            COMMLOST = Communication Lost = Communication with UPS is lost.
+            OFF = Off = UPS is powered off.
+            ONBATT = On Battery = Same as OB.
+            TRIM = Trim = Mains voltage is low, UPS is reducing voltage (step-down).
+            BOOST = Boost = Mains voltage is high, UPS is increasing voltage (step-up).
+            SYNC = Synchronizing = UPS is synchronizing with mains (rare).
+            TEST = Test = Running	UPS is running a self-test.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.[''ups.status'']'
+          master_item:
+            key: opns.ups.raw
+          triggers:
+            - uuid: 61aee5990f854acfb9db63e4c7bffd31
+              expression: 'find(/OPNsense by REST API/nut.status,#1,"like","LB")=1'
+              name: 'Battey low'
+              priority: DISASTER
+            - uuid: 0f77efffd9cc4b1989344c739b2e2274
+              expression: 'find(/OPNsense by REST API/nut.status,#1,"like","OB")=1'
+              name: 'UPS on Battery'
+              priority: HIGH
+        - uuid: dec2fc92cda44ab7b8457171fe693b41
+          name: 'CPU load'
+          type: DEPENDENT
+          key: opns.cpu.load
+          history: 1d
+          value_type: FLOAT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.loadavg
+            - type: REGEX
+              parameters:
+                - ^(\d+\.\d+)
+                - \1
+          master_item:
+            key: opns.raw.load
+          triggers:
+            - uuid: 7c04d91bc29c478cb2b87e1834a742cc
+              expression: 'min(/OPNsense by REST API/opns.cpu.load,5m)>{$OPNS.CPU.LOAD.MAX}'
+              name: 'CPU load is high'
+              opdata: '{ITEM.LASTVALUE}'
+              priority: WARNING
+        - uuid: 2e3316ee08c945fbb0ce4e5b497c72a2
+          name: 'Firewall states current'
+          type: DEPENDENT
+          key: opns.fw.states.current
+          history: 1d
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.current
+          master_item:
+            key: opns.raw.fw.states
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: f352bd8c49cf45ba9a987773990ec8f1
+          name: 'Firewall states max'
+          type: DEPENDENT
+          key: opns.fw.states.max
+          history: 1d
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.limit
+          master_item:
+            key: opns.raw.fw.states
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 1b34be3e87314b90a2910cff259f9c5d
+          name: 'RAW IPsec Phase1'
+          type: HTTP_AGENT
+          key: opns.ipsec.phase1.raw
+          delay: 5m
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // searchPhase1 leaves phase1desc null when the connection carries no description, and the
+                  // discovery uses that field as the entity identity in every prototype key. name is always
+                  // set, so it stands in. Anyone who does have descriptions keeps the keys they already have.
+                  var rows = JSON.parse(value);
+                  for (var i = 0; i < rows.length; i++) {
+                      var desc = rows[i]['phase1desc'];
+                      if (desc === null || desc === undefined || String(desc).trim() === '') {
+                          rows[i]['phase1desc'] = rows[i]['name'];
+                      }
+                  }
+                  return JSON.stringify(rows);
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/ipsec/sessions/searchPhase1'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 726beb61d9504190b8359280984c577a
+          name: 'RAW WireGuard'
+          type: HTTP_AGENT
+          key: opns.wireguard.raw
+          delay: 1m
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/wireguard/service/show'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 69bf5ee4ea6048109296a1981df4b277
+          name: 'ARC Memory'
+          type: DEPENDENT
+          key: opns.memory.arc
+          history: 1d
+          units: B
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.memory.arc
+          master_item:
+            key: opns.raw.memory.status
+        - uuid: b19c177d7b2741598295767c32caf172
+          name: 'Total Memory'
+          type: DEPENDENT
+          key: opns.memory.total
+          history: 1d
+          units: B
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.memory.total
+          master_item:
+            key: opns.raw.memory.status
+        - uuid: 9bea0832897b4a368de2f5b606600237
+          name: 'Used Memory'
+          type: DEPENDENT
+          key: opns.memory.used
+          history: 1d
+          units: B
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.memory.used
+          master_item:
+            key: opns.raw.memory.status
+        - uuid: be5f37c074a7491f8aed6696e1a33e18
+          name: 'Memory utilization in %'
+          type: CALCULATED
+          key: opns.memory.util
+          units: '%'
+          params: 'last(//opns.memory.used)*100/last(//opns.memory.total)'
+          tags:
+            - tag: component
+              value: memory
+          triggers:
+            - uuid: 87806d46705c437180e7477da9522891
+              expression: 'min(/OPNsense by REST API/opns.memory.util,5m)>{$OPNS.MEMORY.UTIL.MAX}'
+              name: 'Memory utilization is high'
+              opdata: '{ITEM.LASTVALUE}'
+              priority: AVERAGE
+        - uuid: 46958e39ecd24222b11c716eb92394a0
+          name: 'Licensed until'
+          type: DEPENDENT
+          key: opns.product.licenseuntil
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.product.product_license.valid_to
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  function convertDateToUnixTimestamp(input) {
+                      if (input === '0' || input === '' || input === null) {
+                          return 0;
+                      }
+                      const date = new Date(input);
+                      const unixTimestamp = Math.floor(date.getTime() / 1000);
+                      if (isNaN(unixTimestamp)) {
+                          return 0;
+                      }
+                      return unixTimestamp;
+                  }
+                  
+                  return convertDateToUnixTimestamp(value);
+          master_item:
+            key: opns.raw.product.info
+          triggers:
+            - uuid: 9aa531a694664a4996fb9f698c99e49a
+              expression: 'last(/OPNsense by REST API/opns.product.licenseuntil)>0 and (last(/OPNsense by REST API/opns.product.licenseuntil) - now()) / 86400 < {$OPNS.LICENSE.EXPIRY.WARN}'
+              name: 'OPNSense Business License expires soon'
+              event_name: 'OPNSense Business License expires soon (less than {$OPNS.LICENSE.EXPIRY.WARN} days)'
+              priority: AVERAGE
+        - uuid: a22f470c7998453a8f7f0cf78cb7604f
+          name: 'Firmware update count'
+          type: DEPENDENT
+          key: opns.firmware.update.count
+          history: 30d
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  if (data.status !== 'update' && data.status !== 'upgrade') {
+                      return 0;
+                  }
+                  if (data.all_packages) {
+                      return Object.keys(data.all_packages).length;
+                  }
+                  if (data.all_sets) {
+                      return Object.keys(data.all_sets).length;
+                  }
+                  return 0;
+          master_item:
+            key: opns.raw.firmware.status
+          tags:
+            - tag: component
+              value: firmware
+        - uuid: 1bbc3b182e4047a888ac88bac4b83a1b
+          name: 'Firmware update packages'
+          type: DEPENDENT
+          key: opns.firmware.update.packages
+          history: 30d
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  var packages = data.all_packages || data.all_sets || {};
+                  var result = [];
+                  Object.keys(packages).sort().forEach(function (name) {
+                      var pkg = packages[name];
+                      result.push(pkg.name + ': ' + pkg.old + ' -> ' + pkg.new + ' (' + pkg.reason + ')');
+                  });
+                  return result.join('\n');
+          master_item:
+            key: opns.raw.firmware.status
+          tags:
+            - tag: component
+              value: firmware
+        - uuid: cb33fd89dc8540a08ab0e657e94bea71
+          name: 'Firmware update requires reboot'
+          type: DEPENDENT
+          key: opns.firmware.update.reboot
+          history: 30d
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.status_reboot
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+          master_item:
+            key: opns.raw.firmware.status
+          tags:
+            - tag: component
+              value: firmware
+        - uuid: 5ed61ed104e3403ebee5274a1d0d0209
+          name: 'Firmware update status'
+          type: DEPENDENT
+          key: opns.firmware.update.status
+          history: 30d
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.status
+          master_item:
+            key: opns.raw.firmware.status
+          tags:
+            - tag: component
+              value: firmware
+          triggers:
+            - uuid: 0d5af49f432a4819b1ac0d3d7d170dde
+              expression: 'find(/OPNsense by REST API/opns.firmware.update.status,#1,"regexp","^(update|upgrade)$")=1 and last(/OPNsense by REST API/opns.firmware.update.count)>0'
+              name: 'OPNsense firmware updates are available'
+              event_name: 'OPNsense firmware updates are available ({ITEM.LASTVALUE})'
+              opdata: 'Updates: {ITEM.LASTVALUE2}'
+              priority: INFO
+              description: 'A firmware update or major upgrade is available.'
+            - uuid: 48d9315e40784037bfabc1a507a6db6e
+              expression: 'find(/OPNsense by REST API/opns.firmware.update.status,#1,"eq","error")=1'
+              name: 'OPNsense firmware update check failed'
+              opdata: '{ITEM.LASTVALUE}'
+              priority: WARNING
+              description: 'The OPNsense firmware update check returned an error.'
+        - uuid: c1105eda7d0140d782ff53119fec0e09
+          name: 'Firmware update status message'
+          type: DEPENDENT
+          key: opns.firmware.update.status_msg
+          history: 30d
+          value_type: TEXT
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.status_msg
+          master_item:
+            key: opns.raw.firmware.status
+          tags:
+            - tag: component
+              value: firmware
+        - uuid: eb750aef7af34e68b80a302f7d3edcf4
+          name: 'RAW Disk'
+          type: HTTP_AGENT
+          key: opns.raw.disk
+          delay: 5m
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var raw = value;
+                  var data;
+                  
+                  try {
+                      data = JSON.parse(raw);
+                  } catch(e) {
+                      throw 'JSON parse error: ' + e + ' | raw value: ' + raw;
+                  }
+                  
+                  if (!data || typeof data.devices === 'undefined') {
+                      throw 'No devices key found. Data: ' + JSON.stringify(data);
+                  }
+                  
+                  function toBytes(str) {
+                      if (!str || str === '-') return 0;
+                  
+                      var units = {
+                          'K': 1024,
+                          'M': 1024 * 1024,
+                          'G': 1024 * 1024 * 1024,
+                          'T': 1024 * 1024 * 1024 * 1024
+                      };
+                  
+                      var s = String(str).trim();
+                      var lastChar = s.charAt(s.length - 1).toUpperCase();
+                  
+                      if (units[lastChar]) {
+                          var num = parseFloat(s.slice(0, -1));
+                          return Math.round(num * units[lastChar]);
+                      }
+                  
+                      return Math.round(parseFloat(s));
+                  }
+                  
+                  for (var i = 0; i < data.devices.length; i++) {
+                      var d = data.devices[i];
+                      d.blocks    = toBytes(d.blocks);
+                      d.used      = toBytes(d.used);
+                      d.available = toBytes(d.available);
+                  }
+                  
+                  return JSON.stringify(data);
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/system/system_disk'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 1e05c03ad3b94bda80a179a98cd5781c
+          name: 'RAW Firewallaction'
+          type: HTTP_AGENT
+          key: opns.raw.fw.action
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/stats?group_by=action'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 5939c685b1a8477780d28361a1d44af9
+          name: 'RAW Firewall Interfaces'
+          type: HTTP_AGENT
+          key: opns.raw.fw.interface.stat
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/pf_statistics/interfaces'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 26ae28b3769944ba8ac7e9ac258f5eb1
+          name: 'RAW Firewall States'
+          type: HTTP_AGENT
+          key: opns.raw.fw.states
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/pf_states'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 85e135e5dc174a53816cd18789a7f684
+          name: 'RAW Gatewaystatus'
+          type: HTTP_AGENT
+          key: opns.raw.gateway.status
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.items
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/routes/gateway/status'
+          tags:
+            - tag: component
+              value: raw
+          triggers:
+            - uuid: 8b1ff7160ba34620959dffa8b5eb743b
+              expression: 'nodata(/OPNsense by REST API/opns.raw.gateway.status,5m)=1'
+              name: 'No data from OPNsense'
+              priority: HIGH
+              description: 'can''t access the OPNsense API'
+        - uuid: 2b7d229bae454019ac1c6e54b0571486
+          name: 'RAW Carp Interfaces'
+          type: HTTP_AGENT
+          key: opns.raw.interfaces.carp
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/interface/get_vip_status'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 7e822f6bcfce4f5daac2429c62afbc48
+          name: 'RAW Interfaces'
+          type: HTTP_AGENT
+          key: opns.raw.interfaces.stat
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.interfaces
+            - type: JSONPATH
+              parameters:
+                - '$.*'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/traffic/_interface'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: f126ae58d3324d6cbfa826d6348c8bb3
+          name: 'RAW Load'
+          type: HTTP_AGENT
+          key: opns.raw.load
+          delay: 5m
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/system/system_time'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 8b36f82be3304f9db115b3248244968c
+          name: 'RAW Memorystatus'
+          type: HTTP_AGENT
+          key: opns.raw.memory.status
+          delay: 5m
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/system/system_resources'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 82e6125309fc4dbb892484ca52008cde
+          name: 'RAW Product Info'
+          type: HTTP_AGENT
+          key: opns.raw.product.info
+          delay: 30m
+          history: 1d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/core/firmware/info'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 1f86f6392bec4c38a6a2ad9a8447b835
+          name: 'RAW Firmware Status'
+          type: HTTP_AGENT
+          key: opns.raw.firmware.status
+          delay: 1d
+          history: 7d
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          request_method: POST
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/core/firmware/status'
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 8b44789b4d3c4e488ce6464b6aa3a9fb
+          name: 'States table utilization in %'
+          type: CALCULATED
+          key: opns.states.util
+          history: 30d
+          value_type: FLOAT
+          units: '%'
+          params: 'last(//opns.fw.states.current)*100/last(//opns.fw.states.max)'
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: 6eaa177f87564fe9b4d00359a89988e8
+              expression: 'min(/OPNsense by REST API/opns.states.util,#3)>{$OPNS.STATE.TABLE.UTIL.MAX}'
+              name: 'State table usage is high'
+              event_name: 'State table usage more than {$OPNS.STATE.TABLE.UTIL.MAX}.'
+              opdata: 'Current utilization: {ITEM.LASTVALUE}'
+              priority: WARNING
+              description: 'Please check the number of connections.'
+        - uuid: 88f4b95b1d66408298874f37dd6dde3d
+          name: 'System Uptime'
+          type: DEPENDENT
+          key: opns.system.uptime
+          history: 1d
+          value_type: FLOAT
+          units: uptime
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.uptime
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var str = value.trim();
+                            var days = 0;
+                            var hours = 0;
+                            var minutes = 0;
+                            var seconds = 0;
+                  
+                            // Extract days if present
+                            var dayMatch = str.match(/(\d+)\s*days?/);
+                            if (dayMatch) {
+                                days = parseInt(dayMatch[1]);
+                            }
+                  
+                            // Extract HH:MM:SS
+                            var timeMatch = str.match(/(\d{1,2}):(\d{2}):(\d{2})/);
+                            if (timeMatch) {
+                                hours = parseInt(timeMatch[1]);
+                                minutes = parseInt(timeMatch[2]);
+                                seconds = parseInt(timeMatch[3]);
+                            }
+                  
+                            return (days * 86400) + (hours * 3600) + (minutes * 60) + seconds;
+          master_item:
+            key: opns.raw.load
+          triggers:
+            - uuid: e7490e5999e741138a484db7d0102b68
+              expression: 'last(/OPNsense by REST API/opns.system.uptime)<600'
+              name: '{HOST.NAME} has been restarted'
+              priority: INFO
+        - uuid: 970bab8307754338b2ad45685f4e785a
+          name: 'RAW UPS'
+          type: HTTP_AGENT
+          key: opns.ups.raw
+          delay: 5m
+          history: 1d
+          value_type: TEXT
+          status: DISABLED
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var data = JSON.parse(value);
+                  var raw = data.response || "";
+                  var result = {};
+                  var lines = raw.split("\n");
+                  
+                  for (var i = 0; i < lines.length; i++) {
+                      var line = lines[i].trim();
+                      var idx = line.indexOf(": ");
+                      if (idx > -1) {
+                          var key = line.substring(0, idx).trim();
+                          var val = line.substring(idx + 2).trim();
+                          result[key] = val;
+                      }
+                  }
+                  return JSON.stringify(result);
+          url: 'https://{HOST.IP}:{$OPNS.PORT}/api/nut/diagnostics/upsstatus'
+          tags:
+            - tag: component
+              value: raw
+        # --- added from OPNsense by HTTP API (github.com/Garfieldttt/opnsense-zabbix-api) ---
+        - uuid: 7eb0efa814084b5689dc9adebc26aea3
+          name: 'OPNsense: System activity (raw)'
+          type: HTTP_AGENT
+          key: opns.activity.raw
+          delay: 1m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Header block of the process listing, which is the only place the API states how busy the processor actually is. The bulk of the response is the process table itself and is not evaluated, so nothing is stored from it.
+          timeout: 15s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/activity/get_activity
+          tags:
+            - tag: component
+              value: raw
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - (CPU:[^"]+)
+                - \1
+        - uuid: 5a76fb08bf03479ca2cc21ca48aac541
+          name: 'OPNsense: Alias tables (raw)'
+          type: HTTP_AGENT
+          key: opns.alias.raw
+          delay: 10m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Entries held by all pf tables together with the configured ceiling. Polled every ten minutes because block lists and GeoIP feeds move on that scale, not by the second.
+          timeout: 10s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/firewall/alias/get_table_size
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 880f25dabb274a84b41e4a669fe90420
+          name: 'CARP: Demotion factor'
+          type: DEPENDENT
+          key: opns.carp.demotion
+          delay: '0'
+          description: How strongly this node is holding itself back from becoming master. Zero means it is willing; anything above means a subsystem has demoted it, which is the usual reason a node refuses to take over when the peer fails.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.carp.demotion
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 3m
+          master_item:
+            key: opns.raw.interfaces.carp
+          tags:
+            - tag: component
+              value: carp
+        - uuid: cd52744956224bd2b1787d2e14041a39
+          name: 'CARP: Maintenance mode'
+          type: DEPENDENT
+          key: opns.carp.maintenance
+          delay: '0'
+          valuemap:
+            name: Enabled state
+          description: Maintenance mode hands every virtual address to the peer and keeps it there. Worth watching because it is easy to switch on for a planned change and just as easy to forget afterwards, leaving the pair permanently one sided.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.carp.maintenancemode
+              error_handler: DISCARD_VALUE
+            - type: BOOL_TO_DECIMAL
+              parameters:
+                - ''
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 3m
+          master_item:
+            key: opns.raw.interfaces.carp
+          tags:
+            - tag: component
+              value: carp
+          triggers:
+            - uuid: 2382bd0b26b74d9ab79040aff56483a4
+              expression: min(/OPNsense by REST API/opns.carp.maintenance,30m)=1
+              name: 'OPNsense: CARP maintenance mode has been on for 30 minutes'
+              priority: WARNING
+              description: Long enough to suggest it was left on rather than switched on for a change in progress. While it is on there is no redundancy.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: e02ce9f81cc14063a7b1c446fb3af9aa
+          name: 'OPNsense: Configuration last changed'
+          type: DEPENDENT
+          key: opns.config.changed
+          delay: '0'
+          units: unixtime
+          description: Timestamp OPNsense records when the configuration is written. Covers every change, not only firewall rules, and needs no extra request because it rides along with the system time that is already polled. The reading is what the firewall itself reports, so a clock that is off shifts it accordingly.
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // "Thu Aug 13 12:03:17 UTC 2026". Date.parse is unreliable with this
+                  // format, so it is taken apart by position.
+                  var m = JSON.parse(value).config.match(
+                      /^\w{3}\s+(\w{3})\s+(\d{1,2})\s+(\d{1,2}):(\d{2}):(\d{2})\s+\S+\s+(\d{4})$/);
+                  if (m === null) { throw 'cannot read config timestamp: ' + value; }
+                  var months = {Jan:0,Feb:1,Mar:2,Apr:3,May:4,Jun:5,Jul:6,Aug:7,Sep:8,Oct:9,Nov:10,Dec:11};
+                  return Math.round(Date.UTC(+m[6], months[m[1]], +m[2], +m[3], +m[4], +m[5]) / 1000);
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.raw.load
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 5794a994a35749d48043a0fa73e68ad7
+              expression: change(/OPNsense by REST API/opns.config.changed)<>0 and last(/OPNsense by REST API/opns.config.changed,#2)>0
+              name: 'OPNsense: Configuration has been changed'
+              priority: INFO
+              description: Someone wrote a new configuration. Broader than the ruleset fingerprint, which reacts to rules only, and the two together tell whether a change touched the firewall rules or something else. The second condition suppresses the jump out of a zero, which is what an item reports after a gap in collection rather than a real change.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 22b8c564642e421da100881b148de591
+          name: 'CPU: Cores'
+          type: DEPENDENT
+          key: opns.cpu.cores
+          delay: '0'
+          description: Physical core count, needed to put the load average into proportion. Parsed by position rather than by wording, because the source string is translated on a localised firewall.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $[0]
+            - type: REGEX
+              parameters:
+                - \(([0-9]+)[^)]*\)\s*$
+                - \1
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: opns.cpu.raw
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: 904436408fba4cfaa15f5fd5cdb1b52f
+          name: 'CPU: Idle time'
+          type: DEPENDENT
+          key: opns.cpu.idle
+          delay: '0'
+          description: Share of processor time spent idle. The one figure top(1) states directly, which is why utilization is derived from it rather than the other way round.
+          master_item:
+            key: opns.activity.raw
+          tags:
+            - tag: component
+              value: cpu
+          value_type: FLOAT
+          units: '%'
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - ([0-9.]+)%\s*idle
+                - \1
+        - uuid: 345edb3a39524da0b0770f67ac2b324e
+          name: 'CPU: Interrupt time'
+          type: DEPENDENT
+          key: opns.cpu.interrupt
+          delay: '0'
+          value_type: FLOAT
+          units: '%'
+          description: Share spent servicing hardware interrupts. On a firewall this is largely network cards, and a high figure means the packet rate is close to what the hardware can take, well before the total utilisation looks alarming.
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - ([0-9.]+)%\s*interrupt
+                - \1
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.activity.raw
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: a73e1693a72d448395eacb728001dc75
+          name: 'OPNsense: CPU type (raw)'
+          type: HTTP_AGENT
+          key: opns.cpu.raw
+          delay: 1m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Processor model with core and thread count. Static inventory, but polled at the same interval as the load average it is divided into, because a calculated item goes unsupported while a referenced item has no data yet. The dependent item discards unchanged values, so this costs a request rather than history. This is also the only endpoint addressed in camelCase, because the action name carries consecutive capitals that the snake_case spelling does not reproduce; its privilege matches by wildcard, so the spelling raises no access problem.
+          timeout: 10s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/cpu_usage/get_c_p_u_type
+          tags:
+            - tag: component
+              value: raw
+        - uuid: fd2c14332bbc4577b845a35eef6db24f
+          name: 'CPU: System time'
+          type: DEPENDENT
+          key: opns.cpu.system
+          delay: '0'
+          value_type: FLOAT
+          units: '%'
+          description: Share spent in the kernel, which on a firewall is mostly packet forwarding and rule evaluation.
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - ([0-9.]+)%\s*system
+                - \1
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.activity.raw
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: ae9132d58e0949db843f69cf946b9107
+          name: 'CPU: User time'
+          type: DEPENDENT
+          key: opns.cpu.user
+          delay: '0'
+          value_type: FLOAT
+          units: '%'
+          description: Share spent in user space, which covers the web interface, the configuration daemon and plugins such as an IDS.
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - ([0-9.]+)%\s*user
+                - \1
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.activity.raw
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: 878eee3e84b84d99ba0a99f011286bba
+          name: 'CPU: Utilization'
+          type: CALCULATED
+          key: opns.cpu.util
+          delay: 1m
+          value_type: FLOAT
+          units: '%'
+          description: Everything that is not idle. Derived from the idle share the firewall reports, because that is the one figure the API states directly and the rest have to be added up otherwise.
+          tags:
+            - tag: component
+              value: cpu
+          triggers:
+            - uuid: b8d1df19a30b4748a4d76455246e703a
+              expression: avg(/OPNsense by REST API/opns.cpu.util,10m)>{$OPNS.CPU.UTIL.WARN}
+              name: 'OPNsense: CPU utilization is high'
+              priority: WARNING
+              description: 'Sustained load on the processor. Read alongside the interrupt share: if that dominates, the limit is packet handling rather than anything running on the box.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: performance
+          params: 100-last(//opns.cpu.idle)
+        - uuid: eba5299b68524fcfadf7c0133f3325d2
+          name: 'Firewall log: Blocked entries'
+          type: DEPENDENT
+          key: opns.fwlog.block
+          delay: '0'
+          description: Blocked entries in the window the endpoint returns. Meaningful only against the window size, which is what the blocked share divides by.
+          master_item:
+            key: opns.raw.fw.action
+          tags:
+            - tag: component
+              value: firewall
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $[?(@.label == "block")].value.first()
+        - uuid: 631cc81690bf4104ba61511134be5e4f
+          name: 'Firewall log: Blocked share'
+          type: CALCULATED
+          key: opns.fwlog.block.pct
+          delay: 1m
+          value_type: FLOAT
+          units: '%'
+          description: 'Share of blocked entries among the most recent logged packets. Deliberately a share and not a count: the endpoint returns a fixed window of the last log entries, so the counts always add up to that window size and say nothing on their own. The span of time covered therefore varies with how much the firewall logs, and only rules with logging enabled appear at all. What a normal share looks like differs per site, so this ships without a trigger.'
+          tags:
+            - tag: component
+              value: firewall
+          params: last(//opns.fwlog.block) / last(//opns.fwlog.total) * 100
+        - uuid: b8ea4e11dceb43d2a4d7b86b6f75a5b8
+          name: 'Firewall log: Window size'
+          type: DEPENDENT
+          key: opns.fwlog.total
+          delay: '0'
+          description: Number of entries the endpoint reports on. A fixed window of the most recent logged packets, so this normally sits at a constant value, and only rules with logging enabled are counted at all.
+          master_item:
+            key: opns.raw.fw.action
+          tags:
+            - tag: component
+              value: firewall
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $[*].value.sum()
+        - uuid: 5c46821c5d6a47b8a141619da8310571
+          name: 'mbuf: Clusters in use'
+          type: DEPENDENT
+          key: opns.mbuf.cluster.current
+          description: mbuf clusters currently taken from the fixed kernel pool. Grows with the number of packets in flight, not with configured memory.
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $['mbuf-statistics']['cluster-current']
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.mbuf.raw
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 7c2660cdad234f88998ccfa6beb60369
+          name: 'mbuf: Cluster limit'
+          type: DEPENDENT
+          key: opns.mbuf.cluster.max
+          description: Upper bound of the cluster pool, set by kern.ipc.nmbclusters. Raising that sysctl is the remedy when the pool runs dry.
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $['mbuf-statistics']['cluster-max']
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.mbuf.raw
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 27dc3ef4b9ab46af94e93e5b990c5242
+          name: 'mbuf: Cluster utilization'
+          type: CALCULATED
+          key: opns.mbuf.cluster.pused
+          delay: 1m
+          value_type: FLOAT
+          units: '%'
+          params: last(/{HOST.HOST}/opns.mbuf.cluster.current) / last(/{HOST.HOST}/opns.mbuf.cluster.max) * 100
+          description: mbuf clusters are a fixed kernel pool. Once it is exhausted the firewall stops forwarding traffic while still answering ping and reporting free system memory, which makes this failure hard to recognise from the outside.
+          tags:
+            - tag: component
+              value: memory
+          triggers:
+            - uuid: 40f68e99de3b46089f859e114d796c2b
+              expression: min(/OPNsense by REST API/opns.mbuf.cluster.pused,5m)>{$OPNS.MBUF.UTIL.WARN}
+              dependencies:
+                - name: 'OPNsense: Kernel denied network memory requests'
+                  expression: change(/OPNsense by REST API/opns.mbuf.denied)>0
+              name: 'OPNsense: mbuf cluster pool is filling up'
+              priority: AVERAGE
+              description: Approaching the cluster limit. Raise kern.ipc.nmbclusters before it is reached, because exhaustion costs traffic, not just performance.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: 8c44b806faf04781851571ec5103ab67
+          name: 'mbuf: Denied requests'
+          type: DEPENDENT
+          key: opns.mbuf.denied
+          delay: '0'
+          description: Sum of the mbuf, cluster and packet allocation failures reported by the kernel. A cumulative counter since boot that should stay at zero for the entire uptime, so the trigger fires on any increase rather than on a threshold.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $['mbuf-statistics']['mbuf-failures','cluster-failures','packet-failures','jumbop-failures','jumbo9-failures','jumbo16-failures','sfbufs-alloc-failed'].sum()
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.mbuf.raw
+          tags:
+            - tag: component
+              value: memory
+          triggers:
+            - uuid: 36f575293b0f46a081c31dcfa5ff33b2
+              expression: change(/OPNsense by REST API/opns.mbuf.denied)>0
+              name: 'OPNsense: Kernel denied network memory requests'
+              priority: HIGH
+              description: The kernel ran out of mbufs or clusters and dropped traffic. Raise kern.ipc.nmbclusters. The counter never decreases, so this fires once per new occurrence.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: 950e29ed7dfd45988c3f835fa4b38726
+          name: 'OPNsense: mbuf statistics (raw)'
+          type: HTTP_AGENT
+          key: opns.mbuf.raw
+          delay: 1m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Kernel network memory pool, the libxo output of netstat -m.
+          timeout: 10s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/interface/get_memory_statistics
+          tags:
+            - tag: component
+              value: raw
+        - uuid: d235e1e4d18f4bb2bca4790286755a9d
+          name: 'netisr: Queue drops'
+          type: DEPENDENT
+          key: opns.netisr.queue.drops
+          delay: '0'
+          description: Packets discarded because a netisr queue was full, summed over all protocols and worker streams. This is the symptom of a firewall that cannot keep up with its offered load, and it is invisible in interface counters.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.netisr.workstream[*].work[*]['queue-drops'].sum()
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.netisr.raw
+          tags:
+            - tag: component
+              value: network
+          triggers:
+            - uuid: c1f276eb83d74611ba6fc213555c9a64
+              expression: change(/OPNsense by REST API/opns.netisr.queue.drops)>0
+              name: 'OPNsense: netisr queue is dropping packets'
+              priority: AVERAGE
+              description: The kernel discarded packets before they reached the firewall rules. Check load, interface queue lengths and net.isr tuning. The counter never decreases, so this fires once per new occurrence.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: c2cdfadb29e84fd8bb904211665b5e15
+          name: 'OPNsense: netisr statistics (raw)'
+          type: HTTP_AGENT
+          key: opns.netisr.raw
+          delay: 1m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Network dispatch queues, the libxo output of netstat -Q.
+          timeout: 10s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/interface/get_netisr_statistics
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 856c563ec269469d9db02822226ae56f
+          name: 'NTP: Offset of the selected peer'
+          type: DEPENDENT
+          key: opns.ntp.offset
+          delay: '0'
+          value_type: FLOAT
+          units: ms
+          description: How far the local clock sits from the peer it is currently steering by. A drifting firewall clock breaks IPsec, certificate validation and the correlation of its own logs, and it does so without any other symptom.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows[?(@.status == "*" || @.status == "o")].offset.first()
+            - type: LTRIM
+              parameters:
+                - +
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.ntp.raw
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 9cfabe6d7b474088af479d1fcbb399ba
+              expression: abs(last(/OPNsense by REST API/opns.ntp.offset))>{$OPNS.NTP.OFFSET.WARN}
+              name: 'OPNsense: Clock offset is high'
+              priority: WARNING
+              description: The local clock has drifted away from its time source. Check reachability of the configured servers.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 3023f9b23bf64a17bab519fc92bdae44
+          name: 'NTP: Reachable peers'
+          type: DEPENDENT
+          key: opns.ntp.peers.reachable
+          delay: '0'
+          description: Configured time sources that have answered recently. Pool placeholders are excluded, they are not servers but slots the daemon still has to fill.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows[?(@.reach != "0")].length()
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.ntp.raw
+          tags:
+            - tag: component
+              value: system
+        - uuid: 459e6362615548df981382c9722f2526
+          name: 'OPNsense: NTP peers (raw)'
+          type: HTTP_AGENT
+          key: opns.ntp.raw
+          delay: 5m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Peer list of the time daemon with selection state, stratum, reach, offset and jitter.
+          timeout: 10s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/ntpd/service/status
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 4d091f2b85ae4531858498fb09322738
+          name: 'NTP: Stratum of the selected peer'
+          type: DEPENDENT
+          key: opns.ntp.stratum
+          delay: '0'
+          description: Distance of the chosen source from a reference clock. A stratum of 16 means the daemon is not synchronised at all.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows[?(@.status == "*" || @.status == "o")].stratum.first()
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.ntp.raw
+          tags:
+            - tag: component
+              value: system
+        - uuid: 0645e61723774f1384f84c28dffd74a2
+          name: 'NTP: Synchronised'
+          type: DEPENDENT
+          key: opns.ntp.synced
+          delay: '0'
+          valuemap:
+            name: NTP sync state
+          description: 'Whether the daemon has settled on a time source. Unsynchronised is the state that matters: the clock then follows nothing and drifts freely.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows[?(@.status == "*" || @.status == "o")].status.first()
+            - type: STR_REPLACE
+              parameters:
+                - '*'
+                - '1'
+            - type: STR_REPLACE
+              parameters:
+                - o
+                - '1'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 15m
+          master_item:
+            key: opns.ntp.raw
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 1b6f07b78b804b6499745caf77ed0395
+              expression: min(/OPNsense by REST API/opns.ntp.synced,30m)=0
+              name: 'OPNsense: Clock is not synchronised'
+              priority: WARNING
+              description: No time source has been selected for half an hour. Right after a boot this is normal for a few minutes, beyond that the configured servers are unreachable or refusing.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 919a48795c78468aa88733d44155207c
+          name: 'OpenVPN: sessions (raw)'
+          type: HTTP_AGENT
+          key: opns.openvpn.raw
+          delay: 1m
+          history: '0'
+          trends: '0'
+          value_type: TEXT
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          timeout: 15s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/openvpn/service/search_sessions
+          description: Every OpenVPN instance and every client connected to a server, in one request. Instances that are enabled but not running are included with an empty status, so a server that died is still discovered rather than disappearing.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 423452f382fd4cbc99a4e9db62373d02
+          name: 'pf: Bad offset packets per second'
+          type: DEPENDENT
+          key: opns.pf.counter.badoffset.rate
+          description: Packets whose header offset field was invalid. Normally zero for the whole uptime.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters['bad-offset'].rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: dc96d30a4f524505a8c1e17e879d2c4c
+              expression: last(/OPNsense by REST API/opns.pf.counter.badoffset.rate)>0
+              name: 'OPNsense: pf is seeing malformed packets'
+              priority: WARNING
+              description: Packets with a bad offset are normally zero. A sustained rate points at a broken sender or an attack.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: security
+        - uuid: c3fd8b5e0414426fa41373b3ccdf9e15
+          name: 'pf: Fragmented packets per second'
+          type: DEPENDENT
+          key: opns.pf.counter.fragment.rate
+          description: Fragmented packets seen by pf. Some fragmentation is normal, a rising rate usually means an MTU mismatch somewhere on the path.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters.fragment.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: e96d5dac69a2446c8dd3b99e75712175
+          name: 'pf: Rule matches per second'
+          type: DEPENDENT
+          key: opns.pf.counter.match.rate
+          description: Packets that matched a filter rule. The general throughput measure of the ruleset.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters.match.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 2d7cbfa137dd4c0792e1b1186f6622ab
+          name: 'pf: Packets dropped for memory per second'
+          type: DEPENDENT
+          key: opns.pf.counter.memdrop.rate
+          description: Packets dropped because pf could not allocate memory for a state or a fragment. Traffic is lost when this is non zero.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters.memory.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: d2f0c7675f394f17b5f4c726183b3c89
+              expression: last(/OPNsense by REST API/opns.pf.counter.memdrop.rate)>0
+              name: 'OPNsense: pf is dropping packets due to memory'
+              priority: HIGH
+              description: pf ran out of memory for states or fragments. Traffic is being lost. Check the state and table limits.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: b31d1b029204431e81cc1196bc9e5f54
+          name: 'pf: Normalized packets per second'
+          type: DEPENDENT
+          key: opns.pf.counter.normalize.rate
+          description: Packets rewritten by scrub rules, most often reassembled fragments.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters.normalize.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: a92076c2581041ae8382592bb4c83b40
+          name: 'pf: Short packets per second'
+          type: DEPENDENT
+          key: opns.pf.counter.short.rate
+          description: Packets shorter than their own header claimed. Normally zero, and malformed by definition.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters.short.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: ff6e69899d864fec931c833dfa42087f
+          name: 'pf: Source limit hits per second'
+          type: DEPENDENT
+          key: opns.pf.counter.srclimit.rate
+          description: Connections refused because one source exceeded the number of states its rule allows it.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters['src-limit'].rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: 553ec8441b4c402ea0b2f23d2061c0e2
+              expression: last(/OPNsense by REST API/opns.pf.counter.srclimit.rate)>0
+              name: 'OPNsense: pf source limit is being hit'
+              priority: WARNING
+              description: A single source exceeded its allowed number of states.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: security
+        - uuid: 963ab60978654c578d9dcff3c4048eb5
+          name: 'pf: State limit hits per second'
+          type: DEPENDENT
+          key: opns.pf.counter.statelimit.rate
+          description: Connections refused because the state table is at its limit. Every one of these is a connection that did not happen.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters['state-limit'].rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: 6e26c768a4cd45b2830a1ef34e9e2ce0
+              expression: last(/OPNsense by REST API/opns.pf.counter.statelimit.rate)>0
+              name: 'OPNsense: pf state limit is being hit'
+              priority: HIGH
+              description: New connections are refused because the state limit is reached. Raise the limit or find the source.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: 795dcee83aad48178ee38ab00d7c6855
+          name: 'pf: State mismatches per second'
+          type: DEPENDENT
+          key: opns.pf.counter.statemismatch.rate
+          description: Packets that did not fit the state they were matched against. Isolated ones are normal on an asymmetric path, a sustained rate is not.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info.counters['state-mismatch'].rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 7f44e8094d434a9fb96cfb9dcebcea21
+          name: 'pf: Overload table insertions per second'
+          type: DEPENDENT
+          key: opns.pf.overload.rate
+          description: Entries added to the overload table, where pf collects sources that tripped a connection rate limit. Rises during brute force attempts against an exposed service.
+          delay: '0'
+          value_type: FLOAT
+          units: '!/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info['limit-counters']['overload-table-insertion'].rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 5987fa50eb3e4f11a5979dfb38c892d9
+          name: 'pf: Rule evaluations per second'
+          type: DEPENDENT
+          key: opns.pf.rules.evaluations.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!/s'
+          description: How many rule tests pf performs per second across the whole ruleset. Rises with traffic and with ruleset length, and shows what a reordering or a large alias table costs. The counters reset when the ruleset is reloaded, which the rate calculation absorbs by discarding the decrease.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.evaluations
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.pf.rules.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 456b01b2f46144f4bf9a58d8d05b6b44
+          name: 'pf: Filter rules loaded'
+          type: DEPENDENT
+          key: opns.pf.rules.filter.count
+          delay: '0'
+          description: Number of filter rules in the running ruleset. Counting instead of tracking the rules themselves keeps this to one item and survives a changing WAN address, which rewrites rule text without changing the rule count.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.filter
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.pf.rules.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: da9efe8816c64b848b45b3bc294f69d7
+              expression: change(/OPNsense by REST API/opns.pf.rules.filter.count)<>0 and last(/OPNsense by REST API/opns.pf.rules.filter.count,#2)>0
+              name: 'OPNsense: Number of filter rules has changed'
+              priority: INFO
+              description: Rules were added or removed. Useful for correlating a fault with a change to the ruleset. Edits to an existing rule do not change the count and are not detected. The second condition suppresses the jump out of a zero, which is what an item reports after a gap in collection rather than a real change.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: b0dec4eb53ac4829b8673d8293f2740e
+          name: 'pf: Ruleset fingerprint'
+          type: DEPENDENT
+          key: opns.pf.rules.fingerprint
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: Hash over the text of every filter and NAT rule, sorted so that reordering alone does not register. Catches what the rule counts cannot, namely an edit to an existing rule, which leaves the number of rules untouched. Counters are excluded from the hash, otherwise it would change with every packet. On a firewall whose WAN address changes, expect this to move with it. Rules written against an interface keep a symbolic form such as (vtnet0:1), but the generated anti-spoofing rules and every route-to statement embed the address literally; on the firewall this was measured against, 22 of 176 rules did so. The trigger is INFO for that reason, and a changed address is in fairness a changed ruleset.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.fingerprint
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.pf.rules.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: 454dd0be5d8a4d6dab26d3df5217712e
+              expression: last(/OPNsense by REST API/opns.pf.rules.fingerprint,#1)<>last(/OPNsense by REST API/opns.pf.rules.fingerprint,#2)
+              name: 'OPNsense: Ruleset has changed'
+              priority: INFO
+              description: 'A rule was added, removed, edited or reworded. Together with the rule counts this separates the cases: if the counts moved as well, rules were added or removed, if they did not, an existing rule was edited.'
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 39b75639c3ac4996bc75d74a62865913
+          name: 'pf: NAT rules loaded'
+          type: DEPENDENT
+          key: opns.pf.rules.nat.count
+          description: Number of NAT rules in the running ruleset. Changes when the configuration is applied, so it works as a change signal.
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.nat
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.pf.rules.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: fb0d07ce68cb465f9eae5770b80b4cbe
+              expression: change(/OPNsense by REST API/opns.pf.rules.nat.count)<>0 and last(/OPNsense by REST API/opns.pf.rules.nat.count,#2)>0
+              name: 'OPNsense: Number of NAT rules has changed'
+              description: NAT rules were added or removed. Edits to an existing rule leave the count unchanged and are not detected. The second condition suppresses the jump out of a zero, which is what an item reports after a gap in collection rather than a real change.
+              priority: INFO
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 880f175ff8e14a579d38138783e445df
+          name: 'OPNsense: pf ruleset (raw)'
+          type: HTTP_AGENT
+          key: opns.pf.rules.raw
+          delay: 10m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Running filter and NAT ruleset with per rule counters. Polled every ten minutes because the response carries the full text of every rule and rule changes are not a per minute concern.
+          timeout: 30s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/pf_statistics/rules
+          tags:
+            - tag: component
+              value: raw
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // The ruleset response is around 50 kB and keyed by the rule text itself. Counting and
+                  // hashing it once here keeps five items off that payload.
+                  var rules = JSON.parse(value).rules || {};
+                  var filter = rules['filter rules'] || {};
+                  var nat = rules['nat rules'] || {};
+                  var names = Object.keys(filter), unused = 0, evaluations = 0;
+                  for (var i = 0; i < names.length; i++) {
+                      var r = filter[names[i]];
+                      evaluations += Number(r.evaluations) || 0;
+                      if ((Number(r.evaluations) || 0) === 0) { unused++; }
+                  }
+                  // order independent checksum over the rule texts, so a reordered ruleset still reads as a
+                  // change while an unchanged one keeps its fingerprint
+                  var h = 0;
+                  for (var j = 0; j < names.length; j++) {
+                      var s = names[j], k = 0;
+                      for (var c = 0; c < s.length; c++) { k = (k * 31 + s.charCodeAt(c)) & 0xffffffff; }
+                      h = (h ^ k) >>> 0;
+                  }
+                  return JSON.stringify({
+                      filter: names.length,
+                      nat: Object.keys(nat).length,
+                      unused: unused,
+                      evaluations: evaluations,
+                      fingerprint: h.toString(16)
+                  });
+        - uuid: 89ddb269af3a4879be58a1fff6a08439
+          name: 'pf: Rules never matched'
+          type: DEPENDENT
+          key: opns.pf.rules.unused
+          delay: '0'
+          description: 'Rules with no evaluation since the ruleset was last loaded. Useful for spotting rules that no longer do anything, but only meaningful after a decent uptime: a reload resets every counter, so right after a configuration change this equals the total rule count. Deliberately has no trigger for that reason.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.unused
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.pf.rules.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 95b2ca0fa6134daaa151414eee3575bb
+          name: 'pf: Source nodes'
+          type: DEPENDENT
+          key: opns.pf.srcnodes.current
+          description: Source tracking entries in use. One per client for rules using sticky-address or a source limit, so this grows with the number of distinct clients rather than with connections.
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info['source-tracking-table']['current-entries'].total
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 49beccb1ba5d4a89b0a3f3cf6422c147
+          name: 'pf: Source node limit'
+          type: DEPENDENT
+          key: opns.pf.srcnodes.limit
+          description: Maximum number of source tracking entries pf will hold.
+          delay: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.memory['src-nodes']
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.pfmem.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 4482acd5acba4a319836e243886b236a
+          name: 'pf: Source tracking table utilization'
+          type: CALCULATED
+          key: opns.pf.srcnodes.pused
+          delay: 1m
+          value_type: FLOAT
+          units: '%'
+          description: Source tracking holds one entry per client for rules using sticky-address or source limits. Exhausting it rejects new connections from new clients while the state table still looks healthy.
+          params: last(/{HOST.HOST}/opns.pf.srcnodes.current) / last(/{HOST.HOST}/opns.pf.srcnodes.limit) * 100
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: c0d1801db6ee4edcb76c70be448e6848
+              expression: min(/OPNsense by REST API/opns.pf.srcnodes.pused,5m)>{$OPNS.PF.SRCNODES.UTIL.CRIT}
+              dependencies:
+                - name: 'OPNsense: pf source limit is being hit'
+                  expression: last(/OPNsense by REST API/opns.pf.counter.srclimit.rate)>0
+              name: 'OPNsense: pf source tracking table is filling up'
+              priority: HIGH
+              description: Once the limit is reached pf refuses connections from clients it has no entry for.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: 4a364f940f60437782a9ffd986481857
+          name: 'pf: State table inserts per second'
+          type: DEPENDENT
+          key: opns.pf.states.inserts.rate
+          description: New connections entering the state table per second.
+          delay: '0'
+          value_type: FLOAT
+          units: '!/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info['state-table'].inserts.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 513d9a0f957d4ca28df298041e41fc24
+          name: 'pf: State table removals per second'
+          type: DEPENDENT
+          key: opns.pf.states.removals.rate
+          description: Connections leaving the state table per second, through closure or timeout. Should roughly track the insert rate in steady state.
+          delay: '0'
+          value_type: FLOAT
+          units: '!/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info['state-table'].removals.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: f2096ea5267e485b958eb9632c4f115f
+          name: 'pf: State table searches per second'
+          type: DEPENDENT
+          key: opns.pf.states.searches.rate
+          description: State table lookups per second, one or more per forwarded packet. The busiest counter on a loaded firewall.
+          delay: '0'
+          value_type: FLOAT
+          units: '!/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info['state-table'].searches.rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: c676ffb898fe469a8dd6c3ff02cddf9a
+          name: 'pf: SYN floods detected per second'
+          type: DEPENDENT
+          key: opns.pf.synfloods.rate
+          description: Destinations for which pf switched to syncookies because half open connections piled up.
+          delay: '0'
+          value_type: FLOAT
+          units: '!/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.info['limit-counters']['synfloods-detected'].rate
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.pfinfo.raw
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: 54f8ec875d9d4c048144d02233352761
+              expression: last(/OPNsense by REST API/opns.pf.synfloods.rate)>0
+              name: 'OPNsense: SYN flood detected'
+              priority: AVERAGE
+              description: pf activated syncookies for at least one destination.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: security
+        - uuid: d486f63882d14a08a862fb7a431b5df1
+          name: 'pf: Table entry limit'
+          type: DEPENDENT
+          key: opns.pf.tables.entries.limit
+          delay: '0'
+          description: Ceiling for all pf table entries combined, from the firewall maximum table entries setting.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.size
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 6h
+          master_item:
+            key: opns.alias.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: a6be66c60f72496493246cce43c7ef65
+          name: 'pf: Table entry utilization'
+          type: CALCULATED
+          key: opns.pf.tables.entries.pused
+          delay: 10m
+          value_type: FLOAT
+          units: '%'
+          description: 'How much of the table entry budget the aliases consume. Exceeding it is not a slow degradation: pf refuses to load a ruleset whose tables do not fit, so the firewall keeps running on the previous one and quietly ignores the change that was just applied.'
+          params: last(/{HOST.HOST}/opns.pf.tables.entries.used) / last(/{HOST.HOST}/opns.pf.tables.entries.limit) * 100
+          tags:
+            - tag: component
+              value: firewall
+          triggers:
+            - uuid: 0e20e54b0f37455d8593c879fa32222a
+              expression: last(/OPNsense by REST API/opns.pf.tables.entries.pused)>{$OPNS.PF.TABLES.UTIL.WARN}
+              name: 'OPNsense: pf table entries are filling up'
+              priority: WARNING
+              description: Raise the maximum table entries setting before a block list update pushes the ruleset over the limit.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: dfa0da992bd54d39bb5c048411c39bbb
+          name: 'pf: Table entries in use'
+          type: DEPENDENT
+          key: opns.pf.tables.entries.used
+          delay: '0'
+          description: Addresses currently held across all pf tables, which is what aliases, block lists and GeoIP feeds fill.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.used
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.alias.raw
+          tags:
+            - tag: component
+              value: firewall
+        - uuid: 4ad859a6301447b6a43846676dcc00b1
+          name: 'OPNsense: pf statistics (raw)'
+          type: HTTP_AGENT
+          key: opns.pfinfo.raw
+          delay: 1m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Full pfctl -si output: state table, source tracking, counters and limit counters. Rates are already computed by pf.'
+          timeout: 10s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/pf_statistics/info
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 967c1287711547a28d31eca0be83ae7f
+          name: 'OPNsense: pf limits (raw)'
+          type: HTTP_AGENT
+          key: opns.pfmem.raw
+          delay: 1m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: 'Hard limits for states, source nodes, fragments and table entries. These change only with the configuration, but are polled at the same interval as the counters they are compared against: a calculated item goes unsupported while a referenced item has no data yet, so a slower interval here would leave the source tracking utilisation unsupported after every template link.'
+          timeout: 10s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/firewall/pf_statistics/memory
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 4116ade82445463e8ae1a960bc0bbc87
+          name: 'IP: Packets with a bad checksum per second'
+          type: DEPENDENT
+          key: opns.proto.ip.badsum.rate
+          description: IP packets discarded because the header checksum did not match. Steady non zero values point at a hardware or cabling fault rather than at an attack.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.statistics.ip['dropped-bad-checksum']
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.proto.raw
+          tags:
+            - tag: component
+              value: network
+          triggers:
+            - uuid: 27d21c533fac4367abb8b00b2a578a30
+              expression: min(/OPNsense by REST API/opns.proto.ip.badsum.rate,10m)>0
+              name: 'OPNsense: Receiving IP packets with bad checksums'
+              priority: WARNING
+              description: A sustained rate points at faulty cabling, a failing NIC or a broken device upstream. Occasional single packets are normal.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: hardware
+        - uuid: 9e27d7423067482fb255250a65be0890
+          name: 'IP: Fragments dropped per second'
+          type: DEPENDENT
+          key: opns.proto.ip.fragdrop.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: Fragments the kernel could not reassemble. Typically an MTU problem, often on a tunnel.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.statistics.ip['dropped-fragments']
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.proto.raw
+          tags:
+            - tag: component
+              value: network
+        - uuid: 3db8eb89bd4b4336902ee7c3cd94e70c
+          name: 'IP: Packets that cannot be forwarded per second'
+          type: DEPENDENT
+          key: opns.proto.ip.nofwd.rate
+          description: Packets the firewall was asked to route onward but could not, for instance because forwarding is disabled for that address family.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.statistics.ip['packets-cannot-forward']
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.proto.raw
+          tags:
+            - tag: component
+              value: network
+        - uuid: 5803fc13b61449e9882d56d82f2a05ab
+          name: 'IP: Packets discarded for lack of a route per second'
+          type: DEPENDENT
+          key: opns.proto.ip.noroute.rate
+          description: Packets discarded because no route matched their destination. Rises when a gateway or a tunnel disappears while traffic for it keeps arriving.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.statistics.ip['discard-no-route']
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.proto.raw
+          tags:
+            - tag: component
+              value: network
+          triggers:
+            - uuid: d480978e26e7473483a68b45500f3245
+              expression: min(/OPNsense by REST API/opns.proto.ip.noroute.rate,10m)>0
+              name: 'OPNsense: Packets discarded for lack of a route'
+              priority: WARNING
+              description: Traffic arrives for destinations the firewall has no route to. Check the routing table and whether a gateway or a tunnel went down.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: 611ec9c6e1de434aa6e50c9b4043bcc4
+          name: 'OPNsense: Protocol statistics (raw)'
+          type: HTTP_AGENT
+          key: opns.proto.raw
+          delay: 1m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Per protocol kernel counters, the libxo output of netstat -s.
+          timeout: 10s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/interface/get_protocol_statistics
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 2cda74e706fe480c9289bfd9bce3b845
+          name: 'TCP: Segments with a bad checksum per second'
+          type: DEPENDENT
+          key: opns.proto.tcp.badsum.rate
+          description: TCP segments discarded on a checksum mismatch, counted separately from the IP layer.
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.statistics.tcp['discard-bad-checksum']
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.proto.raw
+          tags:
+            - tag: component
+              value: network
+        - uuid: 3edf2a259a4449869da8f7ad99e5d436
+          name: 'TCP: Retransmitted segments per second'
+          type: DEPENDENT
+          key: opns.proto.tcp.retrans.rate
+          delay: '0'
+          value_type: FLOAT
+          units: '!p/s'
+          description: Retransmissions sent by the firewall itself, so this reflects the quality of its own connections rather than of forwarded traffic.
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.statistics.tcp['sent-retransmitted-packets']
+              error_handler: DISCARD_VALUE
+            - type: CHANGE_PER_SECOND
+              parameters:
+                - ''
+          master_item:
+            key: opns.proto.raw
+          tags:
+            - tag: component
+              value: network
+        - uuid: e08fc9eb7aa8404cb1f5656ace4398f5
+          name: 'OPNsense: Services (raw)'
+          type: HTTP_AGENT
+          key: opns.services.raw
+          delay: 5m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Run state of every service the firewall knows about, including the packet filter itself.
+          timeout: 10s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/core/service/search
+          tags:
+            - tag: component
+              value: raw
+        - uuid: a04a3dd1198a4b2a902f086885261950
+          name: 'OPNsense: Swap (raw)'
+          type: HTTP_AGENT
+          key: opns.swap.raw
+          delay: 5m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Swap devices with total and used, in KB. The list is empty on installations without swap, which is why the items below are discovered rather than static.
+          timeout: 10s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/system/system_swap
+          tags:
+            - tag: component
+              value: raw
+        - uuid: 4385d0ee72094fcb8d19f3eea6d3d360
+          name: Load average (15 min)
+          type: DEPENDENT
+          key: opns.system.load.avg15
+          description: Run queue length averaged over fifteen minutes. Shows whether a load is sustained or passing.
+          delay: '0'
+          value_type: FLOAT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.loadavg
+            - type: REGEX
+              parameters:
+                - ^[^,]*,[^,]*,\s*([0-9.]+)
+                - \1
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.raw.load
+          tags:
+            - tag: component
+              value: cpu
+        - uuid: b4ab5970077c4de390398d888b170018
+          name: Load average (5 min)
+          type: DEPENDENT
+          key: opns.system.load.avg5
+          description: Run queue length averaged over five minutes. The value to alert on, since it ignores brief spikes.
+          delay: '0'
+          value_type: FLOAT
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.loadavg
+            - type: REGEX
+              parameters:
+                - ^[^,]*,\s*([0-9.]+)
+                - \1
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 5m
+          master_item:
+            key: opns.raw.load
+          tags:
+            - tag: component
+              value: cpu
+          triggers:
+            - uuid: 66d63013d37e4c42a069ee85793475c3
+              expression: avg(/OPNsense by REST API/opns.system.load.avg5,10m)>{$OPNS.LOAD.AVG5.WARN}
+              name: 'OPNsense: Load average is high'
+              priority: WARNING
+              description: The 5 minute average has been above the threshold for 10 minutes.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: performance
+        - uuid: b7b0b932ed5145a68bc519dbeee81c7a
+          name: Load average per core (5 min)
+          type: CALCULATED
+          key: opns.system.load.percore
+          delay: 1m
+          value_type: FLOAT
+          description: Five minute load divided by the number of cores. A load of 4 means saturation on a two core appliance and idling on a sixteen core one, so this is the figure that is comparable between firewalls. The API offers no true CPU utilisation, which makes this the closest available measure of saturation.
+          params: last(/{HOST.HOST}/opns.system.load.avg5) / last(/{HOST.HOST}/opns.cpu.cores)
+          tags:
+            - tag: component
+              value: cpu
+          triggers:
+            - uuid: 4d67083fd891482881629dd8e9f760c9
+              expression: avg(/OPNsense by REST API/opns.system.load.percore,15m)>{$OPNS.LOAD.PERCORE.WARN}
+              name: 'OPNsense: Load per core is high'
+              priority: WARNING
+              description: Sustained demand above what the cores can serve. Unlike the raw load average this does not need a per host threshold.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: performance
+        - uuid: 1c669275ef6f41f6b7e255dc838f9b29
+          name: 'OPNsense: Temperature sensors (raw)'
+          type: HTTP_AGENT
+          key: opns.temperature.raw
+          delay: 1m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          authtype: BASIC
+          username: '{$OPNS.KEY}'
+          password: '{$OPNS.SECRET}'
+          description: Sensor readings as a JSON array. Hardware without sensors, notably virtual machines, returns an empty array, so nothing is discovered and no item goes unsupported.
+          timeout: 10s
+          url: https://{HOST.IP}:{$OPNS.PORT}/api/diagnostics/system/system_temperature
+          tags:
+            - tag: component
+              value: raw
+        - uuid: ce65b79664fc47f8a21f7283252af4bf
+          name: 'OPNsense: Version'
+          type: DEPENDENT
+          key: opns.version
+          description: Product name, version and architecture as one string. Changes after an update was applied.
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.product_version
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: opns.raw.product.info
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 3fab70ab33034cbe8f06e6e5ffae3e9d
+              expression: last(/OPNsense by REST API/opns.version,#1)<>last(/OPNsense by REST API/opns.version,#2)
+              name: 'OPNsense: Version has changed'
+              priority: INFO
+              description: An update was most likely applied.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+      discovery_rules:
+        - uuid: 504c286823af4f10aab2af2d048252eb
+          name: 'Disk Discovery'
+          type: DEPENDENT
+          key: opns.disk.discovery
+          filter:
+            conditions:
+              - macro: '{#FSNAME}'
+                value: '{$OPNS.FS.FSNAME.MATCHES}'
+              - macro: '{#FSNAME}'
+                value: '{$OPNS.FS.FSNAME.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#FSTYPE}'
+                value: '{$OPNS.FS.FSTYPE.MATCHES}'
+              - macro: '{#FSTYPE}'
+                value: '{$OPNS.FS.FSTYPE.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+          lifetime: 1h
+          item_prototypes:
+            - uuid: fb1bfa2c64174b4c98b75e94b6aba07b
+              name: 'FS [{#FSNAME}]: Get data'
+              type: DEPENDENT
+              key: 'opns.disk.data[{#FSNAME},data]'
+              history: 1h
+              value_type: TEXT
+              description: 'Intermediate data of `{#FSNAME}` filesystem.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.devices.[?(@.mountpoint==''{#FSNAME}'')].first()'
+              master_item:
+                key: opns.raw.disk
+              tags:
+                - tag: component
+                  value: raw
+                - tag: component
+                  value: storage
+                - tag: filesystem
+                  value: '{#FSNAME}'
+                - tag: fstype
+                  value: '{#FSTYPE}'
+            - uuid: cec81fb95e9d454598fc36e969263ada
+              name: 'FS [{#FSNAME}]: Space: Available'
+              type: DEPENDENT
+              key: 'opns.disk.size[{#FSNAME},available]'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.available
+              master_item:
+                key: 'opns.disk.data[{#FSNAME},data]'
+              tags:
+                - tag: component
+                  value: storage
+                - tag: filesystem
+                  value: '{#FSNAME}'
+                - tag: fstype
+                  value: '{#FSTYPE}'
+            - uuid: a42b3f61d5bb4e558cf02b333665f29a
+              name: 'FS [{#FSNAME}]: Space: Used, in %'
+              type: DEPENDENT
+              key: 'opns.disk.size[{#FSNAME},pused]'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.used_pct
+              master_item:
+                key: 'opns.disk.data[{#FSNAME},data]'
+              tags:
+                - tag: component
+                  value: storage
+                - tag: filesystem
+                  value: '{#FSNAME}'
+                - tag: fstype
+                  value: '{#FSTYPE}'
+              trigger_prototypes:
+                - uuid: 67f455afd96d4e8fad5ea887bc98d6c4
+                  expression: 'min(/OPNsense by REST API/opns.disk.size[{#FSNAME},pused],5m)>{$OPNS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}'
+                  name: 'OPNsense: FS [{#FSNAME}]: Space is critically low'
+                  event_name: 'OPNsense: FS [{#FSNAME}]: Space is critically low (used > {$OPNS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%, total {{?last(//opns.disk.size[{#FSNAME},total])/1024/1024/1024}.fmtnum(1)}GB)'
+                  opdata: 'Space used: {{ITEM.LASTVALUE1}.fmtnum(1)}%'
+                  priority: AVERAGE
+                  description: |
+                    The volume's space usage exceeds the `{$OPNS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}%` limit.
+                    The trigger expression is based on the current used and maximum available spaces.
+                    Event name represents the total volume space, which can differ from the maximum available space, depending on the filesystem type.
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: availability
+                    - tag: scope
+                      value: capacity
+                - uuid: 74ebfeae491b46f29141a51e84b66715
+                  expression: 'min(/OPNsense by REST API/opns.disk.size[{#FSNAME},pused],5m)>{$OPNS.FS.PUSED.MAX.WARN:"{#FSNAME}"}'
+                  name: 'OPNsense: FS [{#FSNAME}]: Space is low'
+                  event_name: 'OPNsense: FS [{#FSNAME}]: Space is low (used > {$OPNS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%, total {{?last(//opns.disk.size[{#FSNAME},total])/1024/1024/1024}.fmtnum(1)}GB)'
+                  opdata: 'Space used: {{ITEM.LASTVALUE1}.fmtnum(1)}%'
+                  priority: WARNING
+                  description: |
+                    The volume's space usage exceeds the `{$OPNS.FS.PUSED.MAX.WARN:"{#FSNAME}"}%` limit.
+                    The trigger expression is based on the current used and maximum available spaces.
+                    Event name represents the total volume space, which can differ from the maximum available space, depending on the filesystem type.
+                  dependencies:
+                    - name: 'OPNsense: FS [{#FSNAME}]: Space is critically low'
+                      expression: 'min(/OPNsense by REST API/opns.disk.size[{#FSNAME},pused],5m)>{$OPNS.FS.PUSED.MAX.CRIT:"{#FSNAME}"}'
+                  tags:
+                    - tag: scope
+                      value: availability
+                    - tag: scope
+                      value: capacity
+            - uuid: d195be63115d4d6c998be326a291b0d1
+              name: 'FS [{#FSNAME}]: Space: Total'
+              type: DEPENDENT
+              key: 'opns.disk.size[{#FSNAME},total]'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.blocks
+              master_item:
+                key: 'opns.disk.data[{#FSNAME},data]'
+              tags:
+                - tag: component
+                  value: storage
+                - tag: filesystem
+                  value: '{#FSNAME}'
+                - tag: fstype
+                  value: '{#FSTYPE}'
+            - uuid: f707fe04e1844019a10bac898afbe4f5
+              name: 'FS [{#FSNAME}]: Space: Used'
+              type: DEPENDENT
+              key: 'opns.disk.size[{#FSNAME},used]'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.used
+              master_item:
+                key: 'opns.disk.data[{#FSNAME},data]'
+              tags:
+                - tag: component
+                  value: storage
+                - tag: filesystem
+                  value: '{#FSNAME}'
+                - tag: fstype
+                  value: '{#FSTYPE}'
+          master_item:
+            key: opns.raw.disk
+          lld_macro_paths:
+            - lld_macro: '{#FSNAME}'
+              path: $.mountpoint
+            - lld_macro: '{#FSTYPE}'
+              path: $.type
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.devices
+        - uuid: b0c92ab2744b42fe89f1de3933aab459
+          name: 'FW Action Discovery'
+          type: DEPENDENT
+          key: opns.fw.action.discovery
+          lifetime: 1h
+          item_prototypes:
+            - uuid: f6698924485848ca837abd21c04d14f2
+              name: 'Firewall action {#FWACTION}'
+              type: DEPENDENT
+              key: 'opns.fw.action[{#FWACTION}]'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["label"] == "{#FWACTION}")].value.first()'
+              master_item:
+                key: opns.raw.fw.action
+              tags:
+                - tag: component
+                  value: firewall
+          graph_prototypes:
+            - uuid: 79936004c84e4b8db3ba29b07fdfe4e2
+              name: 'OPNSense Action Graph  {#FWACTION}'
+              graph_items:
+                - color: 199C0D
+                  calc_fnc: MIN
+                  item:
+                    host: 'OPNsense by REST API'
+                    key: 'opns.fw.action[{#FWACTION}]'
+          master_item:
+            key: opns.raw.fw.action
+          lld_macro_paths:
+            - lld_macro: '{#FWACTION}'
+              path: $.label
+        - uuid: dbf01922258f4bb9a68a6d589f1a07df
+          name: 'Gateway Discovery'
+          type: DEPENDENT
+          key: opns.gateway.discovery
+          lifetime: 1h
+          item_prototypes:
+            - uuid: 68818cd02e5846bd9f7a82065a86e5fb
+              name: 'Gateway Address {#GWSTATUSNAME}'
+              type: DEPENDENT
+              key: 'opns.gw.status.address[{#GWSTATUSNAME}]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#GWSTATUSNAME}")].address.first()'
+              master_item:
+                key: opns.raw.gateway.status
+              tags:
+                - tag: Gateway
+                  value: '{#GWSTATUSNAME}'
+            - uuid: 0057921138c64e8696c5db0728ffc89c
+              name: 'Gateway RTT {#GWSTATUSNAME}'
+              type: DEPENDENT
+              key: 'opns.gw.status.delay[{#GWSTATUSNAME}]'
+              value_type: FLOAT
+              units: ms
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#GWSTATUSNAME}")].delay.first()'
+                - type: REGEX
+                  parameters:
+                    - '^([0-9.]+)'
+                    - \1
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: opns.raw.gateway.status
+              tags:
+                - tag: Gateway
+                  value: '{#GWSTATUSNAME}'
+            - uuid: 6c1e26e8d6024388966d2b07bc03f77a
+              name: 'Gateway loss {#GWSTATUSNAME}'
+              type: DEPENDENT
+              key: 'opns.gw.status.loss[{#GWSTATUSNAME}]'
+              value_type: FLOAT
+              units: '%'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#GWSTATUSNAME}")].loss.first()'
+                - type: REGEX
+                  parameters:
+                    - '^([0-9.]+)'
+                    - \1
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: opns.raw.gateway.status
+              tags:
+                - tag: Gateway
+                  value: '{#GWSTATUSNAME}'
+              trigger_prototypes:
+                - uuid: 502fa89a336041b48332a640f838730d
+                  expression: 'min(/OPNsense by REST API/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>{$OPNS.GW.HIGH.PACKET.LOSS} and max(/OPNsense by REST API/opns.gw.status.loss[{#GWSTATUSNAME}],5m)<=100'
+                  name: 'Gateway {#GWSTATUSNAME} High packet loss'
+                  priority: HIGH
+                  dependencies:
+                    - name: 'Gateway {#GWSTATUSNAME} is down'
+                      expression: 'min(/OPNsense by REST API/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>99 and max(/OPNsense by REST API/opns.gw.status.loss[{#GWSTATUSNAME}],5m)<=100'
+                - uuid: 57695d3ce51442e3bfd782e7221dc50d
+                  expression: 'min(/OPNsense by REST API/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>99 and max(/OPNsense by REST API/opns.gw.status.loss[{#GWSTATUSNAME}],5m)<=100'
+                  name: 'Gateway {#GWSTATUSNAME} is down'
+                  priority: DISASTER
+                - uuid: 9a255ecc5fa44e938e49a022de9187d0
+                  expression: 'min(/OPNsense by REST API/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>{$OPNS.GW.MIN.PACKET.LOSS} and max(/OPNsense by REST API/opns.gw.status.loss[{#GWSTATUSNAME}],5m)<=100'
+                  name: 'Gateway {#GWSTATUSNAME} Packet loss'
+                  priority: AVERAGE
+                  dependencies:
+                    - name: 'Gateway {#GWSTATUSNAME} High packet loss'
+                      expression: 'min(/OPNsense by REST API/opns.gw.status.loss[{#GWSTATUSNAME}],5m)>{$OPNS.GW.HIGH.PACKET.LOSS} and max(/OPNsense by REST API/opns.gw.status.loss[{#GWSTATUSNAME}],5m)<=100'
+            - uuid: 4f922041b30246ff8bb237418c5bedf3
+              name: 'Gateway Status {#GWSTATUSNAME}'
+              type: DEPENDENT
+              key: 'opns.gw.status.status[{#GWSTATUSNAME}]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#GWSTATUSNAME}")].status_translated.first()'
+              master_item:
+                key: opns.raw.gateway.status
+              tags:
+                - tag: Gateway
+                  value: '{#GWSTATUSNAME}'
+            - uuid: b1fc6817230942239c5889d0395b8e1d
+              name: 'Gateway RTTd {#GWSTATUSNAME}'
+              type: DEPENDENT
+              key: 'opns.gw.status.stddev[{#GWSTATUSNAME}]'
+              value_type: FLOAT
+              units: ms
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#GWSTATUSNAME}")].stddev.first()'
+                - type: REGEX
+                  parameters:
+                    - '^([0-9.]+)'
+                    - \1
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: opns.raw.gateway.status
+              tags:
+                - tag: Gateway
+                  value: '{#GWSTATUSNAME}'
+          trigger_prototypes:
+            - uuid: 6889ca48ddf2422e8a41f51373328ce6
+              expression: 'nodata(/OPNsense by REST API/opns.gw.status.delay[{#GWSTATUSNAME}],10m)=1 and nodata(/OPNsense by REST API/opns.gw.status.loss[{#GWSTATUSNAME}],10m)=1 and nodata(/OPNsense by REST API/opns.gw.status.stddev[{#GWSTATUSNAME}],10m)=1'
+              name: 'Gateway Monitoring on {#GWSTATUSNAME} is disabled'
+              priority: INFO
+              description: 'The gateway has no monitor address, so the firewall never probes it and reports a tilde instead of round trip time, loss and deviation. It also reports the gateway as Online, which says nothing about reachability. While this is the case an outage of this gateway raises nothing, because the down trigger works on packet loss. Set a monitor address under System, Gateways, Single, or accept that this gateway is not checked: https://docs.opnsense.org/manual/gateways.html'
+              dependencies:
+                - name: 'No data from OPNsense'
+                  expression: 'nodata(/OPNsense by REST API/opns.raw.gateway.status,5m)=1'
+          master_item:
+            key: opns.raw.gateway.status
+          lld_macro_paths:
+            - lld_macro: '{#GWSTATUSNAME}'
+              path: $.name
+        - uuid: 9674f5eca4e146c2be5abfac7d493f5f
+          name: 'Interface CARP Discovery'
+          type: DEPENDENT
+          key: opns.interface.carp.discovery
+          lifetime: 1d
+          item_prototypes:
+            - uuid: b9d3064c2a614e9dbfeb995ece356c26
+              name: 'Carp Status of {#OPNS.INTERFACE.NAME}'
+              type: DEPENDENT
+              key: 'opns.carp.status[{#OPNS.INTERFACE.NAME}]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["interface"] == "{#OPNS.INTERFACE.NAME}")].["status"].first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 2h
+              master_item:
+                key: opns.raw.interfaces.carp
+              trigger_prototypes:
+                - uuid: 6d6ec9235fc64b07a9190788187e9e7f
+                  expression: 'change(/OPNsense by REST API/opns.carp.status[{#OPNS.INTERFACE.NAME}])<>0'
+                  name: 'Carp Status Changed on {#OPNS.INTERFACE.NAME}'
+                  opdata: '{#OPNS.INTERFACE.NAME}: {ITEM.LASTVALUE}'
+                  priority: HIGH
+          master_item:
+            key: opns.raw.interfaces.carp
+          lld_macro_paths:
+            - lld_macro: '{#OPNS.INTERFACE.NAME}'
+              path: $.interface
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.rows[*]'
+              error_handler: CUSTOM_ERROR
+              error_handler_params: 'Could not locate any defined CARP interfaces.'
+        - uuid: b28e806ede4642a89206e98f06e4ec51
+          name: 'Interface Stats Discovery'
+          type: DEPENDENT
+          key: opns.interface.stats.discovery
+          item_prototypes:
+            - uuid: 9ff29ab99d8243549153db0c10813006
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: Bytes received'
+              type: DEPENDENT
+              key: 'opns.interface.bytes.received[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#OPNS.INTERFACE.NAME}")].["bytes received"].first()'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.interfaces.stat
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: c2b14007b4c74549ae930033f369276f
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: Bytes transmitted'
+              type: DEPENDENT
+              key: 'opns.interface.bytes.transmitted[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#OPNS.INTERFACE.NAME}")].["bytes transmitted"].first()'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.interfaces.stat
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: 2c9a3ad30a6c442bbc99a97704effbeb
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: collisions'
+              type: DEPENDENT
+              key: 'opns.interface.collisions[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#OPNS.INTERFACE.NAME}")].["collisions"].first()'
+                - type: CHANGE_PER_SECOND
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: opns.raw.interfaces.stat
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: aff6d03779a74ab09a680ef69cd52b9e
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: blocked bytes INv4'
+              type: DEPENDENT
+              key: 'opns.interface.fw.bytes.blockin.v4[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.interfaces.["{#OPNS.INTERFACE.DEVICE}"].["in4_block_bytes"]'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.fw.interface.stat
+              tags:
+                - tag: component
+                  value: firewall
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: 73491d2245fe42e3829f6591173198f1
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: blocked bytes OUTv4'
+              type: DEPENDENT
+              key: 'opns.interface.fw.bytes.blockout.v4[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.interfaces.["{#OPNS.INTERFACE.DEVICE}"].["out4_block_bytes"]'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.fw.interface.stat
+              tags:
+                - tag: component
+                  value: firewall
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: 2df1b43cea4348d48b1cc868cc5e35ac
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: passed bytes INv4'
+              type: DEPENDENT
+              key: 'opns.interface.fw.bytes.passin.v4[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.interfaces.["{#OPNS.INTERFACE.DEVICE}"].["in4_pass_bytes"]'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.fw.interface.stat
+              tags:
+                - tag: component
+                  value: firewall
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: a840c82ec4e04bcc8b7be22fb50e5354
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: passed bytes OUTv4'
+              type: DEPENDENT
+              key: 'opns.interface.fw.bytes.passout.v4[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.interfaces.["{#OPNS.INTERFACE.DEVICE}"].["out4_pass_bytes"]'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.fw.interface.stat
+              tags:
+                - tag: component
+                  value: firewall
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: 9248896570bb457892298002f2404039
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: blocked packets INv4'
+              type: DEPENDENT
+              key: 'opns.interface.fw.packets.blockin.v4[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.interfaces.["{#OPNS.INTERFACE.DEVICE}"].["in4_block_packets"]'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.fw.interface.stat
+              tags:
+                - tag: component
+                  value: firewall
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: 50177b3ac15f461f9ee18aa28e172447
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: blocked packets OUTv4'
+              type: DEPENDENT
+              key: 'opns.interface.fw.packets.blockout.v4[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.interfaces.["{#OPNS.INTERFACE.DEVICE}"].["out4_block_packets"]'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.fw.interface.stat
+              tags:
+                - tag: component
+                  value: firewall
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: 0049be9ac626487d810d4774f0d96346
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: passed packets INv4'
+              type: DEPENDENT
+              key: 'opns.interface.fw.packets.passin.v4[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.interfaces.["{#OPNS.INTERFACE.DEVICE}"].["in4_pass_packets"]'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.fw.interface.stat
+              tags:
+                - tag: component
+                  value: firewall
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: b1f83c9670e846f19bd215ac1c1ac15f
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: passed packets OUTv4'
+              type: DEPENDENT
+              key: 'opns.interface.fw.packets.passout.v4[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.interfaces.["{#OPNS.INTERFACE.DEVICE}"].["out4_pass_packets"]'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.fw.interface.stat
+              tags:
+                - tag: component
+                  value: firewall
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: f780fc2fe87840d1bbdb963b4b605340
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: input queue drops'
+              type: DEPENDENT
+              key: 'opns.interface.input.queue.drops[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#OPNS.INTERFACE.NAME}")].["input queue drops"].first()'
+                - type: CHANGE_PER_SECOND
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: opns.raw.interfaces.stat
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: 23fe6abe4f064b8f9f6b8730f147bf18
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: multicasts received'
+              type: DEPENDENT
+              key: 'opns.interface.multicast.received[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#OPNS.INTERFACE.NAME}")].["multicasts received"].first()'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.interfaces.stat
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: e08b837d4fbf406aba4c5d2eb284925f
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: output errors'
+              type: DEPENDENT
+              key: 'opns.interface.output.errors[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#OPNS.INTERFACE.NAME}")].["output errors"].first()'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.interfaces.stat
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: 7a824dcc83bb41649549e1b6c9fed97d
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: packets received'
+              type: DEPENDENT
+              key: 'opns.interface.packets.received[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#OPNS.INTERFACE.NAME}")].["packets received"].first()'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.interfaces.stat
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: ed33489d4e774d5ab016cc89dd593c06
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: packets transmitted'
+              type: DEPENDENT
+              key: 'opns.interface.packets.transmitted[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#OPNS.INTERFACE.NAME}")].["packets transmitted"].first()'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.raw.interfaces.stat
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+            - uuid: 142ca52cbdb1440bb840e625ba524484
+              name: 'Interface [{#OPNS.INTERFACE.DEVICE}({#OPNS.INTERFACE.NAME})]: packets for unknown protocol'
+              type: DEPENDENT
+              key: 'opns.interface.packets.unknown.protocol[{#OPNS.INTERFACE.DEVICE}]'
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#OPNS.INTERFACE.NAME}")].["packets for unknown protocol"].first()'
+                - type: CHANGE_PER_SECOND
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: opns.raw.interfaces.stat
+              tags:
+                - tag: component
+                  value: network
+                - tag: description
+                  value: '{#OPNS.INTERFACE.NAME}'
+                - tag: interface
+                  value: '{#OPNS.INTERFACE.DEVICE}'
+          master_item:
+            key: opns.raw.interfaces.stat
+          lld_macro_paths:
+            - lld_macro: '{#OPNS.INTERFACE.DEVICE}'
+              path: $.device
+            - lld_macro: '{#OPNS.INTERFACE.NAME}'
+              path: $.name
+        - uuid: 7e3a4b5d98cd48bda344d9500866f5fe
+          name: 'WireGuard Instance Discovery'
+          type: DEPENDENT
+          key: opns.wireguard.instance.discovery
+          filter:
+            conditions:
+              - macro: '{#WG.INSTANCE}'
+                value: '{$OPNS.WG.INSTANCE.MATCHES}'
+              - macro: '{#WG.INSTANCE}'
+                value: '{$OPNS.WG.INSTANCE.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+          lifetime: 1h
+          item_prototypes:
+            - uuid: 365c79af37484c13a23c4f41868221e4
+              name: 'WireGuard instance {#WG.INSTANCE}: status'
+              type: DEPENDENT
+              key: 'opns.wireguard.instance.status[{#WG.IF}]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.if == "{#WG.IF}")].status.first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.INSTANCE}'
+                - tag: interface
+                  value: '{#WG.IF}'
+              trigger_prototypes:
+                - uuid: 9bde0c5a6cc948d9ac90f0c080cec627
+                  expression: 'find(/OPNsense by REST API/opns.wireguard.instance.status[{#WG.IF}],5m,"eq","up")=0'
+                  name: 'WireGuard instance {#WG.INSTANCE} is down'
+                  priority: HIGH
+            - uuid: cd9490630cca4d70bf9898a783e4b831
+              name: 'WireGuard instance {#WG.INSTANCE}: listen port'
+              type: DEPENDENT
+              key: 'opns.wireguard.instance.listen_port[{#WG.IF}]'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.if == "{#WG.IF}")].["listen-port"].first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.INSTANCE}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: fff3adf5119948f5b9d4c9b2a75ea677
+              name: 'WireGuard instance {#WG.INSTANCE}: public key'
+              type: DEPENDENT
+              key: 'opns.wireguard.instance.public_key[{#WG.IF}]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.if == "{#WG.IF}")].["public-key"].first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.INSTANCE}'
+                - tag: interface
+                  value: '{#WG.IF}'
+          master_item:
+            key: opns.wireguard.raw
+          lld_macro_paths:
+            - lld_macro: '{#WG.IF}'
+              path: $.if
+            - lld_macro: '{#WG.INSTANCE}'
+              path: $.name
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var rows = JSON.parse(value);
+                  var instances = [];
+                  for (var i = 0; i < rows.length; i++) {
+                      if (rows[i].type === 'interface') {
+                          if (rows[i].name === '') {
+                              rows[i].name = rows[i].if;
+                          }
+                          instances.push(rows[i]);
+                      }
+                  }
+                  return JSON.stringify(instances);
+        - uuid: a12b61ca5cc74c6a93f7d4d38c88d46f
+          name: 'WireGuard Peer Discovery'
+          type: DEPENDENT
+          key: opns.wireguard.peer.discovery
+          filter:
+            conditions:
+              - macro: '{#WG.NAME}'
+                value: '{$OPNS.WG.PEER.MATCHES}'
+              - macro: '{#WG.NAME}'
+                value: '{$OPNS.WG.PEER.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+              - macro: '{#WG.IFNAME}'
+                value: '{$OPNS.WG.INSTANCE.MATCHES}'
+              - macro: '{#WG.IFNAME}'
+                value: '{$OPNS.WG.INSTANCE.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+          lifetime: 1h
+          item_prototypes:
+            - uuid: ae1c2f757a064802ab184f1426a754d1
+              name: 'WireGuard peer {#WG.NAME}: status'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.status["{#WG.PUBKEY}"]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["peer-status"].first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+              trigger_prototypes:
+                - uuid: 6dcbf31f2e834b95816ecf10e21e389d
+                  expression: 'find(/OPNsense by REST API/opns.wireguard.peer.status["{#WG.PUBKEY}"],5m,"eq","online")=0'
+                  name: 'WireGuard peer {#WG.NAME} is not online'
+                  priority: HIGH
+                  description: 'WireGuard peer status is stale or offline. OPNsense marks peers online when the latest handshake is not older than 300 seconds.'
+            - uuid: 5f0a748e70144af49b8b0766569b76cc
+              name: 'WireGuard peer {#WG.NAME}: latest handshake age'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.latest_handshake_age["{#WG.PUBKEY}"]'
+              units: s
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["latest-handshake-age"].first()'
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      if (value === null || value === '' || value === 'null') {
+                          return 0;
+                      }
+                      return value;
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: dbc90391a7bb435cb39696cd94934ab8
+              name: 'WireGuard peer {#WG.NAME}: latest handshake'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.latest_handshake["{#WG.PUBKEY}"]'
+              units: unixtime
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["latest-handshake"].first()'
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      if (value === null || value === '' || value === 'null') {
+                          return 0;
+                      }
+                      return value;
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: 0e0397686b9c4c61b2e22fd2b066c164
+              name: 'WireGuard peer {#WG.NAME}: endpoint'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.endpoint["{#WG.PUBKEY}"]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].endpoint.first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: db3f7fb64542462aa3b5f0162ee0f745
+              name: 'WireGuard peer {#WG.NAME}: bytes received'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.transfer_rx["{#WG.PUBKEY}"]'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["transfer-rx"].first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: 1b6e494df55547d4a729414d21056a3b
+              name: 'WireGuard peer {#WG.NAME}: bytes received per second'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.transfer_rx.rate["{#WG.PUBKEY}"]'
+              value_type: FLOAT
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["transfer-rx"].first()'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: 7d73f2e3983746b6a81a4a899c38959a
+              name: 'WireGuard peer {#WG.NAME}: bytes sent'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.transfer_tx["{#WG.PUBKEY}"]'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["transfer-tx"].first()'
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+            - uuid: 2cc518e36ae74bd497618c228bcc7a02
+              name: 'WireGuard peer {#WG.NAME}: bytes sent per second'
+              type: DEPENDENT
+              key: 'opns.wireguard.peer.transfer_tx.rate["{#WG.PUBKEY}"]'
+              value_type: FLOAT
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["public-key"] == "{#WG.PUBKEY}")].["transfer-tx"].first()'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.wireguard.raw
+              tags:
+                - tag: WireGuard
+                  value: '{#WG.NAME}'
+                - tag: interface
+                  value: '{#WG.IF}'
+          master_item:
+            key: opns.wireguard.raw
+          lld_macro_paths:
+            - lld_macro: '{#WG.IF}'
+              path: $.if
+            - lld_macro: '{#WG.IFNAME}'
+              path: $.ifname
+            - lld_macro: '{#WG.NAME}'
+              path: $.name
+            - lld_macro: '{#WG.PUBKEY}'
+              path: $.public_key
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  var rows = JSON.parse(value);
+                  var peers = [];
+                  for (var i = 0; i < rows.length; i++) {
+                      if (rows[i].type === 'peer') {
+                          rows[i].public_key = rows[i]['public-key'];
+                          if (rows[i].ifname === '' || rows[i].ifname === null) {
+                              rows[i].ifname = rows[i].if;
+                          }
+                          if (rows[i].name === '') {
+                              rows[i].name = rows[i]['public-key'];
+                          }
+                          peers.push(rows[i]);
+                      }
+                  }
+                  return JSON.stringify(peers);
+        - uuid: 6b2beeec77c24db1ac4ad533cb70388d
+          name: 'IPsec Phase1 Discovery'
+          type: DEPENDENT
+          key: opns.ipsec.phase1.discovery
+          item_prototypes:
+            - uuid: d45b2c7388684a3792444b38efba2462
+              name: '{#IPSECDESC} bytes per second in'
+              type: DEPENDENT
+              key: 'opn.ipsecph1.bytes.in.second[{#IPSECDESC}]'
+              value_type: FLOAT
+              trends: '0'
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["bytes-in"].first()'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase1'
+                  value: '{#IPSECNAME}'
+            - uuid: b4c2cc645f9f4bd48930c396f785ba97
+              name: '{#IPSECDESC} bytes-in total'
+              type: DEPENDENT
+              key: 'opn.ipsecph1.bytes.in.total[{#IPSECDESC}]'
+              trends: '0'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["bytes-in"].first()'
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase1'
+                  value: '{#IPSECNAME}'
+            - uuid: 43296ae7f91b4d1495970e0e0b838de1
+              name: '{#IPSECDESC} bytes per second out'
+              type: DEPENDENT
+              key: 'opn.ipsecph1.bytes.out.second[{#IPSECDESC}]'
+              value_type: FLOAT
+              trends: '0'
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["bytes-out"].first()'
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase1'
+                  value: '{#IPSECNAME}'
+            - uuid: 2ef6f8f9faab4e33868154a304d697d6
+              name: '{#IPSECDESC} bytes-out total'
+              type: DEPENDENT
+              key: 'opn.ipsecph1.bytes.out.total[{#IPSECDESC}]'
+              trends: '0'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["bytes-out"].first()'
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase1'
+                  value: '{#IPSECNAME}'
+            - uuid: e8f90a119bd747678e1bbf396fcca775
+              name: '{#IPSECDESC} connected'
+              type: DEPENDENT
+              key: 'opn.ipsecph1.connected[{#IPSECDESC}]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["connected"].first()'
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase1'
+                  value: '{#IPSECNAME}'
+              trigger_prototypes:
+                - uuid: 4901a5da4fbe4973b908eae879819004
+                  expression: 'find(/OPNsense by REST API/opn.ipsecph1.connected[{#IPSECDESC}],,"like","true")=0'
+                  name: 'IPSec Tunnel {#IPSECDESC} is not connected'
+                  priority: HIGH
+            - uuid: f8cdbb97fc6446eea7bacad4533365e8
+              name: '{#IPSECDESC} lcoaladdress'
+              type: DEPENDENT
+              key: 'opn.ipsecph1.localaddress[{#IPSECDESC}]'
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$..[?(@.["name"] == "{#IPSECNAME}")].["local-addrs"].first()'
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: 'IPSEC Phase1'
+                  value: '{#IPSECNAME}'
+            # --- phase 2 moved here, see merged/ipsec_fix.py ---
+            - uuid: d60b1929f3f24b188a8abdb1247c2966
+              name: 'IPsec {#IPSECDESC}: phase 2 (raw)'
+              type: HTTP_AGENT
+              key: opns.ipsec.phase2.raw[{#IPSECNAME}]
+              delay: 5m
+              history: '0'
+              value_type: TEXT
+              trends: '0'
+              authtype: BASIC
+              username: '{$OPNS.KEY}'
+              password: '{$OPNS.SECRET}'
+              description: Child SAs of this connection. The endpoint takes the connection through a POST parameter and returns an empty set without it, which is why this is one request per tunnel rather than a single master item. The identifier is the name field of the phase 1 row, the same value the web interface sends. Only the two fields that exist nowhere else, mode and state, are read from here; the byte and packet counters come from the phase 1 master, which aggregates the same child SAs itself and costs no request per tunnel.
+              timeout: 15s
+              url: https://{HOST.IP}:{$OPNS.PORT}/api/ipsec/sessions/search_phase2
+              posts: id={#IPSECNAME}
+              headers:
+                - name: Content-Type
+                  value: application/x-www-form-urlencoded
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.rows
+              tags:
+                - tag: component
+                  value: raw
+            - uuid: b5f0aaf5532648ef8d79adcad9c59ef5
+              name: '{#IPSECDESC} bytes-in per second'
+              type: DEPENDENT
+              key: opn.ipsecph2.bytes.in.second[{#IPSECDESC}]
+              trends: '0'
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $..[?(@.["name"] == "{#IPSECNAME}")].["bytes-in"].first()
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: IPSEC Phase2
+                  value: '{#IPSECNAME}'
+            - uuid: 4b327a3a065c44dbb21ebb59e6f86b70
+              name: '{#IPSECDESC} bytes-in'
+              type: DEPENDENT
+              key: opn.ipsecph2.bytes.in[{#IPSECDESC}]
+              trends: '0'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $..[?(@.["name"] == "{#IPSECNAME}")].["bytes-in"].first()
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: IPSEC Phase2
+                  value: '{#IPSECNAME}'
+            - uuid: 81914a2f226d470e8fe1e2d62b1af8d9
+              name: '{#IPSECDESC} bytes-out per second'
+              type: DEPENDENT
+              key: opn.ipsecph2.bytes.out.second[{#IPSECDESC}]
+              trends: '0'
+              units: Bps
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $..[?(@.["name"] == "{#IPSECNAME}")].["bytes-out"].first()
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: IPSEC Phase2
+                  value: '{#IPSECNAME}'
+            - uuid: 1817e20473ba4bec92f5347d873a7f67
+              name: '{#IPSECDESC} bytes-out'
+              type: DEPENDENT
+              key: opn.ipsecph2.bytes.out[{#IPSECDESC}]
+              trends: '0'
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $..[?(@.["name"] == "{#IPSECNAME}")].["bytes-out"].first()
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: IPSEC Phase2
+                  value: '{#IPSECNAME}'
+            - uuid: d5137396fc18452cbe77fd1b2055f089
+              name: '{#IPSECDESC} mode'
+              type: DEPENDENT
+              key: opn.ipsecph2.mode[{#IPSECDESC}]
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $[0]['mode']
+              master_item:
+                key: opns.ipsec.phase2.raw[{#IPSECNAME}]
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: IPSEC Phase2
+                  value: '{#IPSECNAME}'
+            - uuid: 86b0acbd890744f4a7d8a62769fc0973
+              name: '{#IPSECDESC} packets-in per second'
+              type: DEPENDENT
+              key: opn.ipsecph2.packets.in.second[{#IPSECDESC}]
+              trends: '0'
+              units: P/s
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $..[?(@.["name"] == "{#IPSECNAME}")].["packets-in"].first()
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: IPSEC Phase2
+                  value: '{#IPSECNAME}'
+            - uuid: 34b450277293461294f2bf47b3362fee
+              name: '{#IPSECDESC} packets-in'
+              type: DEPENDENT
+              key: opn.ipsecph2.packets.in[{#IPSECDESC}]
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $..[?(@.["name"] == "{#IPSECNAME}")].["packets-in"].first()
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: IPSEC Phase2
+                  value: '{#IPSECNAME}'
+            - uuid: 306b60ba334a4f0e9b1207eeb7310d32
+              name: '{#IPSECDESC} packets-out per second'
+              type: DEPENDENT
+              key: opn.ipsecph2.packets.out.second[{#IPSECDESC}]
+              trends: '0'
+              units: P/s
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $..[?(@.["name"] == "{#IPSECNAME}")].["packets-out"].first()
+                - type: CHANGE_PER_SECOND
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: IPSEC Phase2
+                  value: '{#IPSECNAME}'
+            - uuid: 0aaee9f7efb1484dbac9bb74dffc772f
+              name: '{#IPSECDESC} packets-out'
+              type: DEPENDENT
+              key: opn.ipsecph2.packets.out[{#IPSECDESC}]
+              trends: '0'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $..[?(@.["name"] == "{#IPSECNAME}")].["packets-out"].first()
+              master_item:
+                key: opns.ipsec.phase1.raw
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: IPSEC Phase2
+                  value: '{#IPSECNAME}'
+            - uuid: 6de4e837d95d459996ec605212551237
+              name: '{#IPSECDESC} state'
+              type: DEPENDENT
+              key: opn.ipsecph2.state[{#IPSECDESC}]
+              value_type: TEXT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $[0]['state']
+              master_item:
+                key: opns.ipsec.phase2.raw[{#IPSECNAME}]
+              tags:
+                - tag: IPSEC
+                  value: '{#IPSECDESC}'
+                - tag: IPSEC
+                  value: '{#IPSECNAME}'
+                - tag: IPSEC Phase2
+                  value: '{#IPSECNAME}'
+          trigger_prototypes:
+            - uuid: e3c1e5471d9d470e9fcaddb99642d98b
+              expression: '(change(/OPNsense by REST API/opn.ipsecph1.bytes.out.total[{#IPSECDESC}])=0 or change(/OPNsense by REST API/opn.ipsecph1.bytes.in.total[{#IPSECDESC}])=0) and find(/OPNsense by REST API/opn.ipsecph1.connected[{#IPSECDESC}],,"like","connected")=1'
+              name: 'IPSec Tunnel {#IPSECDESC} no traffic'
+              priority: WARNING
+          master_item:
+            key: opns.ipsec.phase1.raw
+          lld_macro_paths:
+            - lld_macro: '{#IPSECDESC}'
+              path: $.phase1desc
+            - lld_macro: '{#IPSECNAME}'
+              path: $.name
+        # --- added from OPNsense by HTTP API (github.com/Garfieldttt/opnsense-zabbix-api) ---
+        - uuid: f0a8fc199c814bc7b95cc0234b35d825
+          name: Network interfaces (link state and inbound errors)
+          type: DEPENDENT
+          key: opns.net.if.discovery
+          description: One entry per physical and virtual interface. Only link level rows are used, because the per address rows count traffic per IP rather than per interface. Interfaces matching the exclusion macro are skipped.
+          delay: '0'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#IFNAME}'
+                value: '{$OPNS.IF.NAME.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: A
+          item_prototypes:
+            - uuid: 125d0185e6dd4d55b33c2c5e2e5e61b0
+              name: 'Interface {#IFALIAS} ({#IFNAME}): Inbound errors'
+              type: DEPENDENT
+              key: opns.net.if.in.errors[{#IFNAME}]
+              description: Receive errors on this interface. Points at cabling, an optic or the link partner.
+              delay: '0'
+              value_type: FLOAT
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $[?(@.device == "{#IFNAME}")]['input errors'].first()
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              master_item:
+                key: opns.raw.interfaces.stat
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+            - uuid: 163268a164a34c96af929b357d7369fe
+              name: 'Interface {#IFALIAS} ({#IFNAME}): Link status'
+              type: DEPENDENT
+              key: opns.net.if.status[{#IFNAME}]
+              delay: '0'
+              valuemap:
+                name: Link status
+              description: 'Derived from the BSD interface flags: bit 0 is UP, the administrative state, and bit 6 is RUNNING, which is set once the interface has a usable link. Both must be set for the interface to count as up.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $[?(@.device == "{#IFNAME}")]['link state'].first()
+                - type: STR_REPLACE
+                  parameters:
+                    - '1'
+                    - '0'
+                - type: STR_REPLACE
+                  parameters:
+                    - '2'
+                    - '1'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: opns.raw.interfaces.stat
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+              trigger_prototypes:
+                - uuid: 110a1532440747e5b4d548420b2053f6
+                  expression: last(/OPNsense by REST API/opns.net.if.status[{#IFNAME}])=0 and {$OPNS.IF.CONTROL:"{#IFNAME}"}=1
+                  name: 'OPNsense: Interface {#IFALIAS} ({#IFNAME}) is down'
+                  priority: AVERAGE
+                  description: The link is gone or the interface was shut down. Set {$OPNS.IF.CONTROL:"{#IFNAME}"} to 0 for interfaces that are allowed to be down, such as a cold standby uplink.
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: availability
+          master_item:
+            key: opns.raw.interfaces.stat
+          preprocessing: []
+          lld_macro_paths:
+            - lld_macro: '{#IFNAME}'
+              path: $.device
+            - lld_macro: '{#IFALIAS}'
+              path: $.name
+        - uuid: 41c2775dbbc54b2c8ebcff3c6b2ab78e
+          name: netisr queues
+          type: DEPENDENT
+          key: opns.netisr.discovery
+          delay: '0'
+          description: One entry per protocol queue. The summed counter alerts, these tell you which queue is the one overflowing.
+          item_prototypes:
+            - uuid: 055989dca6ec47aa91ba581327ecdf7f
+              name: 'netisr {#NETISR.PROTO}: Queue drops'
+              type: DEPENDENT
+              key: opns.netisr.queue.drops[{#NETISR.PROTO}]
+              description: Packets discarded from this protocol queue before reaching the firewall rules. Identifies which queue the summed counter is reacting to.
+              delay: '0'
+              value_type: FLOAT
+              units: '!/s'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.netisr.workstream[*].work[?(@.name == "{#NETISR.PROTO}")]['queue-drops'].sum()
+              master_item:
+                key: opns.netisr.raw
+              tags:
+                - tag: component
+                  value: network
+                - tag: protocol
+                  value: '{#NETISR.PROTO}'
+          master_item:
+            key: opns.netisr.raw
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.netisr.protocol
+          lld_macro_paths:
+            - lld_macro: '{#NETISR.PROTO}'
+              path: $.name
+        - uuid: 197dc88a53f9474cb7946623455b286f
+          name: OpenVPN instances and clients
+          type: DEPENDENT
+          key: opns.openvpn.discovery
+          delay: '0'
+          description: One entity per instance, plus one per client connected to a server. A client carries the instance id and the client address in its own id, so the two never collide.
+          master_item:
+            key: opns.openvpn.raw
+          lld_macro_paths:
+            - lld_macro: '{#OVPN.ID}'
+              path: $.id
+            - lld_macro: '{#OVPN.DESC}'
+              path: $.description
+            - lld_macro: '{#OVPN.TYPE}'
+              path: $.type
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#OVPN.ID}'
+                value: '{$OPNS.OPENVPN.ID.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: A
+          item_prototypes:
+            - uuid: e0b80df6d63a456095f526e2c48ad6ed
+              name: 'OpenVPN {#OVPN.DESC} ({#OVPN.TYPE}): status'
+              type: DEPENDENT
+              key: opns.openvpn.status[{#OVPN.ID}]
+              delay: '0'
+              description: ok while the instance answers on its management socket. An enabled instance that is not running reports nothing at all, which the trigger treats as down.
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $[?(@.id == "{#OVPN.ID}")].status.first()
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: opns.openvpn.raw
+              tags:
+                - tag: component
+                  value: openvpn
+                - tag: openvpn
+                  value: '{#OVPN.DESC}'
+              value_type: CHAR
+              trigger_prototypes:
+                - uuid: bef2f6149b744929a3667f8147d884e3
+                  expression: find(/OPNsense by REST API/opns.openvpn.status[{#OVPN.ID}],10m,"regexp","^ok$")=0 and {$OPNS.OPENVPN.CONTROL:"{#OVPN.DESC}"}=1
+                  name: OpenVPN {#OVPN.DESC} ({#OVPN.TYPE}) is not up
+                  priority: AVERAGE
+                  manual_close: 'YES'
+                  description: The instance has not reported a working management socket for ten minutes. Set {$OPNS.OPENVPN.CONTROL} to 0, per instance through macro context, for instances that are allowed to be down.
+            - uuid: bfcf4cc326a249b6afbddbcbbba7cf55
+              name: 'OpenVPN {#OVPN.DESC} ({#OVPN.TYPE}): bytes received'
+              type: DEPENDENT
+              key: opns.openvpn.bytes.in[{#OVPN.ID}]
+              delay: '0'
+              description: Total received on this instance or client.
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $[?(@.id == "{#OVPN.ID}")].bytes_received.first()
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: opns.openvpn.raw
+              tags:
+                - tag: component
+                  value: openvpn
+                - tag: openvpn
+                  value: '{#OVPN.DESC}'
+              units: B
+            - uuid: f433f02c175f4388857cc1426852103e
+              name: 'OpenVPN {#OVPN.DESC} ({#OVPN.TYPE}): bytes sent'
+              type: DEPENDENT
+              key: opns.openvpn.bytes.out[{#OVPN.ID}]
+              delay: '0'
+              description: Total sent on this instance or client.
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $[?(@.id == "{#OVPN.ID}")].bytes_sent.first()
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: opns.openvpn.raw
+              tags:
+                - tag: component
+                  value: openvpn
+                - tag: openvpn
+                  value: '{#OVPN.DESC}'
+              units: B
+            - uuid: 0913c64b7ce44989895a1c175372b1dd
+              name: 'OpenVPN {#OVPN.DESC} ({#OVPN.TYPE}): bytes received per second'
+              type: DEPENDENT
+              key: opns.openvpn.bytes.in.rate[{#OVPN.ID}]
+              delay: '0'
+              description: ''
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $[?(@.id == "{#OVPN.ID}")].bytes_received.first()
+                  error_handler: DISCARD_VALUE
+                - &id001
+                  type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              master_item:
+                key: opns.openvpn.raw
+              tags:
+                - tag: component
+                  value: openvpn
+                - tag: openvpn
+                  value: '{#OVPN.DESC}'
+              units: Bps
+            - uuid: 0a214c94d25f4df3a650aa388f221485
+              name: 'OpenVPN {#OVPN.DESC} ({#OVPN.TYPE}): bytes sent per second'
+              type: DEPENDENT
+              key: opns.openvpn.bytes.out.rate[{#OVPN.ID}]
+              delay: '0'
+              description: ''
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $[?(@.id == "{#OVPN.ID}")].bytes_sent.first()
+                  error_handler: DISCARD_VALUE
+                - *id001
+              master_item:
+                key: opns.openvpn.raw
+              tags:
+                - tag: component
+                  value: openvpn
+                - tag: openvpn
+                  value: '{#OVPN.DESC}'
+              units: Bps
+        - uuid: a193ea4493564267bb945680a35be241
+          name: Services
+          type: DEPENDENT
+          key: opns.services.discovery
+          delay: '0'
+          description: 'One entry per known service. Discovery keys on the identifier rather than the name, because a name can appear twice: the DHCP server registers once for IPv4 and once for IPv6 under the same name but distinct identifiers.'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#SERVICE.ID}'
+                value: '{$OPNS.SERVICE.ID.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: A
+          item_prototypes:
+            - uuid: 4b6c3cc410004d19934fecf9ab466b5a
+              name: 'Service {#SERVICE.DESCRIPTION}: Running'
+              type: DEPENDENT
+              key: opns.service.running[{#SERVICE.ID}]
+              delay: '0'
+              valuemap:
+                name: Service state
+              description: Whether this service is running. The packet filter itself appears here, so a firewall that has been disabled while staying reachable becomes visible.
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.rows[?(@.id == "{#SERVICE.ID}")].running.first()
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 10m
+              master_item:
+                key: opns.services.raw
+              tags:
+                - tag: component
+                  value: service
+                - tag: service
+                  value: '{#SERVICE.ID}'
+              trigger_prototypes:
+                - uuid: da4a4099f5d24feeaea0a84c3cfd28e5
+                  expression: min(/OPNsense by REST API/opns.service.running[{#SERVICE.ID}],5m)=0
+                  name: 'OPNsense: Service {#SERVICE.DESCRIPTION} is not running'
+                  priority: AVERAGE
+                  description: The service has been down for five minutes. Add it to {$OPNS.SERVICE.ID.NOT_MATCHES} if it is not supposed to run on this firewall.
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: availability
+          master_item:
+            key: opns.services.raw
+          lld_macro_paths:
+            - lld_macro: '{#SERVICE.DESCRIPTION}'
+              path: $.description
+            - lld_macro: '{#SERVICE.ID}'
+              path: $.id
+            - lld_macro: '{#SERVICE.NAME}'
+              path: $.name
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.rows
+        - uuid: e038144dbbbb4920b09d920c2d91c043
+          name: Swap devices
+          type: DEPENDENT
+          key: opns.swap.discovery
+          delay: '0'
+          description: Discovers nothing on installations without swap, which keeps the template free of unsupported items there.
+          item_prototypes:
+            - uuid: 82807abe917a432580d7d0df5807b0ab
+              name: 'Swap {#SWAPDEV}: utilization'
+              type: CALCULATED
+              key: opns.swap.pused[{#SWAPDEV}]
+              description: Fill level of this swap device. A firewall that swaps at all is short on memory.
+              delay: 5m
+              value_type: FLOAT
+              units: '%'
+              tags:
+                - tag: component
+                  value: memory
+                - tag: swapdev
+                  value: '{#SWAPDEV}'
+              trigger_prototypes:
+                - uuid: 85b857bc0d1a43c4b21b94129f2c83bc
+                  expression: min(/OPNsense by REST API/opns.swap.pused[{#SWAPDEV}],10m)>{$OPNS.SWAP.UTIL.WARN:"{#SWAPDEV}"}
+                  name: 'OPNsense: Swap {#SWAPDEV} is in use'
+                  priority: WARNING
+                  description: A firewall that swaps is short on memory. Sustained swap usage costs throughput.
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: performance
+              params: last(//opns.swap.used[{#SWAPDEV}]) / last(//opns.swap.total[{#SWAPDEV}]) * 100
+            - uuid: b5da115daf2540bba0109e4ca6bbbcb4
+              name: 'Swap {#SWAPDEV}: total'
+              type: DEPENDENT
+              key: opns.swap.total[{#SWAPDEV}]
+              description: Size of this swap device.
+              delay: '0'
+              value_type: FLOAT
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.swap[?(@.device == "{#SWAPDEV}")].total.first()
+                - type: MULTIPLIER
+                  parameters:
+                    - '1024'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: opns.swap.raw
+              tags:
+                - tag: component
+                  value: memory
+                - tag: swapdev
+                  value: '{#SWAPDEV}'
+            - uuid: 6d49c2f5b2a84343bfb466368ee9db86
+              name: 'Swap {#SWAPDEV}: used'
+              type: DEPENDENT
+              key: opns.swap.used[{#SWAPDEV}]
+              description: Swap in use on this device.
+              delay: '0'
+              value_type: FLOAT
+              units: B
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.swap[?(@.device == "{#SWAPDEV}")].used.first()
+                - type: MULTIPLIER
+                  parameters:
+                    - '1024'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: opns.swap.raw
+              tags:
+                - tag: component
+                  value: memory
+                - tag: swapdev
+                  value: '{#SWAPDEV}'
+          master_item:
+            key: opns.swap.raw
+          lld_macro_paths:
+            - lld_macro: '{#SWAPDEV}'
+              path: $.device
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.swap
+        - uuid: e172b60e622b4833aaa4f4a4b6437b1c
+          name: Temperature sensors
+          type: DEPENDENT
+          key: opns.temperature.discovery
+          delay: '0'
+          description: The endpoint returns a JSON array at the root. Virtual machines report no sensors, so nothing is discovered and nothing goes unsupported.
+          item_prototypes:
+            - uuid: 9fd430c46c8f41219eea40d7dc6ea5df
+              name: Temperature {#DEVICE}
+              type: DEPENDENT
+              key: opns.temperature[{#DEVICE}]
+              description: Reading of one hardware sensor. Which physical component it describes depends on the platform, the sensor name carries that.
+              delay: '0'
+              value_type: FLOAT
+              units: °C
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $[?(@.device == "{#DEVICE}")].temperature.first()
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 3m
+              master_item:
+                key: opns.temperature.raw
+              tags:
+                - tag: component
+                  value: temperature
+                - tag: sensor
+                  value: '{#DEVICE}'
+              trigger_prototypes:
+                - uuid: 8217649a9ae14ff6be99475632f5c7c9
+                  expression: avg(/OPNsense by REST API/opns.temperature[{#DEVICE}],5m)>{$OPNS.TEMP.CRIT:"{#DEVICE}"}
+                  name: 'OPNsense: Sensor {#DEVICE} is running hot'
+                  priority: HIGH
+                  description: Sustained high temperature. Check fans, filters and ambient temperature. Adjust {$OPNS.TEMP.CRIT} per hardware, the default suits most x86 appliances.
+                  manual_close: 'YES'
+                  tags:
+                    - tag: scope
+                      value: hardware
+          graph_prototypes:
+            - uuid: a251a765b56f44398c5fe72141d8c577
+              name: Temperature {#DEVICE}
+              graph_items:
+                - color: E53935
+                  item:
+                    host: OPNsense by REST API
+                    key: opns.temperature[{#DEVICE}]
+          master_item:
+            key: opns.temperature.raw
+          lld_macro_paths:
+            - lld_macro: '{#DEVICE}'
+              path: $.device
+            - lld_macro: '{#TYPE}'
+              path: $.type
+      macros:
+        - macro: '{$OPNS.CPU.LOAD.MAX}'
+          value: '2'
+        - macro: '{$OPNS.FS.FSNAME.MATCHES}'
+          value: .+
+          description: 'Used for filesystem discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$OPNS.FS.FSNAME.NOT_MATCHES}'
+          value: ^(/dev|/sys|/run|/proc|.+/shm$)
+          description: 'Used for filesystem discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$OPNS.FS.FSTYPE.MATCHES}'
+          value: ^(btrfs|ext2|ext3|ext4|reiser|xfs|ffs|ufs|jfs|jfs2|vxfs|hfs|apfs|refs|ntfs|fat32|zfs)$
+          description: 'Used for filesystem discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$OPNS.FS.FSTYPE.NOT_MATCHES}'
+          value: ^\s$
+          description: 'Used for filesystem discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$OPNS.FS.PUSED.MAX.CRIT}'
+          value: '95'
+          description: 'The critical threshold of the filesystem utilization.'
+        - macro: '{$OPNS.FS.PUSED.MAX.WARN}'
+          value: '90'
+          description: 'The warning threshold of the filesystem utilization.'
+        - macro: '{$OPNS.GW.HIGH.PACKET.LOSS}'
+          value: '50'
+        - macro: '{$OPNS.GW.MIN.PACKET.LOSS}'
+          value: '10'
+        - macro: '{$OPNS.KEY}'
+        - macro: '{$OPNS.LICENSE.EXPIRY.WARN}'
+          value: '30'
+        - macro: '{$OPNS.MEMORY.UTIL.MAX}'
+          value: '90'
+        - macro: '{$OPNS.NUT.BAT.LOW}'
+          value: '30'
+        - macro: '{$OPNS.NUT.BAT.RUNTIME}'
+          value: '600'
+          description: 'Remaining battery runtime in seconds'
+        - macro: '{$OPNS.NUT.HIGH.LOAD}'
+          value: '80'
+        - macro: '{$OPNS.SECRET}'
+        - macro: '{$OPNS.STATE.TABLE.UTIL.MAX}'
+          value: '90'
+        - macro: '{$OPNS.PORT}'
+          value: '443'
+          description: 'HTTPS API Port'
+        - macro: '{$OPNS.WG.INSTANCE.MATCHES}'
+          value: .+
+          description: 'Regex filter for WireGuard instance discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$OPNS.WG.INSTANCE.NOT_MATCHES}'
+          value: ^$
+          description: 'Regex filter for excluding WireGuard instances from discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$OPNS.WG.PEER.MATCHES}'
+          value: .+
+          description: 'Regex filter for WireGuard peer discovery. Can be overridden on the host or linked template level.'
+        - macro: '{$OPNS.WG.PEER.NOT_MATCHES}'
+          value: ^$
+          description: 'Regex filter for excluding WireGuard peers from discovery. Can be overridden on the host or linked template level.'
+        # --- added from OPNsense by HTTP API (github.com/Garfieldttt/opnsense-zabbix-api) ---
+        - macro: '{$OPNS.CPU.UTIL.WARN}'
+          value: '85'
+          description: Processor utilisation that counts as high, averaged over ten minutes.
+        - macro: '{$OPNS.IF.CONTROL}'
+          value: '1'
+          description: Set to 0, optionally per interface as {$OPNS.IF.CONTROL:"vtnet3"}, to stop the down trigger for interfaces that are allowed to have no link.
+        - macro: '{$OPNS.IF.NAME.NOT_MATCHES}'
+          value: ^(pflog|pfsync|enc|lo)\d*$
+          description: Interfaces that should not be discovered.
+        - macro: '{$OPNS.LOAD.AVG5.WARN}'
+          value: '4'
+          description: Absolute five minute load average that counts as high. Depends on the core count, which is why the per core trigger is usually the better one.
+        - macro: '{$OPNS.LOAD.PERCORE.WARN}'
+          value: '1'
+          description: Five minute load per core that counts as high. A value of 1 means the cores are exactly saturated.
+        - macro: '{$OPNS.MBUF.UTIL.WARN}'
+          value: '80'
+          description: Percentage of the mbuf cluster limit in use that counts as filling up.
+        - macro: '{$OPNS.NTP.OFFSET.WARN}'
+          value: '100'
+          description: Clock offset in milliseconds that counts as high. 100 is generous for a LAN time source and still far below what breaks Kerberos or IPsec.
+        - macro: '{$OPNS.OPENVPN.CONTROL}'
+          value: '1'
+          description: Set to 0, optionally per instance through macro context, to stop the down trigger for instances that are allowed not to run.
+        - macro: '{$OPNS.OPENVPN.ID.NOT_MATCHES}'
+          value: ^$
+          description: Instances or clients excluded from discovery, as a regular expression over the identifier. The default excludes nothing.
+        - macro: '{$OPNS.PF.SRCNODES.UTIL.CRIT}'
+          value: '90'
+          description: Fill level of the source tracking table that counts as critical.
+        - macro: '{$OPNS.PF.TABLES.UTIL.WARN}'
+          value: '80'
+          description: Share of the pf table entry budget that counts as filling up. Relevant where block lists or GeoIP aliases are in use.
+        - macro: '{$OPNS.SERVICE.ID.NOT_MATCHES}'
+          value: ^$
+          description: Services excluded from discovery, as a regular expression over the service identifier. The default excludes nothing.
+        - macro: '{$OPNS.SWAP.UTIL.WARN}'
+          value: '5'
+          description: A firewall should not swap at all, so the default is deliberately low. Can be overridden per device with the device path as context.
+        - macro: '{$OPNS.TEMP.CRIT}'
+          value: '80'
+          description: Temperature threshold in degrees Celsius. Sensors on one board tolerate very different values, so this can be overridden per sensor with the sensor name as context, for example {$OPNS.TEMP.CRIT:"dev.cpu.0.temperature"}.
+      # --- dashboard rebuilt, see merged/dashboard.py ---
+      dashboards:
+        - uuid: 91c43f819db04379b80b032a8f79dea7
+          name: 'OPNsense Info'
+          pages:
+            - name: Overview
+              widgets:
+                - type: gauge
+                  name: Memory
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.memory.util
+                    - type: STRING
+                      name: description
+                      value: Memory utilization
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                - type: gauge
+                  name: State table
+                  x: '18'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.states.util
+                    - type: STRING
+                      name: description
+                      value: pf states
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                - type: gauge
+                  name: Processor
+                  x: '36'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.cpu.util
+                    - type: STRING
+                      name: description
+                      value: CPU utilization
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                - type: gauge
+                  name: Load per core
+                  x: '54'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.system.load.percore
+                    - type: STRING
+                      name: description
+                      value: Load per core
+                    - type: INTEGER
+                      name: max
+                      value: '4'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: ''
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '1'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '2'
+                - type: item
+                  name: CPU load
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.cpu.load
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Uptime
+                  x: '12'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.system.uptime
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Version
+                  x: '24'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.version
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Firmware
+                  x: '36'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.firmware.update.status
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: States in use
+                  x: '48'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.fw.states.current
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: State limit
+                  x: '60'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.fw.states.max
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: svggraph
+                  name: Firewall actions
+                  'y': '6'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '3'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: Firewall action*
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: FWACT
+                - type: honeycomb
+                  name: CARP
+                  x: '36'
+                  'y': '6'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: Carp Status of *
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("Carp Status of (.*)", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: CARPH
+                - type: honeycomb
+                  name: Filesystems
+                  'y': '11'
+                  width: '72'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'FS *: Space: Used, in %'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("FS \[(.*)\]: Space", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: FSHNY
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '90'
+            - name: Packet filter
+              widgets:
+                - type: gauge
+                  name: State table
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.states.util
+                    - type: STRING
+                      name: description
+                      value: State table
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                - type: gauge
+                  name: Source tracking
+                  x: '24'
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.pf.srcnodes.pused
+                    - type: STRING
+                      name: description
+                      value: Source tracking
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                - type: gauge
+                  name: Table entries
+                  x: '48'
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.pf.tables.entries.pused
+                    - type: STRING
+                      name: description
+                      value: Table entries
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                - type: item
+                  name: States in use
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.fw.states.current
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Source nodes
+                  x: '12'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.pf.srcnodes.current
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Table entries
+                  x: '24'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.pf.tables.entries.used
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Filter rules
+                  x: '36'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.pf.rules.filter.count
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: NAT rules
+                  x: '48'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.pf.rules.nat.count
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Rules never matched
+                  x: '60'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.pf.rules.unused
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Ruleset fingerprint
+                  'y': '6'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.pf.rules.fingerprint
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Rule evaluations/s
+                  x: '12'
+                  'y': '6'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.pf.rules.evaluations.rate
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Blocked share of log
+                  x: '24'
+                  'y': '6'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.fwlog.block.pct
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: SYN floods/s
+                  x: '36'
+                  'y': '6'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.pf.synfloods.rate
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: State limit hits/s
+                  x: '48'
+                  'y': '6'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.pf.counter.statelimit.rate
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Source limit hits/s
+                  x: '60'
+                  'y': '6'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.pf.counter.srclimit.rate
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: svggraph
+                  name: State table churn
+                  'y': '9'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '2'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'pf: State table inserts per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'pf: State table removals per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: PFCHU
+                - type: svggraph
+                  name: State table searches
+                  x: '36'
+                  'y': '9'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 8E24AA
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '2'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'pf: State table searches per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: PFSEA
+                - type: svggraph
+                  name: Rule matches and evaluations
+                  'y': '15'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '2'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'pf: Rule matches per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'pf: Rule evaluations per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: PFMAT
+                - type: svggraph
+                  name: Drops and limit hits
+                  x: '36'
+                  'y': '15'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'pf: Packets dropped for memory per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'pf: State limit hits per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: FFD54F
+                    - type: INTEGER
+                      name: ds.2.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: 'pf: Source limit hits per second'
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.3.color
+                      value: 8E24AA
+                    - type: INTEGER
+                      name: ds.3.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.3.items.0
+                      value: 'pf: State mismatches per second'
+                    - type: INTEGER
+                      name: ds.3.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.4.color
+                      value: 00897B
+                    - type: INTEGER
+                      name: ds.4.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.4.items.0
+                      value: 'pf: SYN floods detected per second'
+                    - type: INTEGER
+                      name: ds.4.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.5.color
+                      value: '757575'
+                    - type: INTEGER
+                      name: ds.5.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.5.items.0
+                      value: 'pf: Overload table insertions per second'
+                    - type: INTEGER
+                      name: ds.5.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: PFDRP
+                - type: svggraph
+                  name: Malformed packets
+                  'y': '21'
+                  width: '72'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'pf: Bad offset packets per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'pf: Short packets per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.2.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: 'pf: Fragmented packets per second'
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.3.color
+                      value: 00897B
+                    - type: INTEGER
+                      name: ds.3.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.3.items.0
+                      value: 'pf: Normalized packets per second'
+                    - type: INTEGER
+                      name: ds.3.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: PFMAL
+            - name: Interfaces
+              widgets:
+                - type: honeycomb
+                  name: Link state
+                  width: '72'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Interface *: Link status'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("Interface (.*): Link status", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IFLNK
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: svggraph
+                  name: Traffic
+                  'y': '4'
+                  width: '72'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '3'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'Interface *: Bytes received'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'Interface *: Bytes transmitted'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IFTRF
+                - type: svggraph
+                  name: Blocked bytes IPv4
+                  'y': '10'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: '*blocked bytes INv4'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: '*blocked bytes OUTv4'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IFBLK
+                - type: svggraph
+                  name: Passed bytes IPv4
+                  x: '36'
+                  'y': '10'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: '*passed bytes INv4'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: '*passed bytes OUTv4'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IFPAS
+                - type: svggraph
+                  name: Errors and drops
+                  'y': '16'
+                  width: '72'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'Interface *: Inbound errors'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'Interface *: output errors'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: FFD54F
+                    - type: INTEGER
+                      name: ds.2.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: 'Interface *: input queue drops'
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.3.color
+                      value: 8E24AA
+                    - type: INTEGER
+                      name: ds.3.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.3.items.0
+                      value: 'Interface *: collisions'
+                    - type: INTEGER
+                      name: ds.3.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IFERR
+            - name: Gateways
+              widgets:
+                - type: honeycomb
+                  name: Gateway status
+                  width: '72'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: Gateway Status *
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("Gateway Status (.*)", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: GWYHC
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '4'
+                - type: svggraph
+                  name: Round trip time
+                  'y': '4'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: Gateway RTT *
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: GWRTT
+                - type: svggraph
+                  name: Packet loss
+                  x: '36'
+                  'y': '4'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: Gateway loss *
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: GWLOS
+                - type: svggraph
+                  name: Round trip time deviation
+                  'y': '10'
+                  width: '72'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 8E24AA
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: Gateway RTTd *
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: GWDEV
+            - name: VPN
+              widgets:
+                - type: honeycomb
+                  name: WireGuard peers
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'WireGuard peer *: status'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("WireGuard peer (.*): status", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: WGPHC
+                - type: honeycomb
+                  name: WireGuard instances
+                  x: '36'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'WireGuard instance *: status'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("WireGuard instance (.*): status", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: WGIHC
+                - type: svggraph
+                  name: WireGuard peer traffic
+                  'y': '4'
+                  width: '72'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '3'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'WireGuard peer *: bytes received per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'WireGuard peer *: bytes sent per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: WGTRF
+                - type: honeycomb
+                  name: OpenVPN
+                  'y': '10'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'OpenVPN *: status'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("OpenVPN (.*): status", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: OVPNH
+                - type: svggraph
+                  name: OpenVPN traffic
+                  x: '36'
+                  'y': '10'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '3'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'OpenVPN *: bytes received per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'OpenVPN *: bytes sent per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: OVPNT
+                - type: honeycomb
+                  name: IPsec phase 1
+                  'y': '14'
+                  width: '72'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: '* connected'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("(.*) connected", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IPSHC
+                - type: svggraph
+                  name: IPsec phase 1 traffic
+                  'y': '18'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '3'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: '* bytes per second in'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: '* bytes per second out'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IPS1T
+                - type: svggraph
+                  name: IPsec phase 2 traffic
+                  x: '36'
+                  'y': '18'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '3'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: '* bytes-in per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: '* bytes-out per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IPSTR
+            - name: System
+              widgets:
+                - type: gauge
+                  name: Processor
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.cpu.util
+                    - type: STRING
+                      name: description
+                      value: CPU utilization
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                - type: gauge
+                  name: Memory
+                  x: '24'
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.memory.util
+                    - type: STRING
+                      name: description
+                      value: Memory utilization
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                - type: gauge
+                  name: Load per core
+                  x: '48'
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.system.load.percore
+                    - type: STRING
+                      name: description
+                      value: Load per core
+                    - type: INTEGER
+                      name: max
+                      value: '4'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: ''
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '1'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '2'
+                - type: item
+                  name: Uptime
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.system.uptime
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Version
+                  x: '12'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.version
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Cores
+                  x: '24'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.cpu.cores
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Configuration changed
+                  x: '36'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.config.changed
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Load average 5 min
+                  x: '48'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.system.load.avg5
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Load average 15 min
+                  x: '60'
+                  'y': '3'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.system.load.avg15
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: svggraph
+                  name: Processor utilization
+                  'y': '6'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '3'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'CPU: User time'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '3'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'CPU: System time'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.2.fill
+                      value: '3'
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: 'CPU: Interrupt time'
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.3.color
+                      value: '757575'
+                    - type: INTEGER
+                      name: ds.3.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.3.items.0
+                      value: 'CPU: Utilization'
+                    - type: INTEGER
+                      name: ds.3.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: CPUUT
+                - type: svggraph
+                  name: Load average
+                  x: '36'
+                  'y': '6'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: CPU load
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: Load average (5 min)
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: 8E24AA
+                    - type: INTEGER
+                      name: ds.2.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: Load average (15 min)
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: LOADA
+                - type: honeycomb
+                  name: Temperature sensors
+                  'y': '12'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: Temperature *
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("Temperature (.*)", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: TEMPH
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '65'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '80'
+                - type: honeycomb
+                  name: Swap devices
+                  x: '36'
+                  'y': '12'
+                  width: '36'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Swap *: utilization'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("Swap (.*): utilization", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '13'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: SWAPH
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '5'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '30'
+            - name: Kernel and protocols
+              widgets:
+                - type: gauge
+                  name: mbuf clusters
+                  width: '24'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.mbuf.cluster.pused
+                    - type: STRING
+                      name: description
+                      value: mbuf clusters
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '60'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '80'
+                - type: item
+                  name: Clusters in use
+                  x: '24'
+                  width: '16'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.mbuf.cluster.current
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Denied requests
+                  x: '40'
+                  width: '16'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.mbuf.denied
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: netisr queue drops
+                  x: '56'
+                  width: '16'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.netisr.queue.drops
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: svggraph
+                  name: Kernel network memory
+                  'y': '3'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '3'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'mbuf: Clusters in use'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'mbuf: Denied requests'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: MBUFG
+                - type: svggraph
+                  name: netisr queue drops per protocol
+                  x: '36'
+                  'y': '3'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'netisr *: Queue drops'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '3'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: NETIS
+                - type: svggraph
+                  name: IP errors
+                  'y': '9'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'IP: Packets with a bad checksum per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'IP: Fragments dropped per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.2.color
+                      value: FFD54F
+                    - type: INTEGER
+                      name: ds.2.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.2.items.0
+                      value: 'IP: Packets discarded for lack of a route per second'
+                    - type: INTEGER
+                      name: ds.2.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.3.color
+                      value: 8E24AA
+                    - type: INTEGER
+                      name: ds.3.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.3.items.0
+                      value: 'IP: Packets that cannot be forwarded per second'
+                    - type: INTEGER
+                      name: ds.3.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: IPERR
+                - type: svggraph
+                  name: TCP errors
+                  x: '36'
+                  'y': '9'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E53935
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'TCP: Segments with a bad checksum per second'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: FFA000
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'TCP: Retransmitted segments per second'
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: TCPER
+            - name: Services, clock and power
+              widgets:
+                - type: honeycomb
+                  name: Services
+                  width: '72'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Service *: Running'
+                    - type: STRING
+                      name: primary_label
+                      value: '{{ITEM.NAME}.regsub("Service (.*): Running", "\1")}'
+                    - type: INTEGER
+                      name: primary_label_size
+                      value: '11'
+                    - type: INTEGER
+                      name: primary_label_size_type
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: SVCHC
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '1'
+                - type: item
+                  name: Clock synchronised
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.ntp.synced
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Clock offset
+                  x: '12'
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.ntp.offset
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Stratum
+                  x: '24'
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.ntp.stratum
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: Reachable peers
+                  x: '36'
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.ntp.peers.reachable
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: CARP demotion
+                  x: '48'
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.carp.demotion
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: CARP maintenance
+                  x: '60'
+                  'y': '5'
+                  width: '12'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: opns.carp.maintenance
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: gauge
+                  name: UPS battery
+                  'y': '8'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: nut.battery.charge
+                    - type: STRING
+                      name: description
+                      value: UPS battery
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: E53935
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: FFD54F
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '20'
+                    - type: STRING
+                      name: thresholds.2.color
+                      value: 069C56
+                    - type: STRING
+                      name: thresholds.2.threshold
+                      value: '50'
+                - type: item
+                  name: UPS status
+                  x: '18'
+                  'y': '8'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: nut.status
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: UPS load
+                  x: '36'
+                  'y': '8'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: nut.battery.load
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: UPS runtime
+                  x: '54'
+                  'y': '8'
+                  width: '18'
+                  height: '3'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: OPNsense by REST API
+                        key: nut.battery.runtime
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: svggraph
+                  name: Clock offset
+                  'y': '11'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'NTP: Offset of the selected peer'
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: NTPOF
+                - type: svggraph
+                  name: UPS voltage
+                  x: '36'
+                  'y': '11'
+                  width: '36'
+                  height: '5'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 2774A4
+                    - type: INTEGER
+                      name: ds.0.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: UPS Input Voltage
+                    - type: INTEGER
+                      name: ds.0.width
+                      value: '2'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 069C56
+                    - type: INTEGER
+                      name: ds.1.fill
+                      value: '0'
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: UPS Output Voltage
+                    - type: INTEGER
+                      name: ds.1.width
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_lines
+                      value: '2'
+                    - type: INTEGER
+                      name: legend_statistic
+                      value: '1'
+                    - type: STRING
+                      name: reference
+                      value: UPSVO
+      # --- added from OPNsense by HTTP API (github.com/Garfieldttt/opnsense-zabbix-api) ---
+      valuemaps:
+        - uuid: 1454fbfd0a6345b38f4889113c9fde4c
+          name: Enabled state
+          mappings:
+            - value: '0'
+              newvalue: 'No'
+            - value: '1'
+              newvalue: 'Yes'
+        - uuid: e59405e3f9a3432381462664570c241f
+          name: Link status
+          mappings:
+            - value: '0'
+              newvalue: Down
+            - value: '1'
+              newvalue: Up
+        - uuid: 503105673fd1482cb9f042bf471a1f13
+          name: NTP sync state
+          mappings:
+            - value: '0'
+              newvalue: Not synchronised
+            - value: '1'
+              newvalue: Synchronised
+        - uuid: 8705f47d15f74ee78d30e88b4748dc5c
+          name: Service state
+          mappings:
+            - value: '0'
+              newvalue: Stopped
+            - value: '1'
+              newvalue: Running


### PR DESCRIPTION
## OPNsense by REST API

A second OPNsense template next to `OPNsense by HTTP-JSON`, derived from it and considerably
wider. It carries its own name and its own uuids, so both can be linked to the same host and
importing one does not touch the other.

Everything below was measured against a live OPNsense 26.7 with a restricted monitoring key,
not taken from the documentation.

### What it adds over the template it grew out of

- processor utilisation split into user, system and interrupt, core count and load per core
- the packet filter in depth: state and source tracking tables with their limits, pf counters,
  table entries against the configured ceiling, and the loaded ruleset with size, fingerprint,
  evaluation rate and unmatched rules
- kernel network memory and mbuf clusters, netisr queue drops per protocol, IP and TCP
  protocol error rates
- clock synchronisation with offset, stratum and reachable peers
- service run state, swap per device and temperature per sensor, each discovered
- inbound errors and link state per interface, and the blocked share of the firewall log
- a dashboard of eight pages in place of three

107 items, 14 discovery rules with 70 item prototypes, 52 triggers, 36 macros.

### Three defects of the original are fixed here rather than carried over

| What | Why it failed |
|------|---------------|
| `diagnostics/firewall/pfStates` and `diagnostics/system/systemResources` | The privilege patterns are `pf_states` and `system_resources`, exact rather than wildcards, and `ACL.php` matches them with `preg_match` without the `i` modifier. An administrator key never notices, a monitoring key gets HTTP 403 on the firewall state items, the state table utilization and all memory items |
| IPsec phase 2 | `searchPhase2Action` reads its connection from `getPost('id')` and the template asked with a plain GET, so phase 2 could only ever return an empty row set. It is an item prototype inside the phase 1 rule now, posting one request per connection |
| Gateway without a monitor address | The API answers with a tilde for round trip time, loss and deviation, which was substituted with the literal 9999. That landed in history and made the gateway graphs unreadable. The reading is discarded instead, and the trigger that reports the disabled monitoring is Info rather than Average, since switching it off is a configuration decision |

### Compatibility

The export declares format **7.0** rather than 7.4, so it imports into Zabbix 7.0 and every
later release. Every widget type it uses (gauge, honeycomb, item, svggraph) exists in 7.0.

### Privileges

The README lists the ten privileges the monitoring user needs with their internal ids. Eight
are read only. It also says what the other two permit and how to do without them.

### Licensing

Derived from `OPNsense by HTTP-JSON` in this repository, MIT, Copyright (c) 2021 Zabbix. The
notice travels with it, in the template description and in the README.

Maintained at https://github.com/Garfieldttt/opnsense-zabbix-template.
