### PR TITLE
Add FS S3900R switch monitoring template by SNMP

### DIFF
--- a/Network_Devices/FS/template_fs_s3900r_snmp/7.0/README.md
+++ b/Network_Devices/FS/template_fs_s3900r_snmp/7.0/README.md
@@ -1,0 +1,44 @@
+# FS S3900R by SNMP
+
+## Overview
+
+This template monitors FS (Fiberstore) S3900R series switches via SNMP: device inventory, CPU, memory, interfaces, power supplies, and per-transceiver optical diagnostics (DDM).
+
+Built and verified against a live **S3900-24T4S-R** running firmware `159394` (24x 1G copper + 4x 10G SFP+ uplinks).
+
+## Requirements
+
+- Zabbix server 7.0 or higher
+- SNMP access to the switch (SNMPv2c by default; adjust the host's SNMP interface for v3 if needed)
+
+## A note on the transceiver (DDM) discovery rule
+
+The vendor's own optical-diagnostics OID subtree is **not documented anywhere public** (no FIBERSTORE-MIB covers it, and it isn't the subtree some older FS templates reference, which returns "No Such Object" on real hardware). The OIDs used here (`enterprises.52642.9.63.1.7.1.x`) were found empirically by walking the device and matching live, per-port values against known SFF-8472 scaling constants, then **cross-validated against the switch's own CLI** (`show interface tGigaEthernet 0/X`) — TX/RX power, temperature, voltage, bias current, and all five alarm/warning thresholds matched exactly.
+
+Confidence is high, but this is reverse-engineered, not vendor-documented. If you deploy this on a different S3900R unit or firmware and the transceiver metrics look wrong, please open an issue - the OID mapping (or the `^TGigaEthernet` port-name filter used to scope discovery to SFP+-capable ports) may need adjusting for your hardware.
+
+PSU status codes are similarly empirical: only the healthy status (`1`) has been observed, so the "not in normal state" trigger fires on any other value without knowing what those other codes actually mean.
+
+## Discovery rules
+
+| Name | Description |
+|------|-------------|
+| `net.if.discovery` | Standard IF-MIB interface discovery (traffic, errors, discards, speed, status) |
+| `transceiver.ddm.discovery` | Per-transceiver optical diagnostics (TX/RX power, temperature, voltage, bias current) and their live vendor alarm thresholds, for the 4 SFP+-capable ports |
+| `psu.discovery` | Power supply status |
+
+## Macros
+
+| Macro | Default | Description |
+|-------|---------|-------------|
+| `{$IF.ERRORS.WARN}` | 2 | Interface error-rate warning threshold |
+| `{$IF.UTIL.MAX}` | 90 | Interface bandwidth-utilization warning threshold (%) |
+| `{$IFCONTROL}` | 1 | Set to 0 per-interface to suppress its Link down trigger |
+| `{$NET.IF.IFNAME.NOT_MATCHES}` etc. | - | Standard interface-discovery filters (see item description) |
+
+Transceiver and PSU alarm thresholds are **not** macros - they're read live from the installed module via SNMP, so they automatically track whatever transceiver is actually plugged into a given port.
+
+## Known limitations
+
+- Transceiver RX-power-low and temperature-too-high triggers have no dependency on their interface's Link-down trigger: Zabbix trigger-prototype dependencies only resolve within the same discovery rule, and these come from two separate ones.
+- No chassis temperature or fan monitoring: this device doesn't implement ENTITY-SENSOR-MIB, and no vendor OID for chassis-wide temperature could be found.

