### PR TITLE
Update template_hikvision_nvr_http.yaml

### DIFF
--- a/Unsorted/template_hikvision_nvr/7.4/template_hikvision_nvr_http.yaml
+++ b/Unsorted/template_hikvision_nvr/7.4/template_hikvision_nvr_http.yaml
@@ -795,7 +795,7 @@ zabbix_export:
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - $.storage.hddList.hdd.capacity
+                    - '$.storage.hddList.hdd[?(@.id=="{#HDD_ID}")].capacity.first()'
                 - type: MULTIPLIER
                   parameters:
                     - '1048576'
@@ -813,7 +813,7 @@ zabbix_export:
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - $.storage.hddList.hdd.freeSpace
+                    - '$.storage.hddList.hdd[?(@.id=="{#HDD_ID}")].freeSpace.first()'
                 - type: MULTIPLIER
                   parameters:
                     - '1048576'
@@ -830,7 +830,7 @@ zabbix_export:
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - $.storage.hddList.hdd.hddName
+                    - '$.storage.hddList.hdd[?(@.id=="{#HDD_ID}")].hddName.first()'
               master_item:
                 key: 'hikvision_nvr.hdd[{#HDD_ID}.info]'
               tags:
@@ -844,7 +844,7 @@ zabbix_export:
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - $.storage.hddList.hdd.status
+                    - '$.storage.hddList.hdd[?(@.id=="{#HDD_ID}")].status.first()'
               master_item:
                 key: 'hikvision_nvr.hdd[{#HDD_ID}.info]'
               tags:
@@ -870,7 +870,7 @@ zabbix_export:
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - $.storage.hddList.hdd.hddType
+                    - '$.storage.hddList.hdd[?(@.id=="{#HDD_ID}")].hddType.first()'
               master_item:
                 key: 'hikvision_nvr.hdd[{#HDD_ID}.info]'
               tags:


### PR DESCRIPTION
Fix hdd autodiscovery:

Preprocessing failed for: {"storage":{"@version":"1.0","hddList":{"hdd":[{"@version":"1.0","id":"1","hddName":"hdd1","hddPa...
1. Failed: cannot extract value from json by path "$.storage.hddList.hdd.capacity": no data matches the specified path