### PR TITLE
Add PARKS OLT Health by SNMP template

### DIFF
--- a/Network_Devices/Parks/template_parks_olt_health_by_snmp/7.0/README.md
+++ b/Network_Devices/Parks/template_parks_olt_health_by_snmp/7.0/README.md
@@ -1,0 +1,58 @@
+# Parks OLT Health by SNMP
+
+## Overview
+
+Basic SNMP health template for PARKS Fiberlink OLTs.
+
+Tested on PARKS Fiberlink 30028 with firmware 6.2.0.
+
+## What it monitors
+
+- CPU utilization
+- Memory total
+- Memory used
+- Memory utilization (calculated)
+- Internal unit temperature
+- GPON SFP temperature per port using low-level discovery
+- Uptime
+
+## Triggers
+
+- High and critical CPU utilization
+- High memory utilization
+- High GPON SFP temperature
+- High internal temperature
+- Critical internal temperature with hysteresis
+- Device restart
+
+## Macros
+
+| Macro | Default | Description |
+|---|---:|---|
+| `{$OLT.CPU.UTIL.CRIT}` | `80` | Critical CPU utilization threshold in %. |
+| `{$OLT.CPU.UTIL.WARN}` | `55` | Warning CPU utilization threshold in %. |
+| `{$OLT.MEMORY.UTIL.MAX}` | `90` | Memory utilization warning threshold in %. |
+| `{$OLT.SFP.TEMP.HIGH}` | `70` | High GPON SFP temperature threshold in °C. |
+| `{$OLT.TEMP.CRIT}` | `80` | Critical internal temperature threshold in °C. |
+| `{$OLT.TEMP.CRIT.RESET}` | `79` | Internal temperature threshold for critical trigger recovery. |
+| `{$OLT.TEMP.HIGH}` | `60` | High internal temperature warning threshold in °C. |
+
+## Configuration
+
+Configure the SNMP interface on the monitored OLT and provide the appropriate SNMP community or SNMP credentials for the device.
+
+The template has no external template links and can be imported into a clean Zabbix 7.0 installation.
+
+## Notes
+
+The OIDs were extracted from the original 257consultoria templates (Template Module Generic SNMP Parks / Template OLTs Parks V1.0).
+
+The SFP temperature table `.1.3.6.1.4.1.3893.1.21.1.1.1.14` was confirmed to be indexed by port and is collected using low-level discovery instead of fixed GPON SFP temperature items.
+
+## Author
+
+luiz-camillo
+
+## License
+
+MIT License, consistent with the license of the Zabbix Community Templates repository.