--- a/Network_Devices/FS/template_fs_s3900r_snmp/7.0/template_fs_s3900r_snmp.yaml
+++ b/Network_Devices/FS/template_fs_s3900r_snmp/7.0/template_fs_s3900r_snmp.yaml
@@ -1,0 +1,1550 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 36bff6c29af64692839d077febfc7079
+      name: 'Templates/Network devices'
+  templates:
+    - uuid: 25f40c9d65d64b6bbd6e53b85a5de08c
+      template: 'FS S3900R'
+      name: 'FS S3900R'
+      description: 'This template is used for FS S3900R devices'
+      groups:
+        - name: 'Templates/Network devices'
+      items:
+        - uuid: 5172239aee914bf195c0ef4be7d481c9
+          name: CPUUtilization5Sec
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.25.3.3.1.2.1
+          key: cpuCurrentUti
+          history: 90d
+          units: '%'
+          description: 'The current CPU utilization in percent in the past 5 seconds.'
+          tags:
+            - tag: component
+              value: cpu
+          triggers:
+            - uuid: 6d0f26878db242338eed59567a5eea43
+              expression: 'last(/FS S3900R/cpuCurrentUti)>=90'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'last(/FS S3900R/cpuCurrentUti)<90'
+              name: 'CPU Utilization'
+              priority: HIGH
+              description: 'When the temperature is greater than or equal to 90%, the alarm will be restored when it is less than 90%.'
+              tags:
+                - tag: scope
+                  value: availability
+                - tag: scope
+                  value: performance
+        - uuid: 0d2c519da50b40058fc8c8c0280a29ea
+          name: 'Device MAC'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.17.1.1.0
+          key: deviceMac
+          delay: 1h
+          history: 14d
+          value_type: TEXT
+          trends: '0'
+          description: 'MIB: BRIDGE-MIB. Bridge base MAC - portable, unlike a hardcoded ifIndex.'
+          tags:
+            - tag: component
+              value: system
+        - uuid: cb1da0aeaa324cf5bd0c5b390f480577
+          name: 'Memory Size'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.25.2.2.0
+          key: memoryTotal
+          delay: 1h
+          history: 7d
+          trends: '0'
+          value_type: FLOAT
+          units: B
+          description: 'MIB: hrMemorySize. Spec says KB, but this FS agent returns raw bytes (268435456 = 256MiB, not 256GiB) - no conversion applied.'
+          tags:
+            - tag: component
+              value: memory
+        - uuid: 6c341602ef0b4c63a8703fbfd76d437e
+          name: 'Device HwVersion'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.1.9.1.3.1
+          key: swHardwareVer
+          delay: 1h
+          history: 14d
+          value_type: TEXT
+          trends: '0'
+          description: 'Hardware version, via sysORDescr.1 (FS stuffs the sysDescr banner in here).'
+          preprocessing:
+            - type: REGEX
+              parameters:
+                - 'hardware version:\s*(\S+)'
+                - \1
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: 26a3d0be833f41b99d3ecb10cd38a91d
+              expression: 'last(/FS S3900R/swHardwareVer)<>"A"'
+              name: 'New Hardware Revision {ITEM.VALUE1}'
+              priority: AVERAGE
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 7f51a8ed4aba4e7f8bd84275577188e4
+          name: 'Device SwVersion'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.47.1.1.1.1.10.1
+          key: swOpCodeVer
+          delay: 1h
+          history: 14d
+          value_type: TEXT
+          trends: '0'
+          description: 'Operation code version of the main board.'
+          tags:
+            - tag: component
+              value: system
+        - uuid: 9340eae0db43469e98dbb8d945e4cd99
+          name: 'Serial Number'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.47.1.1.1.1.11.1
+          key: swSerialNumber
+          delay: 1h
+          history: 14d
+          value_type: TEXT
+          trends: '0'
+          description: 'Serial number of the switch.'
+          tags:
+            - tag: component
+              value: system
+        - uuid: 716b17ac6f7240feba25cd66289c0545
+          name: 'Device Contact'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.4.0
+          key: sysContact
+          delay: 1h
+          history: 14d
+          value_type: TEXT
+          trends: '0'
+          description: 'The contact of this node.  If the contact is unknown, the value is the zero-length string.'
+          tags:
+            - tag: component
+              value: system
+        - uuid: 6148945ca5f6463b9cbfb1729353e0a6
+          name: 'Device Model'
+          type: SNMP_AGENT
+          snmp_oid: .1.3.6.1.2.1.47.1.1.1.1.2.1
+          key: sysDeviceModel
+          delay: 1h
+          history: 14d
+          value_type: TEXT
+          trends: '0'
+          description: 'Model of device'
+          tags:
+            - tag: component
+              value: system
+        - uuid: 774f182ca4144096805c3808b3438b2c
+          name: 'Device Location'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.6.0
+          key: sysLocation
+          delay: 1h
+          history: 14d
+          value_type: TEXT
+          trends: '0'
+          description: 'The physical location of this node (e.g., ''telephone closet, 3rd floor'').  If the location is unknown, the value is the zero-length string.'
+          tags:
+            - tag: component
+              value: system
+        - uuid: e0b6d14b64de49d0a368484e07e6ffa9
+          name: 'Device Name'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.5.0
+          key: sysName
+          delay: 1h
+          history: 14d
+          value_type: TEXT
+          trends: '0'
+          description: |
+            An administratively-assigned name for this managed node.  By convention, this is the node's fully-qualified domain name.  If the name is unknown, the value is
+             the zero-length string.
+          tags:
+            - tag: component
+              value: system
+        - uuid: a2a414b276d4488aa31adccee780d739
+          name: SysUptime
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.3.0
+          key: SysUptime
+          history: 90d
+          trends: '0'
+          units: uptime
+          description: 'The time (in hundredths of a second) since the network management portion of the system was last re-initialized.'
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.01'
+          tags:
+            - tag: component
+              value: system
+      discovery_rules:
+        - uuid: 40555eed071e412f882854d3aa72f9c8
+          name: 'Transceiver DDM:discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#IFNAME},1.3.6.1.2.1.31.1.1.1.1,{#IFALIAS},1.3.6.1.2.1.31.1.1.1.18,{#TXPOWER},1.3.6.1.4.1.52642.9.63.1.7.1.2]'
+          key: transceiver.ddm.discovery
+          delay: 1h
+          lifetime: 30d
+          enabled_lifetime_type: DISABLE_IMMEDIATELY
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#IFNAME}'
+                value: '^TGigaEthernet'
+                formulaid: A
+              - macro: '{#TXPOWER}'
+                value: '^-65535$'
+                operator: NOT_MATCHES_REGEX
+                formulaid: B
+          description: |
+            Filtered to ifName ^TGigaEthernet (this model's only 4 SFP+-capable ports) AND vendor TXPOWER <> -65535 (has a module installed). Combining IF-MIB with the vendor OID is only safe once the IF-MIB side is pre-bounded like this - unbounded, it hard-errors. Item-level preprocessing also discards -65535 as a safety net for the up-to-1h gap between a module being pulled and the next discovery run.
+            Readings come from enterprises.52642.9.63.1.7.1.x, by ifIndex (the shipped enterprises.52642.2.1.45.x doesn't exist on real hardware). Vendor-confirmed via CLI on sw45r310 port 27 - all 5 metrics and thresholds matched exactly.
+          item_prototypes:
+            - uuid: fc91e405e58b4805bf0b0d0994e801fa
+              name: 'Interface {#IFNAME}({#IFALIAS}): Transceiver bias current'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.52642.9.63.1.7.1.6.{#SNMPINDEX}'
+              key: 'transceiver.ddm.biascurrent[{#SNMPINDEX}]'
+              history: 30d
+              value_type: FLOAT
+              units: mA
+              trends: '0'
+              description: 'Tx bias current. SFF-8472 raw units, 2 uA.'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - 'if (value == -65535) { throw ''No transceiver installed''; } return value;'
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.002'
+              tags:
+                - tag: component
+                  value: transceiver
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 01e4bdf5d62c443ab76f0a6af8bb227d
+              name: 'Interface {#IFNAME}({#IFALIAS}): Transceiver supply voltage'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.52642.9.63.1.7.1.5.{#SNMPINDEX}'
+              key: 'transceiver.ddm.vcc[{#SNMPINDEX}]'
+              history: 30d
+              value_type: FLOAT
+              units: V
+              trends: '0'
+              description: 'Transceiver Vcc. SFF-8472 raw units, 100 uV.'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - 'if (value == -65535) { throw ''No transceiver installed''; } return value;'
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.0001'
+              tags:
+                - tag: component
+                  value: transceiver
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 411c0f38cdb44e9f9e54e9edca03c090
+              name: 'Interface {#IFNAME}({#IFALIAS}): Transceiver temperature'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.52642.9.63.1.7.1.4.{#SNMPINDEX}'
+              key: 'transceiver.ddm.temperature[{#SNMPINDEX}]'
+              history: 30d
+              value_type: FLOAT
+              units: °C
+              trends: '0'
+              description: 'Transceiver temperature. SFF-8472 raw units, 1/256 degC.'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - 'if (value == -65535) { throw ''No transceiver installed''; } return value;'
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.00390625'
+              tags:
+                - tag: component
+                  value: transceiver
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+              trigger_prototypes:
+                - uuid: a17f5c2e9d8b4f6c8a1e3d5b7c9f2a4e
+                  expression: 'last(/FS S3900R/transceiver.ddm.temperature[{#SNMPINDEX}])>last(/FS S3900R/transceiver.ddm.temp.highwarn[{#SNMPINDEX}])'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/FS S3900R/transceiver.ddm.temperature[{#SNMPINDEX}])<last(/FS S3900R/transceiver.ddm.temp.highwarn[{#SNMPINDEX}])-3'
+                  name: 'Interface {#IFNAME}({#IFALIAS}): Transceiver temperature above module''s own High-Warning threshold'
+                  opdata: 'Current: {ITEM.LASTVALUE1}, threshold: {ITEM.LASTVALUE2}'
+                  priority: WARNING
+                  description: 'Reads the installed module''s own High-Warning threshold live via SNMP instead of a fixed value, so it adapts if a different transceiver is plugged in. No Link-down dependency - cross-rule trigger dependencies don''t resolve in Zabbix.'
+                  tags:
+                    - tag: scope
+                      value: availability
+                    - tag: scope
+                      value: performance
+            - uuid: 1163c05513ec4946b77e90e7b348aabd
+              name: 'Interface {#IFNAME}({#IFALIAS}): Transceiver temperature High-Warning threshold'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.52642.9.63.1.7.1.29.{#SNMPINDEX}'
+              key: 'transceiver.ddm.temp.highwarn[{#SNMPINDEX}]'
+              delay: 1h
+              value_type: FLOAT
+              units: °C
+              trends: '0'
+              description: 'Module''s own High-Warning temperature threshold, read live so the trigger tracks whatever module is actually installed.'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - 'if (value == -65535) { throw ''No transceiver installed''; } return value;'
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.00390625'
+              tags:
+                - tag: component
+                  value: transceiver
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 5575fb1de63a48b890dabd75f077509e
+              name: 'Interface {#IFNAME}({#IFALIAS}): Transceiver RX power'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.52642.9.63.1.7.1.3.{#SNMPINDEX}'
+              key: 'transceiver.ddm.rxpower[{#SNMPINDEX}]'
+              history: 30d
+              value_type: FLOAT
+              units: dBm
+              trends: '0'
+              description: 'RX optical power. Raw units, 0.01 dBm signed.'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - 'if (value == -65535) { throw ''No transceiver installed''; } return value;'
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.01'
+              tags:
+                - tag: component
+                  value: transceiver
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+              trigger_prototypes:
+                - uuid: d28e6f4b1a9c47e0b3d5f8a2c6e9b1f4
+                  expression: 'last(/FS S3900R/transceiver.ddm.rxpower[{#SNMPINDEX}])<last(/FS S3900R/transceiver.ddm.rxpower.lowwarn[{#SNMPINDEX}])'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/FS S3900R/transceiver.ddm.rxpower[{#SNMPINDEX}])>last(/FS S3900R/transceiver.ddm.rxpower.lowwarn[{#SNMPINDEX}])+1'
+                  name: 'Interface {#IFNAME}({#IFALIAS}): Transceiver RX power below module''s own Low-Warning threshold'
+                  opdata: 'Current: {ITEM.LASTVALUE1}, threshold: {ITEM.LASTVALUE2}'
+                  priority: WARNING
+                  description: 'Reads the installed module''s own Low-Warning threshold live via SNMP instead of a fixed value. May indicate a degrading link or dirty connector. No Link-down dependency - see Temperature trigger.'
+                  tags:
+                    - tag: scope
+                      value: availability
+                    - tag: scope
+                      value: performance
+            - uuid: 95452e2152504a89b8610b5caf5a0986
+              name: 'Interface {#IFNAME}({#IFALIAS}): Transceiver RX power Low-Warning threshold'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.52642.9.63.1.7.1.42.{#SNMPINDEX}'
+              key: 'transceiver.ddm.rxpower.lowwarn[{#SNMPINDEX}]'
+              delay: 1h
+              value_type: FLOAT
+              units: dBm
+              trends: '0'
+              description: 'Module''s own Low-Warning RX power threshold, read live so the trigger tracks whatever module is actually installed.'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - 'if (value == -65535) { throw ''No transceiver installed''; } return value;'
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.01'
+              tags:
+                - tag: component
+                  value: transceiver
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: f762f10f67c74654a902fa9447d2c4d9
+              name: 'Interface {#IFNAME}({#IFALIAS}): Transceiver TX power'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.52642.9.63.1.7.1.2.{#SNMPINDEX}'
+              key: 'transceiver.ddm.txpower[{#SNMPINDEX}]'
+              history: 30d
+              value_type: FLOAT
+              units: dBm
+              trends: '0'
+              description: 'TX optical power. Raw units, 0.01 dBm signed.'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - 'if (value == -65535) { throw ''No transceiver installed''; } return value;'
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.01'
+              tags:
+                - tag: component
+                  value: transceiver
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+          graph_prototypes:
+            - uuid: 4203a572f312411eb7779b3103bd5805
+              name: 'Interface {#IFNAME}({#IFALIAS}): Transceiver optical power'
+              graph_items:
+                - drawtype: GRADIENT_LINE
+                  color: 1A7C11
+                  item:
+                    host: 'FS S3900R'
+                    key: 'transceiver.ddm.txpower[{#SNMPINDEX}]'
+                - sortorder: '1'
+                  drawtype: BOLD_LINE
+                  color: 2774A4
+                  item:
+                    host: 'FS S3900R'
+                    key: 'transceiver.ddm.rxpower[{#SNMPINDEX}]'
+                - sortorder: '2'
+                  color: F63100
+                  item:
+                    host: 'FS S3900R'
+                    key: 'transceiver.ddm.rxpower.lowwarn[{#SNMPINDEX}]'
+        - uuid: 511ac9841e134f2eb6357ccfc4a78e1a
+          name: 'Power Supplies:discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#PSUSTATUS},1.3.6.1.4.1.52642.9.189.5.1.1.5.1]'
+          key: psu.discovery
+          delay: 1h
+          lifetime: 30d
+          enabled_lifetime_type: DISABLE_IMMEDIATELY
+          description: |
+            Empirically found (enterprises.52642.9.189.5.1.1.5.1.<psuIndex>), matches ENTITY-MIB's "Power Dev0/1". Not vendor-confirmed - only the healthy status (1) was observed.
+          item_prototypes:
+            - uuid: 1b12c8f2648647e8ab5d2c215e1b6bb4
+              name: 'PSU {#SNMPINDEX}: Status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.4.1.52642.9.189.5.1.1.5.1.{#SNMPINDEX}'
+              key: 'psu.status[{#SNMPINDEX}]'
+              delay: 1m
+              trends: '0'
+              description: 'Raw vendor PSU status code. 1 = observed-normal; other values unconfirmed.'
+              valuemap:
+                name: 'FS PSU status'
+              tags:
+                - tag: component
+                  value: power
+              trigger_prototypes:
+                - uuid: c3d1a2e4f6b84a1e9c7d5e2f1a3b4c5d
+                  expression: 'last(/FS S3900R/psu.status[{#SNMPINDEX}])<>1'
+                  name: 'PSU {#SNMPINDEX}: Not in normal state'
+                  priority: HIGH
+                  description: 'Fires on anything other than the observed-normal value (1); other codes unconfirmed.'
+                  tags:
+                    - tag: scope
+                      value: notice
+        - uuid: bab856f81cbc48a8a70c24a01f3fc2f4
+          name: 'Network Interfaces:discovery'
+          type: SNMP_AGENT
+          snmp_oid: 'discovery[{#IFOPERSTATUS},1.3.6.1.2.1.2.2.1.8,{#IFADMINSTATUS},1.3.6.1.2.1.2.2.1.7,{#IFALIAS},1.3.6.1.2.1.31.1.1.1.18,{#IFNAME},1.3.6.1.2.1.31.1.1.1.1,{#IFDESCR},1.3.6.1.2.1.2.2.1.2,{#IFTYPE},1.3.6.1.2.1.2.2.1.3]'
+          key: net.if.discovery
+          delay: 1h
+          enabled_lifetime_type: DISABLE_AFTER
+          enabled_lifetime: 3d
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#IFADMINSTATUS}'
+                value: '{$NET.IF.IFADMINSTATUS.MATCHES}'
+                formulaid: A
+              - macro: '{#IFADMINSTATUS}'
+                value: '{$NET.IF.IFADMINSTATUS.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: B
+              - macro: '{#IFALIAS}'
+                value: '{$NET.IF.IFALIAS.MATCHES}'
+                formulaid: C
+              - macro: '{#IFALIAS}'
+                value: '{$NET.IF.IFALIAS.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: D
+              - macro: '{#IFDESCR}'
+                value: '{$NET.IF.IFDESCR.MATCHES}'
+                formulaid: E
+              - macro: '{#IFDESCR}'
+                value: '{$NET.IF.IFDESCR.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: F
+              - macro: '{#IFNAME}'
+                value: '{$NET.IF.IFNAME.MATCHES}'
+                formulaid: G
+              - macro: '{#IFNAME}'
+                value: '{$NET.IF.IFNAME.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: H
+              - macro: '{#IFOPERSTATUS}'
+                value: '{$NET.IF.IFOPERSTATUS.MATCHES}'
+                formulaid: I
+              - macro: '{#IFOPERSTATUS}'
+                value: '{$NET.IF.IFOPERSTATUS.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: J
+              - macro: '{#IFTYPE}'
+                value: '{$NET.IF.IFTYPE.MATCHES}'
+                formulaid: K
+              - macro: '{#IFTYPE}'
+                value: '{$NET.IF.IFTYPE.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: L
+          lifetime: 30d
+          description: 'Discovering interfaces from IF-MIB.'
+          item_prototypes:
+            - uuid: 75abfae134984fafbdbc3df45042c3eb
+              name: 'Interface {#IFNAME}({#IFALIAS}): Interface description'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.31.1.1.1.18.{#SNMPINDEX}'
+              key: 'net.if.desc[ifType.{#SNMPINDEX}]'
+              delay: 1h
+              history: 7d
+              value_type: TEXT
+              trends: '0'
+              description: |
+                MIB: IF-MIB
+                The description of interface.
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 1a7fd170849c469781c64e2d4aba6342
+              name: 'Interface {#IFNAME}({#IFALIAS}): Inbound packets discarded'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.13.{#SNMPINDEX}'
+              key: 'net.if.in.discards[ifInDiscards.{#SNMPINDEX}]'
+              delay: 3m
+              history: 7d
+              description: |
+                MIB: IF-MIB
+                The number of inbound packets which were chosen to be discarded
+                even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.
+                One possible reason for discarding such a packet could be to free up buffer space.
+                Discontinuities in the value of this counter can occur at re-initialization of the management system,
+                and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 2452c0b067b84424b0f2a5136f4123ec
+              name: 'Interface {#IFNAME}({#IFALIAS}): Inbound packets with errors'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.14.{#SNMPINDEX}'
+              key: 'net.if.in.errors[ifInErrors.{#SNMPINDEX}]'
+              delay: 3m
+              history: 7d
+              description: |
+                MIB: IF-MIB
+                For packet-oriented interfaces, the number of inbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of inbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: d980d457baca4db484688510e3898719
+              name: 'Interface {#IFNAME}({#IFALIAS}): Bits received'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.31.1.1.1.6.{#SNMPINDEX}'
+              key: 'net.if.in[ifHCInOctets.{#SNMPINDEX}]'
+              delay: 3m
+              history: 7d
+              units: bps
+              description: |
+                MIB: IF-MIB
+                The total number of octets received on the interface, including framing characters. This object is a 64-bit version of ifInOctets. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 9a7d2ada110646ebbd751b1eb11b8fc4
+              name: 'Interface {#IFNAME}({#IFALIAS}): Outbound packets discarded'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.19.{#SNMPINDEX}'
+              key: 'net.if.out.discards[ifOutDiscards.{#SNMPINDEX}]'
+              delay: 3m
+              history: 7d
+              description: |
+                MIB: IF-MIB
+                The number of outbound packets which were chosen to be discarded
+                even though no errors had been detected to prevent their being deliverable to a higher-layer protocol.
+                One possible reason for discarding such a packet could be to free up buffer space.
+                Discontinuities in the value of this counter can occur at re-initialization of the management system,
+                and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 20060546900a452e81d490f9b068b1ec
+              name: 'Interface {#IFNAME}({#IFALIAS}): Outbound packets with errors'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.20.{#SNMPINDEX}'
+              key: 'net.if.out.errors[ifOutErrors.{#SNMPINDEX}]'
+              delay: 3m
+              history: 7d
+              description: |
+                MIB: IF-MIB
+                For packet-oriented interfaces, the number of outbound packets that contained errors preventing them from being deliverable to a higher-layer protocol.  For character-oriented or fixed-length interfaces, the number of outbound transmission units that contained errors preventing them from being deliverable to a higher-layer protocol. Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 02fc6db92b07461e9a51ef927aefb061
+              name: 'Interface {#IFNAME}({#IFALIAS}): Bits sent'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.31.1.1.1.10.{#SNMPINDEX}'
+              key: 'net.if.out[ifHCOutOctets.{#SNMPINDEX}]'
+              delay: 3m
+              history: 7d
+              units: bps
+              description: |
+                MIB: IF-MIB
+                The total number of octets transmitted out of the interface, including framing characters. This object is a 64-bit version of ifOutOctets.Discontinuities in the value of this counter can occur at re-initialization of the management system, and at other times as indicated by the value of ifCounterDiscontinuityTime.
+              preprocessing:
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: e4558ba562e44ece80aed18055f6106a
+              name: 'Interface {#IFNAME}({#IFALIAS}): Speed'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.31.1.1.1.15.{#SNMPINDEX}'
+              key: 'net.if.speed[ifHighSpeed.{#SNMPINDEX}]'
+              delay: 5m
+              history: 7d
+              trends: '0'
+              units: bps
+              description: |
+                MIB: IF-MIB
+                An estimate of the interface's current bandwidth in units of 1,000,000 bits per second. If this object reports a value of `n' then the speed of the interface is somewhere in the range of `n-500,000' to`n+499,999'.  For interfaces which do not vary in bandwidth or for those where no accurate estimation can be made, this object should contain the nominal bandwidth. For a sub-layer which has no concept of bandwidth, this object should be zero.
+              preprocessing:
+                - type: MULTIPLIER
+                  parameters:
+                    - '1000000'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: d97206fbf9c34efda0ec2ea6b957b928
+              name: 'Interface {#IFNAME}({#IFALIAS}): Operational status'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.8.{#SNMPINDEX}'
+              key: 'net.if.status[ifOperStatus.{#SNMPINDEX}]'
+              history: 7d
+              trends: '0'
+              description: |
+                MIB: IF-MIB
+                The current operational state of the interface.
+                - The testing(3) state indicates that no operational packet scan be passed
+                - If ifAdminStatus is down(2) then ifOperStatus should be down(2)
+                - If ifAdminStatus is changed to up(1) then ifOperStatus should change to up(1) if the interface is ready to transmit and receive network traffic
+                - It should change todormant(5) if the interface is waiting for external actions (such as a serial line waiting for an incoming connection)
+                - It should remain in the down(2) state if and only if there is a fault that prevents it from going to the up(1) state
+                - It should remain in the notPresent(6) state if the interface has missing(typically, hardware) components.
+              valuemap:
+                name: 'IF-MIB::ifOperStatus'
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+              trigger_prototypes:
+                - uuid: eb42d53ab5ab4b31a855f2c8c7662338
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and (last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))=1)'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2'
+                  name: 'Interface {#IFNAME}({#IFALIAS}): Link down'
+                  opdata: 'Current state: {ITEM.LASTVALUE1}'
+                  priority: AVERAGE
+                  description: |
+                    This trigger expression works as follows:
+                    1. Can be triggered if operations status is down.
+                    2. {$IFCONTROL:"{#IFNAME}"}=1 - user can redefine Context macro to value - 0. That marks this interface as not important. No new trigger will be fired if this interface is down.
+                    3. {TEMPLATE_NAME:METRIC.diff()}=1) - trigger fires only if operational status was up(1) sometime before. (So, do not fire 'ethernal off' interfaces.)
+
+                    WARNING: if closed manually - won't fire again on next poll, because of .diff.
+                  tags:
+                    - tag: scope
+                      value: availability
+            - uuid: 482a6b386aa244d4b6815e1680e89fab
+              name: 'Interface {#IFNAME}({#IFALIAS}): Interface type'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.2.2.1.3.{#SNMPINDEX}'
+              key: 'net.if.type[ifType.{#SNMPINDEX}]'
+              delay: 1h
+              history: 7d
+              trends: '0'
+              description: |
+                MIB: IF-MIB
+                The type of interface.
+                Additional values for ifType are assigned by the Internet Assigned NumbersAuthority (IANA),
+                through updating the syntax of the IANAifType textual convention.
+              valuemap:
+                name: 'IF-MIB::ifType'
+              preprocessing:
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1d
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+          trigger_prototypes:
+            - uuid: 7379189be04a483bb238f65048992af8
+              expression: |
+                change(/FS S3900R/net.if.speed[ifHighSpeed.{#SNMPINDEX}])<0 and last(/FS S3900R/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0
+                and (
+                last(/FS S3900R/net.if.type[ifType.{#SNMPINDEX}])=6 or
+                last(/FS S3900R/net.if.type[ifType.{#SNMPINDEX}])=7 or
+                last(/FS S3900R/net.if.type[ifType.{#SNMPINDEX}])=11 or
+                last(/FS S3900R/net.if.type[ifType.{#SNMPINDEX}])=62 or
+                last(/FS S3900R/net.if.type[ifType.{#SNMPINDEX}])=69 or
+                last(/FS S3900R/net.if.type[ifType.{#SNMPINDEX}])=117
+                )
+                and
+                (last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2)
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: |
+                (change(/FS S3900R/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0 and last(/FS S3900R/net.if.speed[ifHighSpeed.{#SNMPINDEX}],#2)>0) or
+                (last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}])=2)
+              name: 'Interface {#IFNAME}({#IFALIAS}): Ethernet has changed to lower speed than it was before'
+              opdata: 'Current reported speed: {ITEM.LASTVALUE1}'
+              priority: INFO
+              description: 'This Ethernet connection has transitioned down from its known maximum speed. This might be a sign of autonegotiation issues. Ack to close.'
+              manual_close: 'YES'
+              dependencies:
+                - name: 'Interface {#IFNAME}({#IFALIAS}): Link down'
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and (last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))=1)'
+                  recovery_expression: 'last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2'
+              tags:
+                - tag: scope
+                  value: notice
+            - uuid: ea15aca80c73447b83b0814e50083281
+              expression: |
+                (avg(/FS S3900R/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/FS S3900R/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) or
+                avg(/FS S3900R/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/FS S3900R/net.if.speed[ifHighSpeed.{#SNMPINDEX}])) and
+                last(/FS S3900R/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: |
+                avg(/FS S3900R/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/FS S3900R/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) and
+                avg(/FS S3900R/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/FS S3900R/net.if.speed[ifHighSpeed.{#SNMPINDEX}])
+              name: 'Interface {#IFNAME}({#IFALIAS}): High bandwidth usage ( > {$IF.UTIL.MAX:"{#IFNAME}"}% )'
+              opdata: 'In: {ITEM.LASTVALUE1}, out: {ITEM.LASTVALUE3}, speed: {ITEM.LASTVALUE2}'
+              priority: WARNING
+              description: 'The network interface utilization is close to its estimated maximum bandwidth.'
+              dependencies:
+                - name: 'Interface {#IFNAME}({#IFALIAS}): Link down'
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and (last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))=1)'
+                  recovery_expression: 'last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2'
+              tags:
+                - tag: scope
+                  value: performance
+            - uuid: 2061c79df6f44b2ab33b144ca8485b56
+              expression: |
+                min(/FS S3900R/net.if.in.errors[ifInErrors.{#SNMPINDEX}],5m)>{$IF.ERRORS.WARN:"{#IFNAME}"}
+                or min(/FS S3900R/net.if.out.errors[ifOutErrors.{#SNMPINDEX}],5m)>{$IF.ERRORS.WARN:"{#IFNAME}"}
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: |
+                max(/FS S3900R/net.if.in.errors[ifInErrors.{#SNMPINDEX}],5m)<{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8
+                and max(/FS S3900R/net.if.out.errors[ifOutErrors.{#SNMPINDEX}],5m)<{$IF.ERRORS.WARN:"{#IFNAME}"}*0.8
+              name: 'Interface {#IFNAME}({#IFALIAS}): High error rate ( > {$IF.ERRORS.WARN:"{#IFNAME}"} for 5m)'
+              opdata: 'errors in: {ITEM.LASTVALUE1}, errors out: {ITEM.LASTVALUE2}'
+              priority: WARNING
+              description: 'Recovers when below 80% of {$IF.ERRORS.WARN:"{#IFNAME}"} threshold'
+              dependencies:
+                - name: 'Interface {#IFNAME}({#IFALIAS}): Link down'
+                  expression: '{$IFCONTROL:"{#IFNAME}"}=1 and (last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and (last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}],#1)<>last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}],#2))=1)'
+                  recovery_expression: 'last(/FS S3900R/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2'
+              tags:
+                - tag: scope
+                  value: performance
+          graph_prototypes:
+            - uuid: 19ef60e3ea59465f83511a496bd04fa4
+              name: 'Interface {#IFNAME}({#IFALIAS}): Network traffic'
+              graph_items:
+                - drawtype: GRADIENT_LINE
+                  color: 1A7C11
+                  item:
+                    host: 'FS S3900R'
+                    key: 'net.if.in[ifHCInOctets.{#SNMPINDEX}]'
+                - sortorder: '1'
+                  drawtype: BOLD_LINE
+                  color: 2774A4
+                  item:
+                    host: 'FS S3900R'
+                    key: 'net.if.out[ifHCOutOctets.{#SNMPINDEX}]'
+                - sortorder: '2'
+                  color: F63100
+                  yaxisside: RIGHT
+                  item:
+                    host: 'FS S3900R'
+                    key: 'net.if.out.errors[ifOutErrors.{#SNMPINDEX}]'
+                - sortorder: '3'
+                  color: A54F10
+                  yaxisside: RIGHT
+                  item:
+                    host: 'FS S3900R'
+                    key: 'net.if.in.errors[ifInErrors.{#SNMPINDEX}]'
+                - sortorder: '4'
+                  color: FC6EA3
+                  yaxisside: RIGHT
+                  item:
+                    host: 'FS S3900R'
+                    key: 'net.if.out.discards[ifOutDiscards.{#SNMPINDEX}]'
+                - sortorder: '5'
+                  color: 6C59DC
+                  yaxisside: RIGHT
+                  item:
+                    host: 'FS S3900R'
+                    key: 'net.if.in.discards[ifInDiscards.{#SNMPINDEX}]'
+      tags:
+        - tag: class
+          value: network
+        - tag: target
+          value: FS
+      macros:
+        - macro: '{$IF.ERRORS.WARN}'
+          value: '2'
+        - macro: '{$IF.UTIL.MAX}'
+          value: '90'
+        - macro: '{$IFCONTROL}'
+          value: '1'
+        - macro: '{$NET.IF.IFADMINSTATUS.MATCHES}'
+          value: '^.*'
+          description: 'Ignore notPresent(6)'
+        - macro: '{$NET.IF.IFADMINSTATUS.NOT_MATCHES}'
+          value: ^2$
+          description: 'Ignore down(2) administrative status'
+        - macro: '{$NET.IF.IFALIAS.MATCHES}'
+          value: '.*'
+        - macro: '{$NET.IF.IFALIAS.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+        - macro: '{$NET.IF.IFDESCR.MATCHES}'
+          value: '.*'
+        - macro: '{$NET.IF.IFDESCR.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+        - macro: '{$NET.IF.IFNAME.MATCHES}'
+          value: '^.*$'
+        - macro: '{$NET.IF.IFNAME.NOT_MATCHES}'
+          value: '(^Software Loopback Interface|^NULL[0-9.]*$|^[Ll]o[0-9.]*$|^[Ss]ystem$|^Nu[0-9.]*$|^veth[0-9a-z]+$|docker[0-9]+|br-[a-z0-9]{12})'
+          description: 'Filter out loopbacks, nulls, docker veth links and docker0 bridge by default'
+        - macro: '{$NET.IF.IFOPERSTATUS.MATCHES}'
+          value: '^.*$'
+        - macro: '{$NET.IF.IFOPERSTATUS.NOT_MATCHES}'
+          value: ^6$
+          description: 'Ignore notPresent(6)'
+        - macro: '{$NET.IF.IFTYPE.MATCHES}'
+          value: '.*'
+        - macro: '{$NET.IF.IFTYPE.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+        - macro: '{$SNMP_COMMUNITY}'
+          value: public
+      dashboards:
+        - uuid: ac992cae3b654522a9094b9b728617c4
+          name: 'Network interfaces'
+          pages:
+            - widgets:
+                - type: graphprototype
+                  width: '72'
+                  height: '5'
+                  fields:
+                    - type: INTEGER
+                      name: columns
+                      value: '1'
+                    - type: GRAPH_PROTOTYPE
+                      name: graphid
+                      value:
+                        host: 'FS S3900R'
+                        name: 'Interface {#IFNAME}({#IFALIAS}): Network traffic'
+                    - type: STRING
+                      name: reference
+                      value: AAAAA
+                    - type: INTEGER
+                      name: rows
+                      value: '1'
+                    - type: INTEGER
+                      name: source_type
+                      value: '2'
+      valuemaps:
+        - uuid: b041e9457efc472c961bc8a60504fff6
+          name: 'FS PSU status'
+          mappings:
+            - value: '1'
+              newvalue: Normal
+        - uuid: 9f1a2b4afc7b4e459b39bb81bf870f3f
+          name: 'IF-MIB::ifOperStatus'
+          mappings:
+            - value: '1'
+              newvalue: up
+            - value: '2'
+              newvalue: down
+            - value: '4'
+              newvalue: unknown
+            - value: '5'
+              newvalue: dormant
+            - value: '6'
+              newvalue: notPresent
+            - value: '7'
+              newvalue: lowerLayerDown
+        - uuid: 06644c9e62f54d7c8f968109ba82dbce
+          name: 'IF-MIB::ifType'
+          mappings:
+            - value: '1'
+              newvalue: other
+            - value: '2'
+              newvalue: regular1822
+            - value: '3'
+              newvalue: hdh1822
+            - value: '4'
+              newvalue: ddnX25
+            - value: '5'
+              newvalue: rfc877x25
+            - value: '6'
+              newvalue: ethernetCsmacd
+            - value: '7'
+              newvalue: iso88023Csmacd
+            - value: '8'
+              newvalue: iso88024TokenBus
+            - value: '9'
+              newvalue: iso88025TokenRing
+            - value: '10'
+              newvalue: iso88026Man
+            - value: '11'
+              newvalue: starLan
+            - value: '12'
+              newvalue: proteon10Mbit
+            - value: '13'
+              newvalue: proteon80Mbit
+            - value: '14'
+              newvalue: hyperchannel
+            - value: '15'
+              newvalue: fddi
+            - value: '16'
+              newvalue: lapb
+            - value: '17'
+              newvalue: sdlc
+            - value: '18'
+              newvalue: ds1
+            - value: '19'
+              newvalue: e1
+            - value: '20'
+              newvalue: basicISDN
+            - value: '21'
+              newvalue: primaryISDN
+            - value: '22'
+              newvalue: propPointToPointSerial
+            - value: '23'
+              newvalue: ppp
+            - value: '24'
+              newvalue: softwareLoopback
+            - value: '25'
+              newvalue: eon
+            - value: '26'
+              newvalue: ethernet3Mbit
+            - value: '27'
+              newvalue: nsip
+            - value: '28'
+              newvalue: slip
+            - value: '29'
+              newvalue: ultra
+            - value: '30'
+              newvalue: ds3
+            - value: '31'
+              newvalue: sip
+            - value: '32'
+              newvalue: frameRelay
+            - value: '33'
+              newvalue: rs232
+            - value: '34'
+              newvalue: para
+            - value: '35'
+              newvalue: arcnet
+            - value: '36'
+              newvalue: arcnetPlus
+            - value: '37'
+              newvalue: atm
+            - value: '38'
+              newvalue: miox25
+            - value: '39'
+              newvalue: sonet
+            - value: '40'
+              newvalue: x25ple
+            - value: '41'
+              newvalue: iso88022llc
+            - value: '42'
+              newvalue: localTalk
+            - value: '43'
+              newvalue: smdsDxi
+            - value: '44'
+              newvalue: frameRelayService
+            - value: '45'
+              newvalue: v35
+            - value: '46'
+              newvalue: hssi
+            - value: '47'
+              newvalue: hippi
+            - value: '48'
+              newvalue: modem
+            - value: '49'
+              newvalue: aal5
+            - value: '50'
+              newvalue: sonetPath
+            - value: '51'
+              newvalue: sonetVT
+            - value: '52'
+              newvalue: smdsIcip
+            - value: '53'
+              newvalue: propVirtual
+            - value: '54'
+              newvalue: propMultiplexor
+            - value: '55'
+              newvalue: ieee80212
+            - value: '56'
+              newvalue: fibreChannel
+            - value: '57'
+              newvalue: hippiInterface
+            - value: '58'
+              newvalue: frameRelayInterconnect
+            - value: '59'
+              newvalue: aflane8023
+            - value: '60'
+              newvalue: aflane8025
+            - value: '61'
+              newvalue: cctEmul
+            - value: '62'
+              newvalue: fastEther
+            - value: '63'
+              newvalue: isdn
+            - value: '64'
+              newvalue: v11
+            - value: '65'
+              newvalue: v36
+            - value: '66'
+              newvalue: g703at64k
+            - value: '67'
+              newvalue: g703at2mb
+            - value: '68'
+              newvalue: qllc
+            - value: '69'
+              newvalue: fastEtherFX
+            - value: '70'
+              newvalue: channel
+            - value: '71'
+              newvalue: ieee80211
+            - value: '72'
+              newvalue: ibm370parChan
+            - value: '73'
+              newvalue: escon
+            - value: '74'
+              newvalue: dlsw
+            - value: '75'
+              newvalue: isdns
+            - value: '76'
+              newvalue: isdnu
+            - value: '77'
+              newvalue: lapd
+            - value: '78'
+              newvalue: ipSwitch
+            - value: '79'
+              newvalue: rsrb
+            - value: '80'
+              newvalue: atmLogical
+            - value: '81'
+              newvalue: ds0
+            - value: '82'
+              newvalue: ds0Bundle
+            - value: '83'
+              newvalue: bsc
+            - value: '84'
+              newvalue: async
+            - value: '85'
+              newvalue: cnr
+            - value: '86'
+              newvalue: iso88025Dtr
+            - value: '87'
+              newvalue: eplrs
+            - value: '88'
+              newvalue: arap
+            - value: '89'
+              newvalue: propCnls
+            - value: '90'
+              newvalue: hostPad
+            - value: '91'
+              newvalue: termPad
+            - value: '92'
+              newvalue: frameRelayMPI
+            - value: '93'
+              newvalue: x213
+            - value: '94'
+              newvalue: adsl
+            - value: '95'
+              newvalue: radsl
+            - value: '96'
+              newvalue: sdsl
+            - value: '97'
+              newvalue: vdsl
+            - value: '98'
+              newvalue: iso88025CRFPInt
+            - value: '99'
+              newvalue: myrinet
+            - value: '100'
+              newvalue: voiceEM
+            - value: '101'
+              newvalue: voiceFXO
+            - value: '102'
+              newvalue: voiceFXS
+            - value: '103'
+              newvalue: voiceEncap
+            - value: '104'
+              newvalue: voiceOverIp
+            - value: '105'
+              newvalue: atmDxi
+            - value: '106'
+              newvalue: atmFuni
+            - value: '107'
+              newvalue: atmIma
+            - value: '108'
+              newvalue: pppMultilinkBundle
+            - value: '109'
+              newvalue: ipOverCdlc
+            - value: '110'
+              newvalue: ipOverClaw
+            - value: '111'
+              newvalue: stackToStack
+            - value: '112'
+              newvalue: virtualIpAddress
+            - value: '113'
+              newvalue: mpc
+            - value: '114'
+              newvalue: ipOverAtm
+            - value: '115'
+              newvalue: iso88025Fiber
+            - value: '116'
+              newvalue: tdlc
+            - value: '117'
+              newvalue: gigabitEthernet
+            - value: '118'
+              newvalue: hdlc
+            - value: '119'
+              newvalue: lapf
+            - value: '120'
+              newvalue: v37
+            - value: '121'
+              newvalue: x25mlp
+            - value: '122'
+              newvalue: x25huntGroup
+            - value: '123'
+              newvalue: trasnpHdlc
+            - value: '124'
+              newvalue: interleave
+            - value: '125'
+              newvalue: fast
+            - value: '126'
+              newvalue: ip
+            - value: '127'
+              newvalue: docsCableMaclayer
+            - value: '128'
+              newvalue: docsCableDownstream
+            - value: '129'
+              newvalue: docsCableUpstream
+            - value: '130'
+              newvalue: a12MppSwitch
+            - value: '131'
+              newvalue: tunnel
+            - value: '132'
+              newvalue: coffee
+            - value: '133'
+              newvalue: ces
+            - value: '134'
+              newvalue: atmSubInterface
+            - value: '135'
+              newvalue: l2vlan
+            - value: '136'
+              newvalue: l3ipvlan
+            - value: '137'
+              newvalue: l3ipxvlan
+            - value: '138'
+              newvalue: digitalPowerline
+            - value: '139'
+              newvalue: mediaMailOverIp
+            - value: '140'
+              newvalue: dtm
+            - value: '141'
+              newvalue: dcn
+            - value: '142'
+              newvalue: ipForward
+            - value: '143'
+              newvalue: msdsl
+            - value: '144'
+              newvalue: ieee1394
+            - value: '145'
+              newvalue: if-gsn
+            - value: '146'
+              newvalue: dvbRccMacLayer
+            - value: '147'
+              newvalue: dvbRccDownstream
+            - value: '148'
+              newvalue: dvbRccUpstream
+            - value: '149'
+              newvalue: atmVirtual
+            - value: '150'
+              newvalue: mplsTunnel
+            - value: '151'
+              newvalue: srp
+            - value: '152'
+              newvalue: voiceOverAtm
+            - value: '153'
+              newvalue: voiceOverFrameRelay
+            - value: '154'
+              newvalue: idsl
+            - value: '155'
+              newvalue: compositeLink
+            - value: '156'
+              newvalue: ss7SigLink
+            - value: '157'
+              newvalue: propWirelessP2P
+            - value: '158'
+              newvalue: frForward
+            - value: '159'
+              newvalue: rfc1483
+            - value: '160'
+              newvalue: usb
+            - value: '161'
+              newvalue: ieee8023adLag
+            - value: '162'
+              newvalue: bgppolicyaccounting
+            - value: '163'
+              newvalue: frf16MfrBundle
+            - value: '164'
+              newvalue: h323Gatekeeper
+            - value: '165'
+              newvalue: h323Proxy
+            - value: '166'
+              newvalue: mpls
+            - value: '167'
+              newvalue: mfSigLink
+            - value: '168'
+              newvalue: hdsl2
+            - value: '169'
+              newvalue: shdsl
+            - value: '170'
+              newvalue: ds1FDL
+            - value: '171'
+              newvalue: pos
+            - value: '172'
+              newvalue: dvbAsiIn
+            - value: '173'
+              newvalue: dvbAsiOut
+            - value: '174'
+              newvalue: plc
+            - value: '175'
+              newvalue: nfas
+            - value: '176'
+              newvalue: tr008
+            - value: '177'
+              newvalue: gr303RDT
+            - value: '178'
+              newvalue: gr303IDT
+            - value: '179'
+              newvalue: isup
+            - value: '180'
+              newvalue: propDocsWirelessMaclayer
+            - value: '181'
+              newvalue: propDocsWirelessDownstream
+            - value: '182'
+              newvalue: propDocsWirelessUpstream
+            - value: '183'
+              newvalue: hiperlan2
+            - value: '184'
+              newvalue: propBWAp2Mp
+            - value: '185'
+              newvalue: sonetOverheadChannel
+            - value: '186'
+              newvalue: digitalWrapperOverheadChannel
+            - value: '187'
+              newvalue: aal2
+            - value: '188'
+              newvalue: radioMAC
+            - value: '189'
+              newvalue: atmRadio
+            - value: '190'
+              newvalue: imt
+            - value: '191'
+              newvalue: mvl
+            - value: '192'
+              newvalue: reachDSL
+            - value: '193'
+              newvalue: frDlciEndPt
+            - value: '194'
+              newvalue: atmVciEndPt
+            - value: '195'
+              newvalue: opticalChannel
+            - value: '196'
+              newvalue: opticalTransport
+            - value: '197'
+              newvalue: propAtm
+            - value: '198'
+              newvalue: voiceOverCable
+            - value: '199'
+              newvalue: infiniband
+            - value: '200'
+              newvalue: teLink
+            - value: '201'
+              newvalue: q2931
+            - value: '202'
+              newvalue: virtualTg
+            - value: '203'
+              newvalue: sipTg
+            - value: '204'
+              newvalue: sipSig
+            - value: '205'
+              newvalue: docsCableUpstreamChannel
+            - value: '206'
+              newvalue: econet
+            - value: '207'
+              newvalue: pon155
+            - value: '208'
+              newvalue: pon622
+            - value: '209'
+              newvalue: bridge
+            - value: '210'
+              newvalue: linegroup
+            - value: '211'
+              newvalue: voiceEMFGD
+            - value: '212'
+              newvalue: voiceFGDEANA
+            - value: '213'
+              newvalue: voiceDID
+            - value: '214'
+              newvalue: mpegTransport
+            - value: '215'
+              newvalue: sixToFour
+            - value: '216'
+              newvalue: gtp
+            - value: '217'
+              newvalue: pdnEtherLoop1
+            - value: '218'
+              newvalue: pdnEtherLoop2
+            - value: '219'
+              newvalue: opticalChannelGroup
+            - value: '220'
+              newvalue: homepna
+            - value: '221'
+              newvalue: gfp
+            - value: '222'
+              newvalue: ciscoISLvlan
+            - value: '223'
+              newvalue: actelisMetaLOOP
+            - value: '224'
+              newvalue: fcipLink
+            - value: '225'
+              newvalue: rpr
+            - value: '226'
+              newvalue: qam
+            - value: '227'
+              newvalue: lmp
+            - value: '228'
+              newvalue: cblVectaStar
+            - value: '229'
+              newvalue: docsCableMCmtsDownstream
+            - value: '230'
+              newvalue: adsl2
+            - value: '231'
+              newvalue: macSecControlledIF
+            - value: '232'
+              newvalue: macSecUncontrolledIF
+            - value: '233'
+              newvalue: aviciOpticalEther
+            - value: '234'
+              newvalue: atmbond
+            - value: '235'
+              newvalue: voiceFGDOS
+            - value: '236'
+              newvalue: mocaVersion1
+            - value: '237'
+              newvalue: ieee80216WMAN
+            - value: '238'
+              newvalue: adsl2plus
+            - value: '239'
+              newvalue: dvbRcsMacLayer
+            - value: '240'
+              newvalue: dvbTdm
+            - value: '241'
+              newvalue: dvbRcsTdma
+            - value: '242'
+              newvalue: x86Laps
+            - value: '243'
+              newvalue: wwanPP
+            - value: '244'
+              newvalue: wwanPP2
+            - value: '245'
+              newvalue: voiceEBS
+            - value: '246'
+              newvalue: ifPwType
+            - value: '247'
+              newvalue: ilan
+            - value: '248'
+              newvalue: pip
+            - value: '249'
+              newvalue: aluELP
+            - value: '250'
+              newvalue: gpon
+            - value: '251'
+              newvalue: vdsl2
+            - value: '252'
+              newvalue: capwapDot11Profile
+            - value: '253'
+              newvalue: capwapDot11Bss
+            - value: '254'
+              newvalue: capwapWtpVirtualRadio
+            - value: '255'
+              newvalue: bits
+            - value: '256'
+              newvalue: docsCableUpstreamRfPort
+            - value: '257'
+              newvalue: cableDownstreamRfPort
+            - value: '258'
+              newvalue: vmwareVirtualNic
+            - value: '259'
+              newvalue: ieee802154
+            - value: '260'
+              newvalue: otnOdu
+            - value: '261'
+              newvalue: otnOtu
+            - value: '262'
+              newvalue: ifVfiType
+            - value: '263'
+              newvalue: g9981
+            - value: '264'
+              newvalue: g9982
+            - value: '265'
+              newvalue: g9983
+            - value: '266'
+              newvalue: aluEpon
+            - value: '267'
+              newvalue: aluEponOnu
+            - value: '268'
+              newvalue: aluEponPhysicalUni
+            - value: '269'
+              newvalue: aluEponLogicalLink
+            - value: '270'
+              newvalue: aluGponOnu
+            - value: '271'
+              newvalue: aluGponPhysicalUni
+            - value: '272'
+              newvalue: vmwareNicTeam
+            - value: '277'
+              newvalue: docsOfdmDownstream
+            - value: '278'
+              newvalue: docsOfdmaUpstream
+            - value: '279'
+              newvalue: gfast
+            - value: '280'
+              newvalue: sdci
+            - value: '281'
+              newvalue: xboxWireless
+            - value: '282'
+              newvalue: fastdsl
+            - value: '283'
+              newvalue: docsCableScte55d1FwdOob
+            - value: '284'
+              newvalue: docsCableScte55d1RetOob
+            - value: '285'
+              newvalue: docsCableScte55d2DsOob
+            - value: '286'
+              newvalue: docsCableScte55d2UsOob
+            - value: '287'
+              newvalue: docsCableNdf
+            - value: '288'
+              newvalue: docsCableNdr
+            - value: '289'
+              newvalue: ptm
+            - value: '290'
+              newvalue: ghn
+  graphs:
+    - uuid: d004d3957562466bb88c921fc634e319
+      name: 'Cpu Utilization​'
+      graph_items:
+        - color: '891515'
+          item:
+            host: 'FS S3900R'
+            key: cpuCurrentUti


### PR DESCRIPTION
## Summary
- Adds a Zabbix 7.0 SNMP template for FS (Fiberstore) S3900R series switches
- Covers device inventory, CPU, memory, interfaces, power supplies, and per-transceiver optical diagnostics (DDM)
- Built and verified against a live S3900-24T4S-R (firmware 159394)

## About the transceiver DDM discovery rule
The vendor's optical-diagnostics OID subtree isn't documented in any public FIBERSTORE-MIB. The OIDs used here were found empirically by walking the device and matching live values against SFF-8472 scaling constants, then cross-validated against the switch's own CLI output (`show interface tGigaEthernet 0/X`) - TX/RX power, temperature, voltage, bias current, and all 5 alarm/warning thresholds matched exactly. Full details and caveats are in the README.

## Test plan
- [x] Imported into a local Zabbix 7.0 instance and confirmed no import errors
- [x] Verified live SNMP polling against the reference device for every item (static device info, interfaces, transceiver DDM, PSU status)
- [x] Confirmed discovered item values against the switch's own CLI output
- [x] Ran the repo's local static checks (`00_check_forbidden`, `10_check_template_name`, `20_check_file_structure`) - all pass