### PR TITLE
Fix Jellyfin 12 API authentication and plugin discovery

### DIFF
--- a/Applications/Media_Players/template_jellyfin_by_http/7.4/README.md
+++ b/Applications/Media_Players/template_jellyfin_by_http/7.4/README.md
@@ -240,4 +240,6 @@ The three plugin-discovery regression tests cover duplicate versions sharing an 
 python files/test_plugin_discovery.py
 ```
 
-Import into the production Zabbix 7.4.14 server and runtime compatibility with older Jellyfin versions were not tested in this validation.
+The update was subsequently imported into production Zabbix 7.4.14 on the same date. All 325 existing item IDs and host macro records were preserved. Discovery added nine items; all 334 items became supported, all 325 dependent items received new values, and all four discovery rules completed without errors. The existing API-unavailable problem recovered automatically. The existing template group was reused without enabling template-group creation in the import rules.
+
+Runtime compatibility with older Jellyfin versions was not tested.

--- a/Applications/Media_Players/template_jellyfin_by_http/7.4/README.md
+++ b/Applications/Media_Players/template_jellyfin_by_http/7.4/README.md
@@ -137,6 +137,8 @@ The storage endpoint is handled defensively. If the Jellyfin version does not pr
 - Plugins requiring restart
 - Plugin discovery with status, version and uninstall flag
 
+Jellyfin can return several installed versions or pending-restart entries with the same plugin ID. Discovery creates one set of items per ID and uses the first API entry, matching the status/version lookups and preserving existing item keys. The aggregate plugin counters still evaluate all API entries, including entries requiring a restart.
+
 ### Scheduled tasks
 
 - Scheduled task count
@@ -226,3 +228,16 @@ The storage endpoint is handled defensively. If the Jellyfin version does not pr
 
 - Jellyfin OpenAPI stable specification: <https://repo.jellyfin.org/releases/openapi/jellyfin-openapi-stable.json>
 - Jellyfin OpenAPI archive: <https://repo.jellyfin.org/releases/openapi/>
+- Jellyfin authentication format: <https://gist.github.com/nielsvanvelzen/ea047d9028f676185832e51ffaf12a6f>
+
+## Validation
+
+Validated on 2026-09-08 using an isolated Zabbix 7.4.13 instance querying a live Jellyfin 12.0.0 server. The previous template reproduced HTTP 401 on all nine master items. Importing the update preserved the existing item IDs. After the update, all nine master items, 319 dependent items (including 263 discovered items), and all four discovery rules completed without unsupported-item or discovery errors. API availability reported `1` and the version item reported `12.0.0`.
+
+The three plugin-discovery regression tests cover duplicate versions sharing an ID, fallback names that coincide with JavaScript object properties, and an empty plugin list. Run them from this directory with Python 3, PyYAML and Node.js installed:
+
+```sh
+python files/test_plugin_discovery.py
+```
+
+Import into the production Zabbix 7.4.14 server and runtime compatibility with older Jellyfin versions were not tested in this validation.

--- a/Applications/Media_Players/template_jellyfin_by_http/7.4/README.md
+++ b/Applications/Media_Players/template_jellyfin_by_http/7.4/README.md
@@ -59,7 +59,15 @@ That corresponds to:
 
 ## Creating the API key
 
-In Jellyfin, go to **Dashboard -> Advanced -> API Keys** and create a key for Zabbix. The template sends it in the `X-MediaBrowser-Token` header.
+In Jellyfin, go to **Dashboard -> Advanced -> API Keys** and create a key for Zabbix. The template sends it as `Authorization: MediaBrowser Token="<API key>"`.
+
+## Upgrading to Jellyfin 12
+
+Jellyfin 12 disables legacy authentication by default. Older revisions of this template use `X-MediaBrowser-Token`, causing all nine master items to fail with HTTP 401. Import the updated template with **Update existing** enabled for templates and items, and retain the host's existing secret `{$JELLYFIN.API.TOKEN}` macro. The updated template uses the supported authorization header for every endpoint; enabling legacy authentication in Jellyfin is unnecessary.
+
+The activity log request also uses `sortBy=DateCreated&sortOrder=Descending`. Jellyfin 12 validates this parameter and rejects the older `sortBy=Date` with HTTP 400.
+
+After importing, execute the nine script master items on the linked host or wait for their polling intervals (up to 15 minutes with the defaults). Verify that the master items become supported, dependent items receive new values, and all four discovery rules complete without errors. `Jellyfin: API available` should report `1`, and the API-unavailable problem should recover once the trigger is evaluated with fresh data.
 
 ## Monitored API areas
 

--- a/Applications/Media_Players/template_jellyfin_by_http/7.4/files/test_plugin_discovery.py
+++ b/Applications/Media_Players/template_jellyfin_by_http/7.4/files/test_plugin_discovery.py
@@ -1,0 +1,59 @@
+"""Regression tests for the template's actual plugin discovery JavaScript.
+
+Run with Python 3, PyYAML and Node.js:
+    python files/test_plugin_discovery.py
+"""
+
+import json
+from pathlib import Path
+import subprocess
+import unittest
+
+import yaml
+
+
+class PluginDiscoveryTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        template_path = Path(__file__).resolve().parents[1] / 'template_jellyfin_by_http.yaml'
+        template = yaml.safe_load(template_path.read_text())['zabbix_export']['templates'][0]
+        discovery = next(rule for rule in template['discovery_rules'] if rule['key'] == 'jellyfin.plugin.discovery')
+        cls.script = discovery['preprocessing'][0]['parameters'][0]
+
+    def discover(self, plugins):
+        runner = """
+const input = JSON.parse(require('fs').readFileSync(0, 'utf8'));
+const result = new Function('value', input.script)(JSON.stringify(input.plugins));
+process.stdout.write(result);
+"""
+        result = subprocess.run(['node', '-e', runner],
+            input=json.dumps({'script': self.script, 'plugins': plugins}),
+            text=True, capture_output=True, check=True)
+        return json.loads(result.stdout)
+
+    def test_duplicate_versions_keep_first_entry_for_existing_item_keys(self):
+        rows = self.discover([
+            {'Id': 'ldap', 'Name': 'LDAP', 'Version': '24.0.0.0', 'Status': 'Restart'},
+            {'Id': 'ldap', 'Name': 'LDAP-Auth', 'Version': '24.0.0.0', 'Status': 'Active'},
+            {'Id': 'ldap', 'Name': 'LDAP-Auth', 'Version': '23.0.0.0', 'Status': 'Superseded'},
+            {'Id': 'other', 'Name': 'Other', 'Version': '1.0.0.0', 'Status': 'Active'},
+        ])
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[0], {'{#PLUGIN.ID}': 'ldap', '{#PLUGIN.NAME}': 'LDAP',
+            '{#PLUGIN.STATUS}': 'Restart', '{#PLUGIN.VERSION}': '24.0.0.0'})
+        self.assertEqual(rows[1]['{#PLUGIN.ID}'], 'other')
+
+    def test_name_fallback_and_object_property_names(self):
+        rows = self.discover([
+            {'Name': '__proto__'}, {'Name': '__proto__'},
+            {'Id': 'constructor'}, {'Id': 'toString'}, {},
+        ])
+        self.assertEqual([row['{#PLUGIN.ID}'] for row in rows],
+            ['__proto__', 'constructor', 'toString'])
+
+    def test_empty_plugin_list(self):
+        self.assertEqual(self.discover([]), [])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Applications/Media_Players/template_jellyfin_by_http/7.4/template_jellyfin_by_http.yaml
+++ b/Applications/Media_Players/template_jellyfin_by_http/7.4/template_jellyfin_by_http.yaml
@@ -65,7 +65,7 @@ zabbix_export:
             }
 
             var request = new HttpRequest();
-            request.addHeader('X-MediaBrowser-Token: ' + params.token);
+            request.addHeader('Authorization: MediaBrowser Token="' + encodeURIComponent(params.token) + '"');
 
             var url = String(params.scheme || 'http') + '://' + resolveHost(params) + ':' + String(params.port || '8096') + cleanBasePath(params.basepath) + params.endpoint;
             var response = request.get(encodeURI(url));
@@ -461,7 +461,7 @@ zabbix_export:
             }
 
             var request = new HttpRequest();
-            request.addHeader('X-MediaBrowser-Token: ' + params.token);
+            request.addHeader('Authorization: MediaBrowser Token="' + encodeURIComponent(params.token) + '"');
 
             var url = String(params.scheme || 'http') + '://' + resolveHost(params) + ':' + String(params.port || '8096') + cleanBasePath(params.basepath) + params.endpoint;
             var response = request.get(encodeURI(url));
@@ -719,7 +719,7 @@ zabbix_export:
             }
 
             var request = new HttpRequest();
-            request.addHeader('X-MediaBrowser-Token: ' + params.token);
+            request.addHeader('Authorization: MediaBrowser Token="' + encodeURIComponent(params.token) + '"');
 
             var url = String(params.scheme || 'http') + '://' + resolveHost(params) + ':' + String(params.port || '8096') + cleanBasePath(params.basepath) + params.endpoint;
             var response = request.get(encodeURI(url));
@@ -1080,7 +1080,7 @@ zabbix_export:
             }
 
             var request = new HttpRequest();
-            request.addHeader('X-MediaBrowser-Token: ' + params.token);
+            request.addHeader('Authorization: MediaBrowser Token="' + encodeURIComponent(params.token) + '"');
 
             var url = String(params.scheme || 'http') + '://' + resolveHost(params) + ':' + String(params.port || '8096') + cleanBasePath(params.basepath) + params.endpoint;
             var response = request.get(encodeURI(url));
@@ -1341,7 +1341,7 @@ zabbix_export:
             }
 
             var request = new HttpRequest();
-            request.addHeader('X-MediaBrowser-Token: ' + params.token);
+            request.addHeader('Authorization: MediaBrowser Token="' + encodeURIComponent(params.token) + '"');
 
             var url = String(params.scheme || 'http') + '://' + resolveHost(params) + ':' + String(params.port || '8096') + cleanBasePath(params.basepath) + params.endpoint;
             var response = request.get(encodeURI(url));
@@ -1417,7 +1417,7 @@ zabbix_export:
             }
 
             var request = new HttpRequest();
-            request.addHeader('X-MediaBrowser-Token: ' + params.token);
+            request.addHeader('Authorization: MediaBrowser Token="' + encodeURIComponent(params.token) + '"');
 
             var url = String(params.scheme || 'http') + '://' + resolveHost(params) + ':' + String(params.port || '8096') + cleanBasePath(params.basepath) + params.endpoint;
             var response = request.get(encodeURI(url));
@@ -1548,7 +1548,7 @@ zabbix_export:
             }
 
             var request = new HttpRequest();
-            request.addHeader('X-MediaBrowser-Token: ' + params.token);
+            request.addHeader('Authorization: MediaBrowser Token="' + encodeURIComponent(params.token) + '"');
 
             var url = String(params.scheme || 'http') + '://' + resolveHost(params) + ':' + String(params.port || '8096') + cleanBasePath(params.basepath) + params.endpoint;
             var response = request.get(encodeURI(url));
@@ -1679,7 +1679,7 @@ zabbix_export:
             }
 
             var request = new HttpRequest();
-            request.addHeader('X-MediaBrowser-Token: ' + params.token);
+            request.addHeader('Authorization: MediaBrowser Token="' + encodeURIComponent(params.token) + '"');
 
             var url = String(params.scheme || 'http') + '://' + resolveHost(params) + ':' + String(params.port || '8096') + cleanBasePath(params.basepath) + params.endpoint;
             var response = request.get(encodeURI(url));
@@ -1692,7 +1692,7 @@ zabbix_export:
             - name: basepath
               value: '{$JELLYFIN.BASEPATH}'
             - name: endpoint
-              value: '/System/ActivityLog/Entries?startIndex=0&limit={$JELLYFIN.ACTIVITY.LIMIT}&sortBy=Date&sortOrder=Descending'
+              value: '/System/ActivityLog/Entries?startIndex=0&limit={$JELLYFIN.ACTIVITY.LIMIT}&sortBy=DateCreated&sortOrder=Descending'
             - name: host
               value: '{$JELLYFIN.HOST}'
             - name: host_conn
@@ -1907,7 +1907,7 @@ zabbix_export:
             }
 
             var request = new HttpRequest();
-            request.addHeader('X-MediaBrowser-Token: ' + params.token);
+            request.addHeader('Authorization: MediaBrowser Token="' + encodeURIComponent(params.token) + '"');
 
             var response = request.get(encodeURI(makeBaseUrl(params) + '/System/Info/Storage'));
             var status = request.getStatus();

--- a/Applications/Media_Players/template_jellyfin_by_http/7.4/template_jellyfin_by_http.yaml
+++ b/Applications/Media_Players/template_jellyfin_by_http/7.4/template_jellyfin_by_http.yaml
@@ -2372,7 +2372,7 @@ zabbix_export:
           name: 'Jellyfin: Plugins discovery'
           type: DEPENDENT
           key: jellyfin.plugin.discovery
-          description: 'Discovers installed Jellyfin plugins from /Plugins.'
+          description: 'Discovers one entry per plugin ID from /Plugins. When multiple versions share an ID, uses the first entry, matching the dependent item lookups.'
           item_prototypes:
             - uuid: 98764663f9a44419947aa700846bffc3
               name: 'Jellyfin: Plugin {#PLUGIN.NAME}: Status'
@@ -2494,9 +2494,11 @@ zabbix_export:
                 - |
                   try {
                       var result = [];
+                      var seen = {};
                       JSON.parse(value).forEach(function (plugin) {
                           var id = String(plugin.Id || plugin.Name || '');
-                          if (id) {
+                          if (id && !seen['plugin:' + id]) {
+                              seen['plugin:' + id] = true;
                               result.push({
                                   '{#PLUGIN.ID}': id,
                                   '{#PLUGIN.NAME}': plugin.Name || id,


### PR DESCRIPTION
Fix Jellyfin monitoring after upgrading to version 12:

- Replace legacy authentication with `Authorization: MediaBrowser Token="…"`.
- Use `DateCreated` for activity log sorting to avoid HTTP 400.
- Deduplicate plugin discovery by ID while preserving existing item keys.
- Document upgrade instructions and validation results; add three regression tests.

Validated against live Jellyfin 12.0.0 with Zabbix 7.4.13 and production Zabbix 7.4.14:
- All 334 production items supported; all 325 dependent items received fresh values.
- All four discovery rules completed without errors.
- The API-unavailable problem recovered automatically.
- Existing item IDs, host macro records and template UUIDs preserved.
- Regression tests, repository structure checks and `git diff --check` passed.

Older Jellyfin versions were not runtime-tested.