--- a/Network_Devices/Parks/template_parks_olt_health_by_snmp/7.0/template_parks_olt_health_by_snmp.yaml
+++ b/Network_Devices/Parks/template_parks_olt_health_by_snmp/7.0/template_parks_olt_health_by_snmp.yaml
@@ -1,0 +1,216 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: ce093654f29a4689854dcc0d10ff57d8
+      name: 'Templates/Network devices'
+  templates:
+    - uuid: b04a93e6defe46dea0acfa8637a1dea2
+      template: 'Parks OLT Health by SNMP'
+      name: 'Parks OLT Health by SNMP'
+      description: |
+        Basic health template for PARKS Fiberlink OLTs (e.g. PARKS Fiberlink 30028, firmware 6.2.0).
+
+        Monitors CPU, memory, internal temperature, GPON SFP temperature (via LLD), and uptime.
+
+        OIDs were extracted from the original 257consultoria templates (Template Module Generic SNMP Parks / Template OLTs Parks V1.0).
+        The SFP temperature table (.1.3.6.1.4.1.3893.1.21.1.1.1.14) was confirmed to be indexed by port and converted to LLD
+        instead of using fixed GPON SFP temperature items from the original template.
+
+        Author: luiz-camillo
+      groups:
+        - name: 'Templates/Network devices'
+      items:
+        - uuid: 938452ff3dfe4275923f68f88f8273b0
+          name: 'CPU utilization'
+          type: SNMP_AGENT
+          snmp_oid: 'get[1.3.6.1.4.1.3893.4.4.1.2.0]'
+          key: olt.cpu.utilization
+          value_type: FLOAT
+          units: '%'
+          description: 'CpuSystem (Generic SNMP Parks MIB). Raw value in tenths of a percent.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.1'
+          tags:
+            - tag: component
+              value: cpu
+          triggers:
+            - uuid: 9dde6edb098940b6b58b9e7993836bd7
+              expression: 'min(/Parks OLT Health by SNMP/olt.cpu.utilization,5m)>{$OLT.CPU.UTIL.CRIT}'
+              name: 'OLT: Critical CPU utilization'
+              event_name: 'OLT: Critical CPU utilization (over {$OLT.CPU.UTIL.CRIT}% for 5m)'
+              priority: HIGH
+              tags:
+                - tag: scope
+                  value: performance
+            - uuid: 6eea37543d894f35a701fe90c89c7c74
+              expression: 'min(/Parks OLT Health by SNMP/olt.cpu.utilization,5m)>{$OLT.CPU.UTIL.WARN}'
+              name: 'OLT: High CPU utilization'
+              event_name: 'OLT: High CPU utilization (over {$OLT.CPU.UTIL.WARN}% for 5m)'
+              priority: WARNING
+              tags:
+                - tag: scope
+                  value: performance
+        - uuid: af4382d70ffd4340b35362d7cfc6e054
+          name: 'Memory total'
+          type: SNMP_AGENT
+          snmp_oid: 'get[1.3.6.1.4.1.3893.4.4.2.1.0]'
+          key: olt.memory.total
+          units: B
+          description: 'MemoryTotal (Generic SNMP Parks MIB). Raw value in KB.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 45ff3988abf64387bde3f1a16c9f635c
+          name: 'Memory used'
+          type: SNMP_AGENT
+          snmp_oid: 'get[1.3.6.1.4.1.3893.4.4.2.3.0]'
+          key: olt.memory.used
+          units: B
+          description: 'MemoryUsed (Generic SNMP Parks MIB). Raw value in KB.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '1024'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: d60f4c8492d74691b174cbe9c5f9d3a7
+          name: 'Memory utilization'
+          type: CALCULATED
+          key: olt.memory.utilization
+          value_type: FLOAT
+          units: '%'
+          params: 'last(//olt.memory.used) * 100 / last(//olt.memory.total)'
+          description: 'Memory utilization percentage calculated from olt.memory.used and olt.memory.total.'
+          tags:
+            - tag: component
+              value: memory
+          triggers:
+            - uuid: 633f697537904bd19a0fc1febd92864f
+              expression: 'min(/Parks OLT Health by SNMP/olt.memory.utilization,5m)>{$OLT.MEMORY.UTIL.MAX}'
+              name: 'OLT: High memory utilization'
+              event_name: 'OLT: High memory utilization (over {$OLT.MEMORY.UTIL.MAX}% for 5m)'
+              priority: AVERAGE
+              tags:
+                - tag: scope
+                  value: performance
+        - uuid: 9b8c2b232a3a467baf3deb16e3403a93
+          name: 'Temperature internal unit'
+          type: SNMP_AGENT
+          snmp_oid: 'get[1.3.6.1.4.1.3893.1.27.1.1.3.2]'
+          key: olt.temperature.internal
+          value_type: FLOAT
+          units: '°C'
+          description: 'pkintunitTemperature (Generic SNMP Parks MIB).'
+          tags:
+            - tag: component
+              value: 'internal temperature'
+          triggers:
+            - uuid: c941a314129d4f618f52fa601ffd25cb
+              expression: 'last(/Parks OLT Health by SNMP/olt.temperature.internal)>{$OLT.TEMP.CRIT}'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'last(/Parks OLT Health by SNMP/olt.temperature.internal)<{$OLT.TEMP.CRIT.RESET}'
+              name: 'OLT: Critical internal temperature'
+              event_name: 'OLT: Critical internal temperature (over {$OLT.TEMP.CRIT}°C, recovers below {$OLT.TEMP.CRIT.RESET}°C)'
+              priority: DISASTER
+              tags:
+                - tag: scope
+                  value: availability
+            - uuid: caa7d0d8e0644bfdac6889dfe2250893
+              expression: 'min(/Parks OLT Health by SNMP/olt.temperature.internal,5m)>{$OLT.TEMP.HIGH}'
+              name: 'OLT: High internal temperature'
+              event_name: 'OLT: High internal temperature (over {$OLT.TEMP.HIGH}°C for 5m)'
+              priority: HIGH
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: 3f529a4c7c3e4b1586d0330437d43004
+          name: Uptime
+          type: SNMP_AGENT
+          snmp_oid: 'get[1.3.6.1.2.1.1.3.0]'
+          key: olt.uptime
+          units: uptime
+          description: 'sysUpTime (SNMPv2-MIB). Raw value in hundredths of a second.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.01'
+          tags:
+            - tag: component
+              value: general
+          triggers:
+            - uuid: 64414cad9538415e9a3a66d80f334760
+              expression: 'last(/Parks OLT Health by SNMP/olt.uptime)<10m'
+              name: 'OLT: Has been restarted'
+              event_name: 'OLT: Has been restarted (uptime < 10m)'
+              priority: WARNING
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+      discovery_rules:
+        - uuid: 39ce083967424e7f99a7d14101abdeb8
+          name: 'SFP GPON temperature discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#SNMPVALUE},1.3.6.1.4.1.3893.1.21.1.1.1.14]'
+          key: olt.sfp.temp.discovery
+          delay: 1h
+          description: 'Discovers GPON SFP temperature indexes using the pkSfpDiagTemperature table .1.3.6.1.4.1.3893.1.21.1.1.1.14.'
+          item_prototypes:
+            - uuid: 41fce50c09e5431ba6f496f06c3c78f4
+              name: 'SFP GPON {#SNMPINDEX}: Temperature'
+              type: SNMP_AGENT
+              snmp_oid: 'get[1.3.6.1.4.1.3893.1.21.1.1.1.14.{#SNMPINDEX}]'
+              key: 'olt.sfp.temp[{#SNMPINDEX}]'
+              value_type: FLOAT
+              units: '°C'
+              description: 'pkSfpDiagTemperature.{#SNMPINDEX}. Raw value in hundredths of a degree.'
+              preprocessing:
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.01'
+              tags:
+                - tag: component
+                  value: temperature
+              trigger_prototypes:
+                - uuid: 6eca7da8371246a8903f643b15872841
+                  expression: 'min(/Parks OLT Health by SNMP/olt.sfp.temp[{#SNMPINDEX}],5m)>{$OLT.SFP.TEMP.HIGH}'
+                  name: 'OLT: High temperature on SFP GPON {#SNMPINDEX}'
+                  event_name: 'OLT: High temperature on SFP GPON {#SNMPINDEX} (over {$OLT.SFP.TEMP.HIGH}°C)'
+                  priority: HIGH
+                  tags:
+                    - tag: scope
+                      value: availability
+      tags:
+        - tag: class
+          value: network
+        - tag: target
+          value: parks-olt
+      macros:
+        - macro: '{$OLT.CPU.UTIL.CRIT}'
+          value: '80'
+          description: 'Critical CPU utilization threshold in %.'
+        - macro: '{$OLT.CPU.UTIL.WARN}'
+          value: '55'
+          description: 'Warning CPU utilization threshold in %.'
+        - macro: '{$OLT.MEMORY.UTIL.MAX}'
+          value: '90'
+          description: 'Memory utilization warning threshold in %.'
+        - macro: '{$OLT.SFP.TEMP.HIGH}'
+          value: '70'
+          description: 'High GPON SFP temperature threshold in °C.'
+        - macro: '{$OLT.TEMP.CRIT}'
+          value: '80'
+          description: 'Critical internal temperature threshold in °C.'
+        - macro: '{$OLT.TEMP.CRIT.RESET}'
+          value: '79'
+          description: 'Internal temperature threshold in °C for critical trigger recovery (hysteresis).'
+        - macro: '{$OLT.TEMP.HIGH}'
+          value: '60'
+          description: 'High internal temperature warning threshold in °C.'


### PR DESCRIPTION
## Description

Adds a basic SNMP health template for PARKS Fiberlink OLTs.

### Tested on

* PARKS Fiberlink 30028
* Firmware 6.2.0

The template provides basic health monitoring for PARKS Fiberlink OLT devices via SNMP.
