### PR TITLE
Add template: Parks OLT Health by SNMP (7.0)

### DIFF
--- a/Network_Devices/Parks/template_parks_olt_health_by_snmp/7.0/README.md
+++ b/Network_Devices/Parks/template_parks_olt_health_by_snmp/7.0/README.md
@@ -1,0 +1,79 @@
+# Parks OLT Health by SNMP
+
+## Overview
+
+Basic health template for PARKS Fiberlink OLTs (tested on PARKS Fiberlink 30028 - firmware 6.2.0).
+
+It monitors:
+
+- CPU utilization
+- Memory (total / used / utilization)
+- Internal unit temperature
+- SFP GPON temperature (per port, via low-level discovery)
+- Device uptime
+
+OIDs were taken from the vendor Generic SNMP Parks MIB. The SFP temperature table
+(`.1.3.6.1.4.1.3893.1.21.1.1.1.14`, `pkSfpDiagTemperature`) is indexed by port, so it is
+collected through an LLD rule instead of fixed per-port items.
+
+## Requirements
+
+- Zabbix version: 7.0
+- SNMPv2 interface on the host, with a valid read community.
+
+## Setup
+
+1. Import the template into Zabbix (*Data collection* → *Templates* → *Import*).
+2. Link the template to a host that has an **SNMPv2 interface** configured.
+3. Set the read community on the host (macro `{$SNMP_COMMUNITY}`).
+4. Adjust the threshold macros below if the defaults do not fit your deployment.
+
+## Author
+
+Josivan Pigozzo (RouterX) — https://github.com/JosivanPigozzo
+
+## Macros used
+
+|Name|Description|Default|
+|----|-----------|-------|
+|{$OLT.CPU.UTIL.WARN}|CPU utilization warning threshold, in %.|`55`|
+|{$OLT.CPU.UTIL.CRIT}|CPU utilization critical threshold, in %.|`80`|
+|{$OLT.MEMORY.UTIL.MAX}|Memory utilization warning threshold, in %.|`90`|
+|{$OLT.TEMP.HIGH}|Internal temperature warning threshold, in °C.|`60`|
+|{$OLT.TEMP.CRIT}|Internal temperature critical threshold, in °C (fires above this value).|`80`|
+|{$OLT.TEMP.CRIT.RESET}|Internal temperature at which the critical problem recovers, in °C (hysteresis).|`79`|
+|{$OLT.SFP.TEMP.HIGH}|SFP GPON temperature warning threshold, in °C.|`70`|
+
+## Items collected
+
+|Name|Key|Type|
+|----|---|----|
+|CPU utilization|`olt.cpu.utilization`|SNMP agent|
+|Memory total|`olt.memory.total`|SNMP agent|
+|Memory used|`olt.memory.used`|SNMP agent|
+|Memory utilization|`olt.memory.utilization`|Calculated|
+|Temperature internal unit|`olt.temperature.internal`|SNMP agent|
+|Uptime|`olt.uptime`|SNMP agent|
+
+## Discovery rules
+
+|Name|Key|Description|
+|----|---|-----------|
+|SFP GPON temperature discovery|`olt.sfp.temp.discovery`|Discovers GPON SFP indexes exposing a temperature reading (`pkSfpDiagTemperature`) and creates a per-port temperature item and trigger.|
+
+## Triggers
+
+|Name|Severity|Expression|
+|----|--------|----------|
+|OLT: High CPU utilization|Warning|CPU over `{$OLT.CPU.UTIL.WARN}`% for 5m|
+|OLT: Critical CPU utilization|High|CPU over `{$OLT.CPU.UTIL.CRIT}`% for 5m|
+|OLT: High memory utilization|Average|Memory over `{$OLT.MEMORY.UTIL.MAX}`% for 5m|
+|OLT: High internal temperature|High|Internal temperature over `{$OLT.TEMP.HIGH}`°C for 5m|
+|OLT: Critical internal temperature|Disaster|Internal temperature over `{$OLT.TEMP.CRIT}`°C, recovers below `{$OLT.TEMP.CRIT.RESET}`°C (hysteresis)|
+|OLT: High temperature on SFP GPON {#SNMPINDEX}|High|SFP GPON temperature over `{$OLT.SFP.TEMP.HIGH}`°C|
+|OLT: Has been restarted|Warning|Uptime < 10m|
+
+## License
+
+This template is distributed under the MIT License, in accordance with the Zabbix
+community-templates repository policy.

--- a/Network_Devices/Parks/template_parks_olt_health_by_snmp/7.0/template_parks_olt_health_by_snmp.yaml
+++ b/Network_Devices/Parks/template_parks_olt_health_by_snmp/7.0/template_parks_olt_health_by_snmp.yaml
@@ -1,0 +1,214 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: ce093654f29a4689854dcc0d10ff57d8
+      name: 'Templates/Network devices'
+  templates:
+    - uuid: b04a93e6defe46dea0acfa8637a1dea2
+      template: 'Parks OLT Health by SNMP'
+      name: 'Parks OLT Health by SNMP'
+      description: |
+        Template basica de saude para OLTs PARKS Fiberlink (ex.: PARKS Fiberlink 30028 - Version 6.2.0).
+
+        Monitora: CPU, memoria, temperatura interna, temperatura dos SFPs GPON (via LLD) e uptime.
+
+        OIDs extraidos dos templates originais 257consultoria (Template Module Generic SNMP Parks / Template OLTs Parks V1.0).
+        Tabela de temperatura de SFP (.1.3.6.1.4.1.3893.1.21.1.1.1.14) confirmada como indexada por porta -> convertida em LLD
+        no lugar dos itens fixos GPON x/x SFP Temp do template original.
+      groups:
+        - name: 'Templates/Network devices'
+      items:
+        - uuid: 938452ff3dfe4275923f68f88f8273b0
+          name: 'CPU utilization'
+          type: SNMP_AGENT
+          snmp_oid: 'get[1.3.6.1.4.1.3893.4.4.1.2.0]'
+          key: olt.cpu.utilization
+          value_type: FLOAT
+          units: '%'
+          description: 'CpuSystem (Generic SNMP Parks MIB). Valor bruto em decimos de %.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.1'
+          tags:
+            - tag: component
+              value: cpu
+          triggers:
+            - uuid: 6eea37543d894f35a701fe90c89c7c74
+              expression: 'min(/Parks OLT Health by SNMP/olt.cpu.utilization,5m)>{$OLT.CPU.UTIL.WARN}'
+              name: 'OLT: High CPU utilization'
+              event_name: 'OLT: High CPU utilization (over {$OLT.CPU.UTIL.WARN}% for 5m)'
+              priority: WARNING
+              tags:
+                - tag: scope
+                  value: performance
+            - uuid: 9dde6edb098940b6b58b9e7993836bd7
+              expression: 'min(/Parks OLT Health by SNMP/olt.cpu.utilization,5m)>{$OLT.CPU.UTIL.CRIT}'
+              name: 'OLT: Critical CPU utilization'
+              event_name: 'OLT: Critical CPU utilization (over {$OLT.CPU.UTIL.CRIT}% for 5m)'
+              priority: HIGH
+              tags:
+                - tag: scope
+                  value: performance
+        - uuid: af4382d70ffd4340b35362d7cfc6e054
+          name: 'Memory total'
+          type: SNMP_AGENT
+          snmp_oid: 'get[1.3.6.1.4.1.3893.4.4.2.1.0]'
+          key: olt.memory.total
+          units: B
+          description: 'MemoryTotal (Generic SNMP Parks MIB). Valor bruto em KB.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 45ff3988abf64387bde3f1a16c9f635c
+          name: 'Memory used'
+          type: SNMP_AGENT
+          snmp_oid: 'get[1.3.6.1.4.1.3893.4.4.2.3.0]'
+          key: olt.memory.used
+          units: B
+          description: 'MemoryUsed (Generic SNMP Parks MIB). Valor bruto em KB.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: d60f4c8492d74691b174cbe9c5f9d3a7
+          name: 'Memory utilization'
+          type: CALCULATED
+          key: olt.memory.utilization
+          value_type: FLOAT
+          units: '%'
+          params: 'last(//olt.memory.used) * 100 / last(//olt.memory.total)'
+          description: 'Percentual de memoria utilizada, calculado a partir de olt.memory.used e olt.memory.total.'
+          tags:
+            - tag: component
+              value: memory
+          triggers:
+            - uuid: 633f697537904bd19a0fc1febd92864f
+              expression: 'min(/Parks OLT Health by SNMP/olt.memory.utilization,5m)>{$OLT.MEMORY.UTIL.MAX}'
+              name: 'OLT: High memory utilization'
+              event_name: 'OLT: High memory utilization (over {$OLT.MEMORY.UTIL.MAX}% for 5m)'
+              priority: AVERAGE
+              tags:
+                - tag: scope
+                  value: performance
+        - uuid: 9b8c2b232a3a467baf3deb16e3403a93
+          name: 'Temperature internal unit'
+          type: SNMP_AGENT
+          snmp_oid: 'get[1.3.6.1.4.1.3893.1.27.1.1.3.2]'
+          key: olt.temperature.internal
+          value_type: FLOAT
+          units: °C
+          description: 'pkintunitTemperature (Generic SNMP Parks MIB).'
+          tags:
+            - tag: component
+              value: temperature
+          triggers:
+            - uuid: caa7d0d8e0644bfdac6889dfe2250893
+              expression: 'min(/Parks OLT Health by SNMP/olt.temperature.internal,5m)>{$OLT.TEMP.HIGH}'
+              name: 'OLT: High internal temperature'
+              event_name: 'OLT: High internal temperature (over {$OLT.TEMP.HIGH}°C for 5m)'
+              priority: HIGH
+              tags:
+                - tag: scope
+                  value: availability
+            - uuid: c941a314129d4f618f52fa601ffd25cb
+              expression: 'last(/Parks OLT Health by SNMP/olt.temperature.internal)>{$OLT.TEMP.CRIT}'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'last(/Parks OLT Health by SNMP/olt.temperature.internal)<{$OLT.TEMP.CRIT.RESET}'
+              name: 'OLT: Critical internal temperature'
+              event_name: 'OLT: Critical internal temperature (over {$OLT.TEMP.CRIT}°C, recovers below {$OLT.TEMP.CRIT.RESET}°C)'
+              priority: DISASTER
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: 3f529a4c7c3e4b1586d0330437d43004
+          name: 'Uptime'
+          type: SNMP_AGENT
+          snmp_oid: 'get[1.3.6.1.2.1.1.3.0]'
+          key: olt.uptime
+          units: uptime
+          description: 'sysUpTime (SNMPv2-MIB). Valor bruto em centesimos de segundo.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.01'
+          tags:
+            - tag: component
+              value: general
+          triggers:
+            - uuid: 64414cad9538415e9a3a66d80f334760
+              expression: 'last(/Parks OLT Health by SNMP/olt.uptime)<10m'
+              name: 'OLT: Has been restarted'
+              event_name: 'OLT: Has been restarted (uptime < 10m)'
+              priority: WARNING
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+      discovery_rules:
+        - uuid: 39ce083967424e7f99a7d14101abdeb8
+          name: 'SFP GPON temperature discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},1.3.6.1.4.1.3893.1.21.1.1.1.14]'
+          key: olt.sfp.temp.discovery
+          delay: 1h
+          description: 'Descobre os indices de SFP GPON com leitura de temperatura (pkSfpDiagTemperature), tabela .1.3.6.1.4.1.3893.1.21.1.1.1.14.'
+          item_prototypes:
+            - uuid: 41fce50c09e5431ba6f496f06c3c78f4
+              name: 'SFP GPON {#SNMPINDEX}: Temperature'
+              type: SNMP_AGENT
+              snmp_oid: 'get[1.3.6.1.4.1.3893.1.21.1.1.1.14.{#SNMPINDEX}]'
+              key: 'olt.sfp.temp[{#SNMPINDEX}]'
+              value_type: FLOAT
+              units: °C
+              description: 'pkSfpDiagTemperature.{#SNMPINDEX}. Valor bruto em centesimos de grau.'
+              preprocessing:
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.01'
+              tags:
+                - tag: component
+                  value: temperature
+              trigger_prototypes:
+                - uuid: 6eca7da8371246a8903f643b15872841
+                  expression: 'min(/Parks OLT Health by SNMP/olt.sfp.temp[{#SNMPINDEX}],5m)>{$OLT.SFP.TEMP.HIGH}'
+                  name: 'OLT: High temperature on SFP GPON {#SNMPINDEX}'
+                  event_name: 'OLT: High temperature on SFP GPON {#SNMPINDEX} (over {$OLT.SFP.TEMP.HIGH}°C)'
+                  priority: HIGH
+                  tags:
+                    - tag: scope
+                      value: availability
+      tags:
+        - tag: class
+          value: network
+        - tag: target
+          value: parks-olt
+      macros:
+        - macro: '{$OLT.CPU.UTIL.WARN}'
+          value: '55'
+          description: 'Limiar de alerta de CPU em %.'
+        - macro: '{$OLT.CPU.UTIL.CRIT}'
+          value: '80'
+          description: 'Limiar critico de CPU em %.'
+        - macro: '{$OLT.MEMORY.UTIL.MAX}'
+          value: '90'
+          description: 'Limiar de alerta de uso de memoria em %.'
+        - macro: '{$OLT.TEMP.HIGH}'
+          value: '60'
+          description: 'Limiar de alerta de temperatura interna em °C.'
+        - macro: '{$OLT.TEMP.CRIT}'
+          value: '80'
+          description: 'Limiar critico de temperatura interna em °C (dispara acima deste valor).'
+        - macro: '{$OLT.TEMP.CRIT.RESET}'
+          value: '79'
+          description: 'Temperatura interna em °C para recuperar o alerta critico (histerese).'
+        - macro: '{$OLT.SFP.TEMP.HIGH}'
+          value: '70'
+          description: 'Limiar de alerta de temperatura de SFP GPON em °C.'


### PR DESCRIPTION
## New template: Parks OLT Health by SNMP

Adds a basic SNMP health template for **PARKS Fiberlink OLTs** (tested on PARKS Fiberlink 30028, firmware 6.2.0).

**Path:** `Network_Devices/Parks/template_parks_olt_health_by_snmp/7.0/`

### What it monitors
- CPU utilization
- Memory: total / used / utilization (calculated)
- Internal unit temperature
- SFP GPON temperature per port (via low-level discovery on `pkSfpDiagTemperature`)
- Uptime

### Triggers
CPU (warning/critical), memory, SFP temperature, device restart, and two internal-temperature triggers:
a warning at `{$OLT.TEMP.HIGH}` and a **Disaster** trigger with hysteresis that fires above
`{$OLT.TEMP.CRIT}` (80 °C) and recovers below `{$OLT.TEMP.CRIT.RESET}` (79 °C).

All thresholds are exposed as user macros.

### Compliance with the contribution guidelines
- Zabbix **7.0** YAML export, placed in a `7.0/` version folder.
- Template folder name matches `^template_[.a-zA-Z0-9()_-]+$`.
- Single template file per version folder; `README.md` included.
- Imports without errors on a clean Zabbix 7.0 install; no external template links.
- Distributed under the **MIT License**.
