### PR TITLE
Add Zabbix templates for HP LaserJet MFP printers (E78630, E42540, X57945)

### DIFF
--- a/Printers/HP/template_hp_color_laserjet_mfp_e78630/7.0/README.md
+++ b/Printers/HP/template_hp_color_laserjet_mfp_e78630/7.0/README.md
@@ -1,0 +1,82 @@
+# HP Color LaserJet MFP E78630 by SNMP
+
+## Overview
+
+Monitors an HP Color LaserJet MFP E78630 (and compatible HP Enterprise/Managed printers) over SNMP, using only the standard **Printer-MIB (RFC 3805)** and **Host Resources MIB**. No vendor-specific/private MIB is required for the core metrics, so this template will generally also work — as-is or with minimal changes — on other HP Enterprise/Managed printers that expose the same standard MIBs.
+
+Author: YOUR_NAME_OR_GITHUB_USERNAME (replace before submitting)
+
+## Requirements
+
+- Zabbix version: 7.0
+- SNMP (v1/v2c, tested with v2c) enabled on the printer, with a community string configured (default macro value: `public`)
+- Printer must support Printer-MIB (RFC 3805) and Host Resources MIB (standard on virtually all network-attached HP LaserJet/Enterprise printers)
+
+## Tested versions
+
+- HP Color LaserJet MFP E78630
+
+## Setup
+
+1. Import the template into Zabbix.
+2. Create a host for the printer, add an **SNMP interface** (port 161).
+3. Link the template `HP Color LaserJet MFP E78630 SNMP` to the host.
+4. If the printer's SNMP community string is not `public`, override the `{$SNMP_COMMUNITY}` macro at the host level.
+5. Wait for the discovery rules to run (or trigger them manually via **Execute now**) so that consumables, paper trays, and active alerts are discovered.
+
+## Macros
+
+| Macro | Default | Description |
+|---|---|---|
+| `{$SNMP_COMMUNITY}` | `public` | SNMP community string |
+| `{$SUPPLY.LOW.WARN}` | `20` | Consumable level (%) threshold for a WARNING trigger |
+| `{$SUPPLY.LOW.CRIT}` | `8` | Consumable level (%) threshold for a HIGH (critical) trigger |
+
+## Items collected
+
+- Device model, serial number, system name
+- Device status (`hrDeviceStatus`: running / warning / down)
+- Total pages printed (lifetime engine cycle counter, and its per-second rate)
+- Total monochrome / color impressions (lifetime, HP private MIB — matches the "Grand Total" row on the printer's Usage Page)
+
+### Discovery rule: Consumables (toner/supplies) discovery
+
+Auto-discovers every consumable reported via `prtMarkerSuppliesTable` (toner cartridges, drums, developer units, fuser kit, transfer belt/cleaning unit, document feeder kit, etc.). For each discovered consumable:
+
+- Level (raw, `prtMarkerSuppliesLevel`)
+- Max capacity (`prtMarkerSuppliesMaxCapacity`)
+- Level percent (calculated)
+- A graph showing level (%) over time
+
+### Discovery rule: Paper trays discovery
+
+Auto-discovers every paper tray reported via `prtInputTable`. For each tray:
+
+- Current level
+- Max capacity
+- Status (`prtInputStatus`)
+- A graph showing current level over time
+
+### Discovery rule: Active alerts discovery
+
+Auto-discovers currently active device conditions/alerts via `prtAlertTable` (e.g. toner low, tray empty, cover open, paper jam). This reflects the **live** state — items only exist while the condition is active. It does **not** provide a historical event log (HP does not expose the historical Event Log page via standard SNMP); Zabbix's own Problems history serves as the closest equivalent once triggers have fired at least once.
+
+## Triggers
+
+- Device is in DOWN status
+- Device is in WARNING status
+- `{consumable}` is low / critically low (based on `{$SUPPLY.LOW.WARN}` / `{$SUPPLY.LOW.CRIT}`)
+- `{tray}` reports an issue (empty/jam/offline)
+- `{alert}` (critical) / `{alert}` (warning) / `{alert}` (info) — from the active alerts discovery
+
+## Dashboard
+
+A template dashboard ("HP E78630 Overview") is included with:
+- Graph grid of all discovered consumable levels (%)
+- Graph grid of all discovered tray levels
+- Device status, model, serial number, and total page count widgets
+
+## Known limitations
+
+- The detailed Usage Page breakdown by job type (Print/Copy/Fax) is **not** available via standard SNMP; only the combined lifetime monochrome/color totals could be confirmed against a real device (see "Total monochrome/color impressions" above).
+- Values are only as fresh as the item's polling interval (default 5 minutes for supply/tray levels); they are not push/real-time.

--- a/Printers/HP/template_hp_color_laserjet_mfp_e78630/7.0/README.md
+++ b/Printers/HP/template_hp_color_laserjet_mfp_e78630/7.0/README.md
@@ -4,7 +4,7 @@
 
 Monitors an HP Color LaserJet MFP E78630 (and compatible HP Enterprise/Managed printers) over SNMP, using only the standard **Printer-MIB (RFC 3805)** and **Host Resources MIB**. No vendor-specific/private MIB is required for the core metrics, so this template will generally also work — as-is or with minimal changes — on other HP Enterprise/Managed printers that expose the same standard MIBs.
 
-Author: YOUR_NAME_OR_GITHUB_USERNAME (replace before submitting)
+Author: github.com/ikbalr
 
 ## Requirements
 

--- a/Printers/HP/template_hp_color_laserjet_mfp_e78630/7.0/template_hp_color_laserjet_mfp_e78630.xml
+++ b/Printers/HP/template_hp_color_laserjet_mfp_e78630/7.0/template_hp_color_laserjet_mfp_e78630.xml
@@ -1,0 +1,643 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>7.0</version>
+    <template_groups>
+        <template_group>
+            <uuid>e51ea90bb4c745068d52860dee5504d3</uuid>
+            <name>Templates/Network devices</name>
+        </template_group>
+    </template_groups>
+    <templates>
+        <template>
+            <uuid>8cbcb8212a5b4f90a36746cb782d4300</uuid>
+            <template>HP Color LaserJet MFP E78630 SNMP</template>
+            <name>HP Color LaserJet MFP E78630 SNMP</name>
+            <description>Template for HP Color LaserJet MFP E78630 (and compatible HP Enterprise/Managed printers) via standard SNMP Printer-MIB (RFC 3805).&#13;
+Monitors: toner/consumables level (auto-discovery), paper tray status (auto-discovery), page counters, device status, and general info.&#13;
+Tested target: HP Color LaserJet MFP E78630.&#13;&#13;Author: YOUR_NAME_OR_GITHUB_USERNAME (replace before submitting)</description>
+            <groups>
+                <group>
+                    <name>Templates/Network devices</name>
+                </group>
+            </groups>
+            <items>
+                <item>
+                    <uuid>a0ec8ff76aef4bc2bcb345dc384ab9f8</uuid>
+                    <name>Device model</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.25.3.2.1.3.1</snmp_oid>
+                    <key>printer.model</key>
+                    <delay>1h</delay>
+                    <history>1w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <inventory_link>MODEL</inventory_link>
+                </item>
+                <item>
+                    <uuid>cebac0e516b44e6b8c263fefef63b038</uuid>
+                    <name>Device serial number</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.43.5.1.1.17.1</snmp_oid>
+                    <key>printer.serial</key>
+                    <delay>1h</delay>
+                    <history>1w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <inventory_link>SERIALNO_A</inventory_link>
+                </item>
+                <item>
+                    <uuid>d8189d18ff1342488952775ab894b2d8</uuid>
+                    <name>System name</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.1.5.0</snmp_oid>
+                    <key>printer.sysname</key>
+                    <delay>1h</delay>
+                    <history>1w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                </item>
+                <item>
+                    <uuid>4dc4f290453d4f38874adec30c164830</uuid>
+                    <name>Device status</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.25.3.2.1.5.1</snmp_oid>
+                    <key>printer.device.status</key>
+                    <delay>1m</delay>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <description>hrDeviceStatus: 1 unknown, 2 running, 3 warning, 4 testing, 5 down</description>
+                    <valuemap>
+                        <name>Printer: hrDeviceStatus</name>
+                    </valuemap>
+                    <triggers>
+                        <trigger>
+                            <uuid>40b818c085eb47e8a366508248083ddb</uuid>
+                            <expression>last(/HP Color LaserJet MFP E78630 SNMP/printer.device.status)=5</expression>
+                            <name>{HOST.NAME}: Device is in DOWN status</name>
+                            <priority>HIGH</priority>
+                        </trigger>
+                        <trigger>
+                            <uuid>ed00a1c82313450ca82b0a50304b20de</uuid>
+                            <expression>last(/HP Color LaserJet MFP E78630 SNMP/printer.device.status)=3</expression>
+                            <name>{HOST.NAME}: Device is in WARNING status</name>
+                            <priority>WARNING</priority>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>64f44d90d08042c3804d7b718c6ead39</uuid>
+                    <name>Total pages printed</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.43.10.2.1.4.1.1</snmp_oid>
+                    <key>printer.pagecount.total</key>
+                    <delay>5m</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <units>pages</units>
+                    <preprocessing>
+                        <step>
+                            <type>CHANGE_PER_SECOND</type>
+                        </step>
+                    </preprocessing>
+                </item>
+                <item>
+                    <uuid>5a84a552d6374b52a203a6753cc5970e</uuid>
+                    <name>Total pages printed (counter)</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.43.10.2.1.4.1.1</snmp_oid>
+                    <key>printer.pagecount.counter</key>
+                    <delay>5m</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <units>pages</units>
+                </item>
+                <item>
+                    <uuid>a667ea281e3140e0bbc2f4866c4e1c00</uuid>
+                    <name>Total monochrome impressions (lifetime)</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.11.2.3.9.4.2.1.4.1.2.6.0</snmp_oid>
+                    <key>printer.impressions.mono</key>
+                    <delay>15m</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <units>pages</units>
+                    <description>Grand total monochrome impressions (Print+Copy+Fax combined), Letter/A4 equivalent. Matches "Monochrome" Grand Total on the printer's Usage Page. HP private MIB (Color/Mono Engine Cycles).</description>
+                </item>
+                <item>
+                    <uuid>c40dfd4bc5dc4230ba9bab0c822fe71c</uuid>
+                    <name>Total color impressions (lifetime)</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.11.2.3.9.4.2.1.4.1.2.7.0</snmp_oid>
+                    <key>printer.impressions.color</key>
+                    <delay>15m</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <units>pages</units>
+                    <description>Grand total color impressions (Print+Copy+Fax combined), Letter/A4 equivalent, integer-truncated. Matches "Color" Grand Total on the printer's Usage Page. HP private MIB (Color Engine Cycles).</description>
+                </item>
+            </items>
+            <discovery_rules>
+                <discovery_rule>
+                    <uuid>653adf2562504354818c6bb9e6062fec</uuid>
+                    <name>Consumables (toner/supplies) discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SUPPLY_DESCR},1.3.6.1.2.1.43.11.1.1.6.1,{#SUPPLY_CLASS},1.3.6.1.2.1.43.11.1.1.4.1,{#SUPPLY_UNIT},1.3.6.1.2.1.43.11.1.1.7.1]</snmp_oid>
+                    <key>printer.supplies.discovery</key>
+                    <delay>1h</delay>
+                    <description>Auto-discovers all consumables reported by the printer: Yellow/Magenta/Cyan/Black cartridges, Document Feeder Kit, Toner Collection Unit, etc.</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>1308a8b9b5574820a974bac6a818d5e9</uuid>
+                            <name>{#SUPPLY_DESCR}: Level</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.11.1.1.9.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.supply.level[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>365d</trends>
+                            <value_type>FLOAT</value_type>
+                            <units>%</units>
+                            <description>Raw level. Special values: -1 = level unknown but supply present, -2 = level unavailable, -3 = no supply/not applicable.</description>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>3029da1ba0fb437f8113f313f4baf866</uuid>
+                            <name>{#SUPPLY_DESCR}: Max capacity</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.11.1.1.8.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.supply.maxlevel[{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <value_type>FLOAT</value_type>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>b4604e9c1b22421d9a72e00ee6c96623</uuid>
+                            <name>{#SUPPLY_DESCR}: Level percent</name>
+                            <type>CALCULATED</type>
+                            <key>printer.supply.percent[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>365d</trends>
+                            <value_type>FLOAT</value_type>
+                            <units>%</units>
+                            <params>last(//printer.supply.level[{#SNMPINDEX}]) / last(//printer.supply.maxlevel[{#SNMPINDEX}]) * 100</params>
+                            <description>Calculated only when raw level and max capacity are both &gt;=0 (see trigger for exceptions).</description>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>1d64cd0a00b84337b467e23412cac957</uuid>
+                                    <expression>last(/HP Color LaserJet MFP E78630 SNMP/printer.supply.level[{#SNMPINDEX}])&gt;=0 and last(/HP Color LaserJet MFP E78630 SNMP/printer.supply.percent[{#SNMPINDEX}])&lt;{$SUPPLY.LOW.CRIT}</expression>
+                                    <name>{HOST.NAME}: {#SUPPLY_DESCR} is critically low ({ITEM.LASTVALUE})</name>
+                                    <priority>HIGH</priority>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>4e2dcb70845042eb95d07e1998e0c280</uuid>
+                                    <expression>last(/HP Color LaserJet MFP E78630 SNMP/printer.supply.level[{#SNMPINDEX}])&gt;=0 and last(/HP Color LaserJet MFP E78630 SNMP/printer.supply.percent[{#SNMPINDEX}])&lt;{$SUPPLY.LOW.WARN}</expression>
+                                    <name>{HOST.NAME}: {#SUPPLY_DESCR} is low ({ITEM.LASTVALUE})</name>
+                                    <priority>WARNING</priority>
+                                    <dependencies>
+                                        <dependency>
+                                            <name>{HOST.NAME}: {#SUPPLY_DESCR} is critically low ({ITEM.LASTVALUE})</name>
+                                            <expression>last(/HP Color LaserJet MFP E78630 SNMP/printer.supply.level[{#SNMPINDEX}])&gt;=0 and last(/HP Color LaserJet MFP E78630 SNMP/printer.supply.percent[{#SNMPINDEX}])&lt;{$SUPPLY.LOW.CRIT}</expression>
+                                        </dependency>
+                                    </dependencies>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+            <graph_prototypes>
+                <graph_prototype>
+                    <uuid>a112e21e85a045caa926a8b4000e2cc2</uuid>
+                    <name>{#SUPPLY_DESCR}: Level (%)</name>
+                    <graph_items>
+                        <graph_item>
+                            <color>1A7C11</color>
+                            <item>
+                                <host>HP Color LaserJet MFP E78630 SNMP</host>
+                                <key>printer.supply.percent[{#SNMPINDEX}]</key>
+                            </item>
+                        </graph_item>
+                    </graph_items>
+                </graph_prototype>
+            </graph_prototypes>
+            <preprocessing>
+                <step>
+                    <type>JAVASCRIPT</type>
+                    <parameters>
+                        <parameter>var data = JSON.parse(value);
+function hexDecode(s) {
+    if (!s) { return s; }
+    var t = s.trim();
+    if (!/^([0-9A-Fa-f]{2}[\s]*)+$/.test(t)) { return s; }
+    var hex = t.replace(/\s+/g, '');
+    if (hex.length % 2 !== 0) { return s; }
+    var out = '';
+    for (var i = 0; i &lt; hex.length; i += 2) {
+        var code = parseInt(hex.substr(i, 2), 16);
+        if (code !== 0) { out += String.fromCharCode(code); }
+    }
+    return out.trim() || s;
+}
+for (var i = 0; i &lt; data.length; i++) {
+    if (data[i]['{#SUPPLY_DESCR}'] !== undefined) {
+        data[i]['{#SUPPLY_DESCR}'] = hexDecode(data[i]['{#SUPPLY_DESCR}']);
+    }
+}
+return JSON.stringify(data);</parameter>
+                    </parameters>
+                </step>
+            </preprocessing>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>debd28790ffa4386b7808456e6feb8dc</uuid>
+                    <name>Paper trays discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#TRAY_DESCR},1.3.6.1.2.1.43.8.2.1.13.1]</snmp_oid>
+                    <key>printer.trays.discovery</key>
+                    <delay>1h</delay>
+                    <description>Auto-discovers all paper input trays (Tray 1, Tray 2, Tray 3, ...).</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>17e363eac1f44d06b51e078c2e5bd5f1</uuid>
+                            <name>{#TRAY_DESCR}: Current level</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.8.2.1.10.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.tray.level[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>365d</trends>
+                            <value_type>FLOAT</value_type>
+                            <description>-1 = unknown level but tray not empty, -2 = level unavailable, -3 = tray not applicable. 0 = empty. Positive value = sheets or % depending on printer reporting.</description>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>174aceb989764cf0a6c523d5d5204b73</uuid>
+                            <name>{#TRAY_DESCR}: Max capacity</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.8.2.1.9.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.tray.maxcapacity[{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <value_type>FLOAT</value_type>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>b9cac38f14214e42b08adda9a3a596c5</uuid>
+                            <name>{#TRAY_DESCR}: Status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.8.2.1.11.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.tray.status[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <description>Bitmask (PrtInputStatusTC). 0 = available and no errors (OK). Non-zero generally indicates a condition (e.g. empty, jam, off-line, cover open).</description>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>5b2b4fb722174da4b9894090b536211a</uuid>
+                                    <expression>last(/HP Color LaserJet MFP E78630 SNMP/printer.tray.status[{#SNMPINDEX}])&lt;&gt;0</expression>
+                                    <name>{HOST.NAME}: {#TRAY_DESCR} reports an issue (empty/jam/offline)</name>
+                                    <priority>WARNING</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+            <graph_prototypes>
+                <graph_prototype>
+                    <uuid>0117858f83414933afd28926ec1c32e3</uuid>
+                    <name>{#TRAY_DESCR}: Current level</name>
+                    <graph_items>
+                        <graph_item>
+                            <color>2774A4</color>
+                            <item>
+                                <host>HP Color LaserJet MFP E78630 SNMP</host>
+                                <key>printer.tray.level[{#SNMPINDEX}]</key>
+                            </item>
+                        </graph_item>
+                    </graph_items>
+                </graph_prototype>
+            </graph_prototypes>
+            <preprocessing>
+                <step>
+                    <type>JAVASCRIPT</type>
+                    <parameters>
+                        <parameter>var data = JSON.parse(value);
+function hexDecode(s) {
+    if (!s) { return s; }
+    var t = s.trim();
+    if (!/^([0-9A-Fa-f]{2}[\s]*)+$/.test(t)) { return s; }
+    var hex = t.replace(/\s+/g, '');
+    if (hex.length % 2 !== 0) { return s; }
+    var out = '';
+    for (var i = 0; i &lt; hex.length; i += 2) {
+        var code = parseInt(hex.substr(i, 2), 16);
+        if (code !== 0) { out += String.fromCharCode(code); }
+    }
+    return out.trim() || s;
+}
+for (var i = 0; i &lt; data.length; i++) {
+    if (data[i]['{#TRAY_DESCR}'] !== undefined) {
+        data[i]['{#TRAY_DESCR}'] = hexDecode(data[i]['{#TRAY_DESCR}']);
+    }
+}
+return JSON.stringify(data);</parameter>
+                    </parameters>
+                </step>
+            </preprocessing>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>05fe5799794d4f85a33de8061069826d</uuid>
+                    <name>Active alerts discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#ALERT_DESCR},1.3.6.1.2.1.43.18.1.1.8]</snmp_oid>
+                    <key>printer.alerts.discovery</key>
+                    <delay>3m</delay>
+                    <description>Auto-discovers currently active printer alerts/conditions (prtAlertTable, RFC 3805). Entries only exist while the condition is active - e.g. toner low, tray empty, cover open, paper jam. This is a live status table, NOT a historical event log (HP does not expose the historical Event Log via standard SNMP).</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>ee1632fcd505428e8766f00ce16fab78</uuid>
+                            <name>Alert: {#ALERT_DESCR}</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.18.1.1.2.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.alert.severity[{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <description>prtAlertSeverityLevel: 1=other/info, 3=critical, 4=warning. Item only exists while this specific alert is active on the device.</description>
+                            <valuemap>
+                                <name>Printer: prtAlertSeverityLevel</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>cfc68d9cf898463389daf319f8f4bdaa</uuid>
+                                    <expression>last(/HP Color LaserJet MFP E78630 SNMP/printer.alert.severity[{#SNMPINDEX}])=3</expression>
+                                    <name>{HOST.NAME}: {#ALERT_DESCR} (critical)</name>
+                                    <priority>HIGH</priority>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>8f76c86738124ceba451b738be2378b7</uuid>
+                                    <expression>last(/HP Color LaserJet MFP E78630 SNMP/printer.alert.severity[{#SNMPINDEX}])=4</expression>
+                                    <name>{HOST.NAME}: {#ALERT_DESCR}</name>
+                                    <priority>WARNING</priority>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>1c1b2140374149778621573e2b0322c5</uuid>
+                                    <expression>last(/HP Color LaserJet MFP E78630 SNMP/printer.alert.severity[{#SNMPINDEX}])=1</expression>
+                                    <name>{HOST.NAME}: {#ALERT_DESCR} (info)</name>
+                                    <priority>INFO</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                    <preprocessing>
+                        <step>
+                            <type>JAVASCRIPT</type>
+                            <parameters>
+                                <parameter>var data = JSON.parse(value);
+function hexDecode(s) {
+    if (!s) { return s; }
+    var t = s.trim();
+    if (!/^([0-9A-Fa-f]{2}[\s]*)+$/.test(t)) { return s; }
+    var hex = t.replace(/\s+/g, '');
+    if (hex.length % 2 !== 0) { return s; }
+    var out = '';
+    for (var i = 0; i &lt; hex.length; i += 2) {
+        var code = parseInt(hex.substr(i, 2), 16);
+        if (code !== 0) { out += String.fromCharCode(code); }
+    }
+    return out.trim() || s;
+}
+for (var i = 0; i &lt; data.length; i++) {
+    if (data[i]['{#ALERT_DESCR}'] !== undefined) {
+        data[i]['{#ALERT_DESCR}'] = hexDecode(data[i]['{#ALERT_DESCR}']);
+    }
+}
+return JSON.stringify(data);</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                </discovery_rule>
+            </discovery_rules>
+            <macros>
+                <macro>
+                    <macro>{$SUPPLY.LOW.WARN}</macro>
+                    <value>20</value>
+                    <description>Toner/consumable percentage threshold for WARNING trigger</description>
+                </macro>
+                <macro>
+                    <macro>{$SUPPLY.LOW.CRIT}</macro>
+                    <value>8</value>
+                    <description>Toner/consumable percentage threshold for HIGH (critical) trigger</description>
+                </macro>
+                <macro>
+                    <macro>{$SNMP_COMMUNITY}</macro>
+                    <value>public</value>
+                    <description>SNMP community string, override on host level as needed</description>
+                </macro>
+            </macros>
+            <valuemaps>
+                <valuemap>
+                    <uuid>a5e28f7aeac54f22b73321443d4b00a2</uuid>
+                    <name>Printer: hrDeviceStatus</name>
+                    <mappings>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>unknown</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>running</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>warning</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>4</value>
+                            <newvalue>testing</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>5</value>
+                            <newvalue>down</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+                <valuemap>
+                    <uuid>efbf2fe24b574156a8a253f6ac034431</uuid>
+                    <name>Printer: prtAlertSeverityLevel</name>
+                    <mappings>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>other/info</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>critical</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>4</value>
+                            <newvalue>warning</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+            </valuemaps>
+            <dashboards>
+                <dashboard>
+                    <uuid>7839c7097e6044c79f19b8f2079af679</uuid>
+                    <name>HP E78630 Overview</name>
+                    <pages>
+                        <page>
+                            <widgets>
+                                <widget>
+                                    <type>graphprototype</type>
+                                    <width>24</width>
+                                    <height>6</height>
+                                    <fields>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>columns</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>rows</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>GRAPH_PROTOTYPE</type>
+                                            <name>graphid.0</name>
+                                            <value>
+                                                <host>HP Color LaserJet MFP E78630 SNMP</host>
+                                                <name>{#SUPPLY_DESCR}: Level (%)</name>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAA</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>graphprototype</type>
+                                    <x>24</x>
+                                    <width>24</width>
+                                    <height>6</height>
+                                    <fields>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>columns</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>rows</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>GRAPH_PROTOTYPE</type>
+                                            <name>graphid.0</name>
+                                            <value>
+                                                <host>HP Color LaserJet MFP E78630 SNMP</host>
+                                                <name>{#TRAY_DESCR}: Current level</name>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAB</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>itemvalue</type>
+                                    <y>6</y>
+                                    <width>12</width>
+                                    <height>3</height>
+                                    <fields>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid.0</name>
+                                            <value>
+                                                <host>HP Color LaserJet MFP E78630 SNMP</host>
+                                                <key>printer.device.status</key>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAC</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>itemvalue</type>
+                                    <x>12</x>
+                                    <y>6</y>
+                                    <width>12</width>
+                                    <height>3</height>
+                                    <fields>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid.0</name>
+                                            <value>
+                                                <host>HP Color LaserJet MFP E78630 SNMP</host>
+                                                <key>printer.model</key>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAD</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>itemvalue</type>
+                                    <x>24</x>
+                                    <y>6</y>
+                                    <width>12</width>
+                                    <height>3</height>
+                                    <fields>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid.0</name>
+                                            <value>
+                                                <host>HP Color LaserJet MFP E78630 SNMP</host>
+                                                <key>printer.serial</key>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAE</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>itemvalue</type>
+                                    <x>36</x>
+                                    <y>6</y>
+                                    <width>12</width>
+                                    <height>3</height>
+                                    <fields>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid.0</name>
+                                            <value>
+                                                <host>HP Color LaserJet MFP E78630 SNMP</host>
+                                                <key>printer.pagecount.counter</key>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAF</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                            </widgets>
+                        </page>
+                    </pages>
+                </dashboard>
+            </dashboards>
+        </template>
+    </templates>
+</zabbix_export>

--- a/Printers/HP/template_hp_color_laserjet_mfp_x57945/7.0/README.md
+++ b/Printers/HP/template_hp_color_laserjet_mfp_x57945/7.0/README.md
@@ -1,0 +1,84 @@
+# HP Color LaserJet MFP X57945 by SNMP
+
+## Overview
+
+Monitors an HP Color LaserJet MFP X57945 (and compatible HP Enterprise/Managed printers) over SNMP, using only the standard **Printer-MIB (RFC 3805)** and **Host Resources MIB**. No vendor-specific/private MIB is required for the core metrics, so this template will generally also work — as-is or with minimal changes — on other HP Enterprise/Managed printers that expose the same standard MIBs.
+
+This template is structurally identical to the `template_hp_color_laserjet_mfp_e78630` template — discovery is fully SNMP LLD-based, so it will automatically pick up whatever consumables/trays this device reports.
+
+Author: YOUR_NAME_OR_GITHUB_USERNAME (replace before submitting)
+
+## Requirements
+
+- Zabbix version: 7.0
+- SNMP (v1/v2c, tested with v2c) enabled on the printer, with a community string configured (default macro value: `public`)
+- Printer must support Printer-MIB (RFC 3805) and Host Resources MIB (standard on virtually all network-attached HP LaserJet/Enterprise printers)
+
+## Tested versions
+
+- HP Color LaserJet MFP X57945
+
+## Setup
+
+1. Import the template into Zabbix.
+2. Create a host for the printer, add an **SNMP interface** (port 161).
+3. Link the template `HP Color LaserJet MFP X57945 SNMP` to the host.
+4. If the printer's SNMP community string is not `public`, override the `{$SNMP_COMMUNITY}` macro at the host level.
+5. Wait for the discovery rules to run (or trigger them manually via **Execute now**) so that consumables, paper trays, and active alerts are discovered.
+
+## Macros
+
+| Macro | Default | Description |
+|---|---|---|
+| `{$SNMP_COMMUNITY}` | `public` | SNMP community string |
+| `{$SUPPLY.LOW.WARN}` | `20` | Consumable level (%) threshold for a WARNING trigger |
+| `{$SUPPLY.LOW.CRIT}` | `8` | Consumable level (%) threshold for a HIGH (critical) trigger |
+
+## Items collected
+
+- Device model, serial number, system name
+- Device status (`hrDeviceStatus`: running / warning / down)
+- Total pages printed (lifetime engine cycle counter, and its per-second rate)
+- Total monochrome / color impressions (lifetime, HP private MIB — matches the "Grand Total" row on the printer's Usage Page)
+
+### Discovery rule: Consumables (toner/supplies) discovery
+
+Auto-discovers every consumable reported via `prtMarkerSuppliesTable` (toner cartridges, drums, developer units, fuser kit, transfer belt/cleaning unit, document feeder kit, etc.). For each discovered consumable:
+
+- Level (raw, `prtMarkerSuppliesLevel`)
+- Max capacity (`prtMarkerSuppliesMaxCapacity`)
+- Level percent (calculated)
+- A graph showing level (%) over time
+
+### Discovery rule: Paper trays discovery
+
+Auto-discovers every paper tray reported via `prtInputTable`. For each tray:
+
+- Current level
+- Max capacity
+- Status (`prtInputStatus`)
+- A graph showing current level over time
+
+### Discovery rule: Active alerts discovery
+
+Auto-discovers currently active device conditions/alerts via `prtAlertTable` (e.g. toner low, tray empty, cover open, paper jam). This reflects the **live** state — items only exist while the condition is active. It does **not** provide a historical event log (HP does not expose the historical Event Log page via standard SNMP); Zabbix's own Problems history serves as the closest equivalent once triggers have fired at least once.
+
+## Triggers
+
+- Device is in DOWN status
+- Device is in WARNING status
+- `{consumable}` is low / critically low (based on `{$SUPPLY.LOW.WARN}` / `{$SUPPLY.LOW.CRIT}`)
+- `{tray}` reports an issue (empty/jam/offline)
+- `{alert}` (critical) / `{alert}` (warning) / `{alert}` (info) — from the active alerts discovery
+
+## Dashboard
+
+A template dashboard ("HP X57945 Overview") is included with:
+- Graph grid of all discovered consumable levels (%)
+- Graph grid of all discovered tray levels
+- Device status, model, serial number, and total page count widgets
+
+## Known limitations
+
+- The detailed Usage Page breakdown by job type (Print/Copy/Fax) is **not** available via standard SNMP; only the combined lifetime monochrome/color totals could be confirmed against a real device (see "Total monochrome/color impressions" above).
+- Values are only as fresh as the item's polling interval (default 5 minutes for supply/tray levels); they are not push/real-time.

--- a/Printers/HP/template_hp_color_laserjet_mfp_x57945/7.0/README.md
+++ b/Printers/HP/template_hp_color_laserjet_mfp_x57945/7.0/README.md
@@ -6,7 +6,7 @@ Monitors an HP Color LaserJet MFP X57945 (and compatible HP Enterprise/Managed p
 
 This template is structurally identical to the `template_hp_color_laserjet_mfp_e78630` template — discovery is fully SNMP LLD-based, so it will automatically pick up whatever consumables/trays this device reports.
 
-Author: YOUR_NAME_OR_GITHUB_USERNAME (replace before submitting)
+Author: github.com/ikbalr
 
 ## Requirements
 

--- a/Printers/HP/template_hp_color_laserjet_mfp_x57945/7.0/template_hp_color_laserjet_mfp_x57945.xml
+++ b/Printers/HP/template_hp_color_laserjet_mfp_x57945/7.0/template_hp_color_laserjet_mfp_x57945.xml
@@ -1,0 +1,643 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>7.0</version>
+    <template_groups>
+        <template_group>
+            <uuid>39919738acef4b7c8eeb1928515e8757</uuid>
+            <name>Templates/Network devices</name>
+        </template_group>
+    </template_groups>
+    <templates>
+        <template>
+            <uuid>85921c07993040c1916ea3179765b9fa</uuid>
+            <template>HP Color LaserJet MFP X57945 SNMP</template>
+            <name>HP Color LaserJet MFP X57945 SNMP</name>
+            <description>Template for HP Color LaserJet MFP X57945 (and compatible HP Enterprise/Managed color printers) via standard SNMP Printer-MIB (RFC 3805).&#13;
+Monitors: toner/consumables level (auto-discovery - Yellow/Magenta/Cyan/Black cartridges + drums/developer units/fuser/transfer kits as reported by the device), paper tray status (auto-discovery), page counters, device status, and general info.&#13;
+Tested target: HP Color LaserJet MFP X57945.&#13;&#13;Author: YOUR_NAME_OR_GITHUB_USERNAME (replace before submitting) Structure is identical to the E78630 template (SNMP LLD auto-discovers whatever supplies/trays the device reports), so it also works on other HP Enterprise/Managed mono or color printers.</description>
+            <groups>
+                <group>
+                    <name>Templates/Network devices</name>
+                </group>
+            </groups>
+            <items>
+                <item>
+                    <uuid>e3f42060b3fe4347a45527c1716dafdc</uuid>
+                    <name>Device model</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.25.3.2.1.3.1</snmp_oid>
+                    <key>printer.model</key>
+                    <delay>1h</delay>
+                    <history>1w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <inventory_link>MODEL</inventory_link>
+                </item>
+                <item>
+                    <uuid>656d51ae43e14547a03279b0ba703063</uuid>
+                    <name>Device serial number</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.43.5.1.1.17.1</snmp_oid>
+                    <key>printer.serial</key>
+                    <delay>1h</delay>
+                    <history>1w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <inventory_link>SERIALNO_A</inventory_link>
+                </item>
+                <item>
+                    <uuid>1cfd74087622453e8e33eb7a0b77c3f4</uuid>
+                    <name>System name</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.1.5.0</snmp_oid>
+                    <key>printer.sysname</key>
+                    <delay>1h</delay>
+                    <history>1w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                </item>
+                <item>
+                    <uuid>fedec9d77cfa4190a2793c3c870efa9d</uuid>
+                    <name>Device status</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.25.3.2.1.5.1</snmp_oid>
+                    <key>printer.device.status</key>
+                    <delay>1m</delay>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <description>hrDeviceStatus: 1 unknown, 2 running, 3 warning, 4 testing, 5 down</description>
+                    <valuemap>
+                        <name>Printer: hrDeviceStatus</name>
+                    </valuemap>
+                    <triggers>
+                        <trigger>
+                            <uuid>c05257a14ac6488487493f47b9a9b7ce</uuid>
+                            <expression>last(/HP Color LaserJet MFP X57945 SNMP/printer.device.status)=5</expression>
+                            <name>{HOST.NAME}: Device is in DOWN status</name>
+                            <priority>HIGH</priority>
+                        </trigger>
+                        <trigger>
+                            <uuid>129c3f5f78374090a2e70da3d80660cd</uuid>
+                            <expression>last(/HP Color LaserJet MFP X57945 SNMP/printer.device.status)=3</expression>
+                            <name>{HOST.NAME}: Device is in WARNING status</name>
+                            <priority>WARNING</priority>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>8c3549f93b8e4e31aa14c9f2604b89c7</uuid>
+                    <name>Total pages printed</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.43.10.2.1.4.1.1</snmp_oid>
+                    <key>printer.pagecount.total</key>
+                    <delay>5m</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <units>pages</units>
+                    <preprocessing>
+                        <step>
+                            <type>CHANGE_PER_SECOND</type>
+                        </step>
+                    </preprocessing>
+                </item>
+                <item>
+                    <uuid>529ac49c381840f299466fafc7067c52</uuid>
+                    <name>Total pages printed (counter)</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.43.10.2.1.4.1.1</snmp_oid>
+                    <key>printer.pagecount.counter</key>
+                    <delay>5m</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <units>pages</units>
+                </item>
+                <item>
+                    <uuid>742736b0a31e4faab0320c372629612f</uuid>
+                    <name>Total monochrome impressions (lifetime)</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.11.2.3.9.4.2.1.4.1.2.6.0</snmp_oid>
+                    <key>printer.impressions.mono</key>
+                    <delay>15m</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <units>pages</units>
+                    <description>Grand total monochrome impressions (Print+Copy+Fax combined), Letter/A4 equivalent. Matches "Monochrome" Grand Total on the printer's Usage Page. HP private MIB (Color/Mono Engine Cycles).</description>
+                </item>
+                <item>
+                    <uuid>4441e80cc1994f4e9ae097ad7521973a</uuid>
+                    <name>Total color impressions (lifetime)</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.11.2.3.9.4.2.1.4.1.2.7.0</snmp_oid>
+                    <key>printer.impressions.color</key>
+                    <delay>15m</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <units>pages</units>
+                    <description>Grand total color impressions (Print+Copy+Fax combined), Letter/A4 equivalent, integer-truncated. Matches "Color" Grand Total on the printer's Usage Page. HP private MIB (Color Engine Cycles).</description>
+                </item>
+            </items>
+            <discovery_rules>
+                <discovery_rule>
+                    <uuid>88ca074fea1743f4b2f7837e32388903</uuid>
+                    <name>Consumables (toner/supplies) discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SUPPLY_DESCR},1.3.6.1.2.1.43.11.1.1.6.1,{#SUPPLY_CLASS},1.3.6.1.2.1.43.11.1.1.4.1,{#SUPPLY_UNIT},1.3.6.1.2.1.43.11.1.1.7.1]</snmp_oid>
+                    <key>printer.supplies.discovery</key>
+                    <delay>1h</delay>
+                    <description>Auto-discovers all consumables reported by the printer: Yellow/Magenta/Cyan/Black cartridges, Document Feeder Kit, Toner Collection Unit, etc.</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>46d6afc297094201bfbc0c73a2ec7e5b</uuid>
+                            <name>{#SUPPLY_DESCR}: Level</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.11.1.1.9.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.supply.level[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>365d</trends>
+                            <value_type>FLOAT</value_type>
+                            <units>%</units>
+                            <description>Raw level. Special values: -1 = level unknown but supply present, -2 = level unavailable, -3 = no supply/not applicable.</description>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>a55b2ad5353b4e718121f72a8111f5d9</uuid>
+                            <name>{#SUPPLY_DESCR}: Max capacity</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.11.1.1.8.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.supply.maxlevel[{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <value_type>FLOAT</value_type>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>c383cbc6c7ea4092ba6a5c311ecb62db</uuid>
+                            <name>{#SUPPLY_DESCR}: Level percent</name>
+                            <type>CALCULATED</type>
+                            <key>printer.supply.percent[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>365d</trends>
+                            <value_type>FLOAT</value_type>
+                            <units>%</units>
+                            <params>last(//printer.supply.level[{#SNMPINDEX}]) / last(//printer.supply.maxlevel[{#SNMPINDEX}]) * 100</params>
+                            <description>Calculated only when raw level and max capacity are both &gt;=0 (see trigger for exceptions).</description>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>2a5703f9e06340f4b326da2b94480541</uuid>
+                                    <expression>last(/HP Color LaserJet MFP X57945 SNMP/printer.supply.level[{#SNMPINDEX}])&gt;=0 and last(/HP Color LaserJet MFP X57945 SNMP/printer.supply.percent[{#SNMPINDEX}])&lt;{$SUPPLY.LOW.CRIT}</expression>
+                                    <name>{HOST.NAME}: {#SUPPLY_DESCR} is critically low ({ITEM.LASTVALUE})</name>
+                                    <priority>HIGH</priority>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>1eba5b810a9f4c3db6c7426518d7edda</uuid>
+                                    <expression>last(/HP Color LaserJet MFP X57945 SNMP/printer.supply.level[{#SNMPINDEX}])&gt;=0 and last(/HP Color LaserJet MFP X57945 SNMP/printer.supply.percent[{#SNMPINDEX}])&lt;{$SUPPLY.LOW.WARN}</expression>
+                                    <name>{HOST.NAME}: {#SUPPLY_DESCR} is low ({ITEM.LASTVALUE})</name>
+                                    <priority>WARNING</priority>
+                                    <dependencies>
+                                        <dependency>
+                                            <name>{HOST.NAME}: {#SUPPLY_DESCR} is critically low ({ITEM.LASTVALUE})</name>
+                                            <expression>last(/HP Color LaserJet MFP X57945 SNMP/printer.supply.level[{#SNMPINDEX}])&gt;=0 and last(/HP Color LaserJet MFP X57945 SNMP/printer.supply.percent[{#SNMPINDEX}])&lt;{$SUPPLY.LOW.CRIT}</expression>
+                                        </dependency>
+                                    </dependencies>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+            <graph_prototypes>
+                <graph_prototype>
+                    <uuid>051e31576ba64709bdcc2675ce3ef2e6</uuid>
+                    <name>{#SUPPLY_DESCR}: Level (%)</name>
+                    <graph_items>
+                        <graph_item>
+                            <color>1A7C11</color>
+                            <item>
+                                <host>HP Color LaserJet MFP X57945 SNMP</host>
+                                <key>printer.supply.percent[{#SNMPINDEX}]</key>
+                            </item>
+                        </graph_item>
+                    </graph_items>
+                </graph_prototype>
+            </graph_prototypes>
+            <preprocessing>
+                <step>
+                    <type>JAVASCRIPT</type>
+                    <parameters>
+                        <parameter>var data = JSON.parse(value);
+function hexDecode(s) {
+    if (!s) { return s; }
+    var t = s.trim();
+    if (!/^([0-9A-Fa-f]{2}[\s]*)+$/.test(t)) { return s; }
+    var hex = t.replace(/\s+/g, '');
+    if (hex.length % 2 !== 0) { return s; }
+    var out = '';
+    for (var i = 0; i &lt; hex.length; i += 2) {
+        var code = parseInt(hex.substr(i, 2), 16);
+        if (code !== 0) { out += String.fromCharCode(code); }
+    }
+    return out.trim() || s;
+}
+for (var i = 0; i &lt; data.length; i++) {
+    if (data[i]['{#SUPPLY_DESCR}'] !== undefined) {
+        data[i]['{#SUPPLY_DESCR}'] = hexDecode(data[i]['{#SUPPLY_DESCR}']);
+    }
+}
+return JSON.stringify(data);</parameter>
+                    </parameters>
+                </step>
+            </preprocessing>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>78f0a75efc9449aea4664f17f64478e8</uuid>
+                    <name>Paper trays discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#TRAY_DESCR},1.3.6.1.2.1.43.8.2.1.13.1]</snmp_oid>
+                    <key>printer.trays.discovery</key>
+                    <delay>1h</delay>
+                    <description>Auto-discovers all paper input trays (Tray 1, Tray 2, Tray 3, ...).</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>dffa25ce58ea4a0bbd43fa446a8d4841</uuid>
+                            <name>{#TRAY_DESCR}: Current level</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.8.2.1.10.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.tray.level[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>365d</trends>
+                            <value_type>FLOAT</value_type>
+                            <description>-1 = unknown level but tray not empty, -2 = level unavailable, -3 = tray not applicable. 0 = empty. Positive value = sheets or % depending on printer reporting.</description>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>7dc73dcee4b94f9fb47ca93994f7296f</uuid>
+                            <name>{#TRAY_DESCR}: Max capacity</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.8.2.1.9.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.tray.maxcapacity[{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <value_type>FLOAT</value_type>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>ef98da391faa4201a167ba86f2330796</uuid>
+                            <name>{#TRAY_DESCR}: Status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.8.2.1.11.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.tray.status[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <description>Bitmask (PrtInputStatusTC). 0 = available and no errors (OK). Non-zero generally indicates a condition (e.g. empty, jam, off-line, cover open).</description>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>2e201b6adc964d86b59a7960e5a5087f</uuid>
+                                    <expression>last(/HP Color LaserJet MFP X57945 SNMP/printer.tray.status[{#SNMPINDEX}])&lt;&gt;0</expression>
+                                    <name>{HOST.NAME}: {#TRAY_DESCR} reports an issue (empty/jam/offline)</name>
+                                    <priority>WARNING</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+            <graph_prototypes>
+                <graph_prototype>
+                    <uuid>6c0296b612bd4559a1278d9b3f10f3d6</uuid>
+                    <name>{#TRAY_DESCR}: Current level</name>
+                    <graph_items>
+                        <graph_item>
+                            <color>2774A4</color>
+                            <item>
+                                <host>HP Color LaserJet MFP X57945 SNMP</host>
+                                <key>printer.tray.level[{#SNMPINDEX}]</key>
+                            </item>
+                        </graph_item>
+                    </graph_items>
+                </graph_prototype>
+            </graph_prototypes>
+            <preprocessing>
+                <step>
+                    <type>JAVASCRIPT</type>
+                    <parameters>
+                        <parameter>var data = JSON.parse(value);
+function hexDecode(s) {
+    if (!s) { return s; }
+    var t = s.trim();
+    if (!/^([0-9A-Fa-f]{2}[\s]*)+$/.test(t)) { return s; }
+    var hex = t.replace(/\s+/g, '');
+    if (hex.length % 2 !== 0) { return s; }
+    var out = '';
+    for (var i = 0; i &lt; hex.length; i += 2) {
+        var code = parseInt(hex.substr(i, 2), 16);
+        if (code !== 0) { out += String.fromCharCode(code); }
+    }
+    return out.trim() || s;
+}
+for (var i = 0; i &lt; data.length; i++) {
+    if (data[i]['{#TRAY_DESCR}'] !== undefined) {
+        data[i]['{#TRAY_DESCR}'] = hexDecode(data[i]['{#TRAY_DESCR}']);
+    }
+}
+return JSON.stringify(data);</parameter>
+                    </parameters>
+                </step>
+            </preprocessing>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>cb841ca27ef24282b82508e107ac5087</uuid>
+                    <name>Active alerts discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#ALERT_DESCR},1.3.6.1.2.1.43.18.1.1.8]</snmp_oid>
+                    <key>printer.alerts.discovery</key>
+                    <delay>3m</delay>
+                    <description>Auto-discovers currently active printer alerts/conditions (prtAlertTable, RFC 3805). Entries only exist while the condition is active - e.g. toner low, tray empty, cover open, paper jam. This is a live status table, NOT a historical event log (HP does not expose the historical Event Log via standard SNMP).</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>b7f30b341d7e44299cdde9fd2dbb2f31</uuid>
+                            <name>Alert: {#ALERT_DESCR}</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.18.1.1.2.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.alert.severity[{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <description>prtAlertSeverityLevel: 1=other/info, 3=critical, 4=warning. Item only exists while this specific alert is active on the device.</description>
+                            <valuemap>
+                                <name>Printer: prtAlertSeverityLevel</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>db1388765b6e46fe91ce32aaf7013f1f</uuid>
+                                    <expression>last(/HP Color LaserJet MFP X57945 SNMP/printer.alert.severity[{#SNMPINDEX}])=3</expression>
+                                    <name>{HOST.NAME}: {#ALERT_DESCR} (critical)</name>
+                                    <priority>HIGH</priority>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>7826ad2210be4915a7683369579362b5</uuid>
+                                    <expression>last(/HP Color LaserJet MFP X57945 SNMP/printer.alert.severity[{#SNMPINDEX}])=4</expression>
+                                    <name>{HOST.NAME}: {#ALERT_DESCR}</name>
+                                    <priority>WARNING</priority>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>343be6b0849d45a99bfc975a9bbd7056</uuid>
+                                    <expression>last(/HP Color LaserJet MFP X57945 SNMP/printer.alert.severity[{#SNMPINDEX}])=1</expression>
+                                    <name>{HOST.NAME}: {#ALERT_DESCR} (info)</name>
+                                    <priority>INFO</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                    <preprocessing>
+                        <step>
+                            <type>JAVASCRIPT</type>
+                            <parameters>
+                                <parameter>var data = JSON.parse(value);
+function hexDecode(s) {
+    if (!s) { return s; }
+    var t = s.trim();
+    if (!/^([0-9A-Fa-f]{2}[\s]*)+$/.test(t)) { return s; }
+    var hex = t.replace(/\s+/g, '');
+    if (hex.length % 2 !== 0) { return s; }
+    var out = '';
+    for (var i = 0; i &lt; hex.length; i += 2) {
+        var code = parseInt(hex.substr(i, 2), 16);
+        if (code !== 0) { out += String.fromCharCode(code); }
+    }
+    return out.trim() || s;
+}
+for (var i = 0; i &lt; data.length; i++) {
+    if (data[i]['{#ALERT_DESCR}'] !== undefined) {
+        data[i]['{#ALERT_DESCR}'] = hexDecode(data[i]['{#ALERT_DESCR}']);
+    }
+}
+return JSON.stringify(data);</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                </discovery_rule>
+            </discovery_rules>
+            <macros>
+                <macro>
+                    <macro>{$SUPPLY.LOW.WARN}</macro>
+                    <value>20</value>
+                    <description>Toner/consumable percentage threshold for WARNING trigger</description>
+                </macro>
+                <macro>
+                    <macro>{$SUPPLY.LOW.CRIT}</macro>
+                    <value>8</value>
+                    <description>Toner/consumable percentage threshold for HIGH (critical) trigger</description>
+                </macro>
+                <macro>
+                    <macro>{$SNMP_COMMUNITY}</macro>
+                    <value>public</value>
+                    <description>SNMP community string, override on host level as needed</description>
+                </macro>
+            </macros>
+            <valuemaps>
+                <valuemap>
+                    <uuid>641371a356a74361bcb3ef8a3bac3707</uuid>
+                    <name>Printer: hrDeviceStatus</name>
+                    <mappings>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>unknown</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>running</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>warning</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>4</value>
+                            <newvalue>testing</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>5</value>
+                            <newvalue>down</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+                <valuemap>
+                    <uuid>50c7a10e0c704b8783a2ddc895e11280</uuid>
+                    <name>Printer: prtAlertSeverityLevel</name>
+                    <mappings>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>other/info</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>critical</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>4</value>
+                            <newvalue>warning</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+            </valuemaps>
+            <dashboards>
+                <dashboard>
+                    <uuid>0f6fbc0cff1d4d52a4c6da7d3cca93c8</uuid>
+                    <name>HP X57945 Overview</name>
+                    <pages>
+                        <page>
+                            <widgets>
+                                <widget>
+                                    <type>graphprototype</type>
+                                    <width>24</width>
+                                    <height>6</height>
+                                    <fields>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>columns</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>rows</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>GRAPH_PROTOTYPE</type>
+                                            <name>graphid.0</name>
+                                            <value>
+                                                <host>HP Color LaserJet MFP X57945 SNMP</host>
+                                                <name>{#SUPPLY_DESCR}: Level (%)</name>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAA</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>graphprototype</type>
+                                    <x>24</x>
+                                    <width>24</width>
+                                    <height>6</height>
+                                    <fields>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>columns</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>rows</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>GRAPH_PROTOTYPE</type>
+                                            <name>graphid.0</name>
+                                            <value>
+                                                <host>HP Color LaserJet MFP X57945 SNMP</host>
+                                                <name>{#TRAY_DESCR}: Current level</name>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAB</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>itemvalue</type>
+                                    <y>6</y>
+                                    <width>12</width>
+                                    <height>3</height>
+                                    <fields>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid.0</name>
+                                            <value>
+                                                <host>HP Color LaserJet MFP X57945 SNMP</host>
+                                                <key>printer.device.status</key>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAC</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>itemvalue</type>
+                                    <x>12</x>
+                                    <y>6</y>
+                                    <width>12</width>
+                                    <height>3</height>
+                                    <fields>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid.0</name>
+                                            <value>
+                                                <host>HP Color LaserJet MFP X57945 SNMP</host>
+                                                <key>printer.model</key>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAD</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>itemvalue</type>
+                                    <x>24</x>
+                                    <y>6</y>
+                                    <width>12</width>
+                                    <height>3</height>
+                                    <fields>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid.0</name>
+                                            <value>
+                                                <host>HP Color LaserJet MFP X57945 SNMP</host>
+                                                <key>printer.serial</key>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAE</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>itemvalue</type>
+                                    <x>36</x>
+                                    <y>6</y>
+                                    <width>12</width>
+                                    <height>3</height>
+                                    <fields>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid.0</name>
+                                            <value>
+                                                <host>HP Color LaserJet MFP X57945 SNMP</host>
+                                                <key>printer.pagecount.counter</key>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAF</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                            </widgets>
+                        </page>
+                    </pages>
+                </dashboard>
+            </dashboards>
+        </template>
+    </templates>
+</zabbix_export>

--- a/Printers/HP/template_hp_laserjet_mfp_e42540/7.0/README.md
+++ b/Printers/HP/template_hp_laserjet_mfp_e42540/7.0/README.md
@@ -6,7 +6,7 @@ Monitors an HP LaserJet MFP E42540 (monochrome, and compatible HP Enterprise/Man
 
 This template is structurally identical to the `template_hp_color_laserjet_mfp_e78630` template — since discovery is fully SNMP LLD-based, it will simply discover fewer consumables (typically 1 black cartridge plus drum/maintenance kits) instead of 4 color cartridges.
 
-Author: YOUR_NAME_OR_GITHUB_USERNAME (replace before submitting)
+Author: github.com/ikbalr
 
 ## Requirements
 

--- a/Printers/HP/template_hp_laserjet_mfp_e42540/7.0/README.md
+++ b/Printers/HP/template_hp_laserjet_mfp_e42540/7.0/README.md
@@ -1,0 +1,84 @@
+# HP LaserJet MFP E42540 by SNMP
+
+## Overview
+
+Monitors an HP LaserJet MFP E42540 (monochrome, and compatible HP Enterprise/Managed printers) over SNMP, using only the standard **Printer-MIB (RFC 3805)** and **Host Resources MIB**. No vendor-specific/private MIB is required for the core metrics, so this template will generally also work — as-is or with minimal changes — on other HP Enterprise/Managed printers that expose the same standard MIBs.
+
+This template is structurally identical to the `template_hp_color_laserjet_mfp_e78630` template — since discovery is fully SNMP LLD-based, it will simply discover fewer consumables (typically 1 black cartridge plus drum/maintenance kits) instead of 4 color cartridges.
+
+Author: YOUR_NAME_OR_GITHUB_USERNAME (replace before submitting)
+
+## Requirements
+
+- Zabbix version: 7.0
+- SNMP (v1/v2c, tested with v2c) enabled on the printer, with a community string configured (default macro value: `public`)
+- Printer must support Printer-MIB (RFC 3805) and Host Resources MIB (standard on virtually all network-attached HP LaserJet/Enterprise printers)
+
+## Tested versions
+
+- HP LaserJet MFP E42540
+
+## Setup
+
+1. Import the template into Zabbix.
+2. Create a host for the printer, add an **SNMP interface** (port 161).
+3. Link the template `HP LaserJet MFP E42540 SNMP` to the host.
+4. If the printer's SNMP community string is not `public`, override the `{$SNMP_COMMUNITY}` macro at the host level.
+5. Wait for the discovery rules to run (or trigger them manually via **Execute now**) so that consumables, paper trays, and active alerts are discovered.
+
+## Macros
+
+| Macro | Default | Description |
+|---|---|---|
+| `{$SNMP_COMMUNITY}` | `public` | SNMP community string |
+| `{$SUPPLY.LOW.WARN}` | `20` | Consumable level (%) threshold for a WARNING trigger |
+| `{$SUPPLY.LOW.CRIT}` | `8` | Consumable level (%) threshold for a HIGH (critical) trigger |
+
+## Items collected
+
+- Device model, serial number, system name
+- Device status (`hrDeviceStatus`: running / warning / down)
+- Total pages printed (lifetime engine cycle counter, and its per-second rate)
+- Total monochrome / color impressions (lifetime, HP private MIB — the color counter will typically read 0/not-applicable on this monochrome model)
+
+### Discovery rule: Consumables (toner/supplies) discovery
+
+Auto-discovers every consumable reported via `prtMarkerSuppliesTable` (black toner cartridge, drum, maintenance kit, document feeder kit, etc.). For each discovered consumable:
+
+- Level (raw, `prtMarkerSuppliesLevel`)
+- Max capacity (`prtMarkerSuppliesMaxCapacity`)
+- Level percent (calculated)
+- A graph showing level (%) over time
+
+### Discovery rule: Paper trays discovery
+
+Auto-discovers every paper tray reported via `prtInputTable`. For each tray:
+
+- Current level
+- Max capacity
+- Status (`prtInputStatus`)
+- A graph showing current level over time
+
+### Discovery rule: Active alerts discovery
+
+Auto-discovers currently active device conditions/alerts via `prtAlertTable` (e.g. toner low, tray empty, cover open, paper jam). This reflects the **live** state — items only exist while the condition is active. It does **not** provide a historical event log (HP does not expose the historical Event Log page via standard SNMP); Zabbix's own Problems history serves as the closest equivalent once triggers have fired at least once.
+
+## Triggers
+
+- Device is in DOWN status
+- Device is in WARNING status
+- `{consumable}` is low / critically low (based on `{$SUPPLY.LOW.WARN}` / `{$SUPPLY.LOW.CRIT}`)
+- `{tray}` reports an issue (empty/jam/offline)
+- `{alert}` (critical) / `{alert}` (warning) / `{alert}` (info) — from the active alerts discovery
+
+## Dashboard
+
+A template dashboard ("HP E42540 Overview") is included with:
+- Graph grid of all discovered consumable levels (%)
+- Graph grid of all discovered tray levels
+- Device status, model, serial number, and total page count widgets
+
+## Known limitations
+
+- The detailed Usage Page breakdown by job type (Print/Copy/Fax) is **not** available via standard SNMP.
+- Values are only as fresh as the item's polling interval (default 5 minutes for supply/tray levels); they are not push/real-time.

--- a/Printers/HP/template_hp_laserjet_mfp_e42540/7.0/template_hp_laserjet_mfp_e42540.xml
+++ b/Printers/HP/template_hp_laserjet_mfp_e42540/7.0/template_hp_laserjet_mfp_e42540.xml
@@ -1,0 +1,643 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<zabbix_export>
+    <version>7.0</version>
+    <template_groups>
+        <template_group>
+            <uuid>eb6f92ccce8d4e199f261fee3a48485f</uuid>
+            <name>Templates/Network devices</name>
+        </template_group>
+    </template_groups>
+    <templates>
+        <template>
+            <uuid>e5b3e3086a7d437ea1f261391e700ed9</uuid>
+            <template>HP LaserJet MFP E42540 SNMP</template>
+            <name>HP LaserJet MFP E42540 SNMP</name>
+            <description>Template for HP LaserJet MFP E42540 (and compatible HP Enterprise/Managed monochrome printers) via standard SNMP Printer-MIB (RFC 3805).&#13;
+Monitors: toner/consumables level (auto-discovery - typically 1 Black cartridge + drum/maintenance kits on this model), paper tray status (auto-discovery), page counters, device status, and general info.&#13;
+Tested target: HP LaserJet MFP E42540.&#13;&#13;Author: YOUR_NAME_OR_GITHUB_USERNAME (replace before submitting) Structure is identical to the E78630 template (SNMP LLD auto-discovers whatever supplies/trays the device reports), so it also works on other HP Enterprise/Managed mono or color printers.</description>
+            <groups>
+                <group>
+                    <name>Templates/Network devices</name>
+                </group>
+            </groups>
+            <items>
+                <item>
+                    <uuid>12c19c5258c6494a9f0edef738dace27</uuid>
+                    <name>Device model</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.25.3.2.1.3.1</snmp_oid>
+                    <key>printer.model</key>
+                    <delay>1h</delay>
+                    <history>1w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <inventory_link>MODEL</inventory_link>
+                </item>
+                <item>
+                    <uuid>185e37b0307948e9bba410f7752fd355</uuid>
+                    <name>Device serial number</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.43.5.1.1.17.1</snmp_oid>
+                    <key>printer.serial</key>
+                    <delay>1h</delay>
+                    <history>1w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                    <inventory_link>SERIALNO_A</inventory_link>
+                </item>
+                <item>
+                    <uuid>dcf66484480d4add94dd15ae17a9d63a</uuid>
+                    <name>System name</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.1.5.0</snmp_oid>
+                    <key>printer.sysname</key>
+                    <delay>1h</delay>
+                    <history>1w</history>
+                    <trends>0</trends>
+                    <value_type>CHAR</value_type>
+                </item>
+                <item>
+                    <uuid>1b2e373c3147416d8365321f8fad7498</uuid>
+                    <name>Device status</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.25.3.2.1.5.1</snmp_oid>
+                    <key>printer.device.status</key>
+                    <delay>1m</delay>
+                    <history>7d</history>
+                    <trends>0</trends>
+                    <description>hrDeviceStatus: 1 unknown, 2 running, 3 warning, 4 testing, 5 down</description>
+                    <valuemap>
+                        <name>Printer: hrDeviceStatus</name>
+                    </valuemap>
+                    <triggers>
+                        <trigger>
+                            <uuid>e090b45a5b3f4af0869f0cb3dac50db5</uuid>
+                            <expression>last(/HP LaserJet MFP E42540 SNMP/printer.device.status)=5</expression>
+                            <name>{HOST.NAME}: Device is in DOWN status</name>
+                            <priority>HIGH</priority>
+                        </trigger>
+                        <trigger>
+                            <uuid>579e6d4b8eb34fbcb4f3127c6a8300da</uuid>
+                            <expression>last(/HP LaserJet MFP E42540 SNMP/printer.device.status)=3</expression>
+                            <name>{HOST.NAME}: Device is in WARNING status</name>
+                            <priority>WARNING</priority>
+                        </trigger>
+                    </triggers>
+                </item>
+                <item>
+                    <uuid>da0dc124c92c451bbb1ac1de9d042e04</uuid>
+                    <name>Total pages printed</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.43.10.2.1.4.1.1</snmp_oid>
+                    <key>printer.pagecount.total</key>
+                    <delay>5m</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <units>pages</units>
+                    <preprocessing>
+                        <step>
+                            <type>CHANGE_PER_SECOND</type>
+                        </step>
+                    </preprocessing>
+                </item>
+                <item>
+                    <uuid>5c84c230d770486895f56eb889fb9a18</uuid>
+                    <name>Total pages printed (counter)</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.2.1.43.10.2.1.4.1.1</snmp_oid>
+                    <key>printer.pagecount.counter</key>
+                    <delay>5m</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <units>pages</units>
+                </item>
+                <item>
+                    <uuid>fa957dd539714abf98a23e99f8f3dcc9</uuid>
+                    <name>Total monochrome impressions (lifetime)</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.11.2.3.9.4.2.1.4.1.2.6.0</snmp_oid>
+                    <key>printer.impressions.mono</key>
+                    <delay>15m</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <units>pages</units>
+                    <description>Grand total monochrome impressions (Print+Copy+Fax combined), Letter/A4 equivalent. Matches "Monochrome" Grand Total on the printer's Usage Page. HP private MIB (Color/Mono Engine Cycles).</description>
+                </item>
+                <item>
+                    <uuid>0b204ee13d4f4641b30b95752053f8c9</uuid>
+                    <name>Total color impressions (lifetime)</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>1.3.6.1.4.1.11.2.3.9.4.2.1.4.1.2.7.0</snmp_oid>
+                    <key>printer.impressions.color</key>
+                    <delay>15m</delay>
+                    <history>90d</history>
+                    <trends>365d</trends>
+                    <units>pages</units>
+                    <description>Grand total color impressions (Print+Copy+Fax combined), Letter/A4 equivalent, integer-truncated. Matches "Color" Grand Total on the printer's Usage Page. HP private MIB (Color Engine Cycles).</description>
+                </item>
+            </items>
+            <discovery_rules>
+                <discovery_rule>
+                    <uuid>b5904349d4fe4951b77f04fb9561cd95</uuid>
+                    <name>Consumables (toner/supplies) discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#SUPPLY_DESCR},1.3.6.1.2.1.43.11.1.1.6.1,{#SUPPLY_CLASS},1.3.6.1.2.1.43.11.1.1.4.1,{#SUPPLY_UNIT},1.3.6.1.2.1.43.11.1.1.7.1]</snmp_oid>
+                    <key>printer.supplies.discovery</key>
+                    <delay>1h</delay>
+                    <description>Auto-discovers all consumables reported by the printer: Yellow/Magenta/Cyan/Black cartridges, Document Feeder Kit, Toner Collection Unit, etc.</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>a104991c81e44bccab6558b4309939f7</uuid>
+                            <name>{#SUPPLY_DESCR}: Level</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.11.1.1.9.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.supply.level[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>365d</trends>
+                            <value_type>FLOAT</value_type>
+                            <units>%</units>
+                            <description>Raw level. Special values: -1 = level unknown but supply present, -2 = level unavailable, -3 = no supply/not applicable.</description>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>0a960b8257804ed1a32f85fddfc71126</uuid>
+                            <name>{#SUPPLY_DESCR}: Max capacity</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.11.1.1.8.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.supply.maxlevel[{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <value_type>FLOAT</value_type>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>29d015188bb74279b82019ee8dbc56fc</uuid>
+                            <name>{#SUPPLY_DESCR}: Level percent</name>
+                            <type>CALCULATED</type>
+                            <key>printer.supply.percent[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>365d</trends>
+                            <value_type>FLOAT</value_type>
+                            <units>%</units>
+                            <params>last(//printer.supply.level[{#SNMPINDEX}]) / last(//printer.supply.maxlevel[{#SNMPINDEX}]) * 100</params>
+                            <description>Calculated only when raw level and max capacity are both &gt;=0 (see trigger for exceptions).</description>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>3225db679de04a8e91c160793f2899ee</uuid>
+                                    <expression>last(/HP LaserJet MFP E42540 SNMP/printer.supply.level[{#SNMPINDEX}])&gt;=0 and last(/HP LaserJet MFP E42540 SNMP/printer.supply.percent[{#SNMPINDEX}])&lt;{$SUPPLY.LOW.CRIT}</expression>
+                                    <name>{HOST.NAME}: {#SUPPLY_DESCR} is critically low ({ITEM.LASTVALUE})</name>
+                                    <priority>HIGH</priority>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>5ae55b53aed04ce3931ce8c9f5095fce</uuid>
+                                    <expression>last(/HP LaserJet MFP E42540 SNMP/printer.supply.level[{#SNMPINDEX}])&gt;=0 and last(/HP LaserJet MFP E42540 SNMP/printer.supply.percent[{#SNMPINDEX}])&lt;{$SUPPLY.LOW.WARN}</expression>
+                                    <name>{HOST.NAME}: {#SUPPLY_DESCR} is low ({ITEM.LASTVALUE})</name>
+                                    <priority>WARNING</priority>
+                                    <dependencies>
+                                        <dependency>
+                                            <name>{HOST.NAME}: {#SUPPLY_DESCR} is critically low ({ITEM.LASTVALUE})</name>
+                                            <expression>last(/HP LaserJet MFP E42540 SNMP/printer.supply.level[{#SNMPINDEX}])&gt;=0 and last(/HP LaserJet MFP E42540 SNMP/printer.supply.percent[{#SNMPINDEX}])&lt;{$SUPPLY.LOW.CRIT}</expression>
+                                        </dependency>
+                                    </dependencies>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+            <graph_prototypes>
+                <graph_prototype>
+                    <uuid>d2ab03d365544d33a9706ebbda2efc98</uuid>
+                    <name>{#SUPPLY_DESCR}: Level (%)</name>
+                    <graph_items>
+                        <graph_item>
+                            <color>1A7C11</color>
+                            <item>
+                                <host>HP LaserJet MFP E42540 SNMP</host>
+                                <key>printer.supply.percent[{#SNMPINDEX}]</key>
+                            </item>
+                        </graph_item>
+                    </graph_items>
+                </graph_prototype>
+            </graph_prototypes>
+            <preprocessing>
+                <step>
+                    <type>JAVASCRIPT</type>
+                    <parameters>
+                        <parameter>var data = JSON.parse(value);
+function hexDecode(s) {
+    if (!s) { return s; }
+    var t = s.trim();
+    if (!/^([0-9A-Fa-f]{2}[\s]*)+$/.test(t)) { return s; }
+    var hex = t.replace(/\s+/g, '');
+    if (hex.length % 2 !== 0) { return s; }
+    var out = '';
+    for (var i = 0; i &lt; hex.length; i += 2) {
+        var code = parseInt(hex.substr(i, 2), 16);
+        if (code !== 0) { out += String.fromCharCode(code); }
+    }
+    return out.trim() || s;
+}
+for (var i = 0; i &lt; data.length; i++) {
+    if (data[i]['{#SUPPLY_DESCR}'] !== undefined) {
+        data[i]['{#SUPPLY_DESCR}'] = hexDecode(data[i]['{#SUPPLY_DESCR}']);
+    }
+}
+return JSON.stringify(data);</parameter>
+                    </parameters>
+                </step>
+            </preprocessing>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>3f2699c30826441dbe43105b309fcb20</uuid>
+                    <name>Paper trays discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#TRAY_DESCR},1.3.6.1.2.1.43.8.2.1.13.1]</snmp_oid>
+                    <key>printer.trays.discovery</key>
+                    <delay>1h</delay>
+                    <description>Auto-discovers all paper input trays (Tray 1, Tray 2, Tray 3, ...).</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>3ad2146f66294683aab60508d6d9a1d5</uuid>
+                            <name>{#TRAY_DESCR}: Current level</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.8.2.1.10.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.tray.level[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>365d</trends>
+                            <value_type>FLOAT</value_type>
+                            <description>-1 = unknown level but tray not empty, -2 = level unavailable, -3 = tray not applicable. 0 = empty. Positive value = sheets or % depending on printer reporting.</description>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>ef9cce9c93e144cb90ee98af47de78fe</uuid>
+                            <name>{#TRAY_DESCR}: Max capacity</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.8.2.1.9.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.tray.maxcapacity[{#SNMPINDEX}]</key>
+                            <delay>1h</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <value_type>FLOAT</value_type>
+                        </item_prototype>
+                        <item_prototype>
+                            <uuid>06923fb4edae4058a98b4b1929c9386f</uuid>
+                            <name>{#TRAY_DESCR}: Status</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.8.2.1.11.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.tray.status[{#SNMPINDEX}]</key>
+                            <delay>5m</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <description>Bitmask (PrtInputStatusTC). 0 = available and no errors (OK). Non-zero generally indicates a condition (e.g. empty, jam, off-line, cover open).</description>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>b2e075a84efc4bb8a8cd0dbbff86bec0</uuid>
+                                    <expression>last(/HP LaserJet MFP E42540 SNMP/printer.tray.status[{#SNMPINDEX}])&lt;&gt;0</expression>
+                                    <name>{HOST.NAME}: {#TRAY_DESCR} reports an issue (empty/jam/offline)</name>
+                                    <priority>WARNING</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+            <graph_prototypes>
+                <graph_prototype>
+                    <uuid>865e9ae0130c44469d200d52351646fe</uuid>
+                    <name>{#TRAY_DESCR}: Current level</name>
+                    <graph_items>
+                        <graph_item>
+                            <color>2774A4</color>
+                            <item>
+                                <host>HP LaserJet MFP E42540 SNMP</host>
+                                <key>printer.tray.level[{#SNMPINDEX}]</key>
+                            </item>
+                        </graph_item>
+                    </graph_items>
+                </graph_prototype>
+            </graph_prototypes>
+            <preprocessing>
+                <step>
+                    <type>JAVASCRIPT</type>
+                    <parameters>
+                        <parameter>var data = JSON.parse(value);
+function hexDecode(s) {
+    if (!s) { return s; }
+    var t = s.trim();
+    if (!/^([0-9A-Fa-f]{2}[\s]*)+$/.test(t)) { return s; }
+    var hex = t.replace(/\s+/g, '');
+    if (hex.length % 2 !== 0) { return s; }
+    var out = '';
+    for (var i = 0; i &lt; hex.length; i += 2) {
+        var code = parseInt(hex.substr(i, 2), 16);
+        if (code !== 0) { out += String.fromCharCode(code); }
+    }
+    return out.trim() || s;
+}
+for (var i = 0; i &lt; data.length; i++) {
+    if (data[i]['{#TRAY_DESCR}'] !== undefined) {
+        data[i]['{#TRAY_DESCR}'] = hexDecode(data[i]['{#TRAY_DESCR}']);
+    }
+}
+return JSON.stringify(data);</parameter>
+                    </parameters>
+                </step>
+            </preprocessing>
+                </discovery_rule>
+                <discovery_rule>
+                    <uuid>743974fc1ef94317a7b86e54b73e9e77</uuid>
+                    <name>Active alerts discovery</name>
+                    <type>SNMP_AGENT</type>
+                    <snmp_oid>discovery[{#ALERT_DESCR},1.3.6.1.2.1.43.18.1.1.8]</snmp_oid>
+                    <key>printer.alerts.discovery</key>
+                    <delay>3m</delay>
+                    <description>Auto-discovers currently active printer alerts/conditions (prtAlertTable, RFC 3805). Entries only exist while the condition is active - e.g. toner low, tray empty, cover open, paper jam. This is a live status table, NOT a historical event log (HP does not expose the historical Event Log via standard SNMP).</description>
+                    <item_prototypes>
+                        <item_prototype>
+                            <uuid>3111a746912e41719e43f584f59fe0b8</uuid>
+                            <name>Alert: {#ALERT_DESCR}</name>
+                            <type>SNMP_AGENT</type>
+                            <snmp_oid>1.3.6.1.2.1.43.18.1.1.2.1.{#SNMPINDEX}</snmp_oid>
+                            <key>printer.alert.severity[{#SNMPINDEX}]</key>
+                            <delay>3m</delay>
+                            <history>30d</history>
+                            <trends>0</trends>
+                            <description>prtAlertSeverityLevel: 1=other/info, 3=critical, 4=warning. Item only exists while this specific alert is active on the device.</description>
+                            <valuemap>
+                                <name>Printer: prtAlertSeverityLevel</name>
+                            </valuemap>
+                            <trigger_prototypes>
+                                <trigger_prototype>
+                                    <uuid>c855907172db4ad6a2597a469fc8da1c</uuid>
+                                    <expression>last(/HP LaserJet MFP E42540 SNMP/printer.alert.severity[{#SNMPINDEX}])=3</expression>
+                                    <name>{HOST.NAME}: {#ALERT_DESCR} (critical)</name>
+                                    <priority>HIGH</priority>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>722f4bb55f8c4443a76b49a2a5eba42e</uuid>
+                                    <expression>last(/HP LaserJet MFP E42540 SNMP/printer.alert.severity[{#SNMPINDEX}])=4</expression>
+                                    <name>{HOST.NAME}: {#ALERT_DESCR}</name>
+                                    <priority>WARNING</priority>
+                                </trigger_prototype>
+                                <trigger_prototype>
+                                    <uuid>ee51f7c1bcfa4806a3cef74f53d12f77</uuid>
+                                    <expression>last(/HP LaserJet MFP E42540 SNMP/printer.alert.severity[{#SNMPINDEX}])=1</expression>
+                                    <name>{HOST.NAME}: {#ALERT_DESCR} (info)</name>
+                                    <priority>INFO</priority>
+                                </trigger_prototype>
+                            </trigger_prototypes>
+                        </item_prototype>
+                    </item_prototypes>
+                    <preprocessing>
+                        <step>
+                            <type>JAVASCRIPT</type>
+                            <parameters>
+                                <parameter>var data = JSON.parse(value);
+function hexDecode(s) {
+    if (!s) { return s; }
+    var t = s.trim();
+    if (!/^([0-9A-Fa-f]{2}[\s]*)+$/.test(t)) { return s; }
+    var hex = t.replace(/\s+/g, '');
+    if (hex.length % 2 !== 0) { return s; }
+    var out = '';
+    for (var i = 0; i &lt; hex.length; i += 2) {
+        var code = parseInt(hex.substr(i, 2), 16);
+        if (code !== 0) { out += String.fromCharCode(code); }
+    }
+    return out.trim() || s;
+}
+for (var i = 0; i &lt; data.length; i++) {
+    if (data[i]['{#ALERT_DESCR}'] !== undefined) {
+        data[i]['{#ALERT_DESCR}'] = hexDecode(data[i]['{#ALERT_DESCR}']);
+    }
+}
+return JSON.stringify(data);</parameter>
+                            </parameters>
+                        </step>
+                    </preprocessing>
+                </discovery_rule>
+            </discovery_rules>
+            <macros>
+                <macro>
+                    <macro>{$SUPPLY.LOW.WARN}</macro>
+                    <value>20</value>
+                    <description>Toner/consumable percentage threshold for WARNING trigger</description>
+                </macro>
+                <macro>
+                    <macro>{$SUPPLY.LOW.CRIT}</macro>
+                    <value>8</value>
+                    <description>Toner/consumable percentage threshold for HIGH (critical) trigger</description>
+                </macro>
+                <macro>
+                    <macro>{$SNMP_COMMUNITY}</macro>
+                    <value>public</value>
+                    <description>SNMP community string, override on host level as needed</description>
+                </macro>
+            </macros>
+            <valuemaps>
+                <valuemap>
+                    <uuid>1126cf01ac344b17865efc778d7dada6</uuid>
+                    <name>Printer: hrDeviceStatus</name>
+                    <mappings>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>unknown</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>2</value>
+                            <newvalue>running</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>warning</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>4</value>
+                            <newvalue>testing</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>5</value>
+                            <newvalue>down</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+                <valuemap>
+                    <uuid>786f3a31379c4567a6a9988c57757b1b</uuid>
+                    <name>Printer: prtAlertSeverityLevel</name>
+                    <mappings>
+                        <mapping>
+                            <value>1</value>
+                            <newvalue>other/info</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>3</value>
+                            <newvalue>critical</newvalue>
+                        </mapping>
+                        <mapping>
+                            <value>4</value>
+                            <newvalue>warning</newvalue>
+                        </mapping>
+                    </mappings>
+                </valuemap>
+            </valuemaps>
+            <dashboards>
+                <dashboard>
+                    <uuid>e0e3dfdf33594d0d82375e79441dec97</uuid>
+                    <name>HP E42540 Overview</name>
+                    <pages>
+                        <page>
+                            <widgets>
+                                <widget>
+                                    <type>graphprototype</type>
+                                    <width>24</width>
+                                    <height>6</height>
+                                    <fields>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>columns</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>rows</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>GRAPH_PROTOTYPE</type>
+                                            <name>graphid.0</name>
+                                            <value>
+                                                <host>HP LaserJet MFP E42540 SNMP</host>
+                                                <name>{#SUPPLY_DESCR}: Level (%)</name>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAA</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>graphprototype</type>
+                                    <x>24</x>
+                                    <width>24</width>
+                                    <height>6</height>
+                                    <fields>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>columns</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>INTEGER</type>
+                                            <name>rows</name>
+                                            <value>2</value>
+                                        </field>
+                                        <field>
+                                            <type>GRAPH_PROTOTYPE</type>
+                                            <name>graphid.0</name>
+                                            <value>
+                                                <host>HP LaserJet MFP E42540 SNMP</host>
+                                                <name>{#TRAY_DESCR}: Current level</name>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAB</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>itemvalue</type>
+                                    <y>6</y>
+                                    <width>12</width>
+                                    <height>3</height>
+                                    <fields>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid.0</name>
+                                            <value>
+                                                <host>HP LaserJet MFP E42540 SNMP</host>
+                                                <key>printer.device.status</key>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAC</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>itemvalue</type>
+                                    <x>12</x>
+                                    <y>6</y>
+                                    <width>12</width>
+                                    <height>3</height>
+                                    <fields>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid.0</name>
+                                            <value>
+                                                <host>HP LaserJet MFP E42540 SNMP</host>
+                                                <key>printer.model</key>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAD</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>itemvalue</type>
+                                    <x>24</x>
+                                    <y>6</y>
+                                    <width>12</width>
+                                    <height>3</height>
+                                    <fields>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid.0</name>
+                                            <value>
+                                                <host>HP LaserJet MFP E42540 SNMP</host>
+                                                <key>printer.serial</key>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAE</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                                <widget>
+                                    <type>itemvalue</type>
+                                    <x>36</x>
+                                    <y>6</y>
+                                    <width>12</width>
+                                    <height>3</height>
+                                    <fields>
+                                        <field>
+                                            <type>ITEM</type>
+                                            <name>itemid.0</name>
+                                            <value>
+                                                <host>HP LaserJet MFP E42540 SNMP</host>
+                                                <key>printer.pagecount.counter</key>
+                                            </value>
+                                        </field>
+                                        <field>
+                                            <type>STRING</type>
+                                            <name>reference</name>
+                                            <value>AAAAF</value>
+                                        </field>
+                                    </fields>
+                                </widget>
+                            </widgets>
+                        </page>
+                    </pages>
+                </dashboard>
+            </dashboards>
+        </template>
+    </templates>
+</zabbix_export>


### PR DESCRIPTION
Adds 3 new Zabbix 7.0 templates to monitor HP LaserJet/Color LaserJet MFP Enterprise printers via standard SNMP — Printer-MIB (RFC 3805) and Host Resources MIB. No vendor-specific/private MIB is required for the core functionality, so these templates are also expected to work on other similar HP Enterprise/Managed printers.

- `template_hp_color_laserjet_mfp_e78630` — HP Color LaserJet MFP E78630
- `template_hp_laserjet_mfp_e42540` — HP LaserJet MFP E42540 (monochrome)
- `template_hp_color_laserjet_mfp_x57945` — HP Color LaserJet MFP X57945

All 3 share the same architecture (see below) and are submitted together since they were built and validated as a set.

## What does it monitor?

- Device status (running/warning/down), model, serial number, system name
- Toner/consumables level — auto-discovered via LLD (works for any number/type of supplies the device reports: toner cartridges, drums, developer units, fuser kit, transfer belt/cleaning unit, document feeder kit, etc.)
- Paper tray level & status — auto-discovered via LLD
- Active device alerts (toner low, tray empty, cover open, jam, etc.) — auto-discovered via LLD
- Total pages printed (lifetime + rate), total monochrome/color impressions (lifetime)

## Testing

- **E78630**: tested against a live unit. SNMP walk output was cross-checked against the device's own web UI (Device Status page, Usage Page) to confirm values match.
- **E42540 / X57945**: built using the same verified SNMP MIB structure as the E78630 template; not yet field-tested against a physical unit of these two models.

## Checklist

- [x] Each template follows the folder/naming convention (`template_<name>/7.0/`)
- [x] README.md included per template with setup instructions, macros, and metrics list
- [x] E78630 tested on a real device; E42540/X57945 structurally identical but pending field validation