### PR TITLE
Proxmox VE REST API: add Ceph, HA LRM and SDN, fix PVE 9 defects

### DIFF
--- a/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/README.md
+++ b/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/README.md
@@ -1,15 +1,22 @@
-# Zabbix Template Proxmox VE REST API
+# Zabbix Templates Proxmox VE REST API
 
-This Zabbix template enables full monitoring of a Proxmox VE environment via the official REST API (Proxmox VE 7.0+). No Zabbix agent is required inside VMs or on the PVE host. It collects host and cluster metrics, VM and LXC container data, backup jobs, storage status, tasks, network interfaces, HA resources, disk health, and user accounts. It also covers the PVE services themselves, ZFS pools, replication jobs, certificate expiry, APT repository state and the subscription status.
+Monitoring of Proxmox VE over the official REST API (Proxmox VE 7.0+). No Zabbix agent is needed on the PVE hosts or inside the guests. The import file contains two templates that split the work the same way Proxmox VE does:
 
-Works on standalone single-node setups as well as full clusters.
+| Template | Link it to | Covers |
+|----------|------------|--------|
+| `Proxmox VE Cluster by REST API` | exactly one Zabbix host per cluster (or per standalone node) | Guests on every node, node states, quorum, HA manager, HA local resource managers and HA resources, backup jobs and guests without backup, users, SDN zones and, where present, Ceph |
+| `Proxmox VE Node by REST API` | one Zabbix host per PVE node | Node status, CPU, memory, swap, root filesystem, disks with SMART, ZFS pools, storage, host network, PVE services, tasks, backups, replication, certificates, APT and subscription |
+
+Cluster-wide data is requested once per cluster instead of once per node, so a cluster of ten nodes no longer queries every guest ten times and no longer raises every guest problem ten times.
+
+Ceph is detected automatically. On clusters without Ceph no Ceph item is created and nothing is evaluated.
 
 ---
 
 ## Requirements
 
 - Zabbix Server 7.0 or higher
-- Proxmox VE 7.0 or higher
+- Proxmox VE 7.0 or higher (SDN zone discovery needs Proxmox VE 9)
 - API token with read permissions (see setup below)
 
 ---
@@ -24,7 +31,7 @@ Works on standalone single-node setups as well as full clusters.
 
 2. **Assign read-only role to the user**
    - **Datacenter → Permissions → Add → User Permission**
-   - Path: `/` · User: `zabbix@pam` · Role: `PVEAuditor` · Propagate: ✓ → **Add**
+   - Path: `/` · User: `zabbix@pam` · Role: `PVEAuditor` · Propagate: enabled → **Add**
 
 3. **Create the API token**
    - **Datacenter → Permissions → API Tokens → Add**
@@ -48,9 +55,11 @@ PVEAPIToken=zabbix@pam!Zabbix=<token-secret>
 
 3. **Grant permission to the token explicitly**
    - **Datacenter → Permissions → Add → API Token Permission**
-   - Path: `/` · Token: `zabbix@pam!Zabbix` · Role: `PVEAuditor` · Propagate: ✓ → **Add**
+   - Path: `/` · Token: `zabbix@pam!Zabbix` · Role: `PVEAuditor` · Propagate: enabled → **Add**
 
-> **Note for pending updates:** `/nodes/{node}/apt/update` is the only endpoint in this template that requires `Sys.Modify` rather than `Sys.Audit`, so `PVEAuditor` cannot read it. The corresponding master item `pve.apt.update.raw` and its dependent item are therefore **disabled by default**. Enable them only if you accept granting the monitoring token write level permissions. The repository state is monitored through `/nodes/{node}/apt/repositories` instead, which only needs `Sys.Audit`.
+`PVEAuditor` covers everything both templates read, Ceph included. The one exception:
+
+> **Note for pending updates:** `/nodes/{node}/apt/update` is the only endpoint that requires `Sys.Modify` rather than `Sys.Audit`, so `PVEAuditor` cannot read it. The master item `pve.apt.update.raw` and its dependent item are therefore **disabled by default**. Enable them only if you accept granting the monitoring token write level permissions. The repository state is monitored through `/nodes/{node}/apt/repositories` instead, which only needs `Sys.Audit`.
 
 > **Note for disk monitoring:** `/nodes/{node}/disks/list` requires the `Sys.Audit` privilege. `PVEAuditor` includes this privilege. If disk items show "not supported", verify that the role is applied with **Propagate** enabled and that the token has the correct path `/`.
 
@@ -58,230 +67,233 @@ PVEAPIToken=zabbix@pam!Zabbix=<token-secret>
 
 ## 2. Installation
 
-1. Download `template_proxmox-ve-rest-api.yaml`
-2. In Zabbix: **Data collection → Templates → Import**
-3. Create a new host:
-   - **Data collection → Hosts → Create host**
-   - Host name: e.g. `proxmox01`
-   - Template: `Template Proxmox VE REST API`
-   - Group: e.g. `Virtual machines`
-   - Interfaces: leave empty (template uses HTTP agent, no Zabbix agent needed)
-4. Set the required macros on the host (see below)
+1. Download `7.0/template_proxmox-ve-rest-api.yaml`
+2. In Zabbix: **Data collection → Templates → Import**. The file creates both templates.
+3. Create the hosts. Interfaces stay empty, both templates use the HTTP agent.
+
+**Standalone node:** one host, link both templates, set the macros once.
+
+**Cluster:**
+
+| Host | Template | `{$PVE_IP}` | `{$PVE_NODE}` |
+|------|----------|-------------|---------------|
+| `pve-cluster` | `Proxmox VE Cluster by REST API` | any node, ideally a DNS name or virtual IP that always points to a running node | not needed |
+| `pve01`, `pve02`, ... | `Proxmox VE Node by REST API` | the node itself | the node name as shown in PVE |
+
+Link the cluster template to one host per cluster only. A second host with the same cluster template doubles every cluster request and every guest problem.
+
+### Upgrading from `Template Proxmox VE REST API`
+
+The cluster template keeps the UUID of the former single template. Importing the file with **Delete missing** enabled renames the former template, removes the node items from it and creates the node template next to it. Then link `Proxmox VE Node by REST API` to every host that should keep node monitoring. Guest, HA, backup job and user history is kept. Node items are created anew, so their history starts again.
 
 ---
 
 ## 3. Macros
 
-### Required
+### Connection (both templates)
 
 | Macro | Example | Description |
 |-------|---------|-------------|
-| `{$PVE_IP}` | `192.168.1.10` | IP address or hostname of the PVE server |
+| `{$PVE_IP}` | `192.168.1.10` | IP address or hostname of the PVE API |
 | `{$PVE_PORT}` | `8006` | API port (default: 8006) |
-| `{$PVE_NODE}` | `pve` | Node name as shown in PVE (Datacenter → Node) |
 | `{$PVE_API_USER}` | `zabbix@pam` | API user including realm |
 | `{$PVE_API_TOKEN_ID}` | `Zabbix` | Token ID |
 | `{$PVE_API_TOKEN}` | *(secret)* | Token secret, set as **Secret text** macro type |
+| `{$PVE_NODE}` | `pve` | Node template only: node name as shown in PVE (Datacenter → Node) |
 
-### Threshold Macros
+### Cluster template
 
 | Macro | Default | Description |
 |-------|---------|-------------|
-| `{$CPU_USAGE_AVERAGE}` | `85` | CPU warning threshold (%) |
-| `{$CPU_USAGE_HIGH}` | `99` | CPU critical threshold (%) |
+| `{$CPU_USAGE_AVERAGE}` | `85` | VM CPU warning threshold (%) |
+| `{$CPU_USAGE_HIGH}` | `99` | VM CPU critical threshold (%) |
 | `{$LXC.CPU.WARN}` | `85` | LXC CPU warning threshold (%) |
 | `{$LXC.CPU.HIGH}` | `99` | LXC CPU critical threshold (%) |
+| `{$CLUSTER.NODES.OFFLINE.MAX}` | `0` | Tolerated offline nodes (raise during maintenance) |
+| `{$PVE.NOTBACKEDUP.MAX}` | `0` | Tolerated number of guests without a backup job |
+| `{$PVE.BACKUP.JOBS.MIN}` | `1` | Minimum number of configured backup jobs |
+| `{$PVE.BACKUP.JOB.STALE}` | `2d` | Maximum time a backup job may go without a next run |
+| `{$PVE.USER.EXPIRE.TIME}` | `172800` | Seconds before user expiry to warn (172800 = 2 days) |
+| `{$PVE.GUEST.DETAIL.INTERVAL}` | `10m` | Interval of the per guest status request that supplies balloon size, machine type and LXC swap. This is one request per guest, keep it long in large clusters. |
+| `{$PVE.GUEST.DETAIL.VMID.MATCHES}` | `.*` | Only guests whose VMID matches get the per guest status request. `^$` switches it off for all guests, which leaves one request per minute for all guest metrics together. |
+| `{$CEPH.HEALTH.WARN.PERIOD}` | `15m` | How long Ceph must stay at HEALTH_WARN or worse before the warning fires |
+| `{$CEPH.UTIL.WARN}` / `{$CEPH.UTIL.CRIT}` | `75` / `85` | Ceph raw capacity thresholds (%) |
+| `{$CEPH.OSD.UTIL.WARN}` / `{$CEPH.OSD.UTIL.CRIT}` | `80` / `90` | Per OSD utilization thresholds (%). Ceph itself warns at 85 and stops writes at 95. |
+| `{$CEPH.OSD.LATENCY.MAX}` | `0.2` | OSD commit latency threshold in seconds |
+| `{$CEPH.OSD.LATENCY.PERIOD}` | `30m` | How long the latency must stay above the threshold |
+| `{$CEPH.POOL.UTIL.WARN}` / `{$CEPH.POOL.UTIL.CRIT}` | `80` / `90` | Pool utilization thresholds (%) |
+| `{$CEPH.PG.NOT_CLEAN.PERIOD}` | `1h` | How long placement groups may stay not active+clean |
+| `{$CEPH.POOL.NOT_MATCHES}` | `CHANGE_IF_NEEDED` | Pools whose name matches are not discovered |
+| `{$ENABLE_NODE_STATUS_ALERT}` | `1` | Node offline trigger |
+| `{$ENABLE_VM_STOP_ALERT}` | `1` | VM/LXC stopped trigger, context form per VMID |
+| `{$PVE.BACKUP.JOB.ALERT}` | `1` | Backup job triggers, context form per job |
+
+### Node template
+
+| Macro | Default | Description |
+|-------|---------|-------------|
+| `{$NODE.CPU.UTIL.MAX}` | `90` | Node CPU utilization (%) before the high CPU trigger fires |
 | `{$MEMORY.UTIL.MAX}` | `90` | Host memory warning threshold (%) |
 | `{$SWAP.UTIL.MAX}` | `80` | Host swap warning threshold (%). The trigger stays silent on hosts without swap. |
-| `{$ROOTFS.UTIL.WARN}` | `90` | Root filesystem warning threshold (%) |
-| `{$ROOTFS.UTIL.CRIT}` | `95` | Root filesystem critical threshold (%) |
-| `{$STORAGE.UTIL.WARN}` | `80` | Storage pool warning threshold (%) |
-| `{$STORAGE.UTIL.CRIT}` | `90` | Storage pool critical threshold (%) |
-| `{$CLUSTER.NODES.OFFLINE.MAX}` | `0` | Max. tolerated offline nodes (raise during maintenance) |
-| `{$DISK.WEAROUT.MIN}` | `20` | Min. SSD wearout remaining before warning (%) |
-| `{$PVE.USER.EXPIRE.TIME}` | `172800` | Seconds before user expiry to warn (172800 = 2 days) |
-| `{$DISK.TEMP.MAX}` | `60` | Disk temperature threshold (degrees Celsius). Context form `{$DISK.TEMP.MAX:"/dev/sda"}` raises it for one disk. |
-| `{$NODE.CPU.UTIL.MAX}` | `90` | Node CPU utilization (%) before the high CPU trigger fires. This threshold used to be hardcoded in the trigger expression. |
-| `{$ZFS.UTIL.WARN}` | `80` | ZFS pool usage (%) for the average severity trigger. ZFS performance degrades noticeably above 80%. Context form `{$ZFS.UTIL.WARN:"rpool"}`. |
-| `{$ZFS.UTIL.CRIT}` | `90` | ZFS pool usage (%) for the high severity trigger. |
-| `{$ZFS.FRAG.WARN}` | `60` | ZFS free space fragmentation (%) before warning. |
-| `{$PVE.REPL.FAIL.MAX}` | `0` | Tolerated consecutive failures of a replication job. Context form `{$PVE.REPL.FAIL.MAX:"105-0"}`. |
-| `{$PVE.NOTBACKEDUP.MAX}` | `0` | Tolerated number of guests without a backup job. Raise it if some guests are deliberately excluded. |
-| `{$PVE.APT.REPO.ERRORS.MAX}` | `0` | Tolerated number of unparsable APT repository files. |
-| `{$PVE.APT.REPO.WARN.MAX}` | `0` | Tolerated number of APT repository warnings. A host on the no-subscription repository permanently reports one warning, set this to 1 there. |
-| `{$PVE.APT.UPDATES.MAX}` | `0` | Tolerated number of pending package updates. Only relevant if the disabled apt/update items are switched on. |
-
-### Timing Macros
-
-Values must carry a time unit.
-
-| Macro | Default | Description |
-|-------|---------|-------------|
-| `{$TASK.ALERT.WINDOW}` | `1h` | How long a failed task keeps alerting. Proxmox VE only keeps the most recent tasks, so without this window a one-off failure would alert forever. |
-| `{$BACKUP.ALERT.WINDOW}` | `24h` | How long a failed backup keeps alerting. |
-| `{$DISK.MISSING.TIME}` | `3h` | How long a disk may be absent from the disk list before the missing disk trigger fires. The list refreshes hourly. |
-| `{$IFACE.ACTIVE.WINDOW}` | `7d` | An interface must have been up once within this window before the interface down trigger fires. |
-| `{$PVE.REPL.LAG}` | `2h` | Maximum age of the last successful replication. Must stay above the replication schedule, otherwise the trigger fires between two runs. |
-| `{$PVE.CERT.EXPIRE.DAYS}` | `21d` | Lead time before certificate expiry. |
-| `{$PVE.SUBSCRIPTION.EXPIRE.DAYS}` | `30d` | Lead time before the subscription expires. |
-
-### Discovery Filter Macros
-
-| Macro | Default | Description |
-|-------|---------|-------------|
-| `{$IFACE.NOT_MATCHES}` | `^(tap\|veth\|fwbr\|fwpr\|fwln)` | Host interface names excluded from discovery. The default drops the per-guest interfaces Proxmox creates. |
-| `{$PVE.SERVICE.MATCHES}` | `^(pve-cluster\|pvedaemon\|pveproxy\|pvestatd\|pve-firewall)$` | Which PVE services are discovered. `corosync`, `pve-ha-lrm` and `pve-ha-crm` are excluded by default because they are legitimately inactive on a standalone node. Extend the regex in a cluster. |
-
-### Alert Enable/Disable Macros
-
-Set to `0` to suppress a trigger globally. Supports context macros for per-instance suppression.
-
-| Macro | Default | Description |
-|-------|---------|-------------|
+| `{$ROOTFS.UTIL.WARN}` / `{$ROOTFS.UTIL.CRIT}` | `90` / `95` | Root filesystem thresholds (%) |
+| `{$STORAGE.UTIL.WARN}` / `{$STORAGE.UTIL.CRIT}` | `80` / `90` | Storage thresholds (%) |
+| `{$DISK.WEAROUT.MIN}` | `20` | Minimum SSD wearout remaining before warning (%) |
+| `{$DISK.TEMP.MAX}` | `60` | Disk temperature threshold (degrees Celsius), context form `{$DISK.TEMP.MAX:"/dev/sda"}` |
+| `{$ZFS.UTIL.WARN}` / `{$ZFS.UTIL.CRIT}` | `80` / `90` | ZFS pool usage thresholds (%), context form per pool |
+| `{$ZFS.FRAG.WARN}` | `60` | ZFS free space fragmentation (%) before warning |
+| `{$ZFS.FRAG.UTIL.MIN}` | `70` | Pool usage (%) that must also be reached before the fragmentation warning fires, context form per pool |
+| `{$PVE.REPL.FAIL.MAX}` | `0` | Tolerated consecutive failures of a replication job, context form per job |
+| `{$PVE.APT.REPO.ERRORS.MAX}` | `0` | Tolerated number of unparsable APT repository files |
+| `{$PVE.APT.REPO.WARN.MAX}` | `0` | Tolerated APT repository warnings. A host on the no-subscription repository permanently reports one warning, set this to 1 there. |
+| `{$PVE.APT.UPDATES.MAX}` | `0` | Tolerated pending package updates. Only relevant if the disabled apt/update items are switched on. |
+| `{$TASK.ALERT.WINDOW}` | `1h` | How long a failed task keeps alerting |
+| `{$BACKUP.ALERT.WINDOW}` | `24h` | How long a failed backup keeps alerting |
+| `{$PVE.BACKUP.RUN.MAX}` | `3h` | How long a single backup may run before it is reported as hanging |
+| `{$DISK.MISSING.TIME}` | `3h` | How long a disk may be absent from the disk list before the missing disk trigger fires |
+| `{$IFACE.ACTIVE.WINDOW}` | `7d` | An interface must have been up once within this window before the interface down trigger fires |
+| `{$PVE.REPL.LAG}` | `2h` | Maximum age of the last successful replication |
+| `{$PVE.CERT.EXPIRE.DAYS}` | `21d` | Lead time before certificate expiry |
+| `{$PVE.SUBSCRIPTION.EXPIRE.DAYS}` | `30d` | Lead time before the subscription expires |
+| `{$IFACE.NOT_MATCHES}` | `^(tap\|veth\|fwbr\|fwpr\|fwln)` | Host interface names excluded from discovery |
+| `{$PVE.SERVICE.MATCHES}` | `^(pve-cluster\|pvedaemon\|pveproxy\|pvestatd\|pve-firewall\|pvescheduler\|pve-ha-crm\|pve-ha-lrm)$` | Services to discover. These run on every node, standalone or clustered. `corosync` only runs on cluster members, add it on those hosts. |
 | `{$ENABLE_BACKUP_ALERT}` | `1` | Backup failure trigger |
-| `{$ENABLE_NODE_STATUS_ALERT}` | `1` | Node offline trigger |
 | `{$ENABLE_STORAGE_AVAILABLE_ALERT}` | `1` | Storage high usage trigger |
 | `{$ENABLE_STORAGE_INACTIVE_ALERT}` | `1` | Storage inactive trigger |
 | `{$ENABLE_TASK_ALERT}` | `1` | Task failure trigger |
-| `{$ENABLE_VM_STOP_ALERT}` | `1` | VM/LXC stopped trigger |
-| `{$PVE.SERVICE.STATE.ALERT}` | `1` | PVE service not running trigger. Context form `{$PVE.SERVICE.STATE.ALERT:"pveproxy"}=0` silences one service. |
-| `{$PVE.SUBSCRIPTION.ALERT}` | `0` | Subscription status trigger. Off by default so community hosts do not alert on status `notfound`. Set to `1` on hosts that carry a subscription. |
+| `{$PVE.SERVICE.STATE.ALERT}` | `1` | PVE service not running trigger, context form `{$PVE.SERVICE.STATE.ALERT:"pveproxy"}=0` |
+| `{$PVE.SUBSCRIPTION.ALERT}` | `0` | Subscription status trigger. Off by default so community hosts do not alert on status `notfound`. |
+
+Time macros must carry a unit (`1h`, `30m`).
 
 ---
 
 ## 4. Discovery Rules
 
-| Rule | Source | Discovers |
-|------|--------|-----------|
-| `discover.lxc` | `/cluster/resources` | LXC containers on every node, with CPU, memory, disk, network metrics |
-| `discover.qemu` | `/cluster/resources` | QEMU/KVM VMs on every node, with CPU, memory, disk, network metrics |
-| `discover.nodes` | `/nodes` | Cluster nodes with status and uptime |
-| `discover.storage` | `/nodes/{node}/storage` | Storage pools with capacity and active status |
-| `discover.backup` | `/nodes/{node}/tasks` | Backup jobs (vzdump/PBS), grouped by VM, most recent run |
-| `discover.tasks` | `/nodes/{node}/tasks` | Non-backup tasks, deduplicated per type |
-| `discover.users` | `/access/users` | PVE user accounts with expiration monitoring |
-| `discover.network` | `/nodes/{node}/network` | Host network interfaces (bridge, bond, eth, vlan) |
-| `discover.ha.resources` | `/cluster/ha/status/current` | HA-protected VMs and containers |
-| `discover.disks` | `/nodes/{node}/disks/list` | Physical disks of any type with SMART health, temperature, size and wearout |
-| `discover.pve.services` | `/nodes/{node}/services` | The systemd units PVE manages, with SubState, UnitFileState and ActiveState |
-| `discover.zfs.pools` | `/nodes/{node}/disks/zfs` | Local ZFS pools with health, size, allocated, free, fragmentation, dedup ratio and calculated utilization |
-| `discover.replication` | `/nodes/{node}/replication` | ZFS replication jobs with fail count, last sync, last try, duration and error message |
-| `discover.certificates` | `/nodes/{node}/certificates/info` | Node certificates with expiry timestamp, subject and issuer |
+| Template | Rule | Source | Discovers |
+|----------|------|--------|-----------|
+| Cluster | `discover.qemu` | `/cluster/resources` | VMs on every node with CPU, memory, disk and network metrics |
+| Cluster | `discover.lxc` | `/cluster/resources` | Containers on every node with CPU, memory, disk and network metrics |
+| Cluster | `discover.nodes` | `/nodes` | Cluster nodes with status and uptime |
+| Cluster | `discover.ha.resources` | `/cluster/ha/status/current` | HA-managed VMs and containers |
+| Cluster | `discover.ha.lrm` | `/cluster/ha/status/current` | The HA local resource manager of every node |
+| Cluster | `discover.sdn` | `/cluster/resources` | SDN zones per node (Proxmox VE 9) |
+| Cluster | `discover.backup.jobs` | `/cluster/backup` | Backup jobs with enabled state and next run |
+| Cluster | `discover.users` | `/access/users` | User accounts with expiration |
+| Cluster | `discover.ceph.cluster` | `/cluster/ceph/status` | The Ceph cluster, only when Ceph is set up |
+| Cluster | `discover.ceph.osd` | `/nodes/localhost/ceph/osd` | Every OSD with state, utilization, latency and PG count |
+| Cluster | `discover.ceph.pools` | `/nodes/localhost/ceph/pool` | Every pool with utilization, size and min_size |
+| Node | `discover.storage` | `/nodes/{node}/storage` | Storages with capacity and active status |
+| Node | `discover.backup` | `/nodes/{node}/tasks?typefilter=vzdump` | Backup runs (vzdump/PBS), most recent run per guest |
+| Node | `discover.tasks` | `/nodes/{node}/tasks` | Other tasks, deduplicated per type |
+| Node | `discover.network` | `/nodes/{node}/network` | Host network interfaces |
+| Node | `discover.disks` | `/nodes/{node}/disks/list` | Physical disks with SMART health, temperature, size and wearout |
+| Node | `discover.pve.services` | `/nodes/{node}/services` | PVE systemd units |
+| Node | `discover.zfs.pools` | `/nodes/{node}/disks/zfs` | ZFS pools with health, usage, fragmentation and dedup ratio |
+| Node | `discover.replication` | `/nodes/{node}/replication` | Replication jobs with fail count, last sync and error |
+| Node | `discover.certificates` | `/nodes/{node}/certificates/info` | Node certificates with expiry |
+
+Every rule handles an empty list: a cluster without HA, replication jobs, containers or Ceph discovers nothing and the rule stays supported, and resources that disappear are cleaned up.
 
 ---
 
 ## 5. Triggers
 
-### Host-Level
-
-| Trigger | Severity | Description |
-|---------|----------|-------------|
-| PVE API not reachable | High | No data from API for 5 minutes. When the API is gone this is the cause of every other outage, so it outranks the individual failures. |
-| High CPU usage | Average | PVE host CPU sustained high, threshold via `{$NODE.CPU.UTIL.MAX}` |
-| High load average | Average | Load average ≥ number of CPUs |
-| High memory usage | Average | Configurable via `{$MEMORY.UTIL.MAX}` |
-| High root filesystem usage | Average / High | Two-level: warn and critical |
-| Cluster lost quorum | Disaster | Only fires on actual clusters, not standalone nodes |
-| Cluster nodes offline | High | Configurable tolerance via `{$CLUSTER.NODES.OFFLINE.MAX}` |
-| VMs/LXC not all running | Info | Cluster-wide: running count < total count |
-| Guests not covered by any backup job | Warning | From `/cluster/backup-info/not-backed-up`. Catches the guest that was created after the backup job was defined. |
-| APT repository files are broken | Warning | At least one repository file cannot be parsed, updates will fail |
-| APT repository configuration has warnings | Info | For example the enterprise repository enabled without a subscription |
-| Package updates pending | Info | Disabled by default, like the item it depends on |
-| PVE subscription has expired | Average | The subscription period has ended, the enterprise repository is no longer accessible |
-| PVE subscription expires soon | Warning | Advance warning via `{$PVE.SUBSCRIPTION.EXPIRE.DAYS}`, depends on the expired trigger so only one is open at a time |
-| PVE subscription is not active | Warning | Status invalid, suspended or notfound. Off by default, see `{$PVE.SUBSCRIPTION.ALERT}` |
-
-### VM / LXC Prototypes
+### Cluster template
 
 | Trigger | Severity |
 |---------|----------|
-| CPU over threshold for 5 minutes | Average / High |
-| Memory utilization over threshold | Warning |
-| VM/LXC stopped | High |
-| VM/LXC restarted (uptime < 10 min) | Info |
-| RAM under-provisioned (>90% for 5 min) | Warning |
-| RAM over-provisioned (<20% avg for 24h) | Info |
-| CPU over-provisioned (<5% avg for 24h) | Info |
-
-### Storage Prototypes
-
-| Trigger | Severity |
-|---------|----------|
-| Storage inactive/unavailable | Average |
-| Storage usage over warning threshold | Average |
-| Storage usage over critical threshold | High |
-
-### Other Prototypes
-
-| Trigger | Severity |
-|---------|----------|
-| Backup failed | High |
-| Task failed | Warning |
-| User account expiring within 2 days | Warning |
+| PVE cluster API not reachable (no data for 5 minutes) | High |
+| Cluster lost quorum | Disaster |
+| Cluster nodes offline | High |
 | Node offline | High |
-| Network interface down | Warning |
+| Not all VMs/LXC running | Info |
+| Guests not covered by any backup job | Warning |
+| Backup job disabled, stale or too few jobs | Warning |
+| VM/LXC stopped, restarted, CPU or memory over threshold, over- or under-provisioned | Info to High |
+| VM/LXC migrated to another node | Info |
+| HA manager (CRM) has stopped updating its status | High |
+| HA manager (CRM) reports time drift | Warning |
+| HA LRM on a node is dead, unreadable or has lost its agent lock | High |
+| HA node in maintenance mode | Info |
 | HA resource in error state | High |
-| Disk SMART health not PASSED | High |
-| Disk temperature above `{$DISK.TEMP.MAX}` | Warning |
-| Disk no longer reported by the node | Average |
-| SSD wearout below threshold | Warning |
+| HA resource being fenced or recovered | High |
+| SDN zone in error state | Warning |
+| User account expiring | Warning |
+| Ceph status cannot be read (after it was readable within the last day) | High |
+| Ceph health HEALTH_ERR | High |
+| Ceph health not OK for `{$CEPH.HEALTH.WARN.PERIOD}` | Warning |
+| Ceph OSDs down / OSDs out | Average / Warning |
+| Ceph OSD down (per OSD) | Average |
+| Ceph OSD utilization over warning / critical threshold | Warning / High |
+| Ceph OSD commit latency over threshold | Warning |
+| Ceph monitor(s) out of quorum | Average |
+| Ceph no active manager | High |
+| Ceph placement groups not active+clean for `{$CEPH.PG.NOT_CLEAN.PERIOD}` | Warning |
+| Ceph unfound objects | High |
+| Ceph raw capacity over warning / critical threshold | Warning / High |
+| Ceph pool utilization over warning / critical threshold | Warning / High |
+| Ceph pool with min_size 1 | Warning |
+
+The messages of the active Ceph health checks are in the item `Ceph health checks`. Zabbix shortens item values to 20 characters in trigger names, operational data and descriptions, so the triggers point to that item instead of repeating the text.
+
+### Node template
+
+| Trigger | Severity |
+|---------|----------|
+| PVE API not reachable (no data for 5 minutes) | High |
+| High CPU usage, high load average | Average |
+| High memory usage, high swap usage | Average / Warning |
+| High root filesystem usage | Average / High |
+| Storage inactive, storage usage over warning / critical threshold | Average / High |
+| Disk SMART health not OK, temperature too high, disk missing, SSD wearout low | Warning to High |
+| ZFS pool not ONLINE, usage or fragmentation too high | Warning to High |
 | PVE service not running | Average |
-| ZFS pool not ONLINE | High |
-| ZFS pool fragmentation above `{$ZFS.FRAG.WARN}` | Warning |
-| ZFS pool usage over warning / critical threshold | Average / High |
-| Replication job failing | Average |
-| Replication job has not synced within `{$PVE.REPL.LAG}` | Warning |
+| Network interface down | Warning |
+| Backup failed, backup running longer than `{$PVE.BACKUP.RUN.MAX}` | High / Average |
+| Task failed | Warning |
+| Replication job failing or not synced within `{$PVE.REPL.LAG}` | Average / Warning |
 | Certificate expires within `{$PVE.CERT.EXPIRE.DAYS}` | Warning |
+| APT repository files broken, repository warnings, updates pending | Warning / Info |
+| Subscription expired, expires soon, not active | Average / Warning |
 
 ---
 
-## 6. Dashboard
+## 6. Dashboards
 
-The template includes a pre-built dashboard **"Proxmox VE - Monitoring Dashboard"** with the following pages:
-
-| Page | Contents |
-|------|----------|
-| Overview | Version, Uptime, CPU%, Memory%, Cluster status, VMs running/total, active Problems |
-| PVE | RootFS graph, Load Average (time-series), CPU and Memory graphs |
-| Storage | Utilization pie charts, usage % trend, active status |
-| QEMU/KVM-VMs | CPU, memory, disk I/O, network, status per VM |
-| LXC - Container | CPU, memory, swap, disk I/O, network, status per container |
-| Backup | Backup status per VM |
-| Nodes | Node status and uptime |
-| Cluster | Cluster name, quorum, nodes online/total, VMs running/total, problems |
-| HA & Disks | Network interface status, HA resource states |
-| Tasks | Task status per type |
-| Network | VM and LXC network I/O (current and cumulative) |
+| Template | Dashboard | Pages |
+|----------|-----------|-------|
+| Cluster | Proxmox VE cluster | Overview (cluster, quorum, nodes, guests, HA manager, Ceph, guests without backup job, problems), Virtual machines, LXC containers, Nodes and HA, Ceph |
+| Node | Proxmox VE node | Overview (uptime, kernel, boot mode, subscription, CPU, memory and root filesystem, problems), Storage and disks |
 
 ---
 
 ## 7. Notes
 
-- **Cluster support:** Guest discovery and all guest metrics come from `/cluster/resources`, so VMs and containers on every node are monitored from a single Zabbix host and a live migration does not break their items. Each guest carries a `{#NODE}` macro and a `Node of <vmid>` item, and an informational trigger fires when that value changes. Five guest values are not part of `/cluster/resources` and are still read from the node given by `{$PVE_NODE}`: QEMU balloon size, balloon minimum and machine type, plus LXC swap and maximum swap. For guests on other nodes these five stay empty instead of turning unsupported.
-- **Node-scoped data:** Disks, host network interfaces, storage, tasks, time, version and host status are read per node from `{$PVE_NODE}`. To monitor several nodes in that depth, add one Zabbix host per PVE node with its own `{$PVE_NODE}`.
-- **Single-node without cluster:** Fully supported. `pve.cluster.quorum` returns `1` and `pve.cluster.name` returns `standalone`, the quorum-lost trigger will not fire.
-- **Disk monitoring:** Requires `Sys.Audit` privilege. If disk items show "not supported", check that the API token role is applied with Propagate enabled at path `/`.
-- **HA monitoring:** Only relevant if PVE HA is configured. If no HA resources exist, discovery returns nothing and the rule stays supported. HA data is read from `/cluster/ha/status/current`, which carries the CRM master status and one entry per HA-managed service. The plain `/cluster/ha/status` path is a directory index only and returns no status data.
+- **Load on large clusters:** Guest metrics come from a single `/cluster/resources` request per minute. Zabbix indexes the JSONPath filters of the dependent items, so the cost per guest stays flat as the cluster grows. The only per guest request is the status call for balloon size, machine type and LXC swap; its interval and scope are set with `{$PVE.GUEST.DETAIL.INTERVAL}` and `{$PVE.GUEST.DETAIL.VMID.MATCHES}`. Values that rarely change, such as names, sizes, versions and states, are only stored when they change or once an hour. Numeric items keep 7 days of history and 365 days of trends.
+- **Ceph:** PVE answers every Ceph call with HTTP 500 and `{"data":null,"message":...}` while Ceph is not set up. The Ceph master items accept that status, so they stay supported without Ceph, and the item `Ceph API message` shows the reason. The Ceph items are created by a discovery that only finds something when a Ceph status is returned. OSD and pool data is read from `/nodes/localhost/...`: `localhost` is the node that answers the API call, so the paths work on every node. Pool utilization is reported by Ceph as a fraction and converted to percent.
+- **HA:** HA data is read from `/cluster/ha/status/current`. PVE reports the CRM and LRM states as text such as `pve (active, <timestamp>)`; a regular expression keeps only the state, so the value only changes when the state does. Without HA the manager status reads `unknown` and both HA discoveries find nothing.
+- **Backups:** Backup runs are read with `typefilter=vzdump`. PVE returns only the 50 most recent tasks, and on a node with snapshot or file push automation the unfiltered list can hold no backup at all.
+- **Timeouts:** Every HTTP item sets its timeout explicitly, 20 seconds for the API calls and 10 seconds for the per guest status request. Without it Zabbix falls back to 3 seconds, which `/nodes/{node}/disks/list` exceeds on nodes with several disks.
+- **Reachability:** The "API not reachable" triggers evaluate a small dependent item (`pve.uptime`, `pve.cluster.vms.total`). `nodata()` cannot evaluate the raw API items because they keep no history.
+- **Guests on other nodes:** Every guest carries a `{#NODE}` macro. The per guest status request is sent to the node the guest runs on, so all values are correct for guests on every node, and an informational trigger reports migrations.
+- **Standalone node:** `pve.cluster.quorum` returns `1` and `pve.cluster.name` returns `standalone`, the quorum trigger does not fire.
 - **SSD wearout:** Read from `/nodes/{node}/disks/list`, not from the SMART endpoint, which does not return this value. Disks that report a non-numeric wearout, such as rotating disks, are discarded instead of turning the item unsupported.
 - **CPU temperatures:** Not available through the PVE REST API. Requires an agent or custom script.
-- **Physical NIC traffic:** Not available either. `/nodes/{node}/netstat` returns per-guest tap devices and resets its counters on every read, so there are no byte counters for `eno1` or `vmbr0`. `/nodes/{node}/rrddata` only carries the node aggregate.
-- **ZFS:** `/nodes/{node}/disks/zfs` requires `Sys.Audit` on `/`, not on `/nodes/{node}`. On nodes without ZFS the discovery simply returns nothing and stays supported.
-- **Replication:** The list endpoint already carries the job state, so no extra request per job is needed. Fields such as `last_sync` and `error` are absent before the first run or while the job is healthy; those items discard the value instead of turning unsupported.
-- **Subscription:** `/nodes/{node}/subscription` needs no special permission and answers with HTTP 200 even without a subscription, reporting status `notfound`. Unlike the certificate endpoint it reports `nextduedate` as a plain date string rather than an epoch, so a single JavaScript preprocessing line converts it for the expiry triggers. Those triggers need no enable macro: a host without a subscription reports no due date, so the item stays empty and they cannot fire.
+- **Physical NIC traffic:** Not available either. `/nodes/{node}/netstat` returns per-guest tap devices and resets its counters on every read, so there are no byte counters for `eno1` or `vmbr0`.
+- **ZFS:** `/nodes/{node}/disks/zfs` requires `Sys.Audit` on `/`, not on `/nodes/{node}`.
+- **Replication:** The list endpoint already carries the job state, so no extra request per job is needed.
+- **Subscription:** `/nodes/{node}/subscription` answers with HTTP 200 even without a subscription and reports status `notfound`. The due date is a plain date string, converted to Unix time for the expiry triggers. Without a subscription there is no due date, the item reports 0 and the expiry triggers ignore it.
 - **Permission errors:** The API answers with HTTP 403, so an item lacking permissions turns visibly unsupported rather than silently staying empty.
-- **ZFS pool health:** Stored as a number with a value map rather than as text, so it can be graphed and shown on a dashboard. 0 is ONLINE, everything above is a fault. The mapping is done with preprocessing steps, not with a script. A state outside the seven known zpool states leaves text in place and the item turns visibly unsupported instead of reporting a wrong number.
-- **Long term data:** Numeric performance and capacity items keep 365 days of trends. Timestamp items such as `last_sync` or `notafter` deliberately keep trends disabled, a trend over a Unix timestamp carries no meaning.
+- **ZFS pool health:** Stored as a number with a value map, 0 is ONLINE, everything above is a fault. A state outside the seven known zpool states leaves text in place and the item turns visibly unsupported instead of reporting a wrong number.
 
 ---
 
 ## Screenshots
+
+The screenshots show the single template before the split into a cluster and a node template.
 
 <img width="3801" height="2145" alt="Bildschirmfoto vom 2026-08-16 23-52-55" src="https://github.com/user-attachments/assets/3bb2fc8b-e892-4f7b-8dc8-5356986b9b1d" />
 <img width="3801" height="2145" alt="Bildschirmfoto vom 2026-08-16 23-53-14" src="https://github.com/user-attachments/assets/f548341c-975d-44a3-b4d6-5acbb25517b7" />
 <img width="3801" height="2145" alt="Bildschirmfoto vom 2026-08-16 23-53-22" src="https://github.com/user-attachments/assets/091a82e9-3eef-4fd6-84a4-2a806189fe50" />
 <img width="3801" height="2145" alt="Bildschirmfoto vom 2026-08-16 23-53-29" src="https://github.com/user-attachments/assets/f06dde1f-3244-448d-b9e1-3e9e038b68f2" />
 <img width="3801" height="2145" alt="Bildschirmfoto vom 2026-08-16 23-53-33" src="https://github.com/user-attachments/assets/ba551cbb-49c3-452c-ac75-887503af2e8e" />
-
-
-

--- a/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/README.md
+++ b/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/README.md
@@ -1,15 +1,8 @@
-# Zabbix Templates Proxmox VE REST API
+# Zabbix Template Proxmox VE REST API
 
-Monitoring of Proxmox VE over the official REST API (Proxmox VE 7.0+). No Zabbix agent is needed on the PVE hosts or inside the guests. The import file contains two templates that split the work the same way Proxmox VE does:
+This Zabbix template enables full monitoring of a Proxmox VE environment via the official REST API (Proxmox VE 7.0+). No Zabbix agent is required inside VMs or on the PVE host. It collects host and cluster metrics, VM and LXC container data, backup jobs, storage status, tasks, network interfaces, HA resources, disk health, and user accounts. It also covers the PVE services themselves, ZFS pools, replication jobs, certificate expiry, APT repository state and the subscription status, the HA local resource managers, SDN zones and Ceph.
 
-| Template | Link it to | Covers |
-|----------|------------|--------|
-| `Proxmox VE Cluster by REST API` | exactly one Zabbix host per cluster (or per standalone node) | Guests on every node, node states, quorum, HA manager, HA local resource managers and HA resources, backup jobs and guests without backup, users, SDN zones and, where present, Ceph |
-| `Proxmox VE Node by REST API` | one Zabbix host per PVE node | Node status, CPU, memory, swap, root filesystem, disks with SMART, ZFS pools, storage, host network, PVE services, tasks, backups, replication, certificates, APT and subscription |
-
-Cluster-wide data is requested once per cluster instead of once per node, so a cluster of ten nodes no longer queries every guest ten times and no longer raises every guest problem ten times.
-
-Ceph is detected automatically. On clusters without Ceph no Ceph item is created and nothing is evaluated.
+Works on standalone single-node setups as well as full clusters. Ceph is detected automatically, on clusters without Ceph no Ceph item is created.
 
 ---
 
@@ -31,7 +24,7 @@ Ceph is detected automatically. On clusters without Ceph no Ceph item is created
 
 2. **Assign read-only role to the user**
    - **Datacenter → Permissions → Add → User Permission**
-   - Path: `/` · User: `zabbix@pam` · Role: `PVEAuditor` · Propagate: enabled → **Add**
+   - Path: `/` · User: `zabbix@pam` · Role: `PVEAuditor` · Propagate: ✓ → **Add**
 
 3. **Create the API token**
    - **Datacenter → Permissions → API Tokens → Add**
@@ -55,11 +48,11 @@ PVEAPIToken=zabbix@pam!Zabbix=<token-secret>
 
 3. **Grant permission to the token explicitly**
    - **Datacenter → Permissions → Add → API Token Permission**
-   - Path: `/` · Token: `zabbix@pam!Zabbix` · Role: `PVEAuditor` · Propagate: enabled → **Add**
+   - Path: `/` · Token: `zabbix@pam!Zabbix` · Role: `PVEAuditor` · Propagate: ✓ → **Add**
 
-`PVEAuditor` covers everything both templates read, Ceph included. The one exception:
+`PVEAuditor` also covers the Ceph endpoints.
 
-> **Note for pending updates:** `/nodes/{node}/apt/update` is the only endpoint that requires `Sys.Modify` rather than `Sys.Audit`, so `PVEAuditor` cannot read it. The master item `pve.apt.update.raw` and its dependent item are therefore **disabled by default**. Enable them only if you accept granting the monitoring token write level permissions. The repository state is monitored through `/nodes/{node}/apt/repositories` instead, which only needs `Sys.Audit`.
+> **Note for pending updates:** `/nodes/{node}/apt/update` is the only endpoint in this template that requires `Sys.Modify` rather than `Sys.Audit`, so `PVEAuditor` cannot read it. The corresponding master item `pve.apt.update.raw` and its dependent item are therefore **disabled by default**. Enable them only if you accept granting the monitoring token write level permissions. The repository state is monitored through `/nodes/{node}/apt/repositories` instead, which only needs `Sys.Audit`.
 
 > **Note for disk monitoring:** `/nodes/{node}/disks/list` requires the `Sys.Audit` privilege. `PVEAuditor` includes this privilege. If disk items show "not supported", verify that the role is applied with **Propagate** enabled and that the token has the correct path `/`.
 
@@ -67,158 +60,234 @@ PVEAPIToken=zabbix@pam!Zabbix=<token-secret>
 
 ## 2. Installation
 
-1. Download `7.0/template_proxmox-ve-rest-api.yaml`
-2. In Zabbix: **Data collection → Templates → Import**. The file creates both templates.
-3. Create the hosts. Interfaces stay empty, both templates use the HTTP agent.
+1. Download `template_proxmox-ve-rest-api.yaml`
+2. In Zabbix: **Data collection → Templates → Import**
+3. Create a new host:
+   - **Data collection → Hosts → Create host**
+   - Host name: e.g. `proxmox01`
+   - Template: `Template Proxmox VE REST API`
+   - Group: e.g. `Virtual machines`
+   - Interfaces: leave empty (template uses HTTP agent, no Zabbix agent needed)
+4. Set the required macros on the host (see below)
+5. **Cluster with several nodes:** create one host per node as above, each with `{$PVE_IP}` and `{$PVE_NODE}` of its own node, and set `{$PVE.DATACENTER.COLLECT}` to `0` on all of them but one. Guests, node states, quorum, HA, backup jobs, users, SDN and Ceph are the same on every node; without the switch they are queried and alerted once per node.
 
-**Standalone node:** one host, link both templates, set the macros once.
+| Host | `{$PVE_IP}` / `{$PVE_NODE}` | `{$PVE.DATACENTER.COLLECT}` |
+|------|-----------------------------|-----------------------------|
+| `pve01` | node pve01 | `1` (default) |
+| `pve02`, `pve03`, ... | their own node | `0` |
 
-**Cluster:**
+A standalone node needs nothing beyond steps 1-4.
 
-| Host | Template | `{$PVE_IP}` | `{$PVE_NODE}` |
-|------|----------|-------------|---------------|
-| `pve-cluster` | `Proxmox VE Cluster by REST API` | any node, ideally a DNS name or virtual IP that always points to a running node | not needed |
-| `pve01`, `pve02`, ... | `Proxmox VE Node by REST API` | the node itself | the node name as shown in PVE |
-
-Link the cluster template to one host per cluster only. A second host with the same cluster template doubles every cluster request and every guest problem.
-
-### Upgrading from `Template Proxmox VE REST API`
-
-The cluster template keeps the UUID of the former single template. Importing the file with **Delete missing** enabled renames the former template, removes the node items from it and creates the node template next to it. Then link `Proxmox VE Node by REST API` to every host that should keep node monitoring. Guest, HA, backup job and user history is kept. Node items are created anew, so their history starts again.
+**Upgrading:** Name and UUID of the template are unchanged, so an import updates it in place and keeps the history. Only if you imported the short-lived variant with the two templates `Proxmox VE Cluster by REST API` and `Proxmox VE Node by REST API`: unlink `Proxmox VE Node by REST API` from all hosts first, then import. The import renames the other one back to `Template Proxmox VE REST API` and adds the node items again. Delete `Proxmox VE Node by REST API` afterwards.
 
 ---
 
 ## 3. Macros
 
-### Connection (both templates)
+### Required
 
 | Macro | Example | Description |
 |-------|---------|-------------|
-| `{$PVE_IP}` | `192.168.1.10` | IP address or hostname of the PVE API |
+| `{$PVE_IP}` | `192.168.1.10` | IP address or hostname of the PVE server |
 | `{$PVE_PORT}` | `8006` | API port (default: 8006) |
+| `{$PVE_NODE}` | `pve` | Node name as shown in PVE (Datacenter → Node) |
 | `{$PVE_API_USER}` | `zabbix@pam` | API user including realm |
 | `{$PVE_API_TOKEN_ID}` | `Zabbix` | Token ID |
 | `{$PVE_API_TOKEN}` | *(secret)* | Token secret, set as **Secret text** macro type |
-| `{$PVE_NODE}` | `pve` | Node template only: node name as shown in PVE (Datacenter → Node) |
 
-### Cluster template
+### Cluster and Load Macros
 
 | Macro | Default | Description |
 |-------|---------|-------------|
-| `{$CPU_USAGE_AVERAGE}` | `85` | VM CPU warning threshold (%) |
-| `{$CPU_USAGE_HIGH}` | `99` | VM CPU critical threshold (%) |
+| `{$PVE.DATACENTER.COLLECT}` | `1` | Collect the datacenter-wide data on this host: guests on all nodes, node states, quorum, HA, backup jobs, users, SDN and Ceph. In a cluster keep `1` on one host and set `0` on the others. |
+| `{$PVE.GUEST.DETAIL.INTERVAL}` | `10m` | Interval of the per guest status request that supplies balloon size, machine type and LXC swap. One request per guest, keep it long in large clusters. |
+| `{$PVE.GUEST.DETAIL.VMID.MATCHES}` | `.*` | Only guests whose VMID matches get the per guest status request. `^$` switches it off for all guests. |
+
+### Threshold Macros
+
+| Macro | Default | Description |
+|-------|---------|-------------|
+| `{$CPU_USAGE_AVERAGE}` | `85` | CPU warning threshold (%) |
+| `{$CPU_USAGE_HIGH}` | `99` | CPU critical threshold (%) |
 | `{$LXC.CPU.WARN}` | `85` | LXC CPU warning threshold (%) |
 | `{$LXC.CPU.HIGH}` | `99` | LXC CPU critical threshold (%) |
-| `{$CLUSTER.NODES.OFFLINE.MAX}` | `0` | Tolerated offline nodes (raise during maintenance) |
-| `{$PVE.NOTBACKEDUP.MAX}` | `0` | Tolerated number of guests without a backup job |
-| `{$PVE.BACKUP.JOBS.MIN}` | `1` | Minimum number of configured backup jobs |
-| `{$PVE.BACKUP.JOB.STALE}` | `2d` | Maximum time a backup job may go without a next run |
+| `{$MEMORY.UTIL.MAX}` | `90` | Host memory warning threshold (%) |
+| `{$SWAP.UTIL.MAX}` | `80` | Host swap warning threshold (%). The trigger stays silent on hosts without swap. |
+| `{$ROOTFS.UTIL.WARN}` | `90` | Root filesystem warning threshold (%) |
+| `{$ROOTFS.UTIL.CRIT}` | `95` | Root filesystem critical threshold (%) |
+| `{$STORAGE.UTIL.WARN}` | `80` | Storage pool warning threshold (%) |
+| `{$STORAGE.UTIL.CRIT}` | `90` | Storage pool critical threshold (%) |
+| `{$CLUSTER.NODES.OFFLINE.MAX}` | `0` | Max. tolerated offline nodes (raise during maintenance) |
+| `{$DISK.WEAROUT.MIN}` | `20` | Min. SSD wearout remaining before warning (%) |
 | `{$PVE.USER.EXPIRE.TIME}` | `172800` | Seconds before user expiry to warn (172800 = 2 days) |
-| `{$PVE.GUEST.DETAIL.INTERVAL}` | `10m` | Interval of the per guest status request that supplies balloon size, machine type and LXC swap. This is one request per guest, keep it long in large clusters. |
-| `{$PVE.GUEST.DETAIL.VMID.MATCHES}` | `.*` | Only guests whose VMID matches get the per guest status request. `^$` switches it off for all guests, which leaves one request per minute for all guest metrics together. |
-| `{$CEPH.HEALTH.WARN.PERIOD}` | `15m` | How long Ceph must stay at HEALTH_WARN or worse before the warning fires |
+| `{$DISK.TEMP.MAX}` | `60` | Disk temperature threshold (degrees Celsius). Context form `{$DISK.TEMP.MAX:"/dev/sda"}` raises it for one disk. |
+| `{$NODE.CPU.UTIL.MAX}` | `90` | Node CPU utilization (%) before the high CPU trigger fires. This threshold used to be hardcoded in the trigger expression. |
+| `{$ZFS.UTIL.WARN}` | `80` | ZFS pool usage (%) for the average severity trigger. ZFS performance degrades noticeably above 80%. Context form `{$ZFS.UTIL.WARN:"rpool"}`. |
+| `{$ZFS.UTIL.CRIT}` | `90` | ZFS pool usage (%) for the high severity trigger. |
+| `{$ZFS.FRAG.WARN}` | `60` | ZFS free space fragmentation (%) before warning. |
+| `{$ZFS.FRAG.UTIL.MIN}` | `70` | Pool usage (%) that must also be reached before the fragmentation warning fires. Context form per pool. |
+| `{$PVE.REPL.FAIL.MAX}` | `0` | Tolerated consecutive failures of a replication job. Context form `{$PVE.REPL.FAIL.MAX:"105-0"}`. |
+| `{$PVE.NOTBACKEDUP.MAX}` | `0` | Tolerated number of guests without a backup job. Raise it if some guests are deliberately excluded. |
+| `{$PVE.BACKUP.JOBS.MIN}` | `1` | Minimum number of configured backup jobs. |
+| `{$PVE.APT.REPO.ERRORS.MAX}` | `0` | Tolerated number of unparsable APT repository files. |
+| `{$PVE.APT.REPO.WARN.MAX}` | `0` | Tolerated number of APT repository warnings. A host on the no-subscription repository permanently reports one warning, set this to 1 there. |
+| `{$PVE.APT.UPDATES.MAX}` | `0` | Tolerated number of pending package updates. Only relevant if the disabled apt/update items are switched on. |
 | `{$CEPH.UTIL.WARN}` / `{$CEPH.UTIL.CRIT}` | `75` / `85` | Ceph raw capacity thresholds (%) |
 | `{$CEPH.OSD.UTIL.WARN}` / `{$CEPH.OSD.UTIL.CRIT}` | `80` / `90` | Per OSD utilization thresholds (%). Ceph itself warns at 85 and stops writes at 95. |
 | `{$CEPH.OSD.LATENCY.MAX}` | `0.2` | OSD commit latency threshold in seconds |
-| `{$CEPH.OSD.LATENCY.PERIOD}` | `30m` | How long the latency must stay above the threshold |
 | `{$CEPH.POOL.UTIL.WARN}` / `{$CEPH.POOL.UTIL.CRIT}` | `80` / `90` | Pool utilization thresholds (%) |
-| `{$CEPH.PG.NOT_CLEAN.PERIOD}` | `1h` | How long placement groups may stay not active+clean |
-| `{$CEPH.POOL.NOT_MATCHES}` | `CHANGE_IF_NEEDED` | Pools whose name matches are not discovered |
-| `{$ENABLE_NODE_STATUS_ALERT}` | `1` | Node offline trigger |
-| `{$ENABLE_VM_STOP_ALERT}` | `1` | VM/LXC stopped trigger, context form per VMID |
-| `{$PVE.BACKUP.JOB.ALERT}` | `1` | Backup job triggers, context form per job |
 
-### Node template
+### Timing Macros
+
+Values must carry a time unit.
 
 | Macro | Default | Description |
 |-------|---------|-------------|
-| `{$NODE.CPU.UTIL.MAX}` | `90` | Node CPU utilization (%) before the high CPU trigger fires |
-| `{$MEMORY.UTIL.MAX}` | `90` | Host memory warning threshold (%) |
-| `{$SWAP.UTIL.MAX}` | `80` | Host swap warning threshold (%). The trigger stays silent on hosts without swap. |
-| `{$ROOTFS.UTIL.WARN}` / `{$ROOTFS.UTIL.CRIT}` | `90` / `95` | Root filesystem thresholds (%) |
-| `{$STORAGE.UTIL.WARN}` / `{$STORAGE.UTIL.CRIT}` | `80` / `90` | Storage thresholds (%) |
-| `{$DISK.WEAROUT.MIN}` | `20` | Minimum SSD wearout remaining before warning (%) |
-| `{$DISK.TEMP.MAX}` | `60` | Disk temperature threshold (degrees Celsius), context form `{$DISK.TEMP.MAX:"/dev/sda"}` |
-| `{$ZFS.UTIL.WARN}` / `{$ZFS.UTIL.CRIT}` | `80` / `90` | ZFS pool usage thresholds (%), context form per pool |
-| `{$ZFS.FRAG.WARN}` | `60` | ZFS free space fragmentation (%) before warning |
-| `{$ZFS.FRAG.UTIL.MIN}` | `70` | Pool usage (%) that must also be reached before the fragmentation warning fires, context form per pool |
-| `{$PVE.REPL.FAIL.MAX}` | `0` | Tolerated consecutive failures of a replication job, context form per job |
-| `{$PVE.APT.REPO.ERRORS.MAX}` | `0` | Tolerated number of unparsable APT repository files |
-| `{$PVE.APT.REPO.WARN.MAX}` | `0` | Tolerated APT repository warnings. A host on the no-subscription repository permanently reports one warning, set this to 1 there. |
-| `{$PVE.APT.UPDATES.MAX}` | `0` | Tolerated pending package updates. Only relevant if the disabled apt/update items are switched on. |
-| `{$TASK.ALERT.WINDOW}` | `1h` | How long a failed task keeps alerting |
-| `{$BACKUP.ALERT.WINDOW}` | `24h` | How long a failed backup keeps alerting |
-| `{$PVE.BACKUP.RUN.MAX}` | `3h` | How long a single backup may run before it is reported as hanging |
-| `{$DISK.MISSING.TIME}` | `3h` | How long a disk may be absent from the disk list before the missing disk trigger fires |
-| `{$IFACE.ACTIVE.WINDOW}` | `7d` | An interface must have been up once within this window before the interface down trigger fires |
-| `{$PVE.REPL.LAG}` | `2h` | Maximum age of the last successful replication |
-| `{$PVE.CERT.EXPIRE.DAYS}` | `21d` | Lead time before certificate expiry |
-| `{$PVE.SUBSCRIPTION.EXPIRE.DAYS}` | `30d` | Lead time before the subscription expires |
-| `{$IFACE.NOT_MATCHES}` | `^(tap\|veth\|fwbr\|fwpr\|fwln)` | Host interface names excluded from discovery |
-| `{$PVE.SERVICE.MATCHES}` | `^(pve-cluster\|pvedaemon\|pveproxy\|pvestatd\|pve-firewall\|pvescheduler\|pve-ha-crm\|pve-ha-lrm)$` | Services to discover. These run on every node, standalone or clustered. `corosync` only runs on cluster members, add it on those hosts. |
+| `{$TASK.ALERT.WINDOW}` | `1h` | How long a failed task keeps alerting. Proxmox VE only keeps the most recent tasks, so without this window a one-off failure would alert forever. |
+| `{$BACKUP.ALERT.WINDOW}` | `24h` | How long a failed backup keeps alerting. |
+| `{$PVE.BACKUP.RUN.MAX}` | `3h` | How long a single backup may run before it is reported as hanging. |
+| `{$PVE.BACKUP.JOB.STALE}` | `2d` | Maximum time a backup job may go without a next run. |
+| `{$DISK.MISSING.TIME}` | `3h` | How long a disk may be absent from the disk list before the missing disk trigger fires. The list refreshes hourly. |
+| `{$IFACE.ACTIVE.WINDOW}` | `7d` | An interface must have been up once within this window before the interface down trigger fires. |
+| `{$PVE.REPL.LAG}` | `2h` | Maximum age of the last successful replication. Must stay above the replication schedule, otherwise the trigger fires between two runs. |
+| `{$PVE.CERT.EXPIRE.DAYS}` | `21d` | Lead time before certificate expiry. |
+| `{$PVE.SUBSCRIPTION.EXPIRE.DAYS}` | `30d` | Lead time before the subscription expires. |
+| `{$CEPH.HEALTH.WARN.PERIOD}` | `15m` | How long Ceph must stay at HEALTH_WARN or worse before the warning fires. |
+| `{$CEPH.OSD.LATENCY.PERIOD}` | `30m` | How long the OSD latency must stay above the threshold. |
+| `{$CEPH.PG.NOT_CLEAN.PERIOD}` | `1h` | How long placement groups may stay not active+clean. |
+
+### Discovery Filter Macros
+
+| Macro | Default | Description |
+|-------|---------|-------------|
+| `{$IFACE.NOT_MATCHES}` | `^(tap\|veth\|fwbr\|fwpr\|fwln)` | Host interface names excluded from discovery. The default drops the per-guest interfaces Proxmox creates. |
+| `{$PVE.SERVICE.MATCHES}` | `^(pve-cluster\|pvedaemon\|pveproxy\|pvestatd\|pve-firewall\|pvescheduler\|pve-ha-crm\|pve-ha-lrm)$` | Which PVE services are discovered. These run on every node, standalone or clustered. `corosync` only runs on cluster members, add it on those hosts. |
+| `{$CEPH.POOL.NOT_MATCHES}` | `CHANGE_IF_NEEDED` | Ceph pools whose name matches are not discovered. |
+
+### Alert Enable/Disable Macros
+
+Set to `0` to suppress a trigger globally. Supports context macros for per-instance suppression.
+
+| Macro | Default | Description |
+|-------|---------|-------------|
 | `{$ENABLE_BACKUP_ALERT}` | `1` | Backup failure trigger |
+| `{$ENABLE_NODE_STATUS_ALERT}` | `1` | Node offline trigger |
 | `{$ENABLE_STORAGE_AVAILABLE_ALERT}` | `1` | Storage high usage trigger |
 | `{$ENABLE_STORAGE_INACTIVE_ALERT}` | `1` | Storage inactive trigger |
 | `{$ENABLE_TASK_ALERT}` | `1` | Task failure trigger |
-| `{$PVE.SERVICE.STATE.ALERT}` | `1` | PVE service not running trigger, context form `{$PVE.SERVICE.STATE.ALERT:"pveproxy"}=0` |
-| `{$PVE.SUBSCRIPTION.ALERT}` | `0` | Subscription status trigger. Off by default so community hosts do not alert on status `notfound`. |
-
-Time macros must carry a unit (`1h`, `30m`).
+| `{$ENABLE_VM_STOP_ALERT}` | `1` | VM/LXC stopped trigger |
+| `{$PVE.BACKUP.JOB.ALERT}` | `1` | Backup job triggers. Context form per job. |
+| `{$PVE.SERVICE.STATE.ALERT}` | `1` | PVE service not running trigger. Context form `{$PVE.SERVICE.STATE.ALERT:"pveproxy"}=0` silences one service. |
+| `{$PVE.SUBSCRIPTION.ALERT}` | `0` | Subscription status trigger. Off by default so community hosts do not alert on status `notfound`. Set to `1` on hosts that carry a subscription. |
 
 ---
 
 ## 4. Discovery Rules
 
-| Template | Rule | Source | Discovers |
-|----------|------|--------|-----------|
-| Cluster | `discover.qemu` | `/cluster/resources` | VMs on every node with CPU, memory, disk and network metrics |
-| Cluster | `discover.lxc` | `/cluster/resources` | Containers on every node with CPU, memory, disk and network metrics |
-| Cluster | `discover.nodes` | `/nodes` | Cluster nodes with status and uptime |
-| Cluster | `discover.ha.resources` | `/cluster/ha/status/current` | HA-managed VMs and containers |
-| Cluster | `discover.ha.lrm` | `/cluster/ha/status/current` | The HA local resource manager of every node |
-| Cluster | `discover.sdn` | `/cluster/resources` | SDN zones per node (Proxmox VE 9) |
-| Cluster | `discover.backup.jobs` | `/cluster/backup` | Backup jobs with enabled state and next run |
-| Cluster | `discover.users` | `/access/users` | User accounts with expiration |
-| Cluster | `discover.ceph.cluster` | `/cluster/ceph/status` | The Ceph cluster, only when Ceph is set up |
-| Cluster | `discover.ceph.osd` | `/nodes/localhost/ceph/osd` | Every OSD with state, utilization, latency and PG count |
-| Cluster | `discover.ceph.pools` | `/nodes/localhost/ceph/pool` | Every pool with utilization, size and min_size |
-| Node | `discover.storage` | `/nodes/{node}/storage` | Storages with capacity and active status |
-| Node | `discover.backup` | `/nodes/{node}/tasks?typefilter=vzdump` | Backup runs (vzdump/PBS), most recent run per guest |
-| Node | `discover.tasks` | `/nodes/{node}/tasks` | Other tasks, deduplicated per type |
-| Node | `discover.network` | `/nodes/{node}/network` | Host network interfaces |
-| Node | `discover.disks` | `/nodes/{node}/disks/list` | Physical disks with SMART health, temperature, size and wearout |
-| Node | `discover.pve.services` | `/nodes/{node}/services` | PVE systemd units |
-| Node | `discover.zfs.pools` | `/nodes/{node}/disks/zfs` | ZFS pools with health, usage, fragmentation and dedup ratio |
-| Node | `discover.replication` | `/nodes/{node}/replication` | Replication jobs with fail count, last sync and error |
-| Node | `discover.certificates` | `/nodes/{node}/certificates/info` | Node certificates with expiry |
+| Rule | Source | Discovers |
+|------|--------|-----------|
+| `discover.lxc` | `/cluster/resources` | LXC containers on every node, with CPU, memory, disk, network metrics |
+| `discover.qemu` | `/cluster/resources` | QEMU/KVM VMs on every node, with CPU, memory, disk, network metrics |
+| `discover.nodes` | `/nodes` | Cluster nodes with status and uptime |
+| `discover.storage` | `/nodes/{node}/storage` | Storage pools with capacity and active status |
+| `discover.backup` | `/nodes/{node}/tasks?typefilter=vzdump` | Backup jobs (vzdump/PBS), grouped by VM, most recent run |
+| `discover.backup.jobs` | `/cluster/backup` | Configured backup jobs with enabled state and next run |
+| `discover.tasks` | `/nodes/{node}/tasks` | Non-backup tasks, deduplicated per type |
+| `discover.users` | `/access/users` | PVE user accounts with expiration monitoring |
+| `discover.network` | `/nodes/{node}/network` | Host network interfaces (bridge, bond, eth, vlan) |
+| `discover.ha.resources` | `/cluster/ha/status/current` | HA-protected VMs and containers |
+| `discover.ha.lrm` | `/cluster/ha/status/current` | The HA local resource manager of every node |
+| `discover.sdn` | `/cluster/resources` | SDN zones per node (Proxmox VE 9) |
+| `discover.disks` | `/nodes/{node}/disks/list` | Physical disks of any type with SMART health, temperature, size and wearout |
+| `discover.pve.services` | `/nodes/{node}/services` | The systemd units PVE manages, with SubState, UnitFileState and ActiveState |
+| `discover.zfs.pools` | `/nodes/{node}/disks/zfs` | Local ZFS pools with health, size, allocated, free, fragmentation, dedup ratio and calculated utilization |
+| `discover.replication` | `/nodes/{node}/replication` | ZFS replication jobs with fail count, last sync, last try, duration and error message |
+| `discover.certificates` | `/nodes/{node}/certificates/info` | Node certificates with expiry timestamp, subject and issuer |
+| `discover.ceph.cluster` | `/cluster/ceph/status` | The Ceph cluster, only when Ceph is set up |
+| `discover.ceph.osd` | `/nodes/localhost/ceph/osd` | Every OSD with state, utilization, latency and PG count |
+| `discover.ceph.pools` | `/nodes/localhost/ceph/pool` | Every pool with utilization, size and min_size |
 
-Every rule handles an empty list: a cluster without HA, replication jobs, containers or Ceph discovers nothing and the rule stays supported, and resources that disappear are cleaned up.
+Every rule handles an empty list: a cluster without HA, replication jobs, containers or Ceph discovers nothing, the rule stays supported and resources that disappear are cleaned up.
 
 ---
 
 ## 5. Triggers
 
-### Cluster template
+### Host-Level
+
+| Trigger | Severity | Description |
+|---------|----------|-------------|
+| PVE API not reachable | High | No data from API for 5 minutes. When the API is gone this is the cause of every other outage, so it outranks the individual failures. |
+| High CPU usage | Average | PVE host CPU sustained high, threshold via `{$NODE.CPU.UTIL.MAX}` |
+| High load average | Average | Load average ≥ number of CPUs |
+| High memory usage | Average | Configurable via `{$MEMORY.UTIL.MAX}` |
+| High root filesystem usage | Average / High | Two-level: warn and critical |
+| Cluster lost quorum | Disaster | Only fires on actual clusters, not standalone nodes |
+| Cluster nodes offline | High | Configurable tolerance via `{$CLUSTER.NODES.OFFLINE.MAX}` |
+| VMs/LXC not all running | Info | Cluster-wide: running count < total count |
+| Guests not covered by any backup job | Warning | From `/cluster/backup-info/not-backed-up`. Catches the guest that was created after the backup job was defined. |
+| APT repository files are broken | Warning | At least one repository file cannot be parsed, updates will fail |
+| APT repository configuration has warnings | Info | For example the enterprise repository enabled without a subscription |
+| Package updates pending | Info | Disabled by default, like the item it depends on |
+| PVE subscription has expired | Average | The subscription period has ended, the enterprise repository is no longer accessible |
+| PVE subscription expires soon | Warning | Advance warning via `{$PVE.SUBSCRIPTION.EXPIRE.DAYS}`, depends on the expired trigger so only one is open at a time |
+| PVE subscription is not active | Warning | Status invalid, suspended or notfound. Off by default, see `{$PVE.SUBSCRIPTION.ALERT}` |
+| HA manager (CRM) has stopped updating its status | High | The CRM master reports `old timestamp - dead?` |
+| HA manager (CRM) reports time drift | Warning | The CRM master reports `detected time drift!` |
+
+### VM / LXC Prototypes
 
 | Trigger | Severity |
 |---------|----------|
-| PVE cluster API not reachable (no data for 5 minutes) | High |
-| Cluster lost quorum | Disaster |
-| Cluster nodes offline | High |
-| Node offline | High |
-| Not all VMs/LXC running | Info |
-| Guests not covered by any backup job | Warning |
-| Backup job disabled, stale or too few jobs | Warning |
-| VM/LXC stopped, restarted, CPU or memory over threshold, over- or under-provisioned | Info to High |
+| CPU over threshold for 5 minutes | Average / High |
+| Memory utilization over threshold | Warning |
+| VM/LXC stopped | High |
+| VM/LXC restarted (uptime < 10 min) | Info |
+| RAM under-provisioned (>90% for 5 min) | Warning |
+| RAM over-provisioned (<20% avg for 24h) | Info |
+| CPU over-provisioned (<5% avg for 24h) | Info |
 | VM/LXC migrated to another node | Info |
-| HA manager (CRM) has stopped updating its status | High |
-| HA manager (CRM) reports time drift | Warning |
-| HA LRM on a node is dead, unreadable or has lost its agent lock | High |
-| HA node in maintenance mode | Info |
+
+### Storage Prototypes
+
+| Trigger | Severity |
+|---------|----------|
+| Storage inactive/unavailable | Average |
+| Storage usage over warning threshold | Average |
+| Storage usage over critical threshold | High |
+
+### Other Prototypes
+
+| Trigger | Severity |
+|---------|----------|
+| Backup failed | High |
+| Backup running longer than `{$PVE.BACKUP.RUN.MAX}` | Average |
+| Backup job disabled, too few jobs / job not rescheduled for `{$PVE.BACKUP.JOB.STALE}` | Warning / Average |
+| Task failed | Warning |
+| User account expiring within 2 days | Warning |
+| Node offline | High |
+| Network interface down | Warning |
 | HA resource in error state | High |
 | HA resource being fenced or recovered | High |
+| HA LRM on a node is dead, unreadable or has lost its agent lock | High |
+| HA node in maintenance mode | Info |
 | SDN zone in error state | Warning |
-| User account expiring | Warning |
+| Disk SMART health not PASSED | High |
+| Disk temperature above `{$DISK.TEMP.MAX}` | Warning |
+| Disk no longer reported by the node | Average |
+| SSD wearout below threshold | Warning |
+| PVE service not running | Average |
+| ZFS pool not ONLINE | High |
+| ZFS pool fragmentation above `{$ZFS.FRAG.WARN}` | Warning |
+| ZFS pool usage over warning / critical threshold | Average / High |
+| Replication job failing | Average |
+| Replication job has not synced within `{$PVE.REPL.LAG}` | Warning |
+| Certificate expires within `{$PVE.CERT.EXPIRE.DAYS}` | Warning |
+
+### Ceph
+
+| Trigger | Severity |
+|---------|----------|
 | Ceph status cannot be read (after it was readable within the last day) | High |
 | Ceph health HEALTH_ERR | High |
 | Ceph health not OK for `{$CEPH.HEALTH.WARN.PERIOD}` | Warning |
@@ -236,64 +305,55 @@ Every rule handles an empty list: a cluster without HA, replication jobs, contai
 
 The messages of the active Ceph health checks are in the item `Ceph health checks`. Zabbix shortens item values to 20 characters in trigger names, operational data and descriptions, so the triggers point to that item instead of repeating the text.
 
-### Node template
-
-| Trigger | Severity |
-|---------|----------|
-| PVE API not reachable (no data for 5 minutes) | High |
-| High CPU usage, high load average | Average |
-| High memory usage, high swap usage | Average / Warning |
-| High root filesystem usage | Average / High |
-| Storage inactive, storage usage over warning / critical threshold | Average / High |
-| Disk SMART health not OK, temperature too high, disk missing, SSD wearout low | Warning to High |
-| ZFS pool not ONLINE, usage or fragmentation too high | Warning to High |
-| PVE service not running | Average |
-| Network interface down | Warning |
-| Backup failed, backup running longer than `{$PVE.BACKUP.RUN.MAX}` | High / Average |
-| Task failed | Warning |
-| Replication job failing or not synced within `{$PVE.REPL.LAG}` | Average / Warning |
-| Certificate expires within `{$PVE.CERT.EXPIRE.DAYS}` | Warning |
-| APT repository files broken, repository warnings, updates pending | Warning / Info |
-| Subscription expired, expires soon, not active | Average / Warning |
-
 ---
 
-## 6. Dashboards
+## 6. Dashboard
 
-| Template | Dashboard | Pages |
-|----------|-----------|-------|
-| Cluster | Proxmox VE cluster | Overview (cluster, quorum, nodes, guests, HA manager, Ceph, guests without backup job, problems), Virtual machines, LXC containers, Nodes and HA, Ceph |
-| Node | Proxmox VE node | Overview (uptime, kernel, boot mode, subscription, CPU, memory and root filesystem, problems), Storage and disks |
+The template includes a pre-built dashboard **"Proxmox VE - Monitoring Dashboard"** with the following pages:
+
+| Page | Contents |
+|------|----------|
+| Overview | Cluster, quorum, nodes online, guests running and total, uptime, CPU, memory and root filesystem, problems |
+| Virtual machines | Browse all VM items, VM status, history of the selected item |
+| LXC containers | Browse all container items, container status, history of the selected item |
+| Storage and disks | Storage utilization, disk health and temperature |
+| Nodes and HA | Node status, HA resource states, HA local resource managers, HA manager, nodes offline, kernel, boot mode |
+| Ceph | OSD status, pool utilization, browse all Ceph items |
 
 ---
 
 ## 7. Notes
 
-- **Load on large clusters:** Guest metrics come from a single `/cluster/resources` request per minute. Zabbix indexes the JSONPath filters of the dependent items, so the cost per guest stays flat as the cluster grows. The only per guest request is the status call for balloon size, machine type and LXC swap; its interval and scope are set with `{$PVE.GUEST.DETAIL.INTERVAL}` and `{$PVE.GUEST.DETAIL.VMID.MATCHES}`. Values that rarely change, such as names, sizes, versions and states, are only stored when they change or once an hour. Numeric items keep 7 days of history and 365 days of trends.
-- **Ceph:** PVE answers every Ceph call with HTTP 500 and `{"data":null,"message":...}` while Ceph is not set up. The Ceph master items accept that status, so they stay supported without Ceph, and the item `Ceph API message` shows the reason. The Ceph items are created by a discovery that only finds something when a Ceph status is returned. OSD and pool data is read from `/nodes/localhost/...`: `localhost` is the node that answers the API call, so the paths work on every node. Pool utilization is reported by Ceph as a fraction and converted to percent.
-- **HA:** HA data is read from `/cluster/ha/status/current`. PVE reports the CRM and LRM states as text such as `pve (active, <timestamp>)`; a regular expression keeps only the state, so the value only changes when the state does. Without HA the manager status reads `unknown` and both HA discoveries find nothing.
+- **Cluster support:** Guest discovery and all guest metrics come from `/cluster/resources`, so VMs and containers on every node are monitored from a single Zabbix host and a live migration does not break their items. Each guest carries a `{#NODE}` macro and a `Node of <vmid>` item, and an informational trigger fires when that value changes. Five guest values are not part of `/cluster/resources`: QEMU balloon size, balloon minimum and machine type, plus LXC swap and maximum swap. They are read from `/nodes/{#NODE}/.../status/current`, the node the guest runs on, so they are correct for guests on every node.
+- **Datacenter switch:** `{$PVE.DATACENTER.COLLECT}=0` drops the datacenter-wide data right after the request with a single validation step, so no guest, HA, backup job, user, SDN or Ceph item is discovered on that host and no datacenter trigger fires. The requests themselves still run at their interval, Zabbix cannot switch off an HTTP item by macro.
+- **Node-scoped data:** Disks, host network interfaces, storage, tasks, time, version and host status are read per node from `{$PVE_NODE}`. To monitor several nodes in that depth, add one Zabbix host per PVE node with its own `{$PVE_NODE}`.
+- **Single-node without cluster:** Fully supported. `pve.cluster.quorum` returns `1` and `pve.cluster.name` returns `standalone`, the quorum-lost trigger will not fire.
+- **Load on large clusters:** Guest metrics come from a single `/cluster/resources` request per minute. Zabbix indexes the JSONPath filters of the dependent items, so the cost per guest stays flat as the cluster grows. The only per guest request is the status call above; its interval and scope are set with `{$PVE.GUEST.DETAIL.INTERVAL}` and `{$PVE.GUEST.DETAIL.VMID.MATCHES}`. Values that rarely change, such as names, sizes, versions and states, are only stored when they change or once an hour.
+- **Disk monitoring:** Requires `Sys.Audit` privilege. If disk items show "not supported", check that the API token role is applied with Propagate enabled at path `/`.
+- **HA monitoring:** Only relevant if PVE HA is configured. If no HA resources exist, discovery returns nothing and the rule stays supported. HA data is read from `/cluster/ha/status/current`, which carries the CRM master status, one entry per node LRM and one entry per HA-managed service. PVE reports the CRM and LRM states as text such as `pve (active, <timestamp>)`; a regular expression keeps only the state, so the value only changes when the state does. The plain `/cluster/ha/status` path is a directory index only and returns no status data.
+- **Ceph:** PVE answers every Ceph call with HTTP 500 and `{"data":null,"message":...}` while Ceph is not set up. The Ceph master items accept that status, so they stay supported without Ceph, and the item `Ceph API message` shows the reason. The Ceph items are created by a discovery that only finds something when a Ceph status is returned. OSD and pool data is read from `/nodes/localhost/...`: `localhost` is the node that answers the API call, so the paths work on every node.
 - **Backups:** Backup runs are read with `typefilter=vzdump`. PVE returns only the 50 most recent tasks, and on a node with snapshot or file push automation the unfiltered list can hold no backup at all.
 - **Timeouts:** Every HTTP item sets its timeout explicitly, 20 seconds for the API calls and 10 seconds for the per guest status request. Without it Zabbix falls back to 3 seconds, which `/nodes/{node}/disks/list` exceeds on nodes with several disks.
-- **Reachability:** The "API not reachable" triggers evaluate a small dependent item (`pve.uptime`, `pve.cluster.vms.total`). `nodata()` cannot evaluate the raw API items because they keep no history.
-- **Guests on other nodes:** Every guest carries a `{#NODE}` macro. The per guest status request is sent to the node the guest runs on, so all values are correct for guests on every node, and an informational trigger reports migrations.
-- **Standalone node:** `pve.cluster.quorum` returns `1` and `pve.cluster.name` returns `standalone`, the quorum trigger does not fire.
+- **Reachability:** The "PVE API not reachable" trigger evaluates `pve.uptime`. `nodata()` cannot evaluate the raw API items because they keep no history.
 - **SSD wearout:** Read from `/nodes/{node}/disks/list`, not from the SMART endpoint, which does not return this value. Disks that report a non-numeric wearout, such as rotating disks, are discarded instead of turning the item unsupported.
 - **CPU temperatures:** Not available through the PVE REST API. Requires an agent or custom script.
-- **Physical NIC traffic:** Not available either. `/nodes/{node}/netstat` returns per-guest tap devices and resets its counters on every read, so there are no byte counters for `eno1` or `vmbr0`.
-- **ZFS:** `/nodes/{node}/disks/zfs` requires `Sys.Audit` on `/`, not on `/nodes/{node}`.
-- **Replication:** The list endpoint already carries the job state, so no extra request per job is needed.
-- **Subscription:** `/nodes/{node}/subscription` answers with HTTP 200 even without a subscription and reports status `notfound`. The due date is a plain date string, converted to Unix time for the expiry triggers. Without a subscription there is no due date, the item reports 0 and the expiry triggers ignore it.
+- **Physical NIC traffic:** Not available either. `/nodes/{node}/netstat` returns per-guest tap devices and resets its counters on every read, so there are no byte counters for `eno1` or `vmbr0`. `/nodes/{node}/rrddata` only carries the node aggregate.
+- **ZFS:** `/nodes/{node}/disks/zfs` requires `Sys.Audit` on `/`, not on `/nodes/{node}`. On nodes without ZFS the discovery simply returns nothing and stays supported.
+- **Replication:** The list endpoint already carries the job state, so no extra request per job is needed. Fields such as `last_sync` and `error` are absent before the first run or while the job is healthy; those items discard the value instead of turning unsupported.
+- **Subscription:** `/nodes/{node}/subscription` needs no special permission and answers with HTTP 200 even without a subscription, reporting status `notfound`. Unlike the certificate endpoint it reports `nextduedate` as a plain date string rather than an epoch, so a single JavaScript preprocessing line converts it for the expiry triggers. Without a subscription there is no due date, the item reports `0` and the expiry triggers ignore it.
 - **Permission errors:** The API answers with HTTP 403, so an item lacking permissions turns visibly unsupported rather than silently staying empty.
-- **ZFS pool health:** Stored as a number with a value map, 0 is ONLINE, everything above is a fault. A state outside the seven known zpool states leaves text in place and the item turns visibly unsupported instead of reporting a wrong number.
+- **ZFS pool health:** Stored as a number with a value map rather than as text, so it can be graphed and shown on a dashboard. 0 is ONLINE, everything above is a fault. The mapping is done with preprocessing steps, not with a script. A state outside the seven known zpool states leaves text in place and the item turns visibly unsupported instead of reporting a wrong number.
+- **Long term data:** Numeric performance and capacity items keep 7 days of history and 365 days of trends. Timestamp items such as `last_sync` or `notafter` deliberately keep trends disabled, a trend over a Unix timestamp carries no meaning.
 
 ---
 
 ## Screenshots
-
-The screenshots show the single template before the split into a cluster and a node template.
 
 <img width="3801" height="2145" alt="Bildschirmfoto vom 2026-08-16 23-52-55" src="https://github.com/user-attachments/assets/3bb2fc8b-e892-4f7b-8dc8-5356986b9b1d" />
 <img width="3801" height="2145" alt="Bildschirmfoto vom 2026-08-16 23-53-14" src="https://github.com/user-attachments/assets/f548341c-975d-44a3-b4d6-5acbb25517b7" />
 <img width="3801" height="2145" alt="Bildschirmfoto vom 2026-08-16 23-53-22" src="https://github.com/user-attachments/assets/091a82e9-3eef-4fd6-84a4-2a806189fe50" />
 <img width="3801" height="2145" alt="Bildschirmfoto vom 2026-08-16 23-53-29" src="https://github.com/user-attachments/assets/f06dde1f-3244-448d-b9e1-3e9e038b68f2" />
 <img width="3801" height="2145" alt="Bildschirmfoto vom 2026-08-16 23-53-33" src="https://github.com/user-attachments/assets/ba551cbb-49c3-452c-ac75-887503af2e8e" />
+
+
+

--- a/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/README.md
+++ b/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/README.md
@@ -69,12 +69,12 @@ PVEAPIToken=zabbix@pam!Zabbix=<token-secret>
    - Group: e.g. `Virtual machines`
    - Interfaces: leave empty (template uses HTTP agent, no Zabbix agent needed)
 4. Set the required macros on the host (see below)
-5. **Cluster with several nodes:** create one host per node as above, each with `{$PVE_IP}` and `{$PVE_NODE}` of its own node, and set `{$PVE.DATACENTER.COLLECT}` to `0` on all of them but one. Guests, node states, quorum, HA, backup jobs, users, SDN and Ceph are the same on every node; without the switch they are queried and alerted once per node.
+5. **Cluster with several nodes:** create one host per node as above, each with `{$PVE_IP}` and `{$PVE_NODE}` of its own node, and set `{$PVE.DATACENTER.PAUSE}` to `1-7,00:00-24:00` on all of them but one. Guests, node states, quorum, HA, backup jobs, users, SDN and Ceph are the same on every node; without the pause they are requested and alerted once per node.
 
-| Host | `{$PVE_IP}` / `{$PVE_NODE}` | `{$PVE.DATACENTER.COLLECT}` |
-|------|-----------------------------|-----------------------------|
-| `pve01` | node pve01 | `1` (default) |
-| `pve02`, `pve03`, ... | their own node | `0` |
+| Host | `{$PVE_IP}` / `{$PVE_NODE}` | `{$PVE.DATACENTER.PAUSE}` |
+|------|-----------------------------|---------------------------|
+| `pve01` | node pve01 | `7,23:59-24:00` (default) |
+| `pve02`, `pve03`, ... | their own node | `1-7,00:00-24:00` |
 
 A standalone node needs nothing beyond steps 1-4.
 
@@ -99,7 +99,7 @@ A standalone node needs nothing beyond steps 1-4.
 
 | Macro | Default | Description |
 |-------|---------|-------------|
-| `{$PVE.DATACENTER.COLLECT}` | `1` | Collect the datacenter-wide data on this host: guests on all nodes, node states, quorum, HA, backup jobs, users, SDN and Ceph. In a cluster keep `1` on one host and set `0` on the others. |
+| `{$PVE.DATACENTER.PAUSE}` | `7,23:59-24:00` | Period in which the datacenter-wide data is not requested on this host: guests on all nodes, node states, quorum, HA, backup jobs, users, SDN and Ceph. In a cluster keep the default on one host and set `1-7,00:00-24:00` on the others. The default only skips the last minute of the week. |
 | `{$PVE.GUEST.DETAIL.INTERVAL}` | `10m` | Interval of the per guest status request that supplies balloon size, machine type and LXC swap. One request per guest, keep it long in large clusters. |
 | `{$PVE.GUEST.DETAIL.VMID.MATCHES}` | `.*` | Only guests whose VMID matches get the per guest status request. `^$` switches it off for all guests. |
 
@@ -325,10 +325,10 @@ The template includes a pre-built dashboard **"Proxmox VE - Monitoring Dashboard
 ## 7. Notes
 
 - **Cluster support:** Guest discovery and all guest metrics come from `/cluster/resources`, so VMs and containers on every node are monitored from a single Zabbix host and a live migration does not break their items. Each guest carries a `{#NODE}` macro and a `Node of <vmid>` item, and an informational trigger fires when that value changes. Five guest values are not part of `/cluster/resources`: QEMU balloon size, balloon minimum and machine type, plus LXC swap and maximum swap. They are read from `/nodes/{#NODE}/.../status/current`, the node the guest runs on, so they are correct for guests on every node.
-- **Datacenter switch:** `{$PVE.DATACENTER.COLLECT}=0` drops the datacenter-wide data right after the request with a single validation step, so no guest, HA, backup job, user, SDN or Ceph item is discovered on that host and no datacenter trigger fires. The requests themselves still run at their interval, Zabbix cannot switch off an HTTP item by macro.
+- **Datacenter pause:** The requests for datacenter-wide data carry the flexible interval `0/{$PVE.DATACENTER.PAUSE}`. Zabbix does not poll an item during a flexible interval of 0, so with `1-7,00:00-24:00` no guest, HA, backup job, user, SDN or Ceph data is requested on that host at all, nothing is discovered and no datacenter trigger fires. The syntax of the value is the Zabbix time period, the same as for flexible intervals. Zabbix polls a new item once when it is created, before the host macro is in effect; three preprocessing steps discard that value on a paused host, so it cannot leave a stale datacenter problem behind. Partial pauses, for example `1-7,00:00-06:00` to skip the night, are not discarded and simply poll less. When the pause is set on a host that already collected the datacenter data, the request that was already scheduled still runs once, then the requests stop. The datacenter items and discovered guests of that host keep their last values, and problems they raised stay open until closed; setting the macro before the first data avoids that.
 - **Node-scoped data:** Disks, host network interfaces, storage, tasks, time, version and host status are read per node from `{$PVE_NODE}`. To monitor several nodes in that depth, add one Zabbix host per PVE node with its own `{$PVE_NODE}`.
 - **Single-node without cluster:** Fully supported. `pve.cluster.quorum` returns `1` and `pve.cluster.name` returns `standalone`, the quorum-lost trigger will not fire.
-- **Load on large clusters:** Guest metrics come from a single `/cluster/resources` request per minute. Zabbix indexes the JSONPath filters of the dependent items, so the cost per guest stays flat as the cluster grows. The only per guest request is the status call above; its interval and scope are set with `{$PVE.GUEST.DETAIL.INTERVAL}` and `{$PVE.GUEST.DETAIL.VMID.MATCHES}`. Values that rarely change, such as names, sizes, versions and states, are only stored when they change or once an hour.
+- **Load on large clusters:** Guest metrics come from a single `/cluster/resources` request per minute. Zabbix indexes the JSONPath filters of the dependent items, so the cost per guest stays flat as the cluster grows. The only per guest request is the status call above; its interval and scope are set with `{$PVE.GUEST.DETAIL.INTERVAL}` and `{$PVE.GUEST.DETAIL.VMID.MATCHES}`. Values that rarely change, such as names, sizes, versions and states, are only stored when they change. Only values that are drawn in graphs or evaluated over a time window are written again once an hour. Storage, services, tasks and running backups are polled every 5 minutes: `/nodes/{node}/storage` alone takes more than a second per call, and the shortest trigger window on these values is 15 minutes.
 - **Disk monitoring:** Requires `Sys.Audit` privilege. If disk items show "not supported", check that the API token role is applied with Propagate enabled at path `/`.
 - **HA monitoring:** Only relevant if PVE HA is configured. If no HA resources exist, discovery returns nothing and the rule stays supported. HA data is read from `/cluster/ha/status/current`, which carries the CRM master status, one entry per node LRM and one entry per HA-managed service. PVE reports the CRM and LRM states as text such as `pve (active, <timestamp>)`; a regular expression keeps only the state, so the value only changes when the state does. The plain `/cluster/ha/status` path is a directory index only and returns no status data.
 - **Ceph:** PVE answers every Ceph call with HTTP 500 and `{"data":null,"message":...}` while Ceph is not set up. The Ceph master items accept that status, so they stay supported without Ceph, and the item `Ceph API message` shows the reason. The Ceph items are created by a discovery that only finds something when a Ceph status is returned. OSD and pool data is read from `/nodes/localhost/...`: `localhost` is the node that answers the API call, so the paths work on every node.
@@ -336,6 +336,7 @@ The template includes a pre-built dashboard **"Proxmox VE - Monitoring Dashboard
 - **Timeouts:** Every HTTP item sets its timeout explicitly, 20 seconds for the API calls and 10 seconds for the per guest status request. Without it Zabbix falls back to 3 seconds, which `/nodes/{node}/disks/list` exceeds on nodes with several disks.
 - **Reachability:** The "PVE API not reachable" trigger evaluates `pve.uptime`. `nodata()` cannot evaluate the raw API items because they keep no history.
 - **SSD wearout:** Read from `/nodes/{node}/disks/list`, not from the SMART endpoint, which does not return this value. Disks that report a non-numeric wearout, such as rotating disks, are discarded instead of turning the item unsupported.
+- **CPU I/O wait:** Read from the `wait` field of `/nodes/{node}/status`, which is fetched anyway, so it costs no extra request. High values point to slow or overloaded storage.
 - **CPU temperatures:** Not available through the PVE REST API. Requires an agent or custom script.
 - **Physical NIC traffic:** Not available either. `/nodes/{node}/netstat` returns per-guest tap devices and resets its counters on every read, so there are no byte counters for `eno1` or `vmbr0`. `/nodes/{node}/rrddata` only carries the node aggregate.
 - **ZFS:** `/nodes/{node}/disks/zfs` requires `Sys.Audit` on `/`, not on `/nodes/{node}`. On nodes without ZFS the discovery simply returns nothing and stays supported.

--- a/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/README.md
+++ b/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/README.md
@@ -78,7 +78,7 @@ PVEAPIToken=zabbix@pam!Zabbix=<token-secret>
 
 A standalone node needs nothing beyond steps 1-4.
 
-**Upgrading:** Name and UUID of the template are unchanged, so an import updates it in place and keeps the history. Only if you imported the short-lived variant with the two templates `Proxmox VE Cluster by REST API` and `Proxmox VE Node by REST API`: unlink `Proxmox VE Node by REST API` from all hosts first, then import. The import renames the other one back to `Template Proxmox VE REST API` and adds the node items again. Delete `Proxmox VE Node by REST API` afterwards.
+**Upgrading:** Name and UUID of the template are unchanged, so an import updates it in place and keeps the history.
 
 ---
 

--- a/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/template_proxmox-ve-rest-api.yaml
+++ b/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/template_proxmox-ve-rest-api.yaml
@@ -29,9 +29,9 @@ zabbix_export:
               parameters:
                 - '$.data[?(@.Package=="pve-manager")].Version.first()'
               error_handler: DISCARD_VALUE
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.apt.versions.raw
           tags:
@@ -116,9 +116,9 @@ zabbix_export:
               parameters:
                 - '$.data[?(@.Package=="proxmox-ve")].RunningKernel.first()'
               error_handler: DISCARD_VALUE
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.apt.versions.raw
           tags:
@@ -192,7 +192,7 @@ zabbix_export:
           name: 'PVE backup active raw'
           type: HTTP_AGENT
           key: pve.backup.active.raw
-          delay: '60'
+          delay: 5m
           history: '0'
           value_type: TEXT
           trends: '0'
@@ -225,7 +225,7 @@ zabbix_export:
               value: Backup
           triggers:
             - uuid: 27abcc86c4424e11b36b25b92f9fdf0b
-              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.backup.jobs.count)<{$PVE.BACKUP.JOBS.MIN})'
+              expression: 'last(/Template Proxmox VE REST API/pve.backup.jobs.count)<{$PVE.BACKUP.JOBS.MIN}'
               name: 'Fewer backup jobs configured than expected on {HOST.NAME}'
               opdata: 'Configured jobs: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -235,16 +235,24 @@ zabbix_export:
           name: 'PVE backup jobs raw'
           type: HTTP_AGENT
           key: pve.backup.jobs.raw
-          delay: '600'
+          delay: '600;0/{$PVE.DATACENTER.PAUSE}'
           history: '0'
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /cluster/backup, the configured vzdump backup job definitions. This is the job side of backup monitoring: pve.backup.raw watches the runs, this item watches whether a job exists at all, is enabled and is still being scheduled. A job that was switched off or is no longer advanced by the scheduler starts no run, so it produces no failed task and would otherwise stay invisible. Requires Sys.Audit on /.'
           preprocessing:
+            - type: REGEX
+              parameters:
+                - '^[\s\S]*'
+                - '{$PVE.DATACENTER.PAUSE}|\0'
             - type: NOT_MATCHES_REGEX
               parameters:
-                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+                - '^1\-7,00:00\-24:00\|'
               error_handler: DISCARD_VALUE
+            - type: REGEX
+              parameters:
+                - '^[^|]*\|([\s\S]*)'
+                - \1
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/backup'
           headers:
@@ -504,7 +512,7 @@ zabbix_export:
               value: Ceph
           triggers:
             - uuid: 129264f6d8c44bc58ba06e18f2ae6db1
-              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.ceph.available)=0 and count(/Template Proxmox VE REST API/pve.ceph.available,1d,"eq","1")>0)'
+              expression: 'last(/Template Proxmox VE REST API/pve.ceph.available)=0 and count(/Template Proxmox VE REST API/pve.ceph.available,1d,"eq","1")>0'
               name: 'Ceph status cannot be read'
               opdata: '{ITEM.LASTVALUE1}'
               priority: HIGH
@@ -524,9 +532,9 @@ zabbix_export:
                 - $.message
               error_handler: CUSTOM_VALUE
               error_handler_params: none
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.ceph.status.raw
           tags:
@@ -536,16 +544,24 @@ zabbix_export:
           name: 'PVE Ceph OSD raw'
           type: HTTP_AGENT
           key: pve.ceph.osd.raw
-          delay: 5m
+          delay: '5m;0/{$PVE.DATACENTER.PAUSE}'
           history: '0'
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /nodes/localhost/ceph/osd: the CRUSH tree with every OSD, its state, usage and latency, plus the cluster flags. "localhost" is the node answering the API call, so the path works on every node. HTTP 500 is accepted on purpose: PVE answers every Ceph call with 500 and {"data":null,"message":...} while Ceph is not set up, which keeps this item supported on clusters without Ceph and lets the dependent items tell "no Ceph" apart from a readable status.'
           preprocessing:
+            - type: REGEX
+              parameters:
+                - '^[\s\S]*'
+                - '{$PVE.DATACENTER.PAUSE}|\0'
             - type: NOT_MATCHES_REGEX
               parameters:
-                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+                - '^1\-7,00:00\-24:00\|'
               error_handler: DISCARD_VALUE
+            - type: REGEX
+              parameters:
+                - '^[^|]*\|([\s\S]*)'
+                - \1
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/localhost/ceph/osd'
           status_codes: '200,500'
@@ -561,16 +577,24 @@ zabbix_export:
           name: 'PVE Ceph pools raw'
           type: HTTP_AGENT
           key: pve.ceph.pool.raw
-          delay: 5m
+          delay: '5m;0/{$PVE.DATACENTER.PAUSE}'
           history: '0'
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /nodes/localhost/ceph/pool: every pool with size, min_size and usage. HTTP 500 is accepted on purpose: PVE answers every Ceph call with 500 and {"data":null,"message":...} while Ceph is not set up, which keeps this item supported on clusters without Ceph and lets the dependent items tell "no Ceph" apart from a readable status.'
           preprocessing:
+            - type: REGEX
+              parameters:
+                - '^[\s\S]*'
+                - '{$PVE.DATACENTER.PAUSE}|\0'
             - type: NOT_MATCHES_REGEX
               parameters:
-                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+                - '^1\-7,00:00\-24:00\|'
               error_handler: DISCARD_VALUE
+            - type: REGEX
+              parameters:
+                - '^[^|]*\|([\s\S]*)'
+                - \1
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/localhost/ceph/pool'
           status_codes: '200,500'
@@ -586,15 +610,24 @@ zabbix_export:
           name: 'PVE Ceph status raw'
           type: HTTP_AGENT
           key: pve.ceph.status.raw
+          delay: '1m;0/{$PVE.DATACENTER.PAUSE}'
           history: '0'
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /cluster/ceph/status: health, monitor, manager, OSD and PG maps. HTTP 500 is accepted on purpose: PVE answers every Ceph call with 500 and {"data":null,"message":...} while Ceph is not set up, which keeps this item supported on clusters without Ceph and lets the dependent items tell "no Ceph" apart from a readable status.'
           preprocessing:
+            - type: REGEX
+              parameters:
+                - '^[\s\S]*'
+                - '{$PVE.DATACENTER.PAUSE}|\0'
             - type: NOT_MATCHES_REGEX
               parameters:
-                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+                - '^1\-7,00:00\-24:00\|'
               error_handler: DISCARD_VALUE
+            - type: REGEX
+              parameters:
+                - '^[^|]*\|([\s\S]*)'
+                - \1
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/ceph/status'
           status_codes: '200,500'
@@ -639,9 +672,9 @@ zabbix_export:
                 - '$.data[?(@.type=="cluster")].name.first()'
               error_handler: CUSTOM_VALUE
               error_handler_params: standalone
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1d
+                - ''
           master_item:
             key: pve.cluster.raw
           tags:
@@ -667,7 +700,7 @@ zabbix_export:
               value: Cluster
           triggers:
             - uuid: 3dfb794aebe14bb89850bc56aa2f937c
-              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.cluster.nodes.offline)>{$CLUSTER.NODES.OFFLINE.MAX})'
+              expression: 'last(/Template Proxmox VE REST API/pve.cluster.nodes.offline)>{$CLUSTER.NODES.OFFLINE.MAX}'
               name: '{ITEM.LASTVALUE} cluster node(s) offline'
               priority: HIGH
               description: 'One or more Proxmox VE cluster nodes are offline. Set {$CLUSTER.NODES.OFFLINE.MAX} to a higher value to tolerate planned maintenance.'
@@ -724,7 +757,7 @@ zabbix_export:
               value: Cluster
           triggers:
             - uuid: 46be8e0cb28741a1a25c826eaa7f3525
-              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.cluster.quorum)=0)'
+              expression: 'last(/Template Proxmox VE REST API/pve.cluster.quorum)=0'
               name: 'Proxmox VE cluster has lost quorum'
               priority: DISASTER
               description: 'The cluster is not quorate. /etc/pve is read-only, so guests cannot be started, changed or migrated, and nodes with active HA resources fence themselves.'
@@ -735,16 +768,24 @@ zabbix_export:
           name: 'PVE cluster raw'
           type: HTTP_AGENT
           key: pve.cluster.raw
-          delay: '60'
+          delay: '60;0/{$PVE.DATACENTER.PAUSE}'
           history: '0'
           value_type: TEXT
           trends: '0'
           description: 'Raw cluster status from /api2/json/cluster/status. Used as master for cluster-dependent items.'
           preprocessing:
+            - type: REGEX
+              parameters:
+                - '^[\s\S]*'
+                - '{$PVE.DATACENTER.PAUSE}|\0'
             - type: NOT_MATCHES_REGEX
               parameters:
-                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+                - '^1\-7,00:00\-24:00\|'
               error_handler: DISCARD_VALUE
+            - type: REGEX
+              parameters:
+                - '^[^|]*\|([\s\S]*)'
+                - \1
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/status'
           headers:
@@ -759,16 +800,24 @@ zabbix_export:
           name: 'PVE cluster resources raw'
           type: HTTP_AGENT
           key: pve.cluster.resources.raw
-          delay: '60'
+          delay: '60;0/{$PVE.DATACENTER.PAUSE}'
           history: '0'
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /cluster/resources. Aggregated view of all VMs, LXC containers, storage and nodes across the cluster.'
           preprocessing:
+            - type: REGEX
+              parameters:
+                - '^[\s\S]*'
+                - '{$PVE.DATACENTER.PAUSE}|\0'
             - type: NOT_MATCHES_REGEX
               parameters:
-                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+                - '^1\-7,00:00\-24:00\|'
               error_handler: DISCARD_VALUE
+            - type: REGEX
+              parameters:
+                - '^[^|]*\|([\s\S]*)'
+                - \1
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/resources'
           headers:
@@ -823,9 +872,30 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.data.cpuinfo.cores
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: 1ebd528b09cd418cb91147621d492660
+          name: 'PVE CPU I/O wait'
+          type: DEPENDENT
+          key: pve.cpu.iowait
+          delay: '0'
+          history: 7d
+          value_type: FLOAT
+          units: '%'
+          description: 'Share of CPU time spent waiting for I/O in percent (0-100). Source: /nodes/{node}/status → data.wait * 100. High values point to slow or overloaded storage.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.wait
+            - type: MULTIPLIER
+              parameters:
+                - '100'
           master_item:
             key: pve.status
           tags:
@@ -870,9 +940,9 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.data.cpuinfo.model
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.status
           tags:
@@ -890,9 +960,9 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.data.cpuinfo.cpus
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.status
           tags:
@@ -910,9 +980,9 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - '$.data["current-kernel"].release'
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.status
           tags:
@@ -957,9 +1027,9 @@ zabbix_export:
                 - \1
               error_handler: CUSTOM_VALUE
               error_handler_params: unknown
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.ha.raw
           tags:
@@ -967,13 +1037,13 @@ zabbix_export:
               value: HA
           triggers:
             - uuid: f2ebf17802504d13a6d8c17509ce36a6
-              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.ha.manager.status)="old timestamp - dead?")'
+              expression: 'last(/Template Proxmox VE REST API/pve.ha.manager.status)="old timestamp - dead?"'
               name: 'HA manager (CRM) has stopped updating its status'
               priority: HIGH
               description: 'The CRM master has not written its status for more than 30 seconds. HA resources are no longer managed: failed guests are not recovered and fencing decisions are not made. Check pve-ha-crm on the node named in the HA status.'
               manual_close: 'YES'
             - uuid: 0ff77987c4ff444cb70e80a80def1602
-              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.ha.manager.status)="detected time drift!")'
+              expression: 'last(/Template Proxmox VE REST API/pve.ha.manager.status)="detected time drift!"'
               name: 'HA manager (CRM) reports time drift'
               priority: WARNING
               description: 'The CRM status timestamp lies in the future. The cluster nodes disagree on the time, which disturbs HA decisions. Check the time synchronisation on all nodes.'
@@ -982,16 +1052,24 @@ zabbix_export:
           name: 'PVE HA status raw'
           type: HTTP_AGENT
           key: pve.ha.raw
-          delay: '60'
+          delay: '60;0/{$PVE.DATACENTER.PAUSE}'
           history: '0'
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /cluster/ha/status/current. Contains one entry per quorum, CRM master, LRM and HA-managed service. Used for HA manager status and HA resource discovery. Note that /cluster/ha/status without /current is only a directory index and carries no status data.'
           preprocessing:
+            - type: REGEX
+              parameters:
+                - '^[\s\S]*'
+                - '{$PVE.DATACENTER.PAUSE}|\0'
             - type: NOT_MATCHES_REGEX
               parameters:
-                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+                - '^1\-7,00:00\-24:00\|'
               error_handler: DISCARD_VALUE
+            - type: REGEX
+              parameters:
+                - '^[^|]*\|([\s\S]*)'
+                - \1
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/ha/status/current'
           headers:
@@ -1082,9 +1160,9 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - '$.data["current-kernel"].machine'
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.status
           tags:
@@ -1199,16 +1277,24 @@ zabbix_export:
           name: 'PVE nodes raw'
           type: HTTP_AGENT
           key: pve.nodes.raw
-          delay: '300'
+          delay: '300;0/{$PVE.DATACENTER.PAUSE}'
           history: '0'
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /nodes. Used as source for cluster node discovery and node status items.'
           preprocessing:
+            - type: REGEX
+              parameters:
+                - '^[\s\S]*'
+                - '{$PVE.DATACENTER.PAUSE}|\0'
             - type: NOT_MATCHES_REGEX
               parameters:
-                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+                - '^1\-7,00:00\-24:00\|'
               error_handler: DISCARD_VALUE
+            - type: REGEX
+              parameters:
+                - '^[^|]*\|([\s\S]*)'
+                - \1
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes'
           headers:
@@ -1237,7 +1323,7 @@ zabbix_export:
               value: Backup
           triggers:
             - uuid: f93aea89718e469ea4c5468ca601fbed
-              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.notbackedup.count)>{$PVE.NOTBACKEDUP.MAX})'
+              expression: 'last(/Template Proxmox VE REST API/pve.notbackedup.count)>{$PVE.NOTBACKEDUP.MAX}'
               name: '{ITEM.LASTVALUE} guest(s) not covered by any backup job'
               opdata: 'Guests without backup: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -1247,16 +1333,24 @@ zabbix_export:
           name: 'PVE guests without backup raw'
           type: HTTP_AGENT
           key: pve.notbackedup.raw
-          delay: '3600'
+          delay: '3600;0/{$PVE.DATACENTER.PAUSE}'
           history: '0'
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /cluster/backup-info/not-backed-up, the guests not covered by any backup job. Requires Sys.Audit on /.'
           preprocessing:
+            - type: REGEX
+              parameters:
+                - '^[\s\S]*'
+                - '{$PVE.DATACENTER.PAUSE}|\0'
             - type: NOT_MATCHES_REGEX
               parameters:
-                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+                - '^1\-7,00:00\-24:00\|'
               error_handler: DISCARD_VALUE
+            - type: REGEX
+              parameters:
+                - '^[^|]*\|([\s\S]*)'
+                - \1
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/backup-info/not-backed-up'
           headers:
@@ -1315,9 +1409,9 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.data.rootfs.total
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.status
           tags:
@@ -1357,7 +1451,7 @@ zabbix_export:
           name: 'PVE services raw'
           type: HTTP_AGENT
           key: pve.services.raw
-          delay: '60'
+          delay: 5m
           history: '0'
           value_type: TEXT
           trends: '0'
@@ -1384,9 +1478,9 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.data.cpuinfo.sockets
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.status
           tags:
@@ -1415,7 +1509,7 @@ zabbix_export:
           name: 'PVE storage raw'
           type: HTTP_AGENT
           key: pve.storage.raw
-          delay: '60'
+          delay: 5m
           history: '0'
           value_type: TEXT
           trends: '0'
@@ -1443,9 +1537,9 @@ zabbix_export:
               parameters:
                 - $.data.level
               error_handler: DISCARD_VALUE
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.subscription.raw
           tags:
@@ -1464,9 +1558,9 @@ zabbix_export:
               parameters:
                 - $.data.nextduedate
               error_handler: DISCARD_VALUE
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.subscription.raw
           tags:
@@ -1555,9 +1649,9 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.data.status
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.subscription.raw
           tags:
@@ -1601,9 +1695,9 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.data.swap.total
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.status
           tags:
@@ -1639,9 +1733,9 @@ zabbix_export:
               parameters:
                 - '$.data["boot-info"].mode'
               error_handler: DISCARD_VALUE
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.status
           tags:
@@ -1662,9 +1756,9 @@ zabbix_export:
               parameters:
                 - '$.data["boot-info"].secureboot'
               error_handler: DISCARD_VALUE
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.status
           tags:
@@ -1674,7 +1768,7 @@ zabbix_export:
           name: 'PVE tasks raw'
           type: HTTP_AGENT
           key: pve.tasks.raw
-          delay: '60'
+          delay: 5m
           history: '0'
           value_type: TEXT
           trends: '0'
@@ -1813,9 +1907,9 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - $.data.timezone
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1h
+                - ''
           master_item:
             key: pve.time.raw
           tags:
@@ -1850,16 +1944,24 @@ zabbix_export:
           name: 'PVE user raw'
           type: HTTP_AGENT
           key: pve.user.raw
-          delay: '3600'
+          delay: '3600;0/{$PVE.DATACENTER.PAUSE}'
           history: '0'
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /access/users. Used as source for user discovery and account expiration monitoring.'
           preprocessing:
+            - type: REGEX
+              parameters:
+                - '^[\s\S]*'
+                - '{$PVE.DATACENTER.PAUSE}|\0'
             - type: NOT_MATCHES_REGEX
               parameters:
-                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+                - '^1\-7,00:00\-24:00\|'
               error_handler: DISCARD_VALUE
+            - type: REGEX
+              parameters:
+                - '^[^|]*\|([\s\S]*)'
+                - \1
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/access/users'
           headers:
@@ -1888,9 +1990,9 @@ zabbix_export:
               parameters:
                 - 'pve-manager/([0-9][0-9.]*)'
                 - \1
-            - type: DISCARD_UNCHANGED_HEARTBEAT
+            - type: DISCARD_UNCHANGED
               parameters:
-                - 1d
+                - ''
           master_item:
             key: pve.status
           tags:
@@ -1935,9 +2037,9 @@ zabbix_export:
               params: 'last(/{HOST.HOST}/backup.endtime[{#BCKPID}]) - last(/{HOST.HOST}/backup.starttime[{#BCKPID}])'
               description: 'How long the last finished backup of {#ID} took, in seconds. Derived from the end and start timestamps of the same run, both of which arrive together when the task reaches the archive. The value therefore describes the last completed run, never the one in progress.'
               preprocessing:
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               tags:
                 - tag: PVE
                   value: Backup
@@ -1958,9 +2060,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.bckpid=="{#BCKPID}")].endtime.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.backup.raw
               tags:
@@ -1983,9 +2085,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.bckpid=="{#BCKPID}")].status.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.backup.raw
               tags:
@@ -2006,9 +2108,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.bckpid=="{#BCKPID}")].starttime.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.backup.raw
               tags:
@@ -2123,9 +2225,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.id=="{#BACKUP_JOB_ID}")].enabled.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.backup.jobs.raw
               tags:
@@ -2226,9 +2328,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - $.data.pgmap.bytes_total
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.status.raw
               tags:
@@ -2265,9 +2367,9 @@ zabbix_export:
                     - $.data.flags
                   error_handler: CUSTOM_VALUE
                   error_handler_params: none
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.osd.raw
               tags:
@@ -2287,9 +2389,9 @@ zabbix_export:
                     - $.data.health.checks..message
                   error_handler: CUSTOM_VALUE
                   error_handler_params: none
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.status.raw
               tags:
@@ -2357,9 +2459,9 @@ zabbix_export:
                 - type: BOOL_TO_DECIMAL
                   parameters:
                     - ''
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.status.raw
               tags:
@@ -2385,9 +2487,9 @@ zabbix_export:
                     - $.data.mgrmap.standbys.length()
                   error_handler: CUSTOM_VALUE
                   error_handler_params: '0'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.status.raw
               tags:
@@ -2404,9 +2506,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - $.data.quorum_names.length()
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.status.raw
               tags:
@@ -2423,9 +2525,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - $.data.monmap.mons.length()
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.status.raw
               tags:
@@ -2504,9 +2606,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - $.data.osdmap..num_in_osds.first()
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.status.raw
               tags:
@@ -2523,9 +2625,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - $.data.osdmap..num_osds.first()
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.status.raw
               tags:
@@ -2542,9 +2644,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - $.data.osdmap..num_up_osds.first()
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.status.raw
               tags:
@@ -2579,9 +2681,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - $.data.pgmap.num_pgs
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.status.raw
               tags:
@@ -2819,9 +2921,9 @@ zabbix_export:
                   parameters:
                     - '$.data.root..children[?(@.id=={#OSD_ID})].in.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.osd.raw
               tags:
@@ -2934,9 +3036,9 @@ zabbix_export:
                   parameters:
                     - up
                     - '1'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.osd.raw
               tags:
@@ -3036,9 +3138,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.pool=={#POOL_ID})].min_size.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.pool.raw
               tags:
@@ -3060,9 +3162,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.pool=={#POOL_ID})].size.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ceph.pool.raw
               tags:
@@ -3177,9 +3279,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.filename=="{#CERT_FILE}")].issuer.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.certificates.raw
               tags:
@@ -3200,9 +3302,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.data[?(@.filename=="{#CERT_FILE}")].notafter.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.certificates.raw
               tags:
@@ -3237,9 +3339,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.filename=="{#CERT_FILE}")].subject.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.certificates.raw
               tags:
@@ -3279,9 +3381,9 @@ zabbix_export:
                     - '$.data[?(@.devpath=="{#DISK_DEV}")].health.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: UNKNOWN
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.disks.raw
               tags:
@@ -3428,9 +3530,9 @@ zabbix_export:
                   parameters:
                     - '^[0-9]+(\.[0-9]+)?$'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.disks.raw
               tags:
@@ -3503,9 +3605,9 @@ zabbix_export:
                     - \1
                   error_handler: CUSTOM_VALUE
                   error_handler_params: unknown
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ha.raw
               tags:
@@ -3557,9 +3659,9 @@ zabbix_export:
                     - '$.data[?(@.sid=="{#HA_SID}")].state.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: unknown
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.ha.raw
               tags:
@@ -3839,9 +3941,9 @@ zabbix_export:
                     - '$.data[?(@.vmid=={#VMID} && @.type=="lxc")].name.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: '{#VM_NAME}'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -4113,9 +4215,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.vmid=={#VMID} && @.type=="lxc")].maxcpu.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -4327,9 +4429,9 @@ zabbix_export:
                     - '$.data[?(@.iface=="{#IFACE}")].autostart.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: '0'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.nodes.network.raw
               tags:
@@ -4350,9 +4452,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.iface=="{#IFACE}")].type.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.nodes.network.raw
               tags:
@@ -4411,9 +4513,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.data[?(@.node=="{#NODE_NAME}")].ssl_fingerprint.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.nodes.raw
               tags:
@@ -4548,9 +4650,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.service=="{#SERVICE}")]["active-state"].first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.services.raw
               tags:
@@ -4570,9 +4672,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.data[?(@.service=="{#SERVICE}")].state.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.services.raw
               tags:
@@ -4599,9 +4701,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.service=="{#SERVICE}")]["unit-state"].first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.services.raw
               tags:
@@ -4645,9 +4747,9 @@ zabbix_export:
                   parameters:
                     - $.data.balloon
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: 'vm.status.raw[{#VMID}]'
               tags:
@@ -4766,9 +4868,9 @@ zabbix_export:
                   parameters:
                     - '$.data["running-machine"]'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: 'vm.status.raw[{#VMID}]'
               tags:
@@ -4856,9 +4958,9 @@ zabbix_export:
                     - '$.data[?(@.vmid=={#VMID} && @.type=="qemu")].name.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: '{#VM_NAME}'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -5010,9 +5112,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.vmid=={#VMID} && @.type=="qemu")].maxdisk.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -5140,9 +5242,9 @@ zabbix_export:
                 - type: RTRIM
                   parameters:
                     - '"]'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -5309,9 +5411,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.id=="{#REPL_ID}")].error.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.replication.raw
               tags:
@@ -5431,9 +5533,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.id=="{#SDN_ID}")].status.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -5533,9 +5635,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.data[?(@.storage=="{#STORAGE_NAME}")].content.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.storage.raw
               tags:
@@ -5555,9 +5657,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.data[?(@.storage=="{#STORAGE_NAME}")].type.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.storage.raw
               tags:
@@ -5578,9 +5680,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.data[?(@.storage=="{#STORAGE_NAME}")].shared.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.storage.raw
               tags:
@@ -5733,9 +5835,9 @@ zabbix_export:
                   parameters:
                     - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].endtime.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.tasks.raw
               tags:
@@ -5756,9 +5858,9 @@ zabbix_export:
                   parameters:
                     - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].status.first()'
                   error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.tasks.raw
               tags:
@@ -5785,9 +5887,9 @@ zabbix_export:
                 - type: RTRIM
                   parameters:
                     - '"]'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.tasks.raw
               tags:
@@ -5936,9 +6038,9 @@ zabbix_export:
                     - '$.body.data[?(@.userid==''{#USERID}'')].email.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: 'No email address available.'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.user.raw
               tags:
@@ -5958,9 +6060,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.body.data[?(@.userid==''{#USERID}'')].expire.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.user.raw
               tags:
@@ -5991,9 +6093,9 @@ zabbix_export:
                     - '$.body.data[?(@.userid==''{#USERID}'')].firstname.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: 'No first name available.'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.user.raw
               tags:
@@ -6015,9 +6117,9 @@ zabbix_export:
                     - '$.body.data[?(@.userid==''{#USERID}'')].lastname.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: 'No last name available.'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.user.raw
               tags:
@@ -6037,9 +6139,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.body.data[?(@.userid==''{#USERID}'')][''realm-type''].first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.user.raw
               tags:
@@ -6060,9 +6162,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.body.data[?(@.userid==''{#USERID}'')].enable.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.user.raw
               tags:
@@ -6208,9 +6310,9 @@ zabbix_export:
                   parameters:
                     - SUSPENDED
                     - '6'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.zfs.raw
               tags:
@@ -6243,9 +6345,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.data[?(@.name=="{#ZPOOL}")].size.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
+                - type: DISCARD_UNCHANGED
                   parameters:
-                    - 1h
+                    - ''
               master_item:
                 key: pve.zfs.raw
               tags:
@@ -6414,9 +6516,9 @@ zabbix_export:
         - macro: '{$PVE.CERT.EXPIRE.DAYS}'
           value: 21d
           description: 'Lead time before certificate expiry. Must include a time unit, for example 21d.'
-        - macro: '{$PVE.DATACENTER.COLLECT}'
-          value: '1'
-          description: 'Collect the datacenter-wide data on this host: guests on all nodes, node states, quorum, HA, backup jobs, users, SDN and Ceph. In a cluster keep 1 on one host and set 0 on the others, so this data is not collected and alerted once per node.'
+        - macro: '{$PVE.DATACENTER.PAUSE}'
+          value: '7,23:59-24:00'
+          description: 'Period in which the datacenter-wide data is not requested on this host: guests on all nodes, node states, quorum, HA, backup jobs, users, SDN and Ceph. In a cluster keep the default on one host and set 1-7,00:00-24:00 on the others, so this data is not requested and alerted once per node. The default only skips the last minute of the week.'
         - macro: '{$PVE.GUEST.DETAIL.INTERVAL}'
           value: 10m
           description: 'Interval of the per guest status request (balloon, machine type, LXC swap). One request per guest, so keep it long in large clusters.'
@@ -7505,7 +7607,7 @@ zabbix_export:
       description: 'Swap on the PVE host is filling up. The first condition keeps the trigger silent on hosts without swap instead of turning it unsupported.'
       manual_close: 'YES'
     - uuid: 429391e580264ef398145055ff85100a
-      expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.cluster.vms.running)<last(/Template Proxmox VE REST API/pve.cluster.vms.total))'
+      expression: 'last(/Template Proxmox VE REST API/pve.cluster.vms.running)<last(/Template Proxmox VE REST API/pve.cluster.vms.total)'
       name: '{ITEM.LASTVALUE} of {?last(//pve.cluster.vms.total)} VMs/LXC running'
       priority: INFO
       description: 'One or more VMs or LXC containers are not in running state.'

--- a/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/template_proxmox-ve-rest-api.yaml
+++ b/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/template_proxmox-ve-rest-api.yaml
@@ -5,204 +5,21 @@ zabbix_export:
       name: Templates/Virtualization
   templates:
     - uuid: 512de161946b46af952076320eb2b366
-      template: 'Template Proxmox VE REST API'
-      name: 'Template Proxmox VE REST API'
+      template: 'Proxmox VE Cluster by REST API'
+      name: 'Proxmox VE Cluster by REST API'
       description: |
-        Zabbix template for monitoring Proxmox VE virtual machines using the REST API. No Zabbix agent is required inside the VMs.
+        Cluster-wide part of the Proxmox VE monitoring over the REST API. Link it to exactly one Zabbix host per cluster (or per standalone node): guests on all nodes, node states, HA, backup jobs, users, SDN and, when present, Ceph. Pair it with "Proxmox VE Node by REST API" on one host per node.
         
-        Created by Thomas Rzen.  
-        For documentation, updates, and source code, visit:  
-        https://github.com/Garfieldttt/Zabbix-Template-Proxmox-VE-REST-API
+        Requires a PVEAuditor API token. See the README for setup.
       groups:
         - name: Templates/Virtualization
       items:
-        - uuid: c45a577215ad485082a40f8e6c0597bc
-          name: 'PVE manager package version'
-          type: DEPENDENT
-          key: pve.apt.manager.version
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Installed pve-manager version. Source: /nodes/{node}/apt/versions.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[?(@.Package=="pve-manager")].Version.first()'
-              error_handler: DISCARD_VALUE
-          master_item:
-            key: pve.apt.versions.raw
-          tags:
-            - tag: PVE
-              value: APT
-        - uuid: 4c6198e8bdf14a628f46026f0286317d
-          name: 'APT repository errors'
-          type: DEPENDENT
-          key: pve.apt.repos.errors
-          delay: '0'
-          description: 'Number of unparsable APT repository files. Source: /nodes/{node}/apt/repositories.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.errors.length()
-          master_item:
-            key: pve.apt.repos.raw
-          tags:
-            - tag: PVE
-              value: APT
-          triggers:
-            - uuid: 6cd0c610281c42a3b32c3b1a18f204f7
-              expression: 'last(/Template Proxmox VE REST API/pve.apt.repos.errors)>{$PVE.APT.REPO.ERRORS.MAX}'
-              name: 'APT repository files are broken on {HOST.NAME}'
-              opdata: 'Broken files: {ITEM.LASTVALUE1}'
-              priority: WARNING
-              description: 'At least one APT repository file cannot be parsed. Updates will fail until this is fixed.'
-        - uuid: b5b24417bef745dd8b8bfe73cd670974
-          name: 'PVE APT repositories raw'
-          type: HTTP_AGENT
-          key: pve.apt.repos.raw
-          delay: '3600'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/apt/repositories. Requires Sys.Audit on /nodes/{node}.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/apt/repositories'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: ed86ccf27d174856b34603273da954dd
-          name: 'APT repository warnings'
-          type: DEPENDENT
-          key: pve.apt.repos.warnings
-          delay: '0'
-          description: 'Number of APT repository warnings, for example the enterprise repository being enabled without a subscription. Source: /nodes/{node}/apt/repositories.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data.infos[?(@.kind=="warning")].length()'
-          master_item:
-            key: pve.apt.repos.raw
-          tags:
-            - tag: PVE
-              value: APT
-          triggers:
-            - uuid: 5fe993f6929a4e05ab7bca6e61c8b631
-              expression: 'last(/Template Proxmox VE REST API/pve.apt.repos.warnings)>{$PVE.APT.REPO.WARN.MAX}'
-              name: 'APT repository configuration has warnings on {HOST.NAME}'
-              opdata: 'Warnings: {ITEM.LASTVALUE1}'
-              priority: INFO
-              description: 'PVE reports a problem with the repository configuration, for example the enterprise repository being enabled without a subscription. A host on the no-subscription repository reports one warning permanently, raise {$PVE.APT.REPO.WARN.MAX} to 1 there.'
-              manual_close: 'YES'
-        - uuid: 5525d09ef8c84b9abcd6bccfa90ecf5b
-          name: 'Running kernel (proxmox-ve)'
-          type: DEPENDENT
-          key: pve.apt.running.kernel
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Kernel release the node is currently booted into. Source: /nodes/{node}/apt/versions, package proxmox-ve.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[?(@.Package=="proxmox-ve")].RunningKernel.first()'
-              error_handler: DISCARD_VALUE
-          master_item:
-            key: pve.apt.versions.raw
-          tags:
-            - tag: PVE
-              value: APT
-        - uuid: 2d333630c4b0498b94ce00a7cd35fc47
-          name: 'PVE APT pending updates raw'
-          type: HTTP_AGENT
-          key: pve.apt.update.raw
-          delay: '3600'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          status: DISABLED
-          description: 'Master item. Raw JSON from /nodes/{node}/apt/update. DISABLED by default: this endpoint requires Sys.Modify on /nodes/{node}, which PVEAuditor does not grant. Enable only if you accept giving the monitoring token write level permissions.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/apt/update'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 184a3ada22ad4082a7bddc6f3d6a0abe
-          name: 'APT pending updates'
-          type: DEPENDENT
-          key: pve.apt.updates.count
-          delay: '0'
-          status: DISABLED
-          description: 'Number of pending package updates. DISABLED by default because the master item requires Sys.Modify.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.length()
-          master_item:
-            key: pve.apt.update.raw
-          tags:
-            - tag: PVE
-              value: APT
-          triggers:
-            - uuid: 516ffe6de3804b97aa29d41e333deba3
-              expression: 'last(/Template Proxmox VE REST API/pve.apt.updates.count)>{$PVE.APT.UPDATES.MAX}'
-              name: '{ITEM.LASTVALUE} package update(s) pending on {HOST.NAME}'
-              status: DISABLED
-              priority: INFO
-              description: 'Disabled by default, like the item it depends on. The master item needs Sys.Modify, which PVEAuditor does not grant.'
-              manual_close: 'YES'
-        - uuid: 123ab12e63c04426a943c63fc1539230
-          name: 'PVE APT versions raw'
-          type: HTTP_AGENT
-          key: pve.apt.versions.raw
-          delay: '3600'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/apt/versions. Requires Sys.Audit on /nodes/{node}.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/apt/versions'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 95c94b814aa84f569872151d7249b7a0
-          name: 'PVE backup active raw'
-          type: HTTP_AGENT
-          key: pve.backup.active.raw
-          delay: '60'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/tasks with source=active and typefilter=vzdump, so it carries only backup tasks that are running right now. The task list defaults to source=archive, where a task appears only once it has finished, which is why a running backup is invisible to pve.backup.raw and why a backup that never finishes produces no signal there at all. Returns an empty list while no backup runs. Requires Sys.Audit on /nodes/{node}.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/tasks?source=active&typefilter=vzdump'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
         - uuid: 4b7c777084034f50803f8c03d363b265
           name: 'Backup jobs configured'
           type: DEPENDENT
           key: pve.backup.jobs.count
           delay: '0'
+          history: 7d
           description: 'Number of vzdump backup job definitions in the cluster. Zero means nothing is scheduled at all, regardless of how many guests exist. Source: /cluster/backup.'
           preprocessing:
             - type: JSONPATH
@@ -215,7 +32,7 @@ zabbix_export:
               value: Backup
           triggers:
             - uuid: 27abcc86c4424e11b36b25b92f9fdf0b
-              expression: 'last(/Template Proxmox VE REST API/pve.backup.jobs.count)<{$PVE.BACKUP.JOBS.MIN}'
+              expression: 'last(/Proxmox VE Cluster by REST API/pve.backup.jobs.count)<{$PVE.BACKUP.JOBS.MIN}'
               name: 'Fewer backup jobs configured than expected on {HOST.NAME}'
               opdata: 'Configured jobs: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -240,241 +57,110 @@ zabbix_export:
           tags:
             - tag: PVE
               value: Raw
-        - uuid: 9a98e0c1e615419d8c3fc835aba5b216
-          name: 'PVE backup raw'
+        - uuid: c79be6cf81a7437ca5692b9953a838a1
+          name: 'Ceph available'
+          type: DEPENDENT
+          key: pve.ceph.available
+          delay: '0'
+          history: 7d
+          description: '1 when /cluster/ceph/status returned a Ceph status, 0 otherwise. Stays 0 on clusters without Ceph.'
+          valuemap:
+            name: 'Ceph availability'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$[?(@.fsid)].length()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.ceph.status.raw
+          tags:
+            - tag: PVE
+              value: Ceph
+          triggers:
+            - uuid: 1a658d8982df4bac81285f578303ed59
+              expression: 'last(/Proxmox VE Cluster by REST API/pve.ceph.available)=0 and count(/Proxmox VE Cluster by REST API/pve.ceph.available,1d,"eq","1")>0'
+              name: 'Ceph status cannot be read'
+              opdata: '{ITEM.LASTVALUE1}'
+              priority: HIGH
+              description: 'Ceph was readable within the last day and the API now returns no status. The reason is in the item "Ceph API message"; a common one is lost monitor quorum, which blocks all Ceph I/O. On a cluster where Ceph was removed on purpose the problem resolves itself after a day.'
+              manual_close: 'YES'
+        - uuid: 5cebfd8295f241e9a6b9208bd974b241
+          name: 'Ceph API message'
+          type: DEPENDENT
+          key: pve.ceph.message
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Error text PVE returned instead of a Ceph status, for example "binary not installed" on nodes without Ceph. "none" while the status is readable.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.message
+              error_handler: CUSTOM_VALUE
+              error_handler_params: none
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.ceph.status.raw
+          tags:
+            - tag: PVE
+              value: Ceph
+        - uuid: c5ef7e7824d142909d6bd8e7dea78d99
+          name: 'PVE Ceph OSD raw'
           type: HTTP_AGENT
-          key: pve.backup.raw
-          delay: '300'
+          key: pve.ceph.osd.raw
+          delay: 5m
           history: '0'
           value_type: TEXT
           trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/tasks, filtered and grouped by JavaScript preprocessing to extract only backup tasks (vzdump/PBS), deduplicated to the most recent run per VM.'
-          preprocessing:
-            - type: JAVASCRIPT
-              parameters:
-                - |
-                  // Zabbix JS preprocessing: Extract and group backup tasks (VZDUMP/PBS) from task feed (ES5.1)
-                  try {
-                      var obj = (typeof value === 'string') ? JSON.parse(value) : value;
-                  
-                      // 0) Determine data source
-                      var dataArr = [];
-                      if (obj && obj.data && obj.data instanceof Array) {
-                          dataArr = obj.data;
-                      } else if (obj && obj.body && obj.body.data && obj.body.data instanceof Array) {
-                          dataArr = obj.body.data;
-                      }
-                      if (!dataArr || !dataArr.length) {
-                          return JSON.stringify({ total: 0, data: [] });
-                      }
-                  
-                      // Helper functions
-                      function firstDefined(a, b, c, d) {
-                          if (a !== null && a !== undefined) return a;
-                          if (b !== null && b !== undefined) return b;
-                          if (c !== null && c !== undefined) return c;
-                          if (d !== null && d !== undefined) return d;
-                          return null;
-                      }
-                  
-                      // Robust timestamp conversion: supports epoch (sec/ms), numeric strings, ISO and "YYYY-MM-DD HH:mm:ss"
-                      function toEpochMs(v) {
-                          if (v === null || v === undefined) return -Infinity;
-                          if (typeof v === "number") return v < 1000000000000 ? v * 1000 : v; // sec → ms
-                  
-                          if (typeof v === "string") {
-                              var s = v.trim();
-                  
-                              // Treat purely numeric strings as numbers
-                              if (/^\d+(\.\d+)?$/.test(s)) {
-                                  var n = parseFloat(s);
-                                  return n < 1000000000000 ? n * 1000 : n;
-                              }
-                  
-                              // Parse "YYYY-MM-DD HH:mm:ss" (optional AM/PM)
-                              var m = s.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\s*(AM|PM))?$/i);
-                              if (m) {
-                                  var H = parseInt(m[4], 10), ampm = (m[7] || "").toUpperCase();
-                                  if (ampm) { if (ampm === "PM" && H < 12) H += 12; if (ampm === "AM" && H === 12) H = 0; }
-                                  return Date.UTC(+m[1], +m[2] - 1, +m[3], H, +m[5], +m[6]);
-                              }
-                  
-                              // Fallback: parse as ISO-compatible string
-                              var p = Date.parse(s.replace(/\s+/, "T"));
-                              return isNaN(p) ? -Infinity : p;
-                          }
-                          return -Infinity;
-                      }
-                      
-                  
-                      // Broad backup type matcher
-                      var reVzdump = /vzdump/i;
-                      var reBackup = /backup/i;              // generic (PBS/Proxmox Backup)
-                      var rePbs    = /\bpbs\b/i;             // "pbs" as a whole word
-                      var rePmxb   = /proxmox[- ]?backup/i;  // "proxmox-backup" or "proxmox backup"
-                  
-                      function isBackup(e) {
-                          if (!e) return false;
-                          var t = (e.type != null) ? String(e.type) : "";
-                          var u = (typeof e.upid === "string") ? e.upid : "";
-                          if (reVzdump.test(t) || reBackup.test(t) || rePbs.test(t) || rePmxb.test(t)) return true;
-                          if (reVzdump.test(u) || reBackup.test(u) || rePbs.test(u) || rePmxb.test(u)) return true;
-                          return false;
-                      }
-                  
-                      // 1) Filter backup entries and normalise timestamps
-                      var dumps = [];
-                      for (var i = 0; i < dataArr.length; i++) {
-                          var e = dataArr[i];
-                          if (!isBackup(e)) continue;
-                  
-                          var startRaw = firstDefined(e.starttime, e.start, e.begin, e.pstart);
-                          var endRaw   = firstDefined(e.endtime, e.end, null, null);
-                  
-                          var copy = {};
-                          for (var k in e) { if (e.hasOwnProperty(k)) copy[k] = e[k]; }
-                          copy._startMs = toEpochMs(startRaw);
-                          copy._endMs   = toEpochMs(endRaw);
-                          dumps.push(copy);
-                      }
-                  
-                      if (!dumps.length) {
-                          // No backup entries found in the feed
-                          return JSON.stringify({ total: 0, data: [] });
-                      }
-                  
-                      // 2) Sort by start time
-                      dumps.sort(function(a, b) { return a._startMs - b._startMs; });
-                  
-                      // 3) Replace missing/empty ID with "pve"
-                      for (i = 0; i < dumps.length; i++) {
-                          if (dumps[i].id === null || dumps[i].id === undefined || String(dumps[i].id) === "") {
-                              dumps[i].id = "pve";
-                          }
-                      }
-                  
-                      // 4) Group by id, keep only the most recent run per id (highest _startMs)
-                      var groups = {};
-                      for (i = 0; i < dumps.length; i++) {
-                          var e2 = dumps[i];
-                          var key = String(e2.id);
-                  
-                          if (!groups[key] || e2._startMs > groups[key]._startMs) {
-                              groups[key] = {
-                                  id:        key,
-                                  node:      e2.node,
-                                  status:    e2.status,
-                                  pid:       e2.pid,
-                                  upid:      e2.upid,
-                                  starttime: e2.starttime,
-                                  endtime:   e2.endtime,
-                                  _startMs:  e2._startMs,
-                                  _endMs:    e2._endMs
-                              };
-                          }
-                      }
-                      
-                  
-                      // 5) Sort IDs numerically (numeric first), "pve" last
-                      var ids = [];
-                      for (var id in groups) { if (groups.hasOwnProperty(id)) ids.push(id); }
-                      ids.sort(function(a, b) {
-                          if (a === "pve" && b !== "pve") return 1;
-                          if (b === "pve" && a !== "pve") return -1;
-                          var na = parseFloat(a), nb = parseFloat(b);
-                          var aNum = isFinite(na), bNum = isFinite(nb);
-                          if (aNum && bNum) return na - nb;
-                          if (aNum) return -1;
-                          if (bNum) return 1;
-                          a = String(a); b = String(b);
-                          if (a < b) return -1;
-                          if (a > b) return 1;
-                          return 0;
-                      });
-                  
-                      // 6) Build result
-                      var resultData = [];
-                      for (i = 0; i < ids.length; i++) {
-                          var g2 = groups[ids[i]];
-                          // Remove internal fields
-                          delete g2._startMs; delete g2._endMs;
-                          g2.bckpid = g2.id;
-                          resultData.push(g2);
-                      }
-                  
-                      return JSON.stringify({ total: resultData.length, data: resultData });
-                  
-                  } catch (err) {
-                      return JSON.stringify({ error: "Parsing failed", detail: String(err && err.message || err) });
-                  }
+          description: 'Master item. Raw JSON from /nodes/localhost/ceph/osd: the CRUSH tree with every OSD, its state, usage and latency, plus the cluster flags. "localhost" is the node answering the API call, so the path works on every node. HTTP 500 is accepted on purpose: PVE answers every Ceph call with 500 and {"data":null,"message":...} while Ceph is not set up, which keeps this item supported on clusters without Ceph and lets the dependent items tell "no Ceph" apart from a readable status.'
           timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/tasks'
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/localhost/ceph/osd'
+          status_codes: '200,500'
           headers:
             - name: Authorization
               value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
             - name: Accept
               value: application/json
-          output_format: JSON
           tags:
             - tag: PVE
               value: Raw
-        - uuid: b9d09de6571e41eb9f6b5500b510c377
-          name: 'Backup running'
-          type: DEPENDENT
-          key: pve.backup.running
-          delay: '0'
-          trends: '0'
-          description: 'Number of backup tasks running on this node right now, normally 0 or 1. The value is a counter rather than a forced 0 or 1: if two vzdump tasks ever overlap the item shows 2 and stays readable, only the value map has no entry for it. Source: /nodes/{node}/tasks with source=active.'
-          valuemap:
-            name: 'Backup running'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.length()
-          master_item:
-            key: pve.backup.active.raw
-          tags:
-            - tag: PVE
-              value: Backup
-          triggers:
-            - uuid: c94e008565344aca9077f48fdc06c951
-              expression: 'min(/Template Proxmox VE REST API/pve.backup.running,{$PVE.BACKUP.RUN.MAX})>0'
-              name: 'Backup has been running for more than {$PVE.BACKUP.RUN.MAX} on {HOST.NAME}'
-              opdata: 'Running since: {ITEM.LASTVALUE1}'
-              priority: AVERAGE
-              description: 'A backup task has been running without interruption for the whole period. This is the one backup failure the task archive cannot show: a run that never finishes never reaches the archive, so the status, end time and message items keep reporting the previous successful run and nothing else would ever fire. Check the running task in the PVE task viewer and the target storage.'
-              manual_close: 'YES'
-        - uuid: b481215ab6764b049dbbd06ead48fa94
-          name: 'Backup running since'
-          type: DEPENDENT
-          key: pve.backup.running.since
-          delay: '0'
-          value_type: FLOAT
-          trends: '0'
-          units: unixtime
-          description: 'Start time of the backup that is running right now, available the moment it starts. Zero means no backup is running: the source list is then empty, the JSONPath finds nothing, and the error handler supplies the zero. This is the real start time, unlike Backup starttime, which only moves once the run has finished and reached the task archive. A trend over a Unix timestamp carries no meaning, so trends stay off.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*].starttime.first()'
-              error_handler: CUSTOM_VALUE
-              error_handler_params: '0'
-          master_item:
-            key: pve.backup.active.raw
-          tags:
-            - tag: PVE
-              value: Backup
-        - uuid: b08a4d2843444e51a668c4b5b2a907a8
-          name: 'PVE certificates raw'
+        - uuid: 9954f59493c74257ac8f25dbb3cbade5
+          name: 'PVE Ceph pools raw'
           type: HTTP_AGENT
-          key: pve.certificates.raw
-          delay: '3600'
+          key: pve.ceph.pool.raw
+          delay: 5m
           history: '0'
           value_type: TEXT
           trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/certificates/info. Needs no special permission.'
+          description: 'Master item. Raw JSON from /nodes/localhost/ceph/pool: every pool with size, min_size and usage. HTTP 500 is accepted on purpose: PVE answers every Ceph call with 500 and {"data":null,"message":...} while Ceph is not set up, which keeps this item supported on clusters without Ceph and lets the dependent items tell "no Ceph" apart from a readable status.'
           timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/certificates/info'
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/localhost/ceph/pool'
+          status_codes: '200,500'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 8302d2b844a546dea0271d161bb789ca
+          name: 'PVE Ceph status raw'
+          type: HTTP_AGENT
+          key: pve.ceph.status.raw
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /cluster/ceph/status: health, monitor, manager, OSD and PG maps. HTTP 500 is accepted on purpose: PVE answers every Ceph call with 500 and {"data":null,"message":...} while Ceph is not set up, which keeps this item supported on clusters without Ceph and lets the dependent items tell "no Ceph" apart from a readable status.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/ceph/status'
+          status_codes: '200,500'
           headers:
             - name: Authorization
               value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
@@ -510,6 +196,7 @@ zabbix_export:
           type: CALCULATED
           key: pve.cluster.nodes.offline
           delay: '60'
+          history: 7d
           params: 'last(/{HOST.HOST}/pve.cluster.nodes.total) - last(/{HOST.HOST}/pve.cluster.nodes.online)'
           description: 'Number of offline cluster nodes (total minus online).'
           tags:
@@ -517,7 +204,7 @@ zabbix_export:
               value: Cluster
           triggers:
             - uuid: 3dfb794aebe14bb89850bc56aa2f937c
-              expression: 'last(/Template Proxmox VE REST API/pve.cluster.nodes.offline)>{$CLUSTER.NODES.OFFLINE.MAX}'
+              expression: 'last(/Proxmox VE Cluster by REST API/pve.cluster.nodes.offline)>{$CLUSTER.NODES.OFFLINE.MAX}'
               name: '{ITEM.LASTVALUE} cluster node(s) offline'
               priority: HIGH
               description: 'One or more Proxmox VE cluster nodes are offline. Set {$CLUSTER.NODES.OFFLINE.MAX} to a higher value to tolerate planned maintenance.'
@@ -574,10 +261,10 @@ zabbix_export:
               value: Cluster
           triggers:
             - uuid: 46be8e0cb28741a1a25c826eaa7f3525
-              expression: 'last(/Template Proxmox VE REST API/pve.cluster.quorum)=0'
+              expression: 'last(/Proxmox VE Cluster by REST API/pve.cluster.quorum)=0'
               name: 'Proxmox VE cluster has lost quorum'
               priority: DISASTER
-              description: 'The cluster is not quorate. VMs with HA policies cannot be started or migrated.'
+              description: 'The cluster is not quorate. /etc/pve is read-only, so guests cannot be started, changed or migrated, and nodes with active HA resources fence themselves.'
               tags:
                 - tag: scope
                   value: availability
@@ -590,6 +277,7 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Raw cluster status from /api2/json/cluster/status. Used as master for cluster-dependent items.'
+          timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/status'
           headers:
             - name: Authorization
@@ -608,6 +296,7 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /cluster/resources. Aggregated view of all VMs, LXC containers, storage and nodes across the cluster.'
+          timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/resources'
           headers:
             - name: Authorization
@@ -622,6 +311,7 @@ zabbix_export:
           type: DEPENDENT
           key: pve.cluster.vms.running
           delay: '0'
+          history: 7d
           description: 'Number of QEMU VMs and LXC containers currently in running state across the cluster. Source: /cluster/resources.'
           preprocessing:
             - type: JSONPATH
@@ -637,6 +327,7 @@ zabbix_export:
           type: DEPENDENT
           key: pve.cluster.vms.total
           delay: '0'
+          history: 7d
           description: 'Total number of QEMU VMs and LXC containers registered in the cluster. Source: /cluster/resources.'
           preprocessing:
             - type: JSONPATH
@@ -647,118 +338,14 @@ zabbix_export:
           tags:
             - tag: PVE
               value: Cluster
-        - uuid: 8dc9614f15df4bd2914b15a03731dc02
-          name: 'PVE CPU cores'
-          type: DEPENDENT
-          key: pve.cores
-          delay: '0'
-          trends: '0'
-          units: '!Cores'
-          description: 'Number of physical CPU cores on the PVE host. Source: /nodes/{node}/status → data.cpuinfo.cores.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.cpuinfo.cores
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: 6a0405792aa8410c8c87b82f66659827
-          name: 'PVE CPU utilization'
-          type: DEPENDENT
-          key: pve.cpu.utilization
-          delay: '0'
-          value_type: FLOAT
-          units: '%'
-          description: 'CPU utilization of the PVE host in percent (0-100). Source: /nodes/{node}/status → data.cpu * 100.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.cpu
-            - type: MULTIPLIER
-              parameters:
-                - '100'
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
           triggers:
-            - uuid: 9551ed5e07264f4a90f57a8b8f2c8530
-              expression: 'min(/Template Proxmox VE REST API/pve.cpu.utilization,300)>{$NODE.CPU.UTIL.MAX}'
-              name: 'High CPU usage on {HOST.NAME} (>{$NODE.CPU.UTIL.MAX}%)'
-              opdata: 'CPU utilization: {ITEM.LASTVALUE1}'
-              priority: AVERAGE
-        - uuid: 8d7c1e46d5444b06ad419ffab9415d44
-          name: 'PVE CPU info'
-          type: DEPENDENT
-          key: pve.cpuinfo
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'CPU model name string of the PVE host. Source: /nodes/{node}/status → data.cpuinfo.model.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.cpuinfo.model
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: aff51cdfad424764ab637ceec7b54ff3
-          name: 'PVE CPU threads'
-          type: DEPENDENT
-          key: pve.cpus
-          delay: '0'
-          trends: '0'
-          units: '!Threads'
-          description: 'Total number of logical CPU threads (vCPUs) on the PVE host. Source: /nodes/{node}/status → data.cpuinfo.cpus.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.cpuinfo.cpus
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: bfca65a711d34b0d9543249fe9174097
-          name: 'PVE current kernel'
-          type: DEPENDENT
-          key: pve.current.kernel
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Running Linux kernel release string (e.g. 6.8.12-5-pve). Source: /nodes/{node}/status → data["current-kernel"].release.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data["current-kernel"].release'
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Kernel
-        - uuid: 406db2d98a024857bc7bc617c702901a
-          name: 'PVE disks raw'
-          type: HTTP_AGENT
-          key: pve.disks.raw
-          delay: '3600'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/disks/list. Used for physical disk discovery and SMART health monitoring. Requires Sys.Audit permission on the node.'
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/disks/list'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Disk
+            - uuid: efea0dc15fc74f80b8ff7805792bc444
+              expression: 'nodata(/Proxmox VE Cluster by REST API/pve.cluster.vms.total,300)=1'
+              name: 'PVE cluster API not reachable on {HOST.NAME}'
+              opdata: 'No data for 5 minutes'
+              priority: HIGH
+              description: 'The cluster-wide API calls have returned nothing for 5 minutes. Guest, HA, backup job and Ceph data are stale. Check {$PVE_IP}, the API token and pveproxy on that node. Evaluated on "pve.cluster.vms.total", because nodata() cannot read items that keep no history, such as the raw API item.'
+              manual_close: 'YES'
         - uuid: 570cf6c8fa37488e8165b4ce032e7b24
           name: 'PVE HA manager status'
           type: DEPENDENT
@@ -766,11 +353,17 @@ zabbix_export:
           delay: '0'
           value_type: CHAR
           trends: '0'
-          description: 'Status of the HA manager (CRM master), for example active or wait_for_quorum. Source: /cluster/ha/status/current, entry with type=master. Returns "unknown" when HA is not configured on this cluster.'
+          description: 'State of the HA cluster resource manager (CRM master), taken from the type=master entry of /cluster/ha/status/current. PVE reports it as "<node> (<state>, <timestamp>)"; the regex keeps only the state: active, idle, "old timestamp - dead?" or "detected time drift!". Returns "unknown" when no CRM master exists, which is the case while HA has never been configured.'
           preprocessing:
             - type: JSONPATH
               parameters:
                 - '$.data[?(@.type=="master")].status.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: unknown
+            - type: REGEX
+              parameters:
+                - '^\S+ \(([^,)]+)'
+                - \1
               error_handler: CUSTOM_VALUE
               error_handler_params: unknown
             - type: DISCARD_UNCHANGED_HEARTBEAT
@@ -781,6 +374,19 @@ zabbix_export:
           tags:
             - tag: PVE
               value: HA
+          triggers:
+            - uuid: a5a94355cec64a03b0101bc79d1b44af
+              expression: 'last(/Proxmox VE Cluster by REST API/pve.ha.manager.status)="old timestamp - dead?"'
+              name: 'HA manager (CRM) has stopped updating its status'
+              priority: HIGH
+              description: 'The CRM master has not written its status for more than 30 seconds. HA resources are no longer managed: failed guests are not recovered and fencing decisions are not made. Check pve-ha-crm on the node named in the HA status.'
+              manual_close: 'YES'
+            - uuid: b659321a83a741a5892054c30732be4a
+              expression: 'last(/Proxmox VE Cluster by REST API/pve.ha.manager.status)="detected time drift!"'
+              name: 'HA manager (CRM) reports time drift'
+              priority: WARNING
+              description: 'The CRM status timestamp lies in the future. The cluster nodes disagree on the time, which disturbs HA decisions. Check the time synchronisation on all nodes.'
+              manual_close: 'YES'
         - uuid: 6aebfc77121a42f98a3ecca13b158dd0
           name: 'PVE HA status raw'
           type: HTTP_AGENT
@@ -790,6 +396,7 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /cluster/ha/status/current. Contains one entry per quorum, CRM master, LRM and HA-managed service. Used for HA manager status and HA resource discovery. Note that /cluster/ha/status without /current is only a directory index and carries no status data.'
+          timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/ha/status/current'
           headers:
             - name: Authorization
@@ -799,221 +406,6 @@ zabbix_export:
           tags:
             - tag: PVE
               value: HA
-        - uuid: ee746cfba83e43e0af3053d86bcb2c9c
-          name: 'PVE load average (15 min)'
-          type: DEPENDENT
-          key: pve.loadaverage.fifteen
-          delay: '0'
-          value_type: FLOAT
-          description: 'System load average over the last 15 minutes. Source: /nodes/{node}/status → data.loadavg[2].'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data.loadavg[2]'
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: b0e142359bce47d288156cac52b3cda0
-          name: 'PVE load average (5 min)'
-          type: DEPENDENT
-          key: pve.loadaverage.fiveminute
-          delay: '0'
-          value_type: FLOAT
-          description: 'System load average over the last 5 minutes. Source: /nodes/{node}/status → data.loadavg[1].'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data.loadavg[1]'
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: e30e7acbdeb144f1a9b2ef6147df229b
-          name: 'PVE load average (1 min)'
-          type: DEPENDENT
-          key: pve.loadaverage.oneminute
-          delay: '0'
-          value_type: FLOAT
-          description: 'System load average over the last 1 minute. Source: /nodes/{node}/status → data.loadavg[0].'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data.loadavg[0]'
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: 86a2555f26f04ef99e267d5045947de1
-          name: 'PVE localtime'
-          type: DEPENDENT
-          key: pve.localtime
-          delay: '0'
-          trends: '0'
-          units: unixtime
-          description: 'Current Unix timestamp on the PVE host. Source: /nodes/{node}/time → data.localtime.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.localtime
-          master_item:
-            key: pve.time.raw
-          tags:
-            - tag: PVE
-              value: Localtime
-        - uuid: 05dec93dcbcc4c4c8db9642f51016ee0
-          name: 'PVE machine type'
-          type: DEPENDENT
-          key: pve.machine.type
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Host kernel machine architecture (e.g. x86_64). Source: /nodes/{node}/status → data["current-kernel"].machine.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data["current-kernel"].machine'
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Kernel
-        - uuid: 7a0e1ff3f96c4695a2642bf3aa80e092
-          name: 'PVE memory available'
-          type: DEPENDENT
-          key: pve.memory.free
-          delay: '0'
-          units: Bytes
-          description: 'RAM available for new workloads on the PVE host in bytes, cache and reclaimable memory included. Source: /nodes/{node}/status → data.memory.available. Together with the used value this adds up to the installed total, which data.memory.free does not.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.memory.available
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: e61c53e9214544d5ba50d64223564aad
-          name: 'PVE memory total'
-          type: DEPENDENT
-          key: pve.memory.total
-          delay: '0'
-          units: Bytes
-          description: 'Total installed RAM on the PVE host in bytes. Source: /nodes/{node}/status → data.memory.total.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.memory.total
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: ab8adc650a764a7f81847578f9360f63
-          name: 'PVE memory used'
-          type: DEPENDENT
-          key: pve.memory.used
-          delay: '0'
-          units: Bytes
-          description: 'Used RAM on the PVE host in bytes. Source: /nodes/{node}/status → data.memory.used.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.memory.used
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: 7fe8daafaf8f423dbf3410fef13b850f
-          name: 'PVE memory utilization'
-          type: CALCULATED
-          key: pve.memory.util
-          delay: '60'
-          value_type: FLOAT
-          units: '%'
-          params: '(last(/{HOST.HOST}/pve.memory.used) / last(/{HOST.HOST}/pve.memory.total)) * 100'
-          description: 'Memory utilization of the PVE host in percent, derived from pve.memory.used and pve.memory.total.'
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: ce497662bfd34c9da21c071e7b9b95ce
-          name: 'PVE CPU MHz'
-          type: DEPENDENT
-          key: pve.mhz
-          delay: '0'
-          value_type: FLOAT
-          trends: '0'
-          units: '!MHz'
-          description: 'CPU clock speed in MHz of the PVE host processor. Source: /nodes/{node}/status → data.cpuinfo.mhz.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.cpuinfo.mhz
-              error_handler: DISCARD_VALUE
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: 56a5d7af7e034c53941a3ba7f64fff65
-          name: 'PVE lxc raw'
-          type: HTTP_AGENT
-          key: pve.nodes.lxc.raw
-          delay: '300'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/lxc. Used as source for all LXC container dependent items and discovery rules.'
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/lxc'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 34f01ffa2b17450490d7015da7759c17
-          name: 'PVE network raw'
-          type: HTTP_AGENT
-          key: pve.nodes.network.raw
-          delay: '300'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/network. Used for host network interface discovery.'
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/network'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Network
-        - uuid: 9c7336fea970423989c113561052fd32
-          name: 'PVE qemu raw'
-          type: HTTP_AGENT
-          key: pve.nodes.qemu.raw
-          delay: '300'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/qemu?full=1. Used as source for all QEMU/KVM VM dependent items and discovery rules.'
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/qemu?full=1'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
         - uuid: 294f426f0a9a492598bbf7ea7ba46d9d
           name: 'PVE nodes raw'
           type: HTTP_AGENT
@@ -1038,6 +430,7 @@ zabbix_export:
           type: DEPENDENT
           key: pve.notbackedup.count
           delay: '0'
+          history: 7d
           description: 'Number of guests not covered by any backup job. Source: /cluster/backup-info/not-backed-up.'
           preprocessing:
             - type: JSONPATH
@@ -1050,7 +443,7 @@ zabbix_export:
               value: Backup
           triggers:
             - uuid: f93aea89718e469ea4c5468ca601fbed
-              expression: 'last(/Template Proxmox VE REST API/pve.notbackedup.count)>{$PVE.NOTBACKEDUP.MAX}'
+              expression: 'last(/Proxmox VE Cluster by REST API/pve.notbackedup.count)>{$PVE.NOTBACKEDUP.MAX}'
               name: '{ITEM.LASTVALUE} guest(s) not covered by any backup job'
               opdata: 'Guests without backup: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -1075,544 +468,6 @@ zabbix_export:
           tags:
             - tag: PVE
               value: Raw
-        - uuid: 5be835074ad9406abcf7ed723dffc949
-          name: 'PVE replication raw'
-          type: HTTP_AGENT
-          key: pve.replication.raw
-          delay: '300'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/replication. The list endpoint already carries the job state (last_sync, fail_count, error, duration), so no extra call per job is needed. Requires VM.Audit on the guests.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/replication'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 8ffa4568f4d4410dad143171f541d544
-          name: 'Disk rootfs avail'
-          type: DEPENDENT
-          key: pve.rootfs.avail
-          delay: '0'
-          units: Bytes
-          description: 'Available free space on the PVE root filesystem (/) in bytes. Source: /nodes/{node}/status → data.rootfs.avail.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.rootfs.avail
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Disk
-        - uuid: a3091fd210f446c68cef528c2151b2be
-          name: 'Disk rootfs size'
-          type: DEPENDENT
-          key: pve.rootfs.size
-          delay: '0'
-          units: Bytes
-          description: 'Total size of the PVE root filesystem (/) in bytes. Source: /nodes/{node}/status → data.rootfs.total.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.rootfs.total
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Disk
-        - uuid: e9857891ed7b4259b5accd82e4ef59d9
-          name: 'Disk rootfs used'
-          type: DEPENDENT
-          key: pve.rootfs.used
-          delay: '0'
-          units: Bytes
-          description: 'Used space on the PVE root filesystem (/) in bytes. Source: /nodes/{node}/status → data.rootfs.used.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.rootfs.used
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Disk
-        - uuid: 4284e670220b4548a3d0e2b71e205e74
-          name: 'Disk rootfs utilization'
-          type: CALCULATED
-          key: pve.rootfs.util
-          delay: '60'
-          value_type: FLOAT
-          units: '%'
-          params: '(last(/{HOST.HOST}/pve.rootfs.used) / last(/{HOST.HOST}/pve.rootfs.size)) * 100'
-          description: 'Root filesystem utilization of the PVE host in percent, derived from pve.rootfs.used and pve.rootfs.size.'
-          tags:
-            - tag: PVE
-              value: Filesystem
-        - uuid: fc58a4bcb2ad418ca5948dbee16cecbb
-          name: 'PVE services raw'
-          type: HTTP_AGENT
-          key: pve.services.raw
-          delay: '60'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/services. Requires Sys.Audit on /nodes/{node}.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/services'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 6e6cfbb1bd554a6c94e3c712a4387900
-          name: 'PVE CPU sockets'
-          type: DEPENDENT
-          key: pve.sockets
-          delay: '0'
-          trends: '0'
-          units: '!Sockets'
-          description: 'Number of physical CPU sockets on the PVE host. Source: /nodes/{node}/status → data.cpuinfo.sockets.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.cpuinfo.sockets
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: 894e2a471b4e441e9cf76143b1961e21
-          name: 'PVE status raw'
-          type: HTTP_AGENT
-          key: pve.status
-          delay: '60'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/status. Used as source for all PVE host dependent items (CPU, memory, disk, kernel, uptime, etc.).'
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/status'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-          triggers:
-            - uuid: 4cc6e8941efc4a3592f6dd22f2056969
-              expression: 'nodata(/Template Proxmox VE REST API/pve.status,300)=1'
-              name: 'PVE API not reachable on {HOST.NAME}'
-              opdata: 'No data for 5 minutes'
-              priority: HIGH
-              description: 'The Proxmox VE REST API has not returned data for 5 minutes. Check connectivity, API token, and PVE service status.'
-              manual_close: 'YES'
-        - uuid: e7ccf26004ff4d73b849ec2f0ba9f3a5
-          name: 'PVE storage raw'
-          type: HTTP_AGENT
-          key: pve.storage.raw
-          delay: '60'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/storage. Used as source for all storage discovery rules and dependent items.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/storage'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: dd8b6f60eee343af828ed3b496e69a06
-          name: 'Subscription level'
-          type: DEPENDENT
-          key: pve.subscription.level
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Subscription level code. Absent without a subscription, the value is then discarded instead of turning the item unsupported.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.level
-              error_handler: DISCARD_VALUE
-          master_item:
-            key: pve.subscription.raw
-          tags:
-            - tag: PVE
-              value: Subscription
-        - uuid: a900f847f83843e6b93f9e12feb050d4
-          name: 'Subscription next due date'
-          type: DEPENDENT
-          key: pve.subscription.nextduedate
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Next due date as reported by PVE, a plain date string. The numeric form for alerting is in pve.subscription.nextduedate.epoch.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.nextduedate
-              error_handler: DISCARD_VALUE
-          master_item:
-            key: pve.subscription.raw
-          tags:
-            - tag: PVE
-              value: Subscription
-        - uuid: d3ed6d06a2194635b5580d04303e143d
-          name: 'Subscription expiry'
-          type: DEPENDENT
-          key: pve.subscription.nextduedate.epoch
-          delay: '0'
-          value_type: FLOAT
-          trends: '0'
-          units: unixtime
-          description: 'Expiry date as a Unix timestamp so the remaining time can be compared. PVE reports nextduedate as a plain date string, unlike the certificate endpoint which already delivers an epoch. Zabbix has no preprocessing step that parses a date, hence the one line of JavaScript. Without a subscription the field is absent and the value is discarded.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.nextduedate
-              error_handler: DISCARD_VALUE
-            - type: JAVASCRIPT
-              parameters:
-                - |
-                  // PVE reports nextduedate as YYYY-MM-DD. Anchored to UTC so the
-                  // result does not shift with the server timezone. An unexpected
-                  // format throws, which turns the item visibly unsupported instead
-                  // of silently producing a wrong date.
-                  var t = Date.parse(value + 'T00:00:00Z');
-                  if (isNaN(t)) {
-                      throw 'unexpected nextduedate format: ' + value;
-                  }
-                  return Math.floor(t / 1000);
-          master_item:
-            key: pve.subscription.raw
-          tags:
-            - tag: PVE
-              value: Subscription
-          triggers:
-            - uuid: 3e3366874a4d4191a88632af4344bcce
-              expression: 'last(/Template Proxmox VE REST API/pve.subscription.nextduedate.epoch)-now()<{$PVE.SUBSCRIPTION.EXPIRE.DAYS}'
-              name: 'PVE subscription expires in less than {$PVE.SUBSCRIPTION.EXPIRE.DAYS} on {HOST.NAME}'
-              opdata: 'Expires on: {ITEM.LASTVALUE1}'
-              priority: WARNING
-              description: 'Advance warning before the subscription runs out, so it can be renewed in time. Depends on the expired trigger, so only one of the two is open at a time.'
-              dependencies:
-                - name: 'PVE subscription has expired on {HOST.NAME}'
-                  expression: 'last(/Template Proxmox VE REST API/pve.subscription.nextduedate.epoch)<now()'
-            - uuid: 7350199fa4884df6bf61d5797c37cf4a
-              expression: 'last(/Template Proxmox VE REST API/pve.subscription.nextduedate.epoch)<now()'
-              name: 'PVE subscription has expired on {HOST.NAME}'
-              opdata: 'Expired on: {ITEM.LASTVALUE1}'
-              priority: AVERAGE
-              description: 'The subscription period has ended. Access to the enterprise repository is gone, updates from it will fail. Needs no enable macro: without a subscription PVE does not report a due date, so the item stays empty and this trigger cannot fire on community hosts.'
-        - uuid: 31d2b788dfcc4fcfbe0fd4e02294b579
-          name: 'PVE subscription raw'
-          type: HTTP_AGENT
-          key: pve.subscription.raw
-          delay: '3600'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/subscription. Needs no special permission. Without a subscription the endpoint returns HTTP 200 and status notfound.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/subscription'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: c9a7c697ce26494a9eb98d233d41862f
-          name: 'Subscription status'
-          type: DEPENDENT
-          key: pve.subscription.status
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Subscription status: active, notfound, invalid, expired or suspended. Source: /nodes/{node}/subscription.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.status
-          master_item:
-            key: pve.subscription.raw
-          tags:
-            - tag: PVE
-              value: Subscription
-          triggers:
-            - uuid: 57b2f7fad21f4672874712a66208931a
-              expression: 'last(/Template Proxmox VE REST API/pve.subscription.status)<>"active" and {$PVE.SUBSCRIPTION.ALERT}=1'
-              name: 'PVE subscription is not active on {HOST.NAME} ({ITEM.LASTVALUE})'
-              priority: WARNING
-              description: 'Status is notfound, invalid, expired or suspended. Off by default, set {$PVE.SUBSCRIPTION.ALERT}=1 on hosts that are meant to carry a subscription. Depends on the expired trigger so a lapsed subscription raises one problem, not two.'
-              dependencies:
-                - name: 'PVE subscription has expired on {HOST.NAME}'
-                  expression: 'last(/Template Proxmox VE REST API/pve.subscription.nextduedate.epoch)<now()'
-        - uuid: b3016c59c0024f8fa5306198d1d1b73b
-          name: 'PVE swap free'
-          type: DEPENDENT
-          key: pve.swap.free
-          delay: '0'
-          units: Bytes
-          description: 'Free swap space on the PVE host in bytes. Source: /nodes/{node}/status → data.swap.free. Reports 0 on hosts without swap.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.swap.free
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: f2ae0c9f82084184954595f19a9ed722
-          name: 'PVE swap total'
-          type: DEPENDENT
-          key: pve.swap.total
-          delay: '0'
-          units: Bytes
-          description: 'Configured swap space on the PVE host in bytes. Source: /nodes/{node}/status → data.swap.total. Reports 0 on hosts without swap.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.swap.total
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: 9d49a6ae2695427a84790e829970669d
-          name: 'PVE swap used'
-          type: DEPENDENT
-          key: pve.swap.used
-          delay: '0'
-          units: Bytes
-          description: 'Used swap space on the PVE host in bytes. Source: /nodes/{node}/status → data.swap.used. Swap filling up while memory is not tight usually means pages were evicted during an earlier peak and never came back.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.swap.used
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: fc7f8aba309848fe818a194eae131210
-          name: 'PVE boot mode'
-          type: DEPENDENT
-          key: pve.system.boot.mode
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Boot mode of the PVE host (e.g. efi, legacy-bios). Source: /nodes/{node}/status → data["boot-info"].mode.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data["boot-info"].mode'
-              error_handler: DISCARD_VALUE
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Boot
-        - uuid: 6d8d3b4ace0349838ddb4681d733df82
-          name: 'PVE secureboot'
-          type: DEPENDENT
-          key: pve.system.boot.secureboot
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Secure Boot status on the PVE host. 0 = disabled, 1 = enabled. Source: /nodes/{node}/status → data["boot-info"].secureboot.'
-          valuemap:
-            name: 'PVE secureboot'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data["boot-info"].secureboot'
-              error_handler: DISCARD_VALUE
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Boot
-        - uuid: 8cbc645bf73d4654afa40ff9245ac67c
-          name: 'PVE tasks raw'
-          type: HTTP_AGENT
-          key: pve.tasks.raw
-          delay: '60'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/tasks, processed by JavaScript preprocessing to deduplicate tasks (keeps most recent run per id+type pair, excludes backup tasks handled by pve.backup.raw).'
-          preprocessing:
-            - type: JAVASCRIPT
-              parameters:
-                - |
-                  try {
-                      var obj = (typeof value === 'string') ? JSON.parse(value) : value;
-                      if (!obj || !obj.body || !Array.isArray(obj.body.data)) {
-                          return JSON.stringify({ error: "Invalid structure" });
-                      }
-                  
-                      var records = obj.body.data;
-                      var grouped = {};
-                  
-                      // Helper: normalise timestamp value to milliseconds
-                      // Robust time parsing: numeric strings, ISO, "YYYY-MM-DD HH:mm:ss"
-                      function normTime(v) {
-                          if (v === null || v === undefined) return -Infinity;
-                          if (typeof v === "number") return v < 1000000000000 ? v * 1000 : v;
-                          if (typeof v === "string") {
-                              var s = v.trim();
-                  
-                              // Treat purely numeric strings as numbers
-                              if (/^\d+(\.\d+)?$/.test(s)) {
-                                  var n = parseFloat(s);
-                                  return n < 1000000000000 ? n * 1000 : n;
-                              }
-                  
-                              // Parse "YYYY-MM-DD HH:mm:ss" (optional AM/PM)
-                              var m = s.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\s*(AM|PM))?$/i);
-                              if (m) {
-                                  var H = parseInt(m[4], 10), ampm = (m[7] || "").toUpperCase();
-                                  if (ampm) { if (ampm === "PM" && H < 12) H += 12; if (ampm === "AM" && H === 12) H = 0; }
-                                  return Date.UTC(+m[1], +m[2]-1, +m[3], H, +m[5], +m[6]);
-                              }
-                  
-                              // Fallback: parse as ISO-compatible string (Leerraum → 'T')
-                              var p = Date.parse(s.replace(/\s+/, "T"));
-                              return isNaN(p) ? -Infinity : p;
-                          }
-                          return -Infinity;
-                      }
-                      
-                  
-                      // Process task records
-                      for (var i = 0; i < records.length; i++) {
-                          var e = records[i];
-                          if (!e || !e.id || !e.type) continue;
-                  
-                          var key = e.id + "|" + e.type;
-                  
-                          // Normalise timestamps
-                          var copy = {};
-                          for (var k in e) if (e.hasOwnProperty(k)) copy[k] = e[k];
-                          copy._start = normTime(e.starttime || e.pstart || e.start);
-                  
-                          var existing = grouped[key];
-                          if (!existing || copy._start > existing._rep) {
-                              copy._rep = copy._start;
-                              grouped[key] = copy;
-                          }
-                      }
-                  
-                      // Build result list
-                      var resultList = [];
-                      for (var k in grouped) {
-                          var g = grouped[k];
-                          delete g._start;
-                          delete g._rep;
-                          g.grpid = g.id;
-                          resultList.push(g);
-                      }
-                  
-                      // Sort by ID
-                      // Sort: numeric IDs first, then lexicographic
-                      resultList.sort(function(a, b) {
-                          var aNum = /^\d+$/.test(String(a.id));
-                          var bNum = /^\d+$/.test(String(b.id));
-                          if (aNum && bNum) return Number(a.id) - Number(b.id);
-                          if (aNum && !bNum) return -1;
-                          if (!aNum && bNum) return 1;
-                          return (String(a.id) || "").localeCompare(String(b.id) || "");
-                      });
-                      
-                  
-                      obj.body.data = resultList;
-                      obj.body.total = resultList.length;
-                  
-                      return JSON.stringify(obj);
-                  
-                  } catch (err) {
-                      return JSON.stringify({ error: "Parsing failed", detail: err.message });
-                  }
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/tasks'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          output_format: JSON
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 9b368584e6844582a3ad0e792bdaf408
-          name: 'PVE time raw'
-          type: HTTP_AGENT
-          key: pve.time.raw
-          delay: '60'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/time. Used for timezone and localtime dependent items.'
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/time'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Time
-        - uuid: 6b6b792bf6cd4440acd22a5701f84201
-          name: 'PVE timezone'
-          type: DEPENDENT
-          key: pve.timezone
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Timezone configured on the PVE host (e.g. Europe/Berlin). Source: /nodes/{node}/time → data.timezone.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.timezone
-          master_item:
-            key: pve.time.raw
-          tags:
-            - tag: PVE
-              value: Timezone
-        - uuid: 65168f3bf85e4d4d9c4e56b56a66ca43
-          name: 'PVE uptime'
-          type: DEPENDENT
-          key: pve.uptime
-          delay: '0'
-          trends: '0'
-          units: s
-          description: 'Uptime of the PVE host in seconds since last boot. Source: /nodes/{node}/status → data.uptime.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.uptime
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Uptime
         - uuid: b23531b01ce04f8f9f96042acce215ae
           name: 'PVE user raw'
           type: HTTP_AGENT
@@ -1633,215 +488,7 @@ zabbix_export:
           tags:
             - tag: PVE
               value: Raw
-        - uuid: 6ab7180a35904b229e889d93696c65ad
-          name: 'PVE version'
-          type: DEPENDENT
-          key: pve.version
-          delay: '0'
-          history: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Proxmox VE version string, for example 9.2.10. Source: /nodes/{node}/status → data.pveversion, which carries it as pve-manager/9.2.10/<repoid>. Read from the host status instead of the separate version endpoint, so no extra request per interval is needed.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.pveversion
-            - type: REGEX
-              parameters:
-                - 'pve-manager/([0-9][0-9.]*)'
-                - \1
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1d
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Version
-        - uuid: 8673bb46b5d446598493cabb23888df7
-          name: 'PVE ZFS pools raw'
-          type: HTTP_AGENT
-          key: pve.zfs.raw
-          delay: '300'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/disks/zfs. Requires Sys.Audit on / (not on /nodes/{node}).'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/disks/zfs'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
       discovery_rules:
-        - uuid: 91bb690f87b743cb8045704ac4a4c9e0
-          name: 'Discover backup'
-          type: DEPENDENT
-          key: discover.backup
-          delay: '0'
-          lifetime_type: DELETE_IMMEDIATELY
-          lifetime: '0'
-          item_prototypes:
-            - uuid: 92c26ec56dfd4ec9b420851f7feb5f48
-              name: 'Backup duration {#ID}'
-              type: CALCULATED
-              key: 'backup.duration[{#BCKPID}]'
-              delay: '300'
-              value_type: FLOAT
-              units: s
-              params: 'last(/{HOST.HOST}/backup.endtime[{#BCKPID}]) - last(/{HOST.HOST}/backup.starttime[{#BCKPID}])'
-              description: 'How long the last finished backup of {#ID} took, in seconds. Derived from the end and start timestamps of the same run, both of which arrive together when the task reaches the archive. The value therefore describes the last completed run, never the one in progress.'
-              tags:
-                - tag: PVE
-                  value: Backup
-                - tag: PVE
-                  value: '{#BCKPID}'
-                - tag: vmid
-                  value: '{#BCKPID}'
-            - uuid: b4dc3c9faf174b36a46ce730a1e0953e
-              name: 'Backup endtime {#ID}'
-              type: DEPENDENT
-              key: 'backup.endtime[{#BCKPID}]'
-              delay: '0'
-              units: unixtime
-              description: 'Unix timestamp of the last backup job end time for VM/CT {#ID}. Source: pve.backup.raw → data[bckpid].endtime.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.bckpid=="{#BCKPID}")].endtime.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.backup.raw
-              tags:
-                - tag: PVE
-                  value: Backup
-                - tag: PVE
-                  value: '{#BCKPID}'
-                - tag: vmid
-                  value: '{#BCKPID}'
-            - uuid: 44259cf2a2344ca09ff4a808dafc42cf
-              name: 'Backup message {#ID}'
-              type: DEPENDENT
-              key: 'backup.message[{#BCKPID}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Status text of the last backup job for VM/CT {#BCKPID}, exactly as Proxmox VE reports it. A successful job reports OK, a failed one reports the error message itself. The numeric item Backup status maps only a fixed set of known texts, so this item carries the real cause of a failure.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.bckpid=="{#BCKPID}")].status.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.backup.raw
-              tags:
-                - tag: PVE
-                  value: Backup
-                - tag: vmid
-                  value: '{#BCKPID}'
-            - uuid: 44af4c4fba8a485ca2d6076bed9e01b4
-              name: 'Backup starttime {#ID}'
-              type: DEPENDENT
-              key: 'backup.starttime[{#BCKPID}]'
-              delay: '0'
-              units: unixtime
-              description: 'Unix timestamp of the last backup job start time for VM/CT {#ID}. Source: pve.backup.raw → data[bckpid].starttime.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.bckpid=="{#BCKPID}")].starttime.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.backup.raw
-              tags:
-                - tag: PVE
-                  value: Backup
-                - tag: PVE
-                  value: '{#BCKPID}'
-                - tag: vmid
-                  value: '{#BCKPID}'
-            - uuid: a43334f185c049cb9b1eb4a6b3e813d5
-              name: 'Backup status {#ID}'
-              type: DEPENDENT
-              key: 'backup.status[{#BCKPID}]'
-              delay: '0'
-              description: 'Status of the last backup job for VM/CT {#ID}. 0=OK, 1=running, 2=stopped, 3=error, 4=unknown error.'
-              valuemap:
-                name: 'Backup status'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.bckpid=="{#BCKPID}")].status.first()'
-                  error_handler: DISCARD_VALUE
-                - type: REGEX
-                  parameters:
-                    - '^(OK|running|stopped|error|unknown error)$'
-                    - \0
-                  error_handler: CUSTOM_VALUE
-                  error_handler_params: '4'
-                - type: STR_REPLACE
-                  parameters:
-                    - OK
-                    - '0'
-                - type: STR_REPLACE
-                  parameters:
-                    - running
-                    - '1'
-                - type: STR_REPLACE
-                  parameters:
-                    - stopped
-                    - '2'
-                - type: STR_REPLACE
-                  parameters:
-                    - error
-                    - '3'
-              master_item:
-                key: pve.backup.raw
-              tags:
-                - tag: PVE
-                  value: Backup
-                - tag: PVE
-                  value: '{#BCKPID}'
-                - tag: vmid
-                  value: '{#BCKPID}'
-          trigger_prototypes:
-            - uuid: 6c0aa697138548fe8407c82d28d31a4a
-              expression: 'last(/Template Proxmox VE REST API/backup.status[{#BCKPID}])>=2 and {$ENABLE_BACKUP_ALERT:"{#BCKPID}"}=1 and fuzzytime(/Template Proxmox VE REST API/backup.endtime[{#BCKPID}],{$BACKUP.ALERT.WINDOW})=1'
-              name: 'Backup for {#ID} failed'
-              event_name: 'Backup for {#ID} failed: {?last(//backup.message[{#BCKPID}])}'
-              opdata: 'Backup status: {ITEM.LASTVALUE}'
-              priority: HIGH
-              description: |
-                0. OK: All clear, no errors detected
-                1. running: VM/CT is currently active
-                2. stopped: VM/CT has been shut down
-                3. error: General execution failure; check logs for details
-                4. unknown error: Cannot classify status, please check Proxmox for details
-              manual_close: 'YES'
-          graph_prototypes:
-            - uuid: 1f9f9b88b6394562ae09774bf5190e68
-              name: 'Backup status {#ID}'
-              graph_items:
-                - color: 8E24AA
-                  calc_fnc: ALL
-                  item:
-                    host: 'Template Proxmox VE REST API'
-                    key: 'backup.status[{#BCKPID}]'
-          master_item:
-            key: pve.backup.raw
-          lld_macro_paths:
-            - lld_macro: '{#BCKPID}'
-              path: $.bckpid
-            - lld_macro: '{#ID}'
-              path: $.id
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
         - uuid: d82f27394dbb4634a7802e256d63d054
           name: 'Discover backup jobs'
           type: DEPENDENT
@@ -1863,6 +510,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.id=="{#BACKUP_JOB_ID}")].enabled.first()'
                   error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.backup.jobs.raw
               tags:
@@ -1872,7 +522,7 @@ zabbix_export:
                   value: '{#BACKUP_JOB_ID}'
               trigger_prototypes:
                 - uuid: 9213166e3c774322a4bc6e31d87b4198
-                  expression: 'last(/Template Proxmox VE REST API/backup.job.enabled[{#BACKUP_JOB_ID}])=0 and {$PVE.BACKUP.JOB.ALERT:"{#BACKUP_JOB_ID}"}=1'
+                  expression: 'last(/Proxmox VE Cluster by REST API/backup.job.enabled[{#BACKUP_JOB_ID}])=0 and {$PVE.BACKUP.JOB.ALERT:"{#BACKUP_JOB_ID}"}=1'
                   name: 'Backup job {#BACKUP_JOB_ID} is disabled on {HOST.NAME}'
                   opdata: 'Schedule: {#BACKUP_JOB_SCHEDULE}, storage: {#BACKUP_JOB_STORAGE}'
                   priority: WARNING
@@ -1904,7 +554,7 @@ zabbix_export:
                   value: '{#BACKUP_JOB_ID}'
           trigger_prototypes:
             - uuid: 6279740f47ca48d3adf8795d408d722c
-              expression: 'nodata(/Template Proxmox VE REST API/backup.job.nextrun[{#BACKUP_JOB_ID}],{$PVE.BACKUP.JOB.STALE})=1 and last(/Template Proxmox VE REST API/backup.job.enabled[{#BACKUP_JOB_ID}])=1'
+              expression: 'nodata(/Proxmox VE Cluster by REST API/backup.job.nextrun[{#BACKUP_JOB_ID}],{$PVE.BACKUP.JOB.STALE})=1 and last(/Proxmox VE Cluster by REST API/backup.job.enabled[{#BACKUP_JOB_ID}])=1'
               name: 'Backup job {#BACKUP_JOB_ID} has not been rescheduled for {$PVE.BACKUP.JOB.STALE}'
               opdata: 'Next run: {ITEM.LASTVALUE1}, schedule: {#BACKUP_JOB_SCHEDULE}'
               priority: AVERAGE
@@ -1923,305 +573,1044 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - '$.data[*]'
-        - uuid: fc425a072e654624bdcb690f816894f9
-          name: 'Discover certificates'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: 4b6688341e0b4a1b9944368464cb3967
+          name: 'Discover Ceph cluster'
           type: DEPENDENT
-          key: discover.certificates
+          key: discover.ceph.cluster
           delay: '0'
-          description: 'Discovers the certificates of the node: pve-root-ca.pem, pve-ssl.pem and, if configured, pveproxy-ssl.pem from a custom or ACME certificate.'
+          enabled_lifetime_type: DISABLE_AFTER
+          enabled_lifetime: 1d
+          description: 'Creates the Ceph items only when /cluster/ceph/status returns a Ceph status. On clusters without Ceph it discovers nothing, so no Ceph item exists and nothing is evaluated.'
           item_prototypes:
-            - uuid: 6cc4542bb31644218df1ab33e8a59cbd
-              name: 'Certificate issuer {#CERT_FILE}'
+            - uuid: 1fce79ca0fde478cbaeaedffbc7266d3
+              name: 'Ceph raw capacity available'
               type: DEPENDENT
-              key: 'cert.issuer[{#CERT_FILE}]'
+              key: 'ceph.bytes.avail[{#FSID}]'
+              delay: '0'
+              history: 7d
+              units: B
+              description: 'Raw capacity still free.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.pgmap.bytes_avail
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: adccff89e39145578ac82a5cb31ba6ef
+              name: 'Ceph raw capacity total'
+              type: DEPENDENT
+              key: 'ceph.bytes.total[{#FSID}]'
+              delay: '0'
+              history: 7d
+              units: B
+              description: 'Raw capacity of all OSDs.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.pgmap.bytes_total
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 2a900ec1d37c4074ab2df018faecfdb4
+              name: 'Ceph raw capacity used'
+              type: DEPENDENT
+              key: 'ceph.bytes.used[{#FSID}]'
+              delay: '0'
+              history: 7d
+              units: B
+              description: 'Raw capacity in use, replicas included.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.pgmap.bytes_used
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 9e86fd152f894a6a93de3313ba0e5b42
+              name: 'Ceph OSD flags'
+              type: DEPENDENT
+              key: 'ceph.flags[{#FSID}]'
               delay: '0'
               value_type: CHAR
               trends: '0'
-              description: 'Certificate issuer name.'
+              description: 'Cluster-wide OSD flags such as noout or norebalance. Ceph health reports the maintenance flags as a warning.'
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$.data[?(@.filename=="{#CERT_FILE}")].issuer.first()'
-                  error_handler: DISCARD_VALUE
+                    - $.data.flags
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: none
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
-                key: pve.certificates.raw
+                key: pve.ceph.osd.raw
               tags:
                 - tag: PVE
-                  value: Certificate
-                - tag: PVE
-                  value: '{#CERT_FILE}'
-            - uuid: 34c34d3714f642caa995220ac55d4cbc
-              name: 'Certificate expiry {#CERT_FILE}'
+                  value: Ceph
+            - uuid: c73f0805cd1b4f28b092576b5d6eb26c
+              name: 'Ceph health checks'
               type: DEPENDENT
-              key: 'cert.notafter[{#CERT_FILE}]'
+              key: 'ceph.health.checks[{#FSID}]'
               delay: '0'
-              value_type: FLOAT
+              value_type: TEXT
               trends: '0'
-              units: unixtime
-              description: 'notAfter timestamp. PVE already delivers a Unix epoch, so no conversion is needed.'
+              description: 'Summary messages of all active Ceph health checks, "none" while there are none.'
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$.data[?(@.filename=="{#CERT_FILE}")].notafter.first()'
+                    - $.data.health.checks..message
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: none
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
-                key: pve.certificates.raw
+                key: pve.ceph.status.raw
               tags:
                 - tag: PVE
-                  value: Certificate
+                  value: Ceph
+            - uuid: b36e1250d643426eb604c3ff260d6e6d
+              name: 'Ceph health'
+              type: DEPENDENT
+              key: 'ceph.health[{#FSID}]'
+              delay: '0'
+              history: 7d
+              description: 'Overall Ceph health: 0 HEALTH_OK, 1 HEALTH_WARN, 2 HEALTH_ERR.'
+              valuemap:
+                name: 'Ceph health'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.health.status
+                - type: STR_REPLACE
+                  parameters:
+                    - HEALTH_OK
+                    - '0'
+                - type: STR_REPLACE
+                  parameters:
+                    - HEALTH_WARN
+                    - '1'
+                - type: STR_REPLACE
+                  parameters:
+                    - HEALTH_ERR
+                    - '2'
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
                 - tag: PVE
-                  value: '{#CERT_FILE}'
+                  value: Ceph
               trigger_prototypes:
-                - uuid: f259a1bd684b48ec89304dafcd4cb29f
-                  expression: 'last(/Template Proxmox VE REST API/cert.notafter[{#CERT_FILE}])-now()<{$PVE.CERT.EXPIRE.DAYS}'
-                  name: 'Certificate {#CERT_FILE} expires in less than {$PVE.CERT.EXPIRE.DAYS} on {HOST.NAME}'
+                - uuid: 178e40d95d8743f3a898ac1ebb48b10d
+                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.health[{#FSID}])=2'
+                  name: 'Ceph cluster health is HEALTH_ERR'
+                  priority: HIGH
+                  description: 'Ceph reports HEALTH_ERR. Data may be unavailable or at risk. The active health checks are in the item "Ceph health checks".'
+                  manual_close: 'YES'
+                - uuid: 2aac4387212943e9ab407173e31b33c9
+                  expression: 'min(/Proxmox VE Cluster by REST API/ceph.health[{#FSID}],{$CEPH.HEALTH.WARN.PERIOD})>=1'
+                  name: 'Ceph cluster health is not OK for {$CEPH.HEALTH.WARN.PERIOD}'
                   priority: WARNING
-                  description: 'Applies to pve-ssl.pem, pve-root-ca.pem and any custom or ACME certificate. The cluster CA runs for 50 years, the node certificate for two.'
+                  description: 'Ceph has reported at least HEALTH_WARN for the whole period. Short warnings, for example during a restart, do not fire. The active health checks are in the item "Ceph health checks".'
+                  manual_close: 'YES'
                   dependencies:
-                    - name: 'Certificate {#CERT_FILE} has expired on {HOST.NAME}'
-                      expression: 'last(/Template Proxmox VE REST API/cert.notafter[{#CERT_FILE}])-now()<0'
-                - uuid: 1a30b199323f48aea3f672c249264da5
-                  expression: 'last(/Template Proxmox VE REST API/cert.notafter[{#CERT_FILE}])-now()<0'
-                  name: 'Certificate {#CERT_FILE} has expired on {HOST.NAME}'
-                  priority: AVERAGE
-                  description: 'The certificate is past its notAfter date. Clients and the web interface reject it, and API clients that verify the chain stop connecting. The advance warning depends on this trigger, so only one of the two is open at a time.'
-            - uuid: 89ee399fb63440c4b39c734fab870ac2
-              name: 'Certificate subject {#CERT_FILE}'
+                    - name: 'Ceph cluster health is HEALTH_ERR'
+                      expression: 'last(/Proxmox VE Cluster by REST API/ceph.health[{#FSID}])=2'
+            - uuid: 827de8b97ea34736ac840036c30b8ff5
+              name: 'Ceph manager available'
               type: DEPENDENT
-              key: 'cert.subject[{#CERT_FILE}]'
+              key: 'ceph.mgr.available[{#FSID}]'
               delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Certificate subject name.'
+              history: 7d
+              description: '1 when an active Ceph manager exists.'
+              valuemap:
+                name: 'Ceph availability'
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$.data[?(@.filename=="{#CERT_FILE}")].subject.first()'
-                  error_handler: DISCARD_VALUE
+                    - $.data.mgrmap.available
+                - type: BOOL_TO_DECIMAL
+                  parameters:
+                    - ''
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
-                key: pve.certificates.raw
+                key: pve.ceph.status.raw
               tags:
                 - tag: PVE
-                  value: Certificate
+                  value: Ceph
+              trigger_prototypes:
+                - uuid: d780ff7e44b54f9ca587af71d3e5f892
+                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.mgr.available[{#FSID}])=0'
+                  name: 'Ceph: no active manager'
+                  priority: HIGH
+                  description: 'No Ceph manager is active. Statistics, the dashboard and orchestration stop, and PG statistics go stale.'
+                  manual_close: 'YES'
+            - uuid: 501c083532b74a44a6c85dc260b3264a
+              name: 'Ceph manager standbys'
+              type: DEPENDENT
+              key: 'ceph.mgr.standbys[{#FSID}]'
+              delay: '0'
+              history: 7d
+              description: 'Number of standby Ceph managers.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.mgrmap.standbys.length()
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
                 - tag: PVE
-                  value: '{#CERT_FILE}'
+                  value: Ceph
+            - uuid: 56a4e1a2fd1b42339883e4128c0e624a
+              name: 'Ceph monitors in quorum'
+              type: DEPENDENT
+              key: 'ceph.mons.quorum[{#FSID}]'
+              delay: '0'
+              history: 7d
+              description: 'Number of monitors in the quorum.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.quorum_names.length()
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 52ab2191852541dc9bd8d859534d59ad
+              name: 'Ceph monitors total'
+              type: DEPENDENT
+              key: 'ceph.mons.total[{#FSID}]'
+              delay: '0'
+              history: 7d
+              description: 'Number of monitors in the monitor map. PVE adds the full map to the status on current Ceph releases.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.monmap.mons.length()
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 5197066e9abb4c4990a6b8f3a13bb892
+              name: 'Ceph objects degraded'
+              type: DEPENDENT
+              key: 'ceph.objects.degraded[{#FSID}]'
+              delay: '0'
+              history: 7d
+              description: 'Objects with fewer copies than configured. Ceph omits the field while there are none.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.pgmap.degraded_objects
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 4bfe2b04f12548f1b6dde1a65b136e04
+              name: 'Ceph objects misplaced'
+              type: DEPENDENT
+              key: 'ceph.objects.misplaced[{#FSID}]'
+              delay: '0'
+              history: 7d
+              description: 'Objects stored in the wrong place and waiting to be moved.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.pgmap.misplaced_objects
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 1410e6fd150548e88d188ef77fca575f
+              name: 'Ceph objects unfound'
+              type: DEPENDENT
+              key: 'ceph.objects.unfound[{#FSID}]'
+              delay: '0'
+              history: 7d
+              description: 'Objects Ceph cannot find on any OSD.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.pgmap.unfound_objects
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+              trigger_prototypes:
+                - uuid: 44951557f91a4bd9a899a338f91dcad8
+                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.objects.unfound[{#FSID}])>0'
+                  name: 'Ceph: unfound objects'
+                  opdata: '{ITEM.LASTVALUE1} objects'
+                  priority: HIGH
+                  description: 'Ceph knows objects exist but cannot find any copy. I/O to them blocks, and data loss is possible if the OSDs holding them do not come back.'
+                  manual_close: 'YES'
+            - uuid: 2adf09093ddf41b7aef8c0ba32ee7198
+              name: 'Ceph OSDs in'
+              type: DEPENDENT
+              key: 'ceph.osds.in[{#FSID}]'
+              delay: '0'
+              history: 7d
+              description: 'Number of OSDs that are in, that is, holding data.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.osdmap..num_in_osds.first()
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 854eaeba5cfa4541b85a2ace64370b6d
+              name: 'Ceph OSDs total'
+              type: DEPENDENT
+              key: 'ceph.osds.total[{#FSID}]'
+              delay: '0'
+              history: 7d
+              description: 'Number of OSDs in the OSD map. The deep scan covers both the flat osdmap of current Ceph and the nested osdmap.osdmap of older releases.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.osdmap..num_osds.first()
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: a789d15450a245069b1c07b5317807bc
+              name: 'Ceph OSDs up'
+              type: DEPENDENT
+              key: 'ceph.osds.up[{#FSID}]'
+              delay: '0'
+              history: 7d
+              description: 'Number of OSDs that are up.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.osdmap..num_up_osds.first()
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 55cfbd82a2b14cdbb8d8b81c99b5ca42
+              name: 'Ceph PGs active+clean'
+              type: DEPENDENT
+              key: 'ceph.pgs.clean[{#FSID}]'
+              delay: '0'
+              history: 7d
+              description: 'Number of placement groups whose state starts with active+clean. Scrubbing PGs (active+clean+scrubbing) count as clean, so routine scrubs do not raise the trigger.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data.pgmap.pgs_by_state[?(@.state_name =~ "^active\\+clean")].count.sum()'
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 0d3e06c09560434087cfda670af87c96
+              name: 'Ceph PGs total'
+              type: DEPENDENT
+              key: 'ceph.pgs.total[{#FSID}]'
+              delay: '0'
+              history: 7d
+              description: 'Number of placement groups.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.pgmap.num_pgs
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: d0dbed744cee451a93e574eb86a4d60f
+              name: 'Ceph client read'
+              type: DEPENDENT
+              key: 'ceph.read.bps[{#FSID}]'
+              delay: '0'
+              history: 7d
+              units: B/s
+              description: 'Client read throughput. Ceph omits the field while it is zero.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.pgmap.read_bytes_sec
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 91912d2f86604871bbfabcb66fe32c16
+              name: 'Ceph client read operations'
+              type: DEPENDENT
+              key: 'ceph.read.iops[{#FSID}]'
+              delay: '0'
+              history: 7d
+              units: ops
+              description: 'Client read operations per second.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.pgmap.read_op_per_sec
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 08b573745e0e4421aba3709ba3527c53
+              name: 'Ceph recovery throughput'
+              type: DEPENDENT
+              key: 'ceph.recovery.bps[{#FSID}]'
+              delay: '0'
+              history: 7d
+              units: B/s
+              description: 'Data moved by recovery and backfill.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.pgmap.recovering_bytes_per_sec
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 05d393c5ebab4950b2af56c3178ba4e0
+              name: 'Ceph raw capacity utilization'
+              type: CALCULATED
+              key: 'ceph.util[{#FSID}]'
+              history: 7d
+              value_type: FLOAT
+              units: '%'
+              params: 'last(/{HOST.HOST}/ceph.bytes.used[{#FSID}])/last(/{HOST.HOST}/ceph.bytes.total[{#FSID}])*100'
+              description: 'Used share of the raw capacity.'
+              tags:
+                - tag: PVE
+                  value: Ceph
+              trigger_prototypes:
+                - uuid: e9d4d5ac2b08462b85c14a73d3734931
+                  expression: 'min(/Proxmox VE Cluster by REST API/ceph.util[{#FSID}],5m)>{$CEPH.UTIL.CRIT}'
+                  name: 'Ceph raw capacity is over {$CEPH.UTIL.CRIT}%'
+                  opdata: '{ITEM.LASTVALUE1}'
+                  priority: HIGH
+                  description: 'The raw capacity of the Ceph cluster is almost used up. OSDs refuse writes once they reach the full ratio, and the first OSD fills up before the cluster average does.'
+                  manual_close: 'YES'
+                - uuid: daa5908e05c24b74bb8c94dc9e941c75
+                  expression: 'min(/Proxmox VE Cluster by REST API/ceph.util[{#FSID}],5m)>{$CEPH.UTIL.WARN}'
+                  name: 'Ceph raw capacity is over {$CEPH.UTIL.WARN}%'
+                  opdata: '{ITEM.LASTVALUE1}'
+                  priority: WARNING
+                  description: 'Plan capacity: add OSDs or free space. Ceph needs spare capacity to recover from a failed host.'
+                  manual_close: 'YES'
+                  dependencies:
+                    - name: 'Ceph raw capacity is over {$CEPH.UTIL.CRIT}%'
+                      expression: 'min(/Proxmox VE Cluster by REST API/ceph.util[{#FSID}],5m)>{$CEPH.UTIL.CRIT}'
+            - uuid: e0c48680b284451cb38b3862d5329267
+              name: 'Ceph client write'
+              type: DEPENDENT
+              key: 'ceph.write.bps[{#FSID}]'
+              delay: '0'
+              history: 7d
+              units: B/s
+              description: 'Client write throughput. Ceph omits the field while it is zero.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.pgmap.write_bytes_sec
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+            - uuid: 6fefa5a4d3b74807bf4adbbd15dfac11
+              name: 'Ceph client write operations'
+              type: DEPENDENT
+              key: 'ceph.write.iops[{#FSID}]'
+              delay: '0'
+              history: 7d
+              units: ops
+              description: 'Client write operations per second.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - $.data.pgmap.write_op_per_sec
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: pve.ceph.status.raw
+              tags:
+                - tag: PVE
+                  value: Ceph
+          trigger_prototypes:
+            - uuid: 23fa4140dd5941acb9a040e5c09561a3
+              expression: 'last(/Proxmox VE Cluster by REST API/ceph.mons.quorum[{#FSID}])<last(/Proxmox VE Cluster by REST API/ceph.mons.total[{#FSID}])'
+              name: 'Ceph: monitor(s) out of quorum'
+              opdata: 'In quorum: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
+              priority: AVERAGE
+              description: 'At least one Ceph monitor is not part of the quorum. Losing one more may cost the quorum and stop all Ceph I/O.'
+              manual_close: 'YES'
+            - uuid: 0e5b80522e994ff0b0e79d515cc669a4
+              expression: 'last(/Proxmox VE Cluster by REST API/ceph.osds.up[{#FSID}])<last(/Proxmox VE Cluster by REST API/ceph.osds.total[{#FSID}])'
+              name: 'Ceph: one or more OSDs are down'
+              opdata: 'Up: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
+              priority: AVERAGE
+              description: 'Ceph marks the affected OSDs out after a while and starts to rebalance. The OSD discovery shows which OSD is down.'
+              manual_close: 'YES'
+            - uuid: cc1eebd702744e68a9d40ef71668c7d4
+              expression: 'last(/Proxmox VE Cluster by REST API/ceph.osds.in[{#FSID}])<last(/Proxmox VE Cluster by REST API/ceph.osds.total[{#FSID}])'
+              name: 'Ceph: one or more OSDs are out'
+              opdata: 'In: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
+              priority: WARNING
+              description: 'OSDs that are out hold no data; the cluster runs with reduced capacity and redundancy until they are back in or removed.'
+              manual_close: 'YES'
+            - uuid: 349c4191aff84e5d8257861987945260
+              expression: 'max(/Proxmox VE Cluster by REST API/ceph.pgs.clean[{#FSID}],{$CEPH.PG.NOT_CLEAN.PERIOD})<last(/Proxmox VE Cluster by REST API/ceph.pgs.total[{#FSID}])'
+              name: 'Ceph: placement groups not active+clean for {$CEPH.PG.NOT_CLEAN.PERIOD}'
+              opdata: 'Clean: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
+              priority: WARNING
+              description: 'Some placement groups have not been active+clean at any point of the period. Recovery or backfill is stuck or the cluster lacks OSDs to restore redundancy.'
+              manual_close: 'YES'
+          graph_prototypes:
+            - uuid: 62ea53723ce443d494d8265098f177ca
+              name: 'Ceph client operations'
+              graph_items:
+                - color: 1976D2
+                  item:
+                    host: 'Proxmox VE Cluster by REST API'
+                    key: 'ceph.read.iops[{#FSID}]'
+                - sortorder: '1'
+                  color: FF8F00
+                  item:
+                    host: 'Proxmox VE Cluster by REST API'
+                    key: 'ceph.write.iops[{#FSID}]'
+            - uuid: c2b159575594448abe65ba2532089b0a
+              name: 'Ceph client throughput'
+              graph_items:
+                - color: 1976D2
+                  item:
+                    host: 'Proxmox VE Cluster by REST API'
+                    key: 'ceph.read.bps[{#FSID}]'
+                - sortorder: '1'
+                  color: FF8F00
+                  item:
+                    host: 'Proxmox VE Cluster by REST API'
+                    key: 'ceph.write.bps[{#FSID}]'
+                - sortorder: '2'
+                  color: 8E24AA
+                  item:
+                    host: 'Proxmox VE Cluster by REST API'
+                    key: 'ceph.recovery.bps[{#FSID}]'
+            - uuid: 52f6428700fc451c976ded0e63e72908
+              name: 'Ceph raw capacity'
+              graph_items:
+                - drawtype: FILLED_REGION
+                  color: E45959
+                  item:
+                    host: 'Proxmox VE Cluster by REST API'
+                    key: 'ceph.bytes.used[{#FSID}]'
+                - sortorder: '1'
+                  drawtype: FILLED_REGION
+                  color: 00C48C
+                  item:
+                    host: 'Proxmox VE Cluster by REST API'
+                    key: 'ceph.bytes.avail[{#FSID}]'
           master_item:
-            key: pve.certificates.raw
+            key: pve.ceph.status.raw
           lld_macro_paths:
-            - lld_macro: '{#CERT_FILE}'
-              path: $.filename
+            - lld_macro: '{#FSID}'
+              path: $.fsid
           preprocessing:
             - type: JSONPATH
               parameters:
-                - '$.data[*]'
-        - uuid: b3effaa7e8414b4b80f82b301646e7a2
-          name: 'Discover disks'
+                - '$[?(@.fsid)]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: af70c6046bbd4fb69a1bf98eba508c8e
+          name: 'Discover Ceph OSDs'
           type: DEPENDENT
-          key: discover.disks
+          key: discover.ceph.osd
           delay: '0'
-          description: 'Discovers physical disks from /nodes/{node}/disks/list. Covers every disk type Proxmox VE reports, including SATA, SAS and NVMe. The wearout item is skipped for rotating disks, which do not expose that value.'
+          enabled_lifetime_type: DISABLE_AFTER
+          enabled_lifetime: 1d
+          description: 'Discovers every OSD in the CRUSH tree of /nodes/localhost/ceph/osd. Discovers nothing on clusters without Ceph.'
           item_prototypes:
-            - uuid: 34f801ed3d4f492bb997c571addb024a
-              name: 'Disk {#DISK_DEV} health'
+            - uuid: 5ca75d7030da4ae480c5bde9627b835e
+              name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: in'
               type: DEPENDENT
-              key: 'disk.health[{#DISK_DEV}]'
+              key: 'ceph.osd.in[{#OSD_ID}]'
               delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'SMART health status of disk {#DISK_DEV} ({#DISK_MODEL}). Values: PASSED, FAILED, UNKNOWN. Source: /nodes/{node}/disks/list, which reports the same overall health assessment as the dedicated SMART endpoint, so no extra request per disk is needed.'
+              history: 7d
+              description: '1 when the OSD is in and holds data, 0 when it is out.'
+              valuemap:
+                name: 'Ceph OSD in'
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$.data[?(@.devpath=="{#DISK_DEV}")].health.first()'
-                  error_handler: CUSTOM_VALUE
-                  error_handler_params: UNKNOWN
+                    - '$.data.root..children[?(@.id=={#OSD_ID})].in.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
-                key: pve.disks.raw
+                key: pve.ceph.osd.raw
               tags:
+                - tag: Ceph
+                  value: OSD
                 - tag: PVE
-                  value: Disk
+                  value: Ceph
                 - tag: PVE
-                  value: '{#DISK_DEV}'
-              trigger_prototypes:
-                - uuid: e1ea4b0beadb4577a6b71421c12761a1
-                  expression: 'last(/Template Proxmox VE REST API/disk.health[{#DISK_DEV}])<>"PASSED"'
-                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) SMART health not PASSED on {HOST.NAME}'
-                  priority: HIGH
-                  description: 'SMART health check for disk {#DISK_DEV} returned a non-PASSED status. Immediate investigation recommended.'
-                  manual_close: 'YES'
-            - uuid: 8f6a409c8d1c40dd8ddb78d029f7dcbc
-              name: 'Disk {#DISK_DEV} size'
+                  value: '{#OSD_HOST}'
+            - uuid: 99f03db18cf740aea3b468b09daccf9e
+              name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: apply latency'
               type: DEPENDENT
-              key: 'disk.size[{#DISK_DEV}]'
+              key: 'ceph.osd.latency.apply[{#OSD_ID}]'
               delay: '0'
-              units: Bytes
-              description: 'Total size of physical disk {#DISK_DEV} ({#DISK_MODEL}) in bytes. Source: /nodes/{node}/disks/list.'
+              history: 7d
+              value_type: FLOAT
+              units: s
+              description: 'Apply latency reported by the OSD.'
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$.data[?(@.devpath=="{#DISK_DEV}")].size.first()'
+                    - '$.data.root..children[?(@.id=={#OSD_ID})].apply_latency_ms.first()'
+                  error_handler: DISCARD_VALUE
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.001'
+              master_item:
+                key: pve.ceph.osd.raw
+              tags:
+                - tag: Ceph
+                  value: OSD
+                - tag: PVE
+                  value: Ceph
+                - tag: PVE
+                  value: '{#OSD_HOST}'
+            - uuid: aba4d66025b145eb84bdecbf7d0cfa06
+              name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: commit latency'
+              type: DEPENDENT
+              key: 'ceph.osd.latency.commit[{#OSD_ID}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: s
+              description: 'Commit latency reported by the OSD.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data.root..children[?(@.id=={#OSD_ID})].commit_latency_ms.first()'
+                  error_handler: DISCARD_VALUE
+                - type: MULTIPLIER
+                  parameters:
+                    - '0.001'
+              master_item:
+                key: pve.ceph.osd.raw
+              tags:
+                - tag: Ceph
+                  value: OSD
+                - tag: PVE
+                  value: Ceph
+                - tag: PVE
+                  value: '{#OSD_HOST}'
+              trigger_prototypes:
+                - uuid: d1467778baba4841992335f3e9d9fb82
+                  expression: 'min(/Proxmox VE Cluster by REST API/ceph.osd.latency.commit[{#OSD_ID}],{$CEPH.OSD.LATENCY.PERIOD})>{$CEPH.OSD.LATENCY.MAX}'
+                  name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: commit latency over {$CEPH.OSD.LATENCY.MAX}s'
+                  opdata: '{ITEM.LASTVALUE1}'
+                  priority: WARNING
+                  description: 'The OSD has been slow for the whole period. A failing or overloaded disk slows down every pool it serves.'
+                  manual_close: 'YES'
+            - uuid: dee4b7cd4e034069a6ec0ab98871ad6d
+              name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: placement groups'
+              type: DEPENDENT
+              key: 'ceph.osd.pgs[{#OSD_ID}]'
+              delay: '0'
+              history: 7d
+              description: 'Placement groups on the OSD.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data.root..children[?(@.id=={#OSD_ID})].pgs.first()'
                   error_handler: DISCARD_VALUE
               master_item:
-                key: pve.disks.raw
+                key: pve.ceph.osd.raw
               tags:
+                - tag: Ceph
+                  value: OSD
                 - tag: PVE
-                  value: Disk
+                  value: Ceph
                 - tag: PVE
-                  value: '{#DISK_DEV}'
-              trigger_prototypes:
-                - uuid: 273bb1dc1ff74d379f4c7b1c88c82fcf
-                  expression: 'nodata(/Template Proxmox VE REST API/disk.size[{#DISK_DEV}],{$DISK.MISSING.TIME})=1'
-                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) is no longer reported by {HOST.NAME}'
-                  priority: AVERAGE
-                  description: 'Proxmox VE has stopped listing this disk. Either the disk was removed on purpose or it dropped off the bus. The disk list is refreshed hourly, so {$DISK.MISSING.TIME} must stay well above one hour.'
-                  manual_close: 'YES'
-            - uuid: 57d697c2516d49aaadeca4f761b082dc
-              name: 'Disk {#DISK_DEV} SMART raw'
-              type: HTTP_AGENT
-              key: 'disk.smart.raw[{#DISK_DEV}]'
-              delay: '3600'
-              history: '0'
-              value_type: TEXT
-              trends: '0'
-              description: 'Master item. Raw JSON from /nodes/{node}/disks/smart for disk {#DISK_DEV}. Proxmox VE answers in two shapes: type=ata carries a list of numbered SMART attributes, type=text carries the raw smartctl output used for NVMe and SAS. Source for the disk temperature item.'
-              url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/disks/smart?disk={#DISK_DEV}'
-              headers:
-                - name: Authorization
-                  value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-                - name: Accept
-                  value: application/json
-              tags:
-                - tag: PVE
-                  value: Raw
-                - tag: PVE
-                  value: '{#DISK_DEV}'
-            - uuid: ffcc0cce9a074f4c8061e99dda3f325b
-              name: 'Disk {#DISK_DEV} temperature'
+                  value: '{#OSD_HOST}'
+            - uuid: fa11df6d1fb943139c7fb6f4711c5247
+              name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: status'
               type: DEPENDENT
-              key: 'disk.temp[{#DISK_DEV}]'
+              key: 'ceph.osd.up[{#OSD_ID}]'
               delay: '0'
-              value_type: FLOAT
-              units: '!°C'
-              description: 'Temperature of disk {#DISK_DEV} ({#DISK_MODEL}) in degrees Celsius. Read from the SMART payload of the disk. SATA and SAS disks report it as attribute 194, or 190 on drives that only expose an airflow sensor. NVMe disks report it in the composite Temperature line of the smartctl output. Disks that expose no temperature at all deliver no value.'
+              history: 7d
+              description: '1 when the OSD is up, 0 when it is down.'
+              valuemap:
+                name: 'Ceph OSD status'
               preprocessing:
-                - type: JAVASCRIPT
+                - type: JSONPATH
                   parameters:
-                    - |
-                      // Proxmox returns two different SMART shapes, so both are handled here.
-                      // type=ata  -> numbered attribute list, temperature is id 194 (or 190)
-                      // type=text -> raw smartctl output, temperature is the composite line
-                      var d = JSON.parse(value).data;
-                      if (!d) {
-                          throw 'no SMART payload';
-                      }
-                      if (d.attributes) {
-                          var wanted = ['194', '190'];
-                          for (var w = 0; w < wanted.length; w++) {
-                              for (var i = 0; i < d.attributes.length; i++) {
-                                  var a = d.attributes[i];
-                                  // Proxmox keeps the attribute id as a space padded string
-                                  if (String(a.id).replace(/\s/g, '') !== wanted[w]) {
-                                      continue;
-                                  }
-                                  // the raw column may carry trailing text such as "38 (Min/Max 20/45)"
-                                  var r = String(a.raw).match(/\d+/);
-                                  if (r) {
-                                      return r[0];
-                                  }
-                              }
-                          }
-                      }
-                      if (typeof d.text === 'string') {
-                          var t = d.text.match(/^\s*Temperature:\s+(\d+)\s+Celsius/m);
-                          if (!t) {
-                              t = d.text.match(/^\s*Temperature Sensor 1:\s+(\d+)\s+Celsius/m);
-                          }
-                          if (t) {
-                              return t[1];
-                          }
-                      }
-                      throw 'no temperature in SMART data';
+                    - '$.data.root..children[?(@.id=={#OSD_ID})].status.first()'
+                  error_handler: DISCARD_VALUE
+                - type: STR_REPLACE
+                  parameters:
+                    - down
+                    - '0'
+                - type: STR_REPLACE
+                  parameters:
+                    - up
+                    - '1'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
-                key: 'disk.smart.raw[{#DISK_DEV}]'
+                key: pve.ceph.osd.raw
               tags:
+                - tag: Ceph
+                  value: OSD
                 - tag: PVE
-                  value: Disk
+                  value: Ceph
                 - tag: PVE
-                  value: '{#DISK_DEV}'
+                  value: '{#OSD_HOST}'
               trigger_prototypes:
-                - uuid: a407b65ce7b44bfebd0a2f343dc0300d
-                  expression: 'min(/Template Proxmox VE REST API/disk.temp[{#DISK_DEV}],10m)>{$DISK.TEMP.MAX:"{#DISK_DEV}"}'
-                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) temperature above {$DISK.TEMP.MAX:"{#DISK_DEV}"} C on {HOST.NAME}'
-                  opdata: 'Temperature: {ITEM.LASTVALUE1}'
-                  priority: WARNING
-                  description: 'The disk has stayed above the temperature threshold for 10 minutes. Set {$DISK.TEMP.MAX:"{#DISK_DEV}"} to raise the threshold for a single disk.'
+                - uuid: a0f2b17145724977a4cc66d3e4966fe6
+                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.osd.up[{#OSD_ID}])=0'
+                  name: 'Ceph {#OSD_NAME} on {#OSD_HOST} is down'
+                  priority: AVERAGE
+                  description: 'The OSD daemon is not running or cannot reach the monitors. Check ceph-osd@{#OSD_ID} on {#OSD_HOST} and the disk behind it.'
                   manual_close: 'YES'
-            - uuid: 11439521679e47f8a1e96261a5e98e4d
-              name: 'Disk {#DISK_DEV} wearout'
+            - uuid: c1df354baa8743f6849cf53326fbaf3e
+              name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: utilization'
               type: DEPENDENT
-              key: 'disk.wearout[{#DISK_DEV}]'
+              key: 'ceph.osd.util[{#OSD_ID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: '%'
-              description: 'SSD wearout indicator for disk {#DISK_DEV} in percent remaining life (100% = new, 0% = worn out). Only meaningful for SSDs and NVMe, rotating disks report N/A and are discarded. Source: /nodes/{node}/disks/list. The SMART endpoint does not return this value.'
+              description: 'Used share of the OSD capacity.'
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$.data[?(@.devpath=="{#DISK_DEV}")].wearout.first()'
-                  error_handler: DISCARD_VALUE
-                - type: MATCHES_REGEX
-                  parameters:
-                    - '^[0-9]+(\.[0-9]+)?$'
+                    - '$.data.root..children[?(@.id=={#OSD_ID})].percent_used.first()'
                   error_handler: DISCARD_VALUE
               master_item:
-                key: pve.disks.raw
+                key: pve.ceph.osd.raw
               tags:
+                - tag: Ceph
+                  value: OSD
                 - tag: PVE
-                  value: Disk
+                  value: Ceph
                 - tag: PVE
-                  value: '{#DISK_DEV}'
+                  value: '{#OSD_HOST}'
               trigger_prototypes:
-                - uuid: c5f1c17c33624781a843ccea415667e3
-                  expression: 'last(/Template Proxmox VE REST API/disk.wearout[{#DISK_DEV}])<{$DISK.WEAROUT.MIN}'
-                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) wearout below {$DISK.WEAROUT.MIN}% on {HOST.NAME}'
-                  priority: WARNING
-                  description: 'SSD wearout for disk {#DISK_DEV} is below threshold. Consider replacement planning.'
+                - uuid: 638b17ed15004ab7aafd9b4d576df1b9
+                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.osd.util[{#OSD_ID}])>{$CEPH.OSD.UTIL.CRIT}'
+                  name: 'Ceph {#OSD_NAME} on {#OSD_HOST} is over {$CEPH.OSD.UTIL.CRIT}% full'
+                  opdata: '{ITEM.LASTVALUE1}'
+                  priority: HIGH
+                  description: 'Ceph blocks writes to the whole pool once a single OSD reaches the full ratio (95% by default). Rebalance with reweight or add capacity.'
                   manual_close: 'YES'
+                - uuid: e9fffc5d11804c62aeaa58bac2ad1ebe
+                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.osd.util[{#OSD_ID}])>{$CEPH.OSD.UTIL.WARN}'
+                  name: 'Ceph {#OSD_NAME} on {#OSD_HOST} is over {$CEPH.OSD.UTIL.WARN}% full'
+                  opdata: '{ITEM.LASTVALUE1}'
+                  priority: WARNING
+                  description: 'The OSD fills up faster than the cluster average; check the balancer and reweights.'
+                  manual_close: 'YES'
+                  dependencies:
+                    - name: 'Ceph {#OSD_NAME} on {#OSD_HOST} is over {$CEPH.OSD.UTIL.CRIT}% full'
+                      expression: 'last(/Proxmox VE Cluster by REST API/ceph.osd.util[{#OSD_ID}])>{$CEPH.OSD.UTIL.CRIT}'
           master_item:
-            key: pve.disks.raw
+            key: pve.ceph.osd.raw
           lld_macro_paths:
-            - lld_macro: '{#DISK_DEV}'
-              path: $.devpath
-            - lld_macro: '{#DISK_MODEL}'
-              path: $.model
-            - lld_macro: '{#DISK_SERIAL}'
-              path: $.serial
-            - lld_macro: '{#DISK_TYPE}'
-              path: $.type
+            - lld_macro: '{#OSD_HOST}'
+              path: $.host
+            - lld_macro: '{#OSD_ID}'
+              path: $.id
+            - lld_macro: '{#OSD_NAME}'
+              path: $.name
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data.root..children[?(@.type=="osd")]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: 18f88b7d53de4b81be456c01a8b5c369
+          name: 'Discover Ceph pools'
+          type: DEPENDENT
+          key: discover.ceph.pools
+          delay: '0'
+          filter:
+            conditions:
+              - macro: '{#POOL}'
+                value: '{$CEPH.POOL.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: A
+          enabled_lifetime_type: DISABLE_AFTER
+          enabled_lifetime: 1d
+          description: 'Discovers the Ceph pools from /nodes/localhost/ceph/pool. Discovers nothing on clusters without Ceph. Items are keyed by pool id; the name is in the item name and tags.'
+          item_prototypes:
+            - uuid: bda878b967e540cca8bde0babb6594d7
+              name: 'Ceph pool {#POOL}: min_size'
+              type: DEPENDENT
+              key: 'ceph.pool.min_size[{#POOL_ID}]'
+              delay: '0'
+              history: 7d
+              description: 'Copies that must be available for the pool to accept I/O.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.pool=={#POOL_ID})].min_size.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.ceph.pool.raw
+              tags:
+                - tag: Ceph
+                  value: Pool
+                - tag: 'Ceph pool'
+                  value: '{#POOL}'
+                - tag: PVE
+                  value: Ceph
+            - uuid: c7a2377d7e4545958482504a688fd4a6
+              name: 'Ceph pool {#POOL}: size'
+              type: DEPENDENT
+              key: 'ceph.pool.size[{#POOL_ID}]'
+              delay: '0'
+              history: 7d
+              description: 'Number of copies (replicated) or k+m chunks (erasure coded).'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.pool=={#POOL_ID})].size.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.ceph.pool.raw
+              tags:
+                - tag: Ceph
+                  value: Pool
+                - tag: 'Ceph pool'
+                  value: '{#POOL}'
+                - tag: PVE
+                  value: Ceph
+            - uuid: 0ab62b28f4d04106b38efd2ab40bd8e6
+              name: 'Ceph pool {#POOL}: used'
+              type: DEPENDENT
+              key: 'ceph.pool.used[{#POOL_ID}]'
+              delay: '0'
+              history: 7d
+              units: B
+              description: 'Bytes used by the pool, replicas included.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.pool=={#POOL_ID})].bytes_used.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: pve.ceph.pool.raw
+              tags:
+                - tag: Ceph
+                  value: Pool
+                - tag: 'Ceph pool'
+                  value: '{#POOL}'
+                - tag: PVE
+                  value: Ceph
+            - uuid: c4fc3424825a424897ac1f8a46daf098
+              name: 'Ceph pool {#POOL}: utilization'
+              type: DEPENDENT
+              key: 'ceph.pool.util[{#POOL_ID}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: '%'
+              description: 'Used share of the capacity the pool can still grow into. Ceph reports a fraction; it is converted to percent.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.pool=={#POOL_ID})].percent_used.first()'
+                  error_handler: DISCARD_VALUE
+                - type: MULTIPLIER
+                  parameters:
+                    - '100'
+              master_item:
+                key: pve.ceph.pool.raw
+              tags:
+                - tag: Ceph
+                  value: Pool
+                - tag: 'Ceph pool'
+                  value: '{#POOL}'
+                - tag: PVE
+                  value: Ceph
+              trigger_prototypes:
+                - uuid: 200f52e8661c4d74b0c228d882b30035
+                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.pool.util[{#POOL_ID}])>{$CEPH.POOL.UTIL.CRIT}'
+                  name: 'Ceph pool {#POOL} is over {$CEPH.POOL.UTIL.CRIT}% full'
+                  opdata: '{ITEM.LASTVALUE1}'
+                  priority: HIGH
+                  description: 'The pool is close to its usable capacity. Ceph stops writes to the pool once it is full.'
+                  manual_close: 'YES'
+                - uuid: 0c91dde314d348ac9f4ad348c3a884c0
+                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.pool.util[{#POOL_ID}])>{$CEPH.POOL.UTIL.WARN}'
+                  name: 'Ceph pool {#POOL} is over {$CEPH.POOL.UTIL.WARN}% full'
+                  opdata: '{ITEM.LASTVALUE1}'
+                  priority: WARNING
+                  description: 'Plan capacity for the pool.'
+                  manual_close: 'YES'
+                  dependencies:
+                    - name: 'Ceph pool {#POOL} is over {$CEPH.POOL.UTIL.CRIT}% full'
+                      expression: 'last(/Proxmox VE Cluster by REST API/ceph.pool.util[{#POOL_ID}])>{$CEPH.POOL.UTIL.CRIT}'
+          trigger_prototypes:
+            - uuid: e5ed8415c37c4ce89740ed1d4140cb56
+              expression: 'last(/Proxmox VE Cluster by REST API/ceph.pool.min_size[{#POOL_ID}])=1 and last(/Proxmox VE Cluster by REST API/ceph.pool.size[{#POOL_ID}])>1'
+              name: 'Ceph pool {#POOL} accepts writes with a single copy (min_size 1)'
+              priority: WARNING
+              description: 'With min_size 1 the pool keeps writing while only one copy is left. A second failure then loses data. Set min_size to 2 for size 3.'
+          master_item:
+            key: pve.ceph.pool.raw
+          lld_macro_paths:
+            - lld_macro: '{#POOL_ID}'
+              path: $.pool
+            - lld_macro: '{#POOL}'
+              path: $.pool_name
           preprocessing:
             - type: JSONPATH
               parameters:
                 - '$.data[*]'
               error_handler: CUSTOM_VALUE
               error_handler_params: '[]'
-          overrides:
-            - name: 'No wearout on rotating disks'
-              step: '1'
-              filter:
-                conditions:
-                  - macro: '{#DISK_TYPE}'
-                    value: ^hdd$
-                    formulaid: A
-              operations:
-                - operationobject: ITEM_PROTOTYPE
-                  operator: LIKE
-                  value: wearout
-                  discover: NO_DISCOVER
+        - uuid: 7495dfbf4ad940b9a04c3150e802f97d
+          name: 'Discover HA local resource managers'
+          type: DEPENDENT
+          key: discover.ha.lrm
+          delay: '0'
+          enabled_lifetime_type: DISABLE_AFTER
+          enabled_lifetime: 1d
+          description: 'Discovers one local resource manager (LRM) per node from the type=lrm entries of /cluster/ha/status/current. PVE lists LRMs only once HA has been configured.'
+          item_prototypes:
+            - uuid: 3ff0636454ba45b39598c3348ddff777
+              name: 'HA LRM state on {#HA_NODE}'
+              type: DEPENDENT
+              key: 'ha.lrm.state[{#HA_NODE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'State of the HA local resource manager on {#HA_NODE}: active, idle, wait_for_agent_lock, lost_agent_lock, "maintenance mode", "old timestamp - dead?" or "unable to read lrm status".'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.type=="lrm" && @.node=="{#HA_NODE}")].status.first()'
+                  error_handler: DISCARD_VALUE
+                - type: REGEX
+                  parameters:
+                    - '^\S+ \(([^,)]+)'
+                    - \1
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: unknown
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.ha.raw
+              tags:
+                - tag: PVE
+                  value: HA
+                - tag: PVE
+                  value: '{#HA_NODE}'
+              trigger_prototypes:
+                - uuid: 08f71fc8ee0d46698a0acd10a9c7670a
+                  expression: 'last(/Proxmox VE Cluster by REST API/ha.lrm.state[{#HA_NODE}])="old timestamp - dead?" or last(/Proxmox VE Cluster by REST API/ha.lrm.state[{#HA_NODE}])="unable to read lrm status" or last(/Proxmox VE Cluster by REST API/ha.lrm.state[{#HA_NODE}])="lost_agent_lock"'
+                  name: 'HA LRM on {#HA_NODE} is not working'
+                  priority: HIGH
+                  description: 'The local resource manager on {#HA_NODE} is dead, unreadable or has lost its agent lock. HA guests on this node are not managed, and a node that lost its lock will be fenced.'
+                  manual_close: 'YES'
+                - uuid: 7fc106669cf549c39184c8972d0ddf61
+                  expression: 'last(/Proxmox VE Cluster by REST API/ha.lrm.state[{#HA_NODE}])="maintenance mode"'
+                  name: 'HA node {#HA_NODE} is in maintenance mode'
+                  priority: INFO
+                  description: 'The node has been put into HA maintenance mode. HA resources are migrated away and it does not take part in recovery.'
+          master_item:
+            key: pve.ha.raw
+          lld_macro_paths:
+            - lld_macro: '{#HA_NODE}'
+              path: $.node
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[?(@.type=="lrm")]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
         - uuid: 235e7e42e382487085fdf54efa040b65
           name: 'Discover HA resources'
           type: DEPENDENT
           key: discover.ha.resources
           delay: '0'
-          description: 'Discovers HA-managed resources (VMs and containers) from the service entries of /cluster/ha/status/current. Discovers nothing when HA is not configured, without turning the rule unsupported.'
+          description: 'Discovers HA-managed resources (VMs and containers) from the service entries of /cluster/ha/status/current. Discovers nothing when HA is not configured; the empty list is handled so the rule stays supported and removed resources are cleaned up.'
           item_prototypes:
             - uuid: 1c9ba7d377414184b53b3ed14b57ef26
               name: 'HA state of {#HA_SID}'
@@ -2237,6 +1626,9 @@ zabbix_export:
                     - '$.data[?(@.sid=="{#HA_SID}")].state.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: unknown
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.ha.raw
               tags:
@@ -2245,8 +1637,14 @@ zabbix_export:
                 - tag: PVE
                   value: '{#HA_SID}'
               trigger_prototypes:
+                - uuid: b757e20efadd49ac9b193183c1f24867
+                  expression: 'last(/Proxmox VE Cluster by REST API/ha.resource.state[{#HA_SID}])="fence" or last(/Proxmox VE Cluster by REST API/ha.resource.state[{#HA_SID}])="recovery"'
+                  name: 'HA resource {#HA_SID} is being fenced or recovered'
+                  priority: HIGH
+                  description: 'The node running {#HA_SID} has failed. The CRM is fencing that node (state fence) or moving the resource to another node (state recovery). The guest is down until recovery completes.'
+                  manual_close: 'YES'
                 - uuid: 1e1ce9abf20f4d0eb649fbfe8d50d884
-                  expression: 'last(/Template Proxmox VE REST API/ha.resource.state[{#HA_SID}])="error"'
+                  expression: 'last(/Proxmox VE Cluster by REST API/ha.resource.state[{#HA_SID}])="error"'
                   name: 'HA resource {#HA_SID} is in error state'
                   priority: HIGH
                   description: 'The HA-managed resource {#HA_SID} has entered error state. Check the PVE HA log for details.'
@@ -2260,6 +1658,8 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - '$.data[?(@.type=="service")]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
         - uuid: 553940a5f79343cbb87e6eef7f446131
           name: 'Discover lxc'
           type: DEPENDENT
@@ -2273,6 +1673,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.cpuusage[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: '%'
               description: 'CPU utilization of LXC container {#VMID} in percent (0-100). Source: /cluster/resources -> entry with type=lxc and this vmid, field cpu.'
@@ -2295,21 +1696,22 @@ zabbix_export:
                   value: '{#VMID}'
               trigger_prototypes:
                 - uuid: 4e5c59fc6d1a4a1da537b354b2696a5d
-                  expression: 'min(/Template Proxmox VE REST API/lxc.cpuusage[{#VMID}],300)>{$LXC.CPU.HIGH:"{#VMID}"}'
+                  expression: 'min(/Proxmox VE Cluster by REST API/lxc.cpuusage[{#VMID}],300)>{$LXC.CPU.HIGH:"{#VMID}"}'
                   name: 'CPU usage of LXC {#VMID} over {$LXC.CPU.HIGH:"{#VMID}"}% for 5 minutes'
                   priority: AVERAGE
                 - uuid: cce7280e51c24bd9965f4ea5eb783c87
-                  expression: 'min(/Template Proxmox VE REST API/lxc.cpuusage[{#VMID}],300)>{$LXC.CPU.WARN:"{#VMID}"}'
+                  expression: 'min(/Proxmox VE Cluster by REST API/lxc.cpuusage[{#VMID}],300)>{$LXC.CPU.WARN:"{#VMID}"}'
                   name: 'CPU usage of LXC {#VMID} over {$LXC.CPU.WARN:"{#VMID}"}% for 5 minutes'
                   priority: WARNING
                   dependencies:
                     - name: 'CPU usage of LXC {#VMID} over {$LXC.CPU.HIGH:"{#VMID}"}% for 5 minutes'
-                      expression: 'min(/Template Proxmox VE REST API/lxc.cpuusage[{#VMID}],300)>{$LXC.CPU.HIGH:"{#VMID}"}'
+                      expression: 'min(/Proxmox VE Cluster by REST API/lxc.cpuusage[{#VMID}],300)>{$LXC.CPU.HIGH:"{#VMID}"}'
             - uuid: 392f03aa5456439e84c89e9f57ecc832
               name: 'Disk read rate of {#VMID}'
               type: DEPENDENT
               key: 'lxc.diskread.rate[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: Bps
               description: 'LXC disk read throughput in bytes per second.'
@@ -2335,6 +1737,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.diskwrite.rate[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: Bps
               description: 'LXC disk write throughput in bytes per second.'
@@ -2360,6 +1763,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.disk[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
               description: 'Disk space used by LXC container {#VMID} in bytes (rootfs usage). Source: /cluster/resources -> entry with type=lxc and this vmid, field disk.'
               preprocessing:
@@ -2381,6 +1785,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.maxdisk[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
               description: 'Total disk size allocated to LXC container {#VMID} in bytes. Source: /cluster/resources -> entry with type=lxc and this vmid, field maxdisk.'
               preprocessing:
@@ -2388,6 +1793,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.vmid=={#VMID} && @.type=="lxc")].maxdisk.first()'
                   error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -2402,6 +1810,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.maxmem[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
               description: 'Maximum memory allocated to LXC container {#VMID} in bytes. Source: /cluster/resources -> entry with type=lxc and this vmid, field maxmem.'
               preprocessing:
@@ -2409,6 +1818,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.vmid=={#VMID} && @.type=="lxc")].maxmem.first()'
                   error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -2423,15 +1835,19 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.maxswap[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
-              description: 'Maximum swap space allocated to LXC container {#VMID} in bytes. Source: /nodes/{node}/lxc, field maxswap. Only collected for containers running on the node given by {$PVE_NODE}, because /cluster/resources does not carry swap values.'
+              description: 'Maximum swap space allocated of LXC container {#VMID} in bytes. Source: /nodes/{#NODE}/lxc/{#VMID}/status/current, field maxswap, because /cluster/resources does not carry swap values.'
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$.data[?(@.vmid=={#VMID})].maxswap.first()'
+                    - $.data.maxswap
                   error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
-                key: pve.nodes.lxc.raw
+                key: 'lxc.status.raw[{#VMID}]'
               tags:
                 - tag: LXC-Container
                   value: Memory
@@ -2444,6 +1860,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.memusage[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
               description: 'Current memory usage of LXC container {#VMID} in bytes. Source: /cluster/resources -> entry with type=lxc and this vmid, field mem.'
               preprocessing:
@@ -2465,6 +1882,7 @@ zabbix_export:
               type: CALCULATED
               key: 'lxc.memutil[{#VMID}]'
               delay: '60'
+              history: 7d
               value_type: FLOAT
               units: '%'
               params: 'last(/{HOST.HOST}/lxc.memusage[{#VMID}]) / last(/{HOST.HOST}/lxc.maxmem[{#VMID}]) * 100'
@@ -2490,6 +1908,9 @@ zabbix_export:
                     - '$.data[?(@.vmid=={#VMID} && @.type=="lxc")].name.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: '{#VM_NAME}'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -2504,6 +1925,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.netin.current[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: Bps
               description: 'Current network receive rate of LXC container {#VMID} in bytes/s (derived from the cumulative counter).'
@@ -2529,6 +1951,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.netin[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
               description: 'Cumulative host-level network output (bytes received) on Proxmox host for LXC {#VMID}, since last LXC start.'
               preprocessing:
@@ -2550,6 +1973,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.netout.current[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: Bps
               description: 'Current network transmit rate of LXC container {#VMID} in bytes/s (derived from the cumulative counter).'
@@ -2575,6 +1999,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.netout[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
               description: 'Cumulative host-level network input (bytes received) on Proxmox host for LXC {#VMID}, since last LXC start.'
               preprocessing:
@@ -2618,16 +2043,40 @@ zabbix_export:
                   value: '{#VMID}'
               trigger_prototypes:
                 - uuid: 5609a6c57fb342308e04beab00d469ee
-                  expression: 'change(/Template Proxmox VE REST API/lxc.node[{#VMID}])<>0'
+                  expression: 'change(/Proxmox VE Cluster by REST API/lxc.node[{#VMID}])<>0'
                   name: 'LXC {#VMID} has been migrated to another node'
                   priority: INFO
                   description: 'The cluster node running LXC {#VMID} changed since the previous check, which indicates a migration.'
                   manual_close: 'YES'
+            - uuid: b4bb7123736a461eb815d1c0ea9e800f
+              name: 'LXC {#VMID} status raw'
+              type: HTTP_AGENT
+              key: 'lxc.status.raw[{#VMID}]'
+              delay: '{$PVE.GUEST.DETAIL.INTERVAL}'
+              history: '0'
+              value_type: TEXT
+              trends: '0'
+              description: 'Master item. Raw JSON from /nodes/{#NODE}/lxc/{#VMID}/status/current, addressed through the node the guest runs on, so it works for guests on every cluster node. One request per guest: the interval is {$PVE.GUEST.DETAIL.INTERVAL}, and {$PVE.GUEST.DETAIL.VMID.MATCHES} limits or switches off these requests in large clusters.'
+              timeout: 10s
+              url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{#NODE}/lxc/{#VMID}/status/current'
+              headers:
+                - name: Authorization
+                  value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+                - name: Accept
+                  value: application/json
+              tags:
+                - tag: LXC-Container
+                  value: '{#VMID}'
+                - tag: PVE
+                  value: Raw
+                - tag: vmid
+                  value: '{#VMID}'
             - uuid: ce7c0a635f1a40eeab81f76e560938fd
               name: 'LXC status {#VMID}'
               type: DEPENDENT
               key: 'lxc.status[{#VMID}]'
               delay: '0'
+              history: 7d
               description: 'Runtime status of LXC container {#VMID}. 0 = stopped, 1 = running, 2 = paused. Source: /cluster/resources -> entry with type=lxc and this vmid, field status.'
               valuemap:
                 name: 'VM  and LXC status'
@@ -2664,10 +2113,11 @@ zabbix_export:
               trigger_prototypes:
                 - uuid: ff83e8f239e246b0a1c385029fe3941d
                   expression: |
-                    min(/Template Proxmox VE REST API/lxc.status[{#VMID}],900)=0
-                    and {$ENABLE_VM_STOP_ALERT:"{#VMID}"}=1 and max(/Template Proxmox VE REST API/lxc.status[{#VMID}],24h)=1
+                    max(/Proxmox VE Cluster by REST API/lxc.status[{#VMID}],900)=0
+                    and {$ENABLE_VM_STOP_ALERT:"{#VMID}"}=1
+                    and count(/Proxmox VE Cluster by REST API/lxc.status[{#VMID}],24h,"eq","1")>0
                   recovery_mode: RECOVERY_EXPRESSION
-                  recovery_expression: 'last(/Template Proxmox VE REST API/lxc.status[{#VMID}])=1'
+                  recovery_expression: 'last(/Proxmox VE Cluster by REST API/lxc.status[{#VMID}])=1'
                   name: 'LXC {#VMID} status is stopped'
                   priority: HIGH
                   description: |
@@ -2680,15 +2130,16 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.swap[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
-              description: 'Current swap usage of LXC container {#VMID} in bytes. Source: /nodes/{node}/lxc, field swap. Only collected for containers running on the node given by {$PVE_NODE}, because /cluster/resources does not carry swap values.'
+              description: 'Current swap usage of LXC container {#VMID} in bytes. Source: /nodes/{#NODE}/lxc/{#VMID}/status/current, field swap, because /cluster/resources does not carry swap values.'
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$.data[?(@.vmid=={#VMID})].swap.first()'
+                    - $.data.swap
                   error_handler: DISCARD_VALUE
               master_item:
-                key: pve.nodes.lxc.raw
+                key: 'lxc.status.raw[{#VMID}]'
               tags:
                 - tag: LXC-Container
                   value: Memory
@@ -2701,6 +2152,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.uptime[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: s
               description: 'Uptime of LXC container {#VMID} in seconds since last start. Source: /cluster/resources -> entry with type=lxc and this vmid, field uptime.'
@@ -2723,12 +2175,16 @@ zabbix_export:
               type: DEPENDENT
               key: 'lxc.vcpu[{#VMID}]'
               delay: '0'
+              history: 7d
               description: 'Number of vCPUs assigned to LXC container {#VMID}. Source: /cluster/resources -> entry with type=lxc and this vmid, field cpus.'
               preprocessing:
                 - type: JSONPATH
                   parameters:
                     - '$.data[?(@.vmid=={#VMID} && @.type=="lxc")].maxcpu.first()'
                   error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -2740,7 +2196,7 @@ zabbix_export:
                   value: '{#VMID}'
           trigger_prototypes:
             - uuid: 2dc3bee99506415d9461edbbdb9ce115
-              expression: 'last(/Template Proxmox VE REST API/lxc.status[{#VMID}])=1 and last(/Template Proxmox VE REST API/lxc.uptime[{#VMID}])<600'
+              expression: 'last(/Proxmox VE Cluster by REST API/lxc.status[{#VMID}])=1 and last(/Proxmox VE Cluster by REST API/lxc.uptime[{#VMID}])<600'
               name: 'LXC {#VMID} has been restarted (uptime < 10 min)'
               priority: INFO
               description: 'LXC container was recently started or restarted.'
@@ -2752,7 +2208,7 @@ zabbix_export:
                 - color: 0D47A1
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.cpuusage[{#VMID}]'
             - uuid: 1879f420b8344b57829327af81fe59e6
               name: 'LXC Cumulative network input/output since {#VMID} start'
@@ -2760,13 +2216,13 @@ zabbix_export:
                 - color: 1A7C11
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.netin[{#VMID}]'
                 - sortorder: '1'
                   color: '274482'
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.netout[{#VMID}]'
             - uuid: db5004ac56a648cba11ccc852f4aeede
               name: 'LXC Current network input/output {#VMID}'
@@ -2774,25 +2230,25 @@ zabbix_export:
                 - color: 1A7C11
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.netin.current[{#VMID}]'
                 - sortorder: '1'
                   color: '274482'
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.netout.current[{#VMID}]'
             - uuid: 04ce547c02f9405899376372dffa6aff
               name: 'LXC Disk I/O rate {#VMID}'
               graph_items:
                 - color: E65100
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.diskread.rate[{#VMID}]'
                 - sortorder: '1'
                   color: 1565C0
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.diskwrite.rate[{#VMID}]'
             - uuid: d1ce123e0cda47c8b3352cac115f059e
               name: 'LXC Disk usage {#VMID}'
@@ -2804,20 +2260,20 @@ zabbix_export:
                 - color: 388E3C
                   calc_fnc: MIN
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.maxdisk[{#VMID}]'
                 - sortorder: '1'
                   color: 0040FF
                   calc_fnc: MIN
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.disk[{#VMID}]'
             - uuid: a9871fd798ba440a8dbba4e7cd325f53
               name: 'LXC Memory utilization % {#VMID}'
               graph_items:
                 - color: 1565C0
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.memutil[{#VMID}]'
             - uuid: a02d03993bbb446cae8abc6124d36330
               name: 'LXC Memory utilization {#VMID}'
@@ -2825,13 +2281,13 @@ zabbix_export:
                 - color: 1565C0
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.memusage[{#VMID}]'
                 - sortorder: '1'
                   color: 2E7D32
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.maxmem[{#VMID}]'
             - uuid: 42127aaa69bb44d5b018190469cc46ca
               name: 'LXC status {#VMID}'
@@ -2839,7 +2295,7 @@ zabbix_export:
                 - color: 5E35B1
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.status[{#VMID}]'
             - uuid: 53d79ba0d5cb428bb5100629359e18ad
               name: 'LXC Swap utilization {#VMID}'
@@ -2847,13 +2303,13 @@ zabbix_export:
                 - color: 1565C0
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.swap[{#VMID}]'
                 - sortorder: '1'
                   color: 2E7D32
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'lxc.maxswap[{#VMID}]'
           master_item:
             key: pve.cluster.resources.raw
@@ -2870,117 +2326,22 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - '$.data[?(@.type=="lxc")]'
-        - uuid: cdcb64618a174622909398a4c3f2d5d1
-          name: 'Discover network interfaces'
-          type: DEPENDENT
-          key: discover.network
-          delay: '0'
-          filter:
-            evaltype: AND
-            conditions:
-              - macro: '{#IFACE}'
-                value: '{$IFACE.NOT_MATCHES}'
-                operator: NOT_MATCHES_REGEX
-                formulaid: A
-              - macro: '{#IFACE_TYPE}'
-                value: '^(bridge|bond|eth|en|vlan).*'
-                formulaid: B
-          description: 'Discovers host network interfaces from /nodes/{node}/network. Filters to relevant types (bridge, bond, eth/en*, vlan) and excludes the interface names matching {$IFACE.NOT_MATCHES}, which by default drops the per-guest interfaces Proxmox creates for VMs and containers.'
-          item_prototypes:
-            - uuid: 6ab6551bf8354a489ebbc4bb8281b9cf
-              name: 'Network interface {#IFACE} active'
-              type: DEPENDENT
-              key: 'iface.active[{#IFACE}]'
-              delay: '0'
-              description: 'Active/link state of network interface {#IFACE} on the PVE host. 1 = active, 0 = inactive.'
-              valuemap:
-                name: 'Network interface active'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.iface=="{#IFACE}")].active.first()'
-                  error_handler: CUSTOM_VALUE
-                  error_handler_params: '0'
-              master_item:
-                key: pve.nodes.network.raw
-              tags:
-                - tag: PVE
-                  value: Network
-                - tag: PVE
-                  value: '{#IFACE}'
-            - uuid: 9a5222d23474453985777d17eb16a70f
-              name: 'Network interface {#IFACE} autostart'
-              type: DEPENDENT
-              key: 'iface.autostart[{#IFACE}]'
-              delay: '0'
-              description: 'Configured admin state of network interface {#IFACE}. 1 = the interface has an "auto" entry in /etc/network/interfaces and is expected to be up, 0 = not configured for automatic start. If the API does not report the field at all the item falls back to 1, so that the interface down trigger keeps working and is decided by the activity condition alone.'
-              valuemap:
-                name: 'Network interface autostart'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.iface=="{#IFACE}")].autostart.first()'
-                  error_handler: CUSTOM_VALUE
-                  error_handler_params: '0'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.nodes.network.raw
-              tags:
-                - tag: PVE
-                  value: Network
-                - tag: PVE
-                  value: '{#IFACE}'
-            - uuid: afe0f690dd654826a7fbd90e56d485c5
-              name: 'Network interface {#IFACE} type'
-              type: DEPENDENT
-              key: 'iface.type[{#IFACE}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Type/driver of network interface {#IFACE} (e.g. bridge, bond, eth). Source: /nodes/{node}/network.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.iface=="{#IFACE}")].type.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.nodes.network.raw
-              tags:
-                - tag: PVE
-                  value: Network
-                - tag: PVE
-                  value: '{#IFACE}'
-          trigger_prototypes:
-            - uuid: 9ad045fbeefa4b9db50fdae75cce9a9f
-              expression: 'last(/Template Proxmox VE REST API/iface.active[{#IFACE}])=0 and last(/Template Proxmox VE REST API/iface.autostart[{#IFACE}])=1 and max(/Template Proxmox VE REST API/iface.active[{#IFACE}],{$IFACE.ACTIVE.WINDOW})=1'
-              recovery_mode: RECOVERY_EXPRESSION
-              recovery_expression: 'last(/Template Proxmox VE REST API/iface.active[{#IFACE}])=1'
-              name: 'Network interface {#IFACE} is down on {HOST.NAME}'
-              priority: AVERAGE
-              description: 'Host network interface {#IFACE} is no longer active/up. All three conditions must hold: the interface is down, it is configured to start automatically, and it was active at least once within {$IFACE.ACTIVE.WINDOW}. Interfaces that are configured but were never actually up do not raise this trigger.'
-              manual_close: 'YES'
-          graph_prototypes:
-            - uuid: 92d3124033794ee4ada71893d6960b9c
-              name: 'Network interface {#IFACE} status'
-              graph_items:
-                - color: 1976D2
-                  calc_fnc: ALL
-                  item:
-                    host: 'Template Proxmox VE REST API'
-                    key: 'iface.active[{#IFACE}]'
-          master_item:
-            key: pve.nodes.network.raw
-          lld_macro_paths:
-            - lld_macro: '{#IFACE_TYPE}'
-              path: $.type
-            - lld_macro: '{#IFACE}'
-              path: $.iface
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+          overrides:
+            - name: 'Skip per guest detail requests'
+              step: '1'
+              filter:
+                conditions:
+                  - macro: '{#VMID}'
+                    value: '{$PVE.GUEST.DETAIL.VMID.MATCHES}'
+                    operator: NOT_MATCHES_REGEX
+                    formulaid: A
+              operations:
+                - operationobject: ITEM_PROTOTYPE
+                  operator: REGEXP
+                  value: '(Max\ swap\ of|status\ raw|Swap\ usage\ of)'
+                  discover: NO_DISCOVER
         - uuid: 83905502b5b94a61b6ec0e5811338fcb
           name: 'Discover nodes'
           type: DEPENDENT
@@ -3001,6 +2362,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.data[?(@.node=="{#NODE_NAME}")].ssl_fingerprint.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.nodes.raw
               tags:
@@ -3014,13 +2378,18 @@ zabbix_export:
               key: 'node.status[{#NODE_NAME}]'
               delay: '0'
               trends: '0'
-              description: 'Online status of cluster node {#NODE_NAME}. 1 = online, 0 = offline. Source: /nodes → data[node].status.'
+              description: 'Online status of cluster node {#NODE_NAME}. 1 = online, 0 = offline, 2 = unknown. Source: /nodes → data[node].status. The API returns the enum online, offline or unknown, so unknown is mapped instead of leaving a string that an unsigned item cannot store.'
               valuemap:
                 name: 'Node status'
               preprocessing:
                 - type: JSONPATH
                   parameters:
                     - '$.data[?(@.node=="{#NODE_NAME}")].status.first()'
+                - type: MATCHES_REGEX
+                  parameters:
+                    - ^(online|offline|unknown)$
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: unknown
                 - type: STR_REPLACE
                   parameters:
                     - online
@@ -3029,6 +2398,10 @@ zabbix_export:
                   parameters:
                     - offline
                     - '0'
+                - type: STR_REPLACE
+                  parameters:
+                    - unknown
+                    - '2'
               master_item:
                 key: pve.nodes.raw
               tags:
@@ -3038,8 +2411,11 @@ zabbix_export:
                   value: '{#NODE_NAME}'
               trigger_prototypes:
                 - uuid: e85b8277a1824f2daf365df1a8ce8de2
-                  expression: 'min(/Template Proxmox VE REST API/node.status[{#NODE_NAME}],900)=0 and {$ENABLE_NODE_STATUS_ALERT:"{#NODE_NAME}"}=1'
-                  name: 'Node status {#NODE_NAME} offline'
+                  expression: |
+                    (min(/Proxmox VE Cluster by REST API/node.status[{#NODE_NAME}],900)=0
+                    or max(/Proxmox VE Cluster by REST API/node.status[{#NODE_NAME}],900)=2)
+                    and {$ENABLE_NODE_STATUS_ALERT:"{#NODE_NAME}"}=1
+                  name: 'Node status {#NODE_NAME} not online'
                   priority: HIGH
                   description: |
                     Use the following host macros to control the "Node status" trigger for each Proxmox node:
@@ -3077,7 +2453,7 @@ zabbix_export:
                 - color: 1A7C11
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'node.status[{#NODE_NAME}]'
             - uuid: 4ba4071765ef4551b01cd57a588d8bff
               name: 'Node uptime {#NODE_NAME}'
@@ -3085,7 +2461,7 @@ zabbix_export:
                 - color: 0040FF
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'node.uptime[{#NODE_NAME}]'
           master_item:
             key: pve.nodes.raw
@@ -3096,94 +2472,8 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - '$.data[*]'
-        - uuid: 387f61cb46f74e369013f9cfe29b9868
-          name: 'Discover PVE services'
-          type: DEPENDENT
-          key: discover.pve.services
-          delay: '0'
-          filter:
-            conditions:
-              - macro: '{#SERVICE}'
-                value: '{$PVE.SERVICE.MATCHES}'
-                formulaid: A
-          description: 'Discovers the systemd units PVE manages. The default filter covers the services that must run on every node, standalone or clustered. corosync and the HA services are excluded by default because they are legitimately inactive on a standalone node.'
-          item_prototypes:
-            - uuid: b1c4f04ea721446b9e0886c5e663b7f3
-              name: 'Service active state {#SERVICE}'
-              type: DEPENDENT
-              key: 'pve.service.active_state[{#SERVICE}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Systemd ActiveState: active, inactive or failed.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.service=="{#SERVICE}")]["active-state"].first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.services.raw
-              tags:
-                - tag: PVE
-                  value: Service
-                - tag: PVE
-                  value: '{#SERVICE}'
-            - uuid: d8c668d940794d55bd3730acf2066a54
-              name: 'Service state {#SERVICE}'
-              type: DEPENDENT
-              key: 'pve.service.state[{#SERVICE}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Systemd SubState, for example running, dead or exited.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.service=="{#SERVICE}")].state.first()'
-              master_item:
-                key: pve.services.raw
-              tags:
-                - tag: PVE
-                  value: Service
-                - tag: PVE
-                  value: '{#SERVICE}'
-              trigger_prototypes:
-                - uuid: 13832b562b7b4ef8a7faa050c9e025c2
-                  expression: 'last(/Template Proxmox VE REST API/pve.service.state[{#SERVICE}])<>"running" and {$PVE.SERVICE.STATE.ALERT:"{#SERVICE}"}=1'
-                  name: 'PVE service {#SERVICE} is not running on {HOST.NAME}'
-                  priority: AVERAGE
-                  description: 'Systemd SubState of the service is no longer running. Use {$PVE.SERVICE.STATE.ALERT:"<service>"}=0 to silence a single service, and {$PVE.SERVICE.MATCHES} to control which services are discovered at all.'
-            - uuid: e5b0f194a5474cd5bd603c870316dfbc
-              name: 'Service unit state {#SERVICE}'
-              type: DEPENDENT
-              key: 'pve.service.unit_state[{#SERVICE}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Systemd UnitFileState: enabled, disabled, masked or static.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.service=="{#SERVICE}")]["unit-state"].first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.services.raw
-              tags:
-                - tag: PVE
-                  value: Service
-                - tag: PVE
-                  value: '{#SERVICE}'
-          master_item:
-            key: pve.services.raw
-          lld_macro_paths:
-            - lld_macro: '{#SERVICE}'
-              path: $.service
-            - lld_macro: '{#SVC_DESC}'
-              path: $.desc
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
         - uuid: 1745a92cd0a04b02baa97d96e61c486d
           name: 'Discover qemu'
           type: DEPENDENT
@@ -3197,6 +2487,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.balloon[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
               description: |
                 Balloon size on Proxmox host for VM {#VMID}
@@ -3204,10 +2495,13 @@ zabbix_export:
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$.data[?(@.vmid=={#VMID})].balloon.first()'
+                    - $.data.balloon
                   error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
-                key: pve.nodes.qemu.raw
+                key: 'vm.status.raw[{#VMID}]'
               tags:
                 - tag: QEMU/KVM-VMs
                   value: Memory
@@ -3220,6 +2514,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.cpuusage[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: '%'
               description: 'CPU utilization of VM {#VMID} in percent (0-100). Source: /cluster/resources -> entry with type=qemu and this vmid, field cpu.'
@@ -3242,7 +2537,7 @@ zabbix_export:
                   value: '{#VMID}'
               trigger_prototypes:
                 - uuid: e1ed112879054da082fbcaeac3de5830
-                  expression: 'min(/Template Proxmox VE REST API/vm.cpuusage[{#VMID}],300)>{$CPU_USAGE_AVERAGE:"{#VMID}"}'
+                  expression: 'min(/Proxmox VE Cluster by REST API/vm.cpuusage[{#VMID}],300)>{$CPU_USAGE_AVERAGE:"{#VMID}"}'
                   name: 'CPU usage of VM {#VMID} over {$CPU_USAGE_AVERAGE:"{#VMID}"}% for 5 minutes'
                   priority: WARNING
                   description: |
@@ -3250,9 +2545,9 @@ zabbix_export:
                     Use the context form to change it for a single guest, for example {$CPU_USAGE_AVERAGE:"{#VMID}"}=95, or set it to 100 to silence that guest.
                   dependencies:
                     - name: 'CPU usage of VM {#VMID} over {$CPU_USAGE_HIGH:"{#VMID}"}% for 5 minutes'
-                      expression: 'min(/Template Proxmox VE REST API/vm.cpuusage[{#VMID}],300)>{$CPU_USAGE_HIGH:"{#VMID}"}'
+                      expression: 'min(/Proxmox VE Cluster by REST API/vm.cpuusage[{#VMID}],300)>{$CPU_USAGE_HIGH:"{#VMID}"}'
                 - uuid: 4205c0d40f154884b9cdc12210a0d566
-                  expression: 'min(/Template Proxmox VE REST API/vm.cpuusage[{#VMID}],300)>{$CPU_USAGE_HIGH:"{#VMID}"}'
+                  expression: 'min(/Proxmox VE Cluster by REST API/vm.cpuusage[{#VMID}],300)>{$CPU_USAGE_HIGH:"{#VMID}"}'
                   name: 'CPU usage of VM {#VMID} over {$CPU_USAGE_HIGH:"{#VMID}"}% for 5 minutes'
                   priority: AVERAGE
                   description: |
@@ -3263,6 +2558,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.diskread.rate[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: Bps
               description: 'QEMU VM disk read throughput in bytes per second.'
@@ -3288,6 +2584,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.diskwrite.rate[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: Bps
               description: 'QEMU VM disk write throughput in bytes per second.'
@@ -3319,10 +2616,13 @@ zabbix_export:
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$.data[?(@.vmid=={#VMID})][''running-machine''].first()'
+                    - '$.data["running-machine"]'
                   error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
-                key: pve.nodes.qemu.raw
+                key: 'vm.status.raw[{#VMID}]'
               tags:
                 - tag: QEMU/KVM-VMs
                   value: 'Machine type'
@@ -3335,6 +2635,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.maxmem[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
               description: 'Maximum memory allocated to VM {#VMID} in bytes. Source: /cluster/resources -> entry with type=qemu and this vmid, field maxmem.'
               preprocessing:
@@ -3342,6 +2643,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.vmid=={#VMID} && @.type=="qemu")].maxmem.first()'
                   error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -3356,6 +2660,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.memusage[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
               description: 'Current memory usage of VM {#VMID} in bytes (requires QEMU guest agent or ballooning). Source: /cluster/resources -> entry with type=qemu and this vmid, field mem.'
               preprocessing:
@@ -3377,6 +2682,7 @@ zabbix_export:
               type: CALCULATED
               key: 'vm.memutil[{#VMID}]'
               delay: '60'
+              history: 7d
               value_type: FLOAT
               units: '%'
               params: 'last(/{HOST.HOST}/vm.memusage[{#VMID}]) / last(/{HOST.HOST}/vm.maxmem[{#VMID}]) * 100'
@@ -3402,6 +2708,9 @@ zabbix_export:
                     - '$.data[?(@.vmid=={#VMID} && @.type=="qemu")].name.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: '{#VM_NAME}'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -3416,6 +2725,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.netin.current[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: Bps
               description: 'Current network receive rate of VM {#VMID} in bytes/s (derived from the cumulative counter).'
@@ -3441,6 +2751,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.netin[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
               description: 'Cumulative host-level network input (bytes received) on Proxmox host for VM {#VMID}, since last VM start.'
               preprocessing:
@@ -3462,6 +2773,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.netout.current[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: Bps
               description: 'Current network transmit rate of VM {#VMID} in bytes/s (derived from the cumulative counter).'
@@ -3487,6 +2799,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.netout[{#VMID}]'
               delay: '0'
+              history: 7d
               units: Bytes
               description: 'Cumulative network bytes transmitted by VM {#VMID} since last start. Source: /cluster/resources -> entry with type=qemu and this vmid, field netout.'
               preprocessing:
@@ -3530,7 +2843,7 @@ zabbix_export:
                   value: '{#VMID}'
               trigger_prototypes:
                 - uuid: 0906752ddc0b419593430b655042ce2f
-                  expression: 'change(/Template Proxmox VE REST API/vm.node[{#VMID}])<>0'
+                  expression: 'change(/Proxmox VE Cluster by REST API/vm.node[{#VMID}])<>0'
                   name: 'VM {#VMID} has been migrated to another node'
                   priority: INFO
                   description: 'The cluster node running VM {#VMID} changed since the previous check, which indicates a migration.'
@@ -3540,6 +2853,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.size.maxdisk[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: Bytes
               description: 'Total size of the primary boot disk of VM {#VMID} in bytes. Source: /cluster/resources -> entry with type=qemu and this vmid, field maxdisk. Note: actual disk usage requires guest agent.'
@@ -3548,6 +2862,9 @@ zabbix_export:
                   parameters:
                     - '$.data[?(@.vmid=={#VMID} && @.type=="qemu")].maxdisk.first()'
                   error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -3557,11 +2874,35 @@ zabbix_export:
                   value: '{#VMID}'
                 - tag: vmid
                   value: '{#VMID}'
+            - uuid: b3f0aab825bb444bbfe35302baeed19e
+              name: 'VM {#VMID} status raw'
+              type: HTTP_AGENT
+              key: 'vm.status.raw[{#VMID}]'
+              delay: '{$PVE.GUEST.DETAIL.INTERVAL}'
+              history: '0'
+              value_type: TEXT
+              trends: '0'
+              description: 'Master item. Raw JSON from /nodes/{#NODE}/qemu/{#VMID}/status/current, addressed through the node the guest runs on, so it works for guests on every cluster node. One request per guest: the interval is {$PVE.GUEST.DETAIL.INTERVAL}, and {$PVE.GUEST.DETAIL.VMID.MATCHES} limits or switches off these requests in large clusters.'
+              timeout: 10s
+              url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{#NODE}/qemu/{#VMID}/status/current'
+              headers:
+                - name: Authorization
+                  value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+                - name: Accept
+                  value: application/json
+              tags:
+                - tag: PVE
+                  value: Raw
+                - tag: QEMU/KVM-VMs
+                  value: '{#VMID}'
+                - tag: vmid
+                  value: '{#VMID}'
             - uuid: 7a1dd24b92cb4324a8afebaf8c46db17
               name: 'VM status {#VMID}'
               type: DEPENDENT
               key: 'vm.status[{#VMID}]'
               delay: '0'
+              history: 7d
               description: 'Runtime status of VM {#VMID}. 0 = stopped, 1 = running, 2 = paused. Source: /cluster/resources -> entry with type=qemu and this vmid, field status.'
               valuemap:
                 name: 'VM  and LXC status'
@@ -3597,7 +2938,12 @@ zabbix_export:
                   value: '{#VMID}'
               trigger_prototypes:
                 - uuid: ac085aa97edb40dcb08272e859a39e36
-                  expression: 'max(/Template Proxmox VE REST API/vm.status[{#VMID}],900)=0 and {$ENABLE_VM_STOP_ALERT:"{#VMID}"}=1 and max(/Template Proxmox VE REST API/vm.status[{#VMID}],24h)=1'
+                  expression: |
+                    max(/Proxmox VE Cluster by REST API/vm.status[{#VMID}],900)=0
+                    and {$ENABLE_VM_STOP_ALERT:"{#VMID}"}=1
+                    and count(/Proxmox VE Cluster by REST API/vm.status[{#VMID}],24h,"eq","1")>0
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/Proxmox VE Cluster by REST API/vm.status[{#VMID}])=1'
                   name: 'VM {#VMID} status is stopped'
                   priority: HIGH
                   description: |
@@ -3610,6 +2956,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.uptime[{#VMID}]'
               delay: '0'
+              history: 7d
               value_type: FLOAT
               units: s
               description: 'Uptime of VM {#VMID} in seconds since last start. Source: /cluster/resources -> entry with type=qemu and this vmid, field uptime.'
@@ -3632,6 +2979,7 @@ zabbix_export:
               type: DEPENDENT
               key: 'vm.vcpu[{#VMID}]'
               delay: '0'
+              history: 7d
               description: 'Number of vCPUs assigned to VM {#VMID}. Source: /cluster/resources -> entry with type=qemu and this vmid, field cpus.'
               preprocessing:
                 - type: JSONPATH
@@ -3644,6 +2992,9 @@ zabbix_export:
                 - type: RTRIM
                   parameters:
                     - '"]'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.cluster.resources.raw
               tags:
@@ -3655,7 +3006,7 @@ zabbix_export:
                   value: '{#VMID}'
           trigger_prototypes:
             - uuid: 4b7ca0a0681a43a4a10eb0647292cc90
-              expression: 'last(/Template Proxmox VE REST API/vm.status[{#VMID}])=1 and last(/Template Proxmox VE REST API/vm.uptime[{#VMID}])<600'
+              expression: 'last(/Proxmox VE Cluster by REST API/vm.status[{#VMID}])=1 and last(/Proxmox VE Cluster by REST API/vm.uptime[{#VMID}])<600'
               name: 'VM {#VMID} has been restarted (uptime < 10 min)'
               priority: INFO
               description: 'VM was recently started or restarted.'
@@ -3667,7 +3018,7 @@ zabbix_export:
                 - color: 0D47A1
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'vm.cpuusage[{#VMID}]'
             - uuid: a9fbf2a1b5554bbf81e0b11d2b5ac957
               name: 'VM Cumulative network input/output, since {#VMID} start'
@@ -3675,13 +3026,13 @@ zabbix_export:
                 - color: 1A7C11
                   calc_fnc: MAX
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'vm.netin[{#VMID}]'
                 - sortorder: '1'
                   color: '274482'
                   calc_fnc: MAX
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'vm.netout[{#VMID}]'
             - uuid: 9a01fe6c5b9b43c3bf5287caa9453e47
               name: 'VM Current network input/output {#VMID}'
@@ -3689,32 +3040,32 @@ zabbix_export:
                 - color: 1A7C11
                   calc_fnc: MAX
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'vm.netin.current[{#VMID}]'
                 - sortorder: '1'
                   color: '274482'
                   calc_fnc: MAX
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'vm.netout.current[{#VMID}]'
             - uuid: a04ab78377214299bb04b20f8e41e0a1
               name: 'VM Disk I/O rate {#VMID}'
               graph_items:
                 - color: E65100
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'vm.diskread.rate[{#VMID}]'
                 - sortorder: '1'
                   color: 1565C0
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'vm.diskwrite.rate[{#VMID}]'
             - uuid: 28cab029b5e44a8f996321a5ac97c1ce
               name: 'VM Memory utilization % {#VMID}'
               graph_items:
                 - color: 1565C0
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'vm.memutil[{#VMID}]'
             - uuid: 4a78e07a7bf04c50b779ed61e65c39d8
               name: 'VM Memory utilization {#VMID}'
@@ -3722,13 +3073,13 @@ zabbix_export:
                 - color: 1565C0
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'vm.memusage[{#VMID}]'
                 - sortorder: '1'
                   color: 2E7D32
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'vm.maxmem[{#VMID}]'
             - uuid: 23fbf7d228b544d58f95ccb0cd8230f5
               name: 'VM status {#VMID}'
@@ -3736,7 +3087,7 @@ zabbix_export:
                 - color: 5E35B1
                   calc_fnc: ALL
                   item:
-                    host: 'Template Proxmox VE REST API'
+                    host: 'Proxmox VE Cluster by REST API'
                     key: 'vm.status[{#VMID}]'
           master_item:
             key: pve.cluster.resources.raw
@@ -3753,559 +3104,78 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - '$.data[?(@.type=="qemu")]'
-        - uuid: fb81ff142f814e40b1b0f850dd5280e6
-          name: 'Discover replication jobs'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+          overrides:
+            - name: 'Skip per guest detail requests'
+              step: '1'
+              filter:
+                conditions:
+                  - macro: '{#VMID}'
+                    value: '{$PVE.GUEST.DETAIL.VMID.MATCHES}'
+                    operator: NOT_MATCHES_REGEX
+                    formulaid: A
+              operations:
+                - operationobject: ITEM_PROTOTYPE
+                  operator: REGEXP
+                  value: '(status\ raw|Balloon\ memory|Machine\ type\ of)'
+                  discover: NO_DISCOVER
+        - uuid: 66e47c9a611949818be58f7cbb1a2164
+          name: 'Discover SDN zones'
           type: DEPENDENT
-          key: discover.replication
-          delay: '0'
-          description: 'Discovers ZFS replication jobs. The list endpoint already carries the job state, so no extra request per job is required. Yields nothing on nodes without replication.'
-          item_prototypes:
-            - uuid: e7d91ba232e8415d9e262e3fd052a184
-              name: 'Replication duration {#REPL_ID}'
-              type: DEPENDENT
-              key: 'repl.duration[{#REPL_ID}]'
-              delay: '0'
-              value_type: FLOAT
-              units: s
-              description: 'Duration of the last run in seconds.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.id=="{#REPL_ID}")].duration.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.replication.raw
-              tags:
-                - tag: PVE
-                  value: Replication
-                - tag: PVE
-                  value: '{#REPL_ID}'
-            - uuid: ce87dde3040a4b73ae078022a2a81cea
-              name: 'Replication error {#REPL_ID}'
-              type: DEPENDENT
-              key: 'repl.error[{#REPL_ID}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Error message of the last failed run. Absent while the job is healthy, the value is then discarded instead of turning the item unsupported.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.id=="{#REPL_ID}")].error.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.replication.raw
-              tags:
-                - tag: PVE
-                  value: Replication
-                - tag: PVE
-                  value: '{#REPL_ID}'
-            - uuid: 9ea05f2ef30b49c783cfb5f5516c2a3e
-              name: 'Replication fail count {#REPL_ID}'
-              type: DEPENDENT
-              key: 'repl.fail_count[{#REPL_ID}]'
-              delay: '0'
-              value_type: FLOAT
-              description: 'Consecutive failures of this job. Absent before the first run.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.id=="{#REPL_ID}")].fail_count.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.replication.raw
-              tags:
-                - tag: PVE
-                  value: Replication
-                - tag: PVE
-                  value: '{#REPL_ID}'
-              trigger_prototypes:
-                - uuid: 9d0695a301e54a4dbb9590dd62e79a37
-                  expression: 'last(/Template Proxmox VE REST API/repl.fail_count[{#REPL_ID}])>{$PVE.REPL.FAIL.MAX}'
-                  name: 'Replication job {#REPL_ID} failing on {HOST.NAME}'
-                  event_name: 'Replication job {#REPL_ID} failing: {?last(//repl.error[{#REPL_ID}])}'
-                  priority: AVERAGE
-                  description: 'PVE counts consecutive failures of this replication job. The event name carries the error message PVE reported for the last run.'
-            - uuid: 40786cb4039d42c8bc5703ca03635c1e
-              name: 'Replication last sync {#REPL_ID}'
-              type: DEPENDENT
-              key: 'repl.last_sync[{#REPL_ID}]'
-              delay: '0'
-              value_type: FLOAT
-              trends: '0'
-              units: unixtime
-              description: 'Timestamp of the last successful sync. Absent before the first successful run.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.id=="{#REPL_ID}")].last_sync.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.replication.raw
-              tags:
-                - tag: PVE
-                  value: Replication
-                - tag: PVE
-                  value: '{#REPL_ID}'
-              trigger_prototypes:
-                - uuid: 19f563e0e5ff48de8c738f2c1ca160c0
-                  expression: 'fuzzytime(/Template Proxmox VE REST API/repl.last_sync[{#REPL_ID}],{$PVE.REPL.LAG})=0'
-                  name: 'Replication job {#REPL_ID} has not synced for {$PVE.REPL.LAG}'
-                  priority: WARNING
-                  description: 'Last successful sync is older than {$PVE.REPL.LAG}. Raise the macro for jobs with a wide schedule, it must stay above the replication interval.'
-            - uuid: 3021e56037464324a99f53e163a34b53
-              name: 'Replication last try {#REPL_ID}'
-              type: DEPENDENT
-              key: 'repl.last_try[{#REPL_ID}]'
-              delay: '0'
-              value_type: FLOAT
-              trends: '0'
-              units: unixtime
-              description: 'Timestamp of the last attempt, successful or not.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.id=="{#REPL_ID}")].last_try.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.replication.raw
-              tags:
-                - tag: PVE
-                  value: Replication
-                - tag: PVE
-                  value: '{#REPL_ID}'
-          master_item:
-            key: pve.replication.raw
-          lld_macro_paths:
-            - lld_macro: '{#REPL_GUEST}'
-              path: $.guest
-            - lld_macro: '{#REPL_ID}'
-              path: $.id
-            - lld_macro: '{#REPL_TARGET}'
-              path: $.target
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
-        - uuid: 14efa82386b54af18a8e26377422dd57
-          name: 'Discover storage'
-          type: DEPENDENT
-          key: discover.storage
+          key: discover.sdn
           delay: '0'
           enabled_lifetime_type: DISABLE_AFTER
-          enabled_lifetime: 2d
+          enabled_lifetime: 1d
+          description: 'Discovers the SDN entries (zones and, from PVE 9, fabrics) per node from the type=network entries of /cluster/resources. PVE 8 lists them as type=sdn, which this rule does not cover.'
           item_prototypes:
-            - uuid: 07551137b00f485bbbe712b675cf2b75
-              name: 'Storage active status {#STORAGE_NAME}'
+            - uuid: 2320714ee3674baf98f9f80241f71ae7
+              name: 'SDN {#SDN_TYPE} {#SDN} on {#NODE}: status'
               type: DEPENDENT
-              key: 'storage.active[{#STORAGE_NAME}]'
+              key: 'sdn.status[{#SDN_ID}]'
               delay: '0'
-              description: 'Availability status of storage pool {#STORAGE_NAME}. 1 = active/available, 0 = inactive/not mounted.'
-              valuemap:
-                name: 'Storage active status'
+              value_type: CHAR
+              trends: '0'
+              description: 'Status of SDN {#SDN_TYPE} {#SDN} on node {#NODE} as reported by pvestatd, for example ok, pending or error.'
               preprocessing:
                 - type: JSONPATH
                   parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].active.first()'
+                    - '$.data[?(@.id=="{#SDN_ID}")].status.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
-                key: pve.storage.raw
+                key: pve.cluster.resources.raw
               tags:
                 - tag: PVE
-                  value: Storage
+                  value: SDN
                 - tag: PVE
-                  value: '{#STORAGE_NAME}'
+                  value: '{#NODE}'
               trigger_prototypes:
-                - uuid: cf31e839babb4b8a90b395ad3df47023
-                  expression: 'min(/Template Proxmox VE REST API/storage.active[{#STORAGE_NAME}],900)=0 and {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=1'
-                  name: 'Storage [{#STORAGE_NAME}] not available'
-                  priority: AVERAGE
-                  description: |
-                    Use the following host macros to control the "Storage not available" trigger for each storage:
-                    {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=1 enables the "Storage not available" trigger
-                    {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=0 disables (suppresses) the "Storage not available" trigger
-            - uuid: 8e1de775d9524b27b37ad414ce961d9b
-              name: 'Storage available {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.avail[{#STORAGE_NAME}]'
-              delay: '0'
-              units: Bytes
-              description: 'Free space available on storage pool {#STORAGE_NAME} in bytes. Source: /nodes/{node}/storage.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].avail.first()'
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-            - uuid: 7f8d7a2cbdab48f097d46c92b870bb1b
-              name: 'Storage content {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.content[{#STORAGE_NAME}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Content types supported by storage pool {#STORAGE_NAME} (e.g. images,backup,iso). Source: /nodes/{node}/storage → data[storage].content.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].content.first()'
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-            - uuid: 4f6028533a65470ca71894fdfd256d20
-              name: 'Storage type {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.name[{#STORAGE_NAME}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Storage backend type/driver of {#STORAGE_NAME} (e.g. dir, zfspool, lvm, nfs). Source: /nodes/{node}/storage → data[storage].type.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].type.first()'
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-            - uuid: 37b0fd0f4af0451c9b4b6bae31ed0ab2
-              name: 'Storage shared status {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.shared[{#STORAGE_NAME}]'
-              delay: '0'
-              trends: '0'
-              description: 'Indicates whether the storage {#STORAGE_NAME} is shared across the cluster (Shared = 1) or available only locally (Not Shared = 0).'
-              valuemap:
-                name: 'Storage shared status'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].shared.first()'
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-            - uuid: 1d760dcaa1124491a918f1b73f20c6d3
-              name: 'Storage total {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.size[{#STORAGE_NAME}]'
-              delay: '0'
-              units: Bytes
-              description: 'Total capacity of storage pool {#STORAGE_NAME} in bytes. Source: /nodes/{node}/storage.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].total.first()'
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-            - uuid: 68f65c17913043368ffbe2db02887a10
-              name: 'Storage used {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.used[{#STORAGE_NAME}]'
-              delay: '0'
-              units: Bytes
-              description: 'Used space on storage pool {#STORAGE_NAME} in bytes. Source: /nodes/{node}/storage.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].used.first()'
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-            - uuid: 4f1446c1a3f1407b8b796e47b9208321
-              name: 'Storage utilization {#STORAGE_NAME} (%)'
-              type: CALCULATED
-              key: 'storage.util[{#STORAGE_NAME}]'
-              delay: '60'
-              value_type: FLOAT
-              units: '%'
-              params: 'last(/{HOST.HOST}/storage.used[{#STORAGE_NAME}]) / last(/{HOST.HOST}/storage.size[{#STORAGE_NAME}]) * 100'
-              description: 'Storage utilization as percentage of total size.'
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-              trigger_prototypes:
-                - uuid: 2b032af2b5d54593a4f5910d6ae3f912
-                  expression: 'last(/Template Proxmox VE REST API/storage.util[{#STORAGE_NAME}]) > {$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"} and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
-                  name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} >{$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"}%)'
-                  opdata: 'Used: {ITEM.LASTVALUE1}'
-                  priority: HIGH
-                  description: |
-                    Storage utilization exceeded the critical threshold {$STORAGE.UTIL.CRIT}%.
-                    Use context macro {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=0 to suppress.
-                - uuid: 3827182fb0fe498d8e4c09401168d998
-                  expression: 'last(/Template Proxmox VE REST API/storage.util[{#STORAGE_NAME}]) > {$STORAGE.UTIL.WARN:"{#STORAGE_NAME}"} and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
-                  name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} >{$STORAGE.UTIL.WARN:"{#STORAGE_NAME}"}%)'
-                  opdata: 'Used: {ITEM.LASTVALUE1}'
-                  priority: AVERAGE
-                  description: |
-                    Storage utilization exceeded the warning threshold {$STORAGE.UTIL.WARN}%.
-                    Use context macro {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=0 to suppress.
-                  dependencies:
-                    - name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} >{$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"}%)'
-                      expression: 'last(/Template Proxmox VE REST API/storage.util[{#STORAGE_NAME}]) > {$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"} and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
-          graph_prototypes:
-            - uuid: e49e5464b78446aabd4313abefda14c1
-              name: 'Storage active state {#STORAGE_NAME}'
-              graph_items:
-                - color: 00FF00
-                  calc_fnc: ALL
-                  item:
-                    host: 'Template Proxmox VE REST API'
-                    key: 'storage.active[{#STORAGE_NAME}]'
-            - uuid: b5e6a1f14c5b4752a18926ed9a269f9f
-              name: 'Storage usage {#STORAGE_NAME}'
-              yaxismax: '0'
-              show_work_period: 'NO'
-              show_triggers: 'NO'
-              type: EXPLODED
-              graph_items:
-                - color: 0040FF
-                  calc_fnc: LAST
-                  item:
-                    host: 'Template Proxmox VE REST API'
-                    key: 'storage.used[{#STORAGE_NAME}]'
-                - sortorder: '1'
-                  color: 388E3C
-                  calc_fnc: LAST
-                  item:
-                    host: 'Template Proxmox VE REST API'
-                    key: 'storage.avail[{#STORAGE_NAME}]'
-            - uuid: dc57dfa3ca394ee38c6fe9b13804d1b8
-              name: 'Storage utilization % {#STORAGE_NAME}'
-              graph_items:
-                - color: E53935
-                  item:
-                    host: 'Template Proxmox VE REST API'
-                    key: 'storage.util[{#STORAGE_NAME}]'
+                - uuid: 99bc5f68eaf342f0949adc5e5763e731
+                  expression: 'last(/Proxmox VE Cluster by REST API/sdn.status[{#SDN_ID}])="error"'
+                  name: 'SDN {#SDN_TYPE} {#SDN} on {#NODE} is in error state'
+                  priority: WARNING
+                  description: 'The SDN configuration could not be applied on {#NODE}. Guests attached to it may have no network. Check Datacenter > SDN and the node syslog.'
+                  manual_close: 'YES'
           master_item:
-            key: pve.storage.raw
+            key: pve.cluster.resources.raw
           lld_macro_paths:
-            - lld_macro: '{#STORAGE_NAME}'
-              path: $.storage
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
-        - uuid: eb63de9ec0e6489e9da820ee39cd1f00
-          name: 'Discover tasks'
-          type: DEPENDENT
-          key: discover.tasks
-          delay: '0'
-          filter:
-            conditions:
-              - macro: '{#TYPE}'
-                value: '.*\bvzdump\b.*'
-                operator: NOT_MATCHES_REGEX
-                formulaid: A
-          lifetime_type: DELETE_IMMEDIATELY
-          lifetime: '0'
-          item_prototypes:
-            - uuid: be929b6a65ab46109a509d6f96b2348b
-              name: 'Task endtime {#TYPE} {#ID}'
-              type: DEPENDENT
-              key: 'task.endtime[{#GRPID},{#TYPE}]'
-              delay: '0'
-              trends: '0'
-              units: unixtime
-              description: 'Unix timestamp of the last end time for task type {#TYPE} on VM/CT {#GRPID}. Source: pve.tasks.raw.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].endtime.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.tasks.raw
-              tags:
-                - tag: PVE
-                  value: Tasks
-                - tag: vmid
-                  value: '{#GRPID}'
-            - uuid: 5dda8b03514e474cbe5879096a17c133
-              name: 'Task message {#TYPE} {#ID}'
-              type: DEPENDENT
-              key: 'task.message[{#GRPID},{#TYPE}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Status text of the last task of type {#TYPE} for VM/CT {#GRPID}, exactly as Proxmox VE reports it. A successful task reports OK, a failed one reports the error message itself. The numeric item Task Status maps only a fixed set of known texts, so this item carries the real cause of a failure.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].status.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.tasks.raw
-              tags:
-                - tag: PVE
-                  value: Tasks
-                - tag: vmid
-                  value: '{#GRPID}'
-            - uuid: 1b938d0bb1b542e281b2d554d24225b4
-              name: 'Task starttime {#TYPE} {#ID}'
-              type: DEPENDENT
-              key: 'task.starttime[{#GRPID},{#TYPE}]'
-              delay: '0'
-              trends: '0'
-              units: unixtime
-              description: 'Unix timestamp of the last start time for task type {#TYPE} on VM/CT {#GRPID}. Source: pve.tasks.raw.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].starttime.first()'
-                  error_handler: DISCARD_VALUE
-                - type: LTRIM
-                  parameters:
-                    - '["'
-                - type: RTRIM
-                  parameters:
-                    - '"]'
-              master_item:
-                key: pve.tasks.raw
-              tags:
-                - tag: PVE
-                  value: Tasks
-                - tag: vmid
-                  value: '{#GRPID}'
-            - uuid: 07fbf01babe4452487bcc8fa7de63d1e
-              name: 'Task Status: {#TYPE} {#ID}'
-              type: DEPENDENT
-              key: 'task.status[{#GRPID},{#TYPE}]'
-              delay: '0'
-              trends: '0'
-              description: |
-                0. OK: All clear, no errors detected.
-                1. running: VM/CT is currently active.
-                2. stopped: VM/CT has been shut down.
-                3. error: General execution failure; check logs for details.
-                4. unexpected status: Returned state not anticipated by the script/API.
-                5. CT locked (disk): Container's disk is locked (e.g. during backup or migration).
-                6. timeout waiting on system: Operation exceeded its time limit and was aborted.
-                7. Failed to run vncproxy.: Unable to start the VNC proxy process.
-                8. unable to read tail (got 0 b): Failed to read log tail; zero bytes returned.
-                9. interrupted by signal: Process was terminated by a signal (e.g. SIGINT/SIGTERM).
-                10. unknown error: Cannot classify status, please check Proxmox for details
-              valuemap:
-                name: 'Tasks status'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].status.first()'
-                  error_handler: DISCARD_VALUE
-                - type: REGEX
-                  parameters:
-                    - '^(OK|running|stopped|error|unexpected status|CT is locked \(disk\)|timeout waiting on systemd|Failed to run vncproxy\.|unable to read tail \(got 0 bytes\)|interrupted by signal)$'
-                    - \0
-                  error_handler: CUSTOM_VALUE
-                  error_handler_params: '10'
-                - type: STR_REPLACE
-                  parameters:
-                    - OK
-                    - '0'
-                - type: STR_REPLACE
-                  parameters:
-                    - running
-                    - '1'
-                - type: STR_REPLACE
-                  parameters:
-                    - stopped
-                    - '2'
-                - type: STR_REPLACE
-                  parameters:
-                    - error
-                    - '3'
-                - type: STR_REPLACE
-                  parameters:
-                    - 'unexpected status'
-                    - '4'
-                - type: STR_REPLACE
-                  parameters:
-                    - 'CT is locked (disk)'
-                    - '5'
-                - type: STR_REPLACE
-                  parameters:
-                    - 'timeout waiting on systemd'
-                    - '6'
-                - type: STR_REPLACE
-                  parameters:
-                    - 'Failed to run vncproxy.'
-                    - '7'
-                - type: STR_REPLACE
-                  parameters:
-                    - 'unable to read tail (got 0 bytes)'
-                    - '8'
-                - type: STR_REPLACE
-                  parameters:
-                    - 'interrupted by signal'
-                    - '9'
-              master_item:
-                key: pve.tasks.raw
-              tags:
-                - tag: PVE
-                  value: Tasks
-                - tag: vmid
-                  value: '{#GRPID}'
-          trigger_prototypes:
-            - uuid: 19e5d067d25941169192a9ff6461b787
-              expression: 'last(/Template Proxmox VE REST API/task.status[{#GRPID},{#TYPE}])>1 and {$ENABLE_TASK_ALERT:"{#GRPID}"}=1 and fuzzytime(/Template Proxmox VE REST API/task.endtime[{#GRPID},{#TYPE}],{$TASK.ALERT.WINDOW})=1'
-              name: 'Proxmox task {#TYPE} {#ID} failed'
-              event_name: 'Proxmox task {#TYPE} {#ID} failed: {ITEM.VALUE}'
-              opdata: 'Current task status: {ITEM.LASTVALUE}'
-              priority: WARNING
-              description: |
-                A task of type {#TYPE} for VM/CT {#ID} finished with a status other than OK.
-                The problem clears as soon as a later task of the same id and type succeeds, and it expires on its own once the failure is older than {$TASK.ALERT.WINDOW}, because Proxmox VE only keeps the most recent tasks in its task list.
-                Use context macro to suppress per-task:
-                {$ENABLE_TASK_ALERT:"{#GRPID}"}=0 suppresses this trigger for a specific task.
-                {$ENABLE_TASK_ALERT}=0 disables all task failure alerts globally.
-              manual_close: 'YES'
-          graph_prototypes:
-            - uuid: 3d3673ff518e45a2979ecfbb6aa8b5e6
-              name: 'Task status {#TYPE} {#ID}'
-              graph_items:
-                - color: 00897B
-                  calc_fnc: ALL
-                  item:
-                    host: 'Template Proxmox VE REST API'
-                    key: 'task.status[{#GRPID},{#TYPE}]'
-          master_item:
-            key: pve.tasks.raw
-          lld_macro_paths:
-            - lld_macro: '{#GRPID}'
-              path: $.grpid
-            - lld_macro: '{#ID}'
+            - lld_macro: '{#NODE}'
+              path: $.node
+            - lld_macro: '{#SDN_ID}'
               path: $.id
-            - lld_macro: '{#TYPE}'
-              path: $.type
+            - lld_macro: '{#SDN_TYPE}'
+              path: '$[''network-type'']'
+            - lld_macro: '{#SDN}'
+              path: $.network
           preprocessing:
             - type: JSONPATH
               parameters:
-                - '$.body.data[*]'
+                - '$.data[?(@.type=="network")]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
         - uuid: c16a8fe279a84b10bc7f06f3ab2bca76
           name: 'Discover users'
           type: DEPENDENT
@@ -4328,6 +3198,9 @@ zabbix_export:
                     - '$.body.data[?(@.userid==''{#USERID}'')].email.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: 'No email address available.'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.user.raw
               tags:
@@ -4340,12 +3213,16 @@ zabbix_export:
               type: DEPENDENT
               key: 'user.expiration[{#USERID}]'
               delay: '0'
+              history: 7d
               units: unixtime
               description: 'Account expiration date/time for PVE user {#USERID} as Unix timestamp. 0 = never expires. Source: /access/users → data[userid].expire.'
               preprocessing:
                 - type: JSONPATH
                   parameters:
                     - '$.body.data[?(@.userid==''{#USERID}'')].expire.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.user.raw
               tags:
@@ -4355,7 +3232,7 @@ zabbix_export:
                   value: '{#USERID}'
               trigger_prototypes:
                 - uuid: 749e797e101a40abb81a572dcd08bc06
-                  expression: 'last(/Template Proxmox VE REST API/user.expiration[{#USERID}])>0 and last(/Template Proxmox VE REST API/user.expiration[{#USERID}])-now()<{$PVE.USER.EXPIRE.TIME:"{#USERID}"}'
+                  expression: 'last(/Proxmox VE Cluster by REST API/user.expiration[{#USERID}])>0 and last(/Proxmox VE Cluster by REST API/user.expiration[{#USERID}])-now()<{$PVE.USER.EXPIRE.TIME:"{#USERID}"}'
                   name: 'User {#USERID} account expires soon on {HOST.NAME}'
                   priority: WARNING
                   description: |
@@ -4376,6 +3253,9 @@ zabbix_export:
                     - '$.body.data[?(@.userid==''{#USERID}'')].firstname.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: 'No first name available.'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.user.raw
               tags:
@@ -4397,6 +3277,9 @@ zabbix_export:
                     - '$.body.data[?(@.userid==''{#USERID}'')].lastname.first()'
                   error_handler: CUSTOM_VALUE
                   error_handler_params: 'No last name available.'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.user.raw
               tags:
@@ -4416,6 +3299,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.body.data[?(@.userid==''{#USERID}'')][''realm-type''].first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.user.raw
               tags:
@@ -4436,6 +3322,9 @@ zabbix_export:
                 - type: JSONPATH
                   parameters:
                     - '$.body.data[?(@.userid==''{#USERID}'')].enable.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
               master_item:
                 key: pve.user.raw
               tags:
@@ -4452,214 +3341,42 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - '$.body.data[*]'
-        - uuid: 92df286f4a31496c887b1992534efb2c
-          name: 'Discover ZFS pools'
-          type: DEPENDENT
-          key: discover.zfs.pools
-          delay: '0'
-          description: 'Discovers local ZFS pools. Yields nothing on nodes without ZFS. The master item needs Sys.Audit on / and turns unsupported with HTTP 403 otherwise.'
-          item_prototypes:
-            - uuid: f29490ff777948a2a8dbca4014d8fbfd
-              name: 'ZFS pool allocated {#ZPOOL}'
-              type: DEPENDENT
-              key: 'zfs.alloc[{#ZPOOL}]'
-              delay: '0'
-              value_type: FLOAT
-              units: Bytes
-              description: 'Allocated bytes in the pool.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.name=="{#ZPOOL}")].alloc.first()'
-              master_item:
-                key: pve.zfs.raw
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-            - uuid: 2167f0fa32e24ac9803b5aa3cd346bbe
-              name: 'ZFS pool dedup ratio {#ZPOOL}'
-              type: DEPENDENT
-              key: 'zfs.dedup[{#ZPOOL}]'
-              delay: '0'
-              value_type: FLOAT
-              trends: '0'
-              description: 'Deduplication ratio, 1.0 when dedup is off.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.name=="{#ZPOOL}")].dedup.first()'
-              master_item:
-                key: pve.zfs.raw
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-            - uuid: 673b04f727fa43ddaec262e4b73edb20
-              name: 'ZFS pool fragmentation {#ZPOOL}'
-              type: DEPENDENT
-              key: 'zfs.frag[{#ZPOOL}]'
-              delay: '0'
-              value_type: FLOAT
-              units: '%'
-              description: 'Free space fragmentation in percent.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.name=="{#ZPOOL}")].frag.first()'
-              master_item:
-                key: pve.zfs.raw
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-            - uuid: 65fb9ba3975e4f7bb54ff6991aa9a2b2
-              name: 'ZFS pool free {#ZPOOL}'
-              type: DEPENDENT
-              key: 'zfs.free[{#ZPOOL}]'
-              delay: '0'
-              value_type: FLOAT
-              units: Bytes
-              description: 'Free bytes in the pool.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.name=="{#ZPOOL}")].free.first()'
-              master_item:
-                key: pve.zfs.raw
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-            - uuid: 9dbc38322f79490b8e0e76c7c015ddbb
-              name: 'ZFS pool health {#ZPOOL}'
-              type: DEPENDENT
-              key: 'zfs.health[{#ZPOOL}]'
-              delay: '0'
-              description: 'zpool health as a number so it can be graphed and used on a dashboard. 0 is ONLINE, everything above is a fault. The value map turns it back into the zpool wording.'
-              valuemap:
-                name: 'ZFS pool health'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.name=="{#ZPOOL}")].health.first()'
-                - type: STR_REPLACE
-                  parameters:
-                    - ONLINE
-                    - '0'
-                - type: STR_REPLACE
-                  parameters:
-                    - DEGRADED
-                    - '1'
-                - type: STR_REPLACE
-                  parameters:
-                    - FAULTED
-                    - '2'
-                - type: STR_REPLACE
-                  parameters:
-                    - OFFLINE
-                    - '3'
-                - type: STR_REPLACE
-                  parameters:
-                    - REMOVED
-                    - '4'
-                - type: STR_REPLACE
-                  parameters:
-                    - UNAVAIL
-                    - '5'
-                - type: STR_REPLACE
-                  parameters:
-                    - SUSPENDED
-                    - '6'
-              master_item:
-                key: pve.zfs.raw
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-              trigger_prototypes:
-                - uuid: 8b079af5e75b46a8a6e974087ca2f097
-                  expression: 'last(/Template Proxmox VE REST API/zfs.health[{#ZPOOL}])=1'
-                  name: 'ZFS pool {#ZPOOL} is DEGRADED on {HOST.NAME}'
-                  priority: AVERAGE
-                  description: 'The pool still serves data but has lost redundancy, so a second failure means data loss. Check /nodes/{node}/disks/zfs/{pool} for the failing vdev, the detail endpoint reports read, write and checksum errors per device.'
-                - uuid: d65a4e365c134cea9cf48cfca9c173dc
-                  expression: 'last(/Template Proxmox VE REST API/zfs.health[{#ZPOOL}])>=2'
-                  name: 'ZFS pool {#ZPOOL} is not usable on {HOST.NAME}'
-                  event_name: 'ZFS pool {#ZPOOL} is {ITEM.VALUE1} on {HOST.NAME}'
-                  priority: HIGH
-                  description: 'The pool is FAULTED, OFFLINE, REMOVED, UNAVAIL or SUSPENDED, so it no longer serves data. DEGRADED is reported separately at a lower severity because the pool keeps running. Check /nodes/{node}/disks/zfs/{pool} for the failing vdev, the detail endpoint reports read, write and checksum errors per device.'
-            - uuid: 60c15d2ea06e465897ef285127da047c
-              name: 'ZFS pool size {#ZPOOL}'
-              type: DEPENDENT
-              key: 'zfs.size[{#ZPOOL}]'
-              delay: '0'
-              value_type: FLOAT
-              units: Bytes
-              description: 'Total pool size in bytes.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.name=="{#ZPOOL}")].size.first()'
-              master_item:
-                key: pve.zfs.raw
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-            - uuid: 609a0e36820844edb94bfd9d3d8d6ff6
-              name: 'ZFS pool utilization {#ZPOOL}'
-              type: CALCULATED
-              key: 'zfs.util[{#ZPOOL}]'
-              delay: '300'
-              value_type: FLOAT
-              units: '%'
-              params: '100*last(//zfs.alloc[{#ZPOOL}])/last(//zfs.size[{#ZPOOL}])'
-              description: 'Allocated share of the pool. Calculated from alloc and size, PVE does not report a percentage.'
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-              trigger_prototypes:
-                - uuid: 21550648e49a43e6ae6580a431bf048f
-                  expression: 'last(/Template Proxmox VE REST API/zfs.util[{#ZPOOL}])>{$ZFS.UTIL.CRIT:"{#ZPOOL}"}'
-                  name: 'ZFS pool {#ZPOOL} usage above {$ZFS.UTIL.CRIT:"{#ZPOOL}"}% on {HOST.NAME}'
-                  priority: HIGH
-                  description: 'ZFS performance degrades sharply once a pool fills up. Keep pools below 80%.'
-                - uuid: 875ee85867384cefac96493b00c8559e
-                  expression: 'last(/Template Proxmox VE REST API/zfs.util[{#ZPOOL}])>{$ZFS.UTIL.WARN:"{#ZPOOL}"}'
-                  name: 'ZFS pool {#ZPOOL} usage above {$ZFS.UTIL.WARN:"{#ZPOOL}"}% on {HOST.NAME}'
-                  priority: AVERAGE
-                  description: 'ZFS performance degrades sharply once a pool fills up. Keep pools below 80%.'
-                  dependencies:
-                    - name: 'ZFS pool {#ZPOOL} usage above {$ZFS.UTIL.CRIT:"{#ZPOOL}"}% on {HOST.NAME}'
-                      expression: 'last(/Template Proxmox VE REST API/zfs.util[{#ZPOOL}])>{$ZFS.UTIL.CRIT:"{#ZPOOL}"}'
-          trigger_prototypes:
-            - uuid: ed2b6ba1d4cb4b029e7b75c0ff414ea0
-              expression: 'last(/Template Proxmox VE REST API/zfs.frag[{#ZPOOL}])>{$ZFS.FRAG.WARN:"{#ZPOOL}"} and last(/Template Proxmox VE REST API/zfs.util[{#ZPOOL}])>{$ZFS.FRAG.UTIL.MIN:"{#ZPOOL}"}'
-              name: 'ZFS pool {#ZPOOL} free space is fragmented on {HOST.NAME}'
-              priority: WARNING
-              description: 'Fragmentation describes the free space, not the stored data, so on its own it costs nothing. It starts to hurt once the pool is also fairly full, because the allocator then has to satisfy writes from ever smaller free segments. The trigger therefore requires both {$ZFS.FRAG.WARN} and {$ZFS.FRAG.UTIL.MIN} to be exceeded. Freeing space and removing old snapshots helps, defragmenting a zpool is not possible.'
-          master_item:
-            key: pve.zfs.raw
-          lld_macro_paths:
-            - lld_macro: '{#ZPOOL}'
-              path: $.name
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
       macros:
-        - macro: '{$BACKUP.ALERT.WINDOW}'
-          value: 24h
-          description: 'How long a failed backup keeps alerting. The problem clears earlier if a later backup of the same guest succeeds. The value must include a time unit, for example 24h or 2d.'
+        - macro: '{$CEPH.HEALTH.WARN.PERIOD}'
+          value: 15m
+          description: 'How long Ceph must stay in HEALTH_WARN or worse before the warning fires.'
+        - macro: '{$CEPH.OSD.LATENCY.MAX}'
+          value: '0.2'
+          description: 'OSD commit latency threshold in seconds.'
+        - macro: '{$CEPH.OSD.LATENCY.PERIOD}'
+          value: 30m
+          description: 'How long the OSD latency must stay over the threshold.'
+        - macro: '{$CEPH.OSD.UTIL.CRIT}'
+          value: '90'
+          description: 'OSD utilization high threshold in percent (Ceph full default is 95).'
+        - macro: '{$CEPH.OSD.UTIL.WARN}'
+          value: '80'
+          description: 'OSD utilization warning threshold in percent (Ceph nearfull default is 85).'
+        - macro: '{$CEPH.PG.NOT_CLEAN.PERIOD}'
+          value: 1h
+          description: 'How long PGs may stay not active+clean before the warning fires.'
+        - macro: '{$CEPH.POOL.NOT_MATCHES}'
+          value: CHANGE_IF_NEEDED
+          description: 'Pools whose name matches are not discovered.'
+        - macro: '{$CEPH.POOL.UTIL.CRIT}'
+          value: '90'
+          description: 'Pool utilization high threshold in percent.'
+        - macro: '{$CEPH.POOL.UTIL.WARN}'
+          value: '80'
+          description: 'Pool utilization warning threshold in percent.'
+        - macro: '{$CEPH.UTIL.CRIT}'
+          value: '85'
+          description: 'Ceph raw capacity high threshold in percent.'
+        - macro: '{$CEPH.UTIL.WARN}'
+          value: '75'
+          description: 'Ceph raw capacity warning threshold in percent.'
         - macro: '{$CLUSTER.NODES.OFFLINE.MAX}'
           value: '0'
           description: 'Maximum tolerated offline cluster nodes before triggering an alert. Set to 1+ during planned maintenance.'
@@ -4669,60 +3386,18 @@ zabbix_export:
         - macro: '{$CPU_USAGE_HIGH}'
           value: '99'
           description: 'High CPU usage threshold (%) for warning level trigger'
-        - macro: '{$DISK.MISSING.TIME}'
-          value: 3h
-          description: 'How long a disk may be absent from the Proxmox disk list before the missing disk trigger fires. The list is refreshed once per hour, so keep this well above 1h. The value must include a time unit.'
-        - macro: '{$DISK.TEMP.MAX}'
-          value: '60'
-          description: 'Temperature threshold for physical disks in degrees Celsius. Use the context form {$DISK.TEMP.MAX:"/dev/sda"} to raise it for a single disk.'
-        - macro: '{$DISK.WEAROUT.MIN}'
-          value: '20'
-          description: 'Minimum SSD wearout remaining (%) before triggering a warning. Default: 20%.'
-        - macro: '{$ENABLE_BACKUP_ALERT}'
-          value: '1'
-          description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
         - macro: '{$ENABLE_NODE_STATUS_ALERT}'
           value: '1'
           description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
-        - macro: '{$ENABLE_STORAGE_AVAILABLE_ALERT}'
-          value: '1'
-          description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
-        - macro: '{$ENABLE_STORAGE_INACTIVE_ALERT}'
-          value: '1'
-          description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
-        - macro: '{$ENABLE_TASK_ALERT}'
-          value: '1'
-          description: 'To enable task failure alerts set to 1. Use context macro {$ENABLE_TASK_ALERT:"{#GRPID}"}=0 to suppress alerts for individual tasks.'
         - macro: '{$ENABLE_VM_STOP_ALERT}'
           value: '1'
           description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
-        - macro: '{$IFACE.ACTIVE.WINDOW}'
-          value: 7d
-          description: 'Lookback window for the network interface down trigger. The interface must have been active at least once within this period, otherwise it is treated as configured but never used and does not alert. The value must include a time unit (e.g. 7d, 24h).'
-        - macro: '{$IFACE.NOT_MATCHES}'
-          value: ^(tap|veth|fwbr|fwpr|fwln)
-          description: 'LLD filter: host network interface names to exclude (regex). The default drops the per-guest interfaces Proxmox creates for VMs and containers, which appear and disappear together with the guest.'
         - macro: '{$LXC.CPU.HIGH}'
           value: '99'
           description: 'Critical threshold for LXC CPU utilization (%) over 5 minutes.'
         - macro: '{$LXC.CPU.WARN}'
           value: '85'
           description: 'Warning threshold for LXC CPU utilization (%) over 5 minutes.'
-        - macro: '{$MEMORY.UTIL.MAX}'
-          value: '90'
-          description: 'Warning threshold for memory utilization of the PVE host itself (%). Guest memory is not covered by this macro.'
-        - macro: '{$NODE.CPU.UTIL.MAX}'
-          value: '90'
-          description: 'Node CPU utilization (%) before the high CPU trigger fires. The threshold used to be hardcoded in the trigger expression.'
-        - macro: '{$PVE.APT.REPO.ERRORS.MAX}'
-          value: '0'
-          description: 'Tolerated number of unparsable APT repository files before alerting.'
-        - macro: '{$PVE.APT.REPO.WARN.MAX}'
-          value: '0'
-          description: 'Tolerated number of APT repository warnings. A host on the no-subscription repository permanently reports one warning, set this to 1 there.'
-        - macro: '{$PVE.APT.UPDATES.MAX}'
-          value: '0'
-          description: 'Tolerated number of pending package updates. Only relevant if the disabled apt/update items are switched on.'
         - macro: '{$PVE.BACKUP.JOB.ALERT}'
           value: '1'
           description: 'Disabled backup job trigger. Set to 0 to suppress it everywhere, or use the context form {$PVE.BACKUP.JOB.ALERT:"backup-a5c9d88a-bc0e"}=0 to silence one job that is switched off on purpose.'
@@ -4732,33 +3407,15 @@ zabbix_export:
         - macro: '{$PVE.BACKUP.JOBS.MIN}'
           value: '1'
           description: 'Minimum number of vzdump backup job definitions expected on this cluster. Set to 0 on hosts that are deliberately backed up from somewhere else.'
-        - macro: '{$PVE.BACKUP.RUN.MAX}'
-          value: 3h
-          description: 'How long a backup may run before it is treated as stuck. The value must include a time unit, for example 3h or 90m, and must stay above the normal runtime of the longest job, otherwise the trigger fires during every regular run.'
-        - macro: '{$PVE.CERT.EXPIRE.DAYS}'
-          value: 21d
-          description: 'Lead time before certificate expiry. Must include a time unit, for example 21d.'
+        - macro: '{$PVE.GUEST.DETAIL.INTERVAL}'
+          value: 10m
+          description: 'Interval of the per guest status request (balloon, machine type, LXC swap). One request per guest, so keep it long in large clusters.'
+        - macro: '{$PVE.GUEST.DETAIL.VMID.MATCHES}'
+          value: '.*'
+          description: 'Guests whose VMID matches get the per guest status request. Set to ^$ to switch it off for all guests.'
         - macro: '{$PVE.NOTBACKEDUP.MAX}'
           value: '0'
           description: 'Tolerated number of guests without a backup job. Raise it if some guests are deliberately excluded from backup.'
-        - macro: '{$PVE.REPL.FAIL.MAX}'
-          value: '0'
-          description: 'Tolerated consecutive failures of a replication job. Use the context form {$PVE.REPL.FAIL.MAX:"105-0"} for a single job.'
-        - macro: '{$PVE.REPL.LAG}'
-          value: 2h
-          description: 'Maximum age of the last successful replication. Must stay above the replication schedule, otherwise the trigger fires between two runs. Must include a time unit.'
-        - macro: '{$PVE.SERVICE.MATCHES}'
-          value: ^(pve-cluster|pvedaemon|pveproxy|pvestatd|pve-firewall)$
-          description: 'Which PVE services are discovered. corosync, pve-ha-lrm and pve-ha-crm are excluded by default because they are legitimately inactive on a standalone node. In a cluster extend the regex accordingly.'
-        - macro: '{$PVE.SERVICE.STATE.ALERT}'
-          value: '1'
-          description: 'Enables the service state trigger. Use the context form {$PVE.SERVICE.STATE.ALERT:"pveproxy"}=0 to silence a single service.'
-        - macro: '{$PVE.SUBSCRIPTION.ALERT}'
-          value: '0'
-          description: 'Set to 1 on hosts that are meant to carry a subscription. Off by default so community hosts do not alert on status notfound.'
-        - macro: '{$PVE.SUBSCRIPTION.EXPIRE.DAYS}'
-          value: 30d
-          description: 'Lead time before the subscription expires. Must include a time unit, for example 30d. The expiry triggers need no enable macro: hosts without a subscription report no due date, so the item stays empty.'
         - macro: '{$PVE.USER.EXPIRE.TIME}'
           value: '172800'
           description: 'Seconds before user account expiration to trigger warning (default 172800 = 2 days).'
@@ -4774,45 +3431,12 @@ zabbix_export:
         - macro: '{$PVE_IP}'
           value: localhost
           description: 'The IP address or hostname of the Proxmox VE API server.'
-        - macro: '{$PVE_NODE}'
-          value: pve
-          description: 'The Proxmox VE node identifier (e.g. "pve") used in API endpoint paths.'
         - macro: '{$PVE_PORT}'
           value: '8006'
           description: 'The TCP port number on which the Proxmox VE API listens (default: 8006).'
-        - macro: '{$ROOTFS.UTIL.CRIT}'
-          value: '95'
-          description: 'Critical threshold for root filesystem utilization (%).'
-        - macro: '{$ROOTFS.UTIL.WARN}'
-          value: '90'
-          description: 'Warning threshold for root filesystem utilization (%).'
-        - macro: '{$STORAGE.UTIL.CRIT}'
-          value: '90'
-          description: 'Critical threshold for storage utilization (%). Triggers when storage used exceeds this value.'
-        - macro: '{$STORAGE.UTIL.WARN}'
-          value: '80'
-          description: 'Warning threshold for storage utilization (%). Triggers when storage used exceeds this value.'
-        - macro: '{$SWAP.UTIL.MAX}'
-          value: '80'
-          description: 'Warning threshold for swap utilization of the PVE host (%). The trigger stays silent on hosts that have no swap configured.'
-        - macro: '{$TASK.ALERT.WINDOW}'
-          value: 1h
-          description: 'How long a failed task keeps alerting. The problem clears earlier if a later task of the same id and type succeeds. Proxmox VE only keeps the most recent tasks in its task list, so without this window a one-off failure would alert forever. The value must include a time unit, for example 1h or 30m.'
-        - macro: '{$ZFS.FRAG.UTIL.MIN}'
-          value: '70'
-          description: 'Pool usage (%) that must be reached before the fragmentation warning fires. Fragmented free space only costs write performance on a pool that is also filling up. Use the context form {$ZFS.FRAG.UTIL.MIN:"rpool"} per pool.'
-        - macro: '{$ZFS.FRAG.WARN}'
-          value: '60'
-          description: 'ZFS free space fragmentation (%) before warning. Use the context form {$ZFS.FRAG.WARN:"rpool"} per pool.'
-        - macro: '{$ZFS.UTIL.CRIT}'
-          value: '90'
-          description: 'ZFS pool usage (%) for the high severity trigger. Use the context form {$ZFS.UTIL.CRIT:"rpool"} per pool.'
-        - macro: '{$ZFS.UTIL.WARN}'
-          value: '80'
-          description: 'ZFS pool usage (%) for the average severity trigger. ZFS performance degrades noticeably above 80%.'
       dashboards:
         - uuid: a6999e1b8414408ab403f86cba2b272b
-          name: 'Proxmox VE - Monitoring Dashboard'
+          name: 'Proxmox VE cluster'
           auto_start: 'NO'
           pages:
             - name: Overview
@@ -4824,7 +3448,7 @@ zabbix_export:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Template Proxmox VE REST API'
+                        host: 'Proxmox VE Cluster by REST API'
                         key: pve.cluster.name
                     - type: INTEGER
                       name: show.1
@@ -4832,59 +3456,25 @@ zabbix_export:
                     - type: INTEGER
                       name: show.2
                       value: '3'
-                - type: gauge
-                  name: 'CPU utilization'
+                - type: item
+                  name: 'HA manager'
                   'y': '2'
                   width: '24'
-                  height: '5'
                   fields:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Template Proxmox VE REST API'
-                        key: pve.cpu.utilization
+                        host: 'Proxmox VE Cluster by REST API'
+                        key: pve.ha.manager.status
                     - type: INTEGER
-                      name: max
-                      value: '100'
+                      name: show.1
+                      value: '2'
                     - type: INTEGER
-                      name: min
-                      value: '0'
-                    - type: STRING
-                      name: thresholds.0.color
-                      value: FFBF59
-                    - type: STRING
-                      name: thresholds.0.threshold
-                      value: '80'
-                    - type: STRING
-                      name: thresholds.1.color
-                      value: E45959
-                    - type: STRING
-                      name: thresholds.1.threshold
-                      value: '90'
-                    - type: STRING
-                      name: units
-                      value: '%'
-                - type: svggraph
-                  name: 'CPU utilization'
-                  'y': '7'
-                  width: '36'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: ds.0.color
-                      value: 1976D2
-                    - type: STRING
-                      name: ds.0.items.0
-                      value: 'PVE CPU utilization'
-                    - type: INTEGER
-                      name: ds.0.type
-                      value: '0'
-                    - type: STRING
-                      name: reference
-                      value: PVOV1
+                      name: show.2
+                      value: '3'
                 - type: problems
                   name: Problems
-                  'y': '13'
+                  'y': '4'
                   width: '72'
                   height: '8'
                 - type: item
@@ -4895,7 +3485,7 @@ zabbix_export:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Template Proxmox VE REST API'
+                        host: 'Proxmox VE Cluster by REST API'
                         key: pve.cluster.quorum
                     - type: INTEGER
                       name: show.1
@@ -4911,7 +3501,7 @@ zabbix_export:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Template Proxmox VE REST API'
+                        host: 'Proxmox VE Cluster by REST API'
                         key: pve.cluster.nodes.online
                     - type: INTEGER
                       name: show.1
@@ -4919,48 +3509,48 @@ zabbix_export:
                     - type: INTEGER
                       name: show.2
                       value: '3'
-                - type: gauge
-                  name: 'Memory utilization'
+                - type: item
+                  name: Ceph
                   x: '24'
                   'y': '2'
                   width: '24'
-                  height: '5'
                   fields:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Template Proxmox VE REST API'
-                        key: pve.memory.util
+                        host: 'Proxmox VE Cluster by REST API'
+                        key: pve.ceph.available
                     - type: INTEGER
-                      name: max
-                      value: '100'
+                      name: show.1
+                      value: '2'
                     - type: INTEGER
-                      name: min
-                      value: '0'
-                    - type: STRING
-                      name: thresholds.0.color
-                      value: FFBF59
-                    - type: STRING
-                      name: thresholds.0.threshold
-                      value: '80'
-                    - type: STRING
-                      name: thresholds.1.color
-                      value: E45959
-                    - type: STRING
-                      name: thresholds.1.threshold
-                      value: '90'
-                    - type: STRING
-                      name: units
-                      value: '%'
+                      name: show.2
+                      value: '3'
                 - type: item
-                  name: 'Guests running'
+                  name: 'Nodes offline'
                   x: '36'
                   width: '12'
                   fields:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Template Proxmox VE REST API'
+                        host: 'Proxmox VE Cluster by REST API'
+                        key: pve.cluster.nodes.offline
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: 'Guests running'
+                  x: '48'
+                  width: '12'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Proxmox VE Cluster by REST API'
                         key: pve.cluster.vms.running
                     - type: INTEGER
                       name: show.1
@@ -4968,103 +3558,33 @@ zabbix_export:
                     - type: INTEGER
                       name: show.2
                       value: '3'
-                - type: piechart
-                  name: Memory
-                  x: '36'
-                  'y': '7'
-                  width: '18'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: ds.0.color
-                      value: E45959
-                    - type: STRING
-                      name: ds.0.items.0
-                      value: 'PVE memory used'
-                    - type: STRING
-                      name: ds.1.color
-                      value: 00C48C
-                    - type: STRING
-                      name: ds.1.items.0
-                      value: 'PVE memory available'
                 - type: item
-                  name: 'Guests total'
+                  name: 'Guests without backup job'
                   x: '48'
-                  width: '12'
+                  'y': '2'
+                  width: '24'
                   fields:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Template Proxmox VE REST API'
-                        key: pve.cluster.vms.total
+                        host: 'Proxmox VE Cluster by REST API'
+                        key: pve.notbackedup.count
                     - type: INTEGER
                       name: show.1
                       value: '2'
                     - type: INTEGER
                       name: show.2
                       value: '3'
-                - type: gauge
-                  name: 'Root filesystem'
-                  x: '48'
-                  'y': '2'
-                  width: '24'
-                  height: '5'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Template Proxmox VE REST API'
-                        key: pve.rootfs.util
-                    - type: INTEGER
-                      name: max
-                      value: '100'
-                    - type: INTEGER
-                      name: min
-                      value: '0'
-                    - type: STRING
-                      name: thresholds.0.color
-                      value: FFBF59
-                    - type: STRING
-                      name: thresholds.0.threshold
-                      value: '80'
-                    - type: STRING
-                      name: thresholds.1.color
-                      value: E45959
-                    - type: STRING
-                      name: thresholds.1.threshold
-                      value: '90'
-                    - type: STRING
-                      name: units
-                      value: '%'
-                - type: piechart
-                  name: 'Root filesystem'
-                  x: '54'
-                  'y': '7'
-                  width: '18'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: ds.0.color
-                      value: E45959
-                    - type: STRING
-                      name: ds.0.items.0
-                      value: 'Disk rootfs used'
-                    - type: STRING
-                      name: ds.1.color
-                      value: 00C48C
-                    - type: STRING
-                      name: ds.1.items.0
-                      value: 'Disk rootfs avail'
                 - type: item
-                  name: Uptime
+                  name: 'Guests total'
                   x: '60'
                   width: '12'
                   fields:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Template Proxmox VE REST API'
-                        key: pve.uptime
+                        host: 'Proxmox VE Cluster by REST API'
+                        key: pve.cluster.vms.total
                     - type: INTEGER
                       name: show.1
                       value: '2'
@@ -5245,6 +3765,3551 @@ zabbix_export:
                     - type: INTEGER
                       name: source_type
                       value: '1'
+            - name: 'Nodes and HA'
+              widgets:
+                - type: honeycomb
+                  name: 'Node status'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Node status *'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '1'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: PVE
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: Node
+                    - type: STRING
+                      name: primary_label
+                      value: '{ITEM.NAME}'
+                    - type: STRING
+                      name: reference
+                      value: PVND1
+                - type: item
+                  name: 'HA manager'
+                  'y': '6'
+                  width: '18'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Proxmox VE Cluster by REST API'
+                        key: pve.ha.manager.status
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: honeycomb
+                  name: 'HA local resource managers'
+                  'y': '8'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'HA LRM state on *'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '1'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: PVE
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: HA
+                    - type: STRING
+                      name: primary_label
+                      value: '{ITEM.NAME}'
+                    - type: STRING
+                      name: reference
+                      value: PVHA1
+                - type: item
+                  name: 'Nodes offline'
+                  x: '18'
+                  'y': '6'
+                  width: '18'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Proxmox VE Cluster by REST API'
+                        key: pve.cluster.nodes.offline
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: honeycomb
+                  name: 'HA resource states'
+                  x: '36'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'HA state of *'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '1'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: PVE
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: HA
+                    - type: STRING
+                      name: primary_label
+                      value: '{ITEM.NAME}'
+                    - type: STRING
+                      name: reference
+                      value: PVND2
+            - name: Ceph
+              widgets:
+                - type: honeycomb
+                  name: 'Ceph OSD status'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Ceph * status'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '1'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: Ceph
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: OSD
+                    - type: STRING
+                      name: primary_label
+                      value: '{ITEM.NAME}'
+                    - type: STRING
+                      name: reference
+                      value: PVCE2
+                - type: itemnavigator
+                  name: 'Browse Ceph items'
+                  'y': '6'
+                  width: '18'
+                  height: '14'
+                  fields:
+                    - type: INTEGER
+                      name: group_by.0.attribute
+                      value: '3'
+                    - type: STRING
+                      name: group_by.0.tag_name
+                      value: Ceph
+                    - type: STRING
+                      name: items.0
+                      value: '*'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '0'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: PVE
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: Ceph
+                    - type: STRING
+                      name: reference
+                      value: PVCE1
+                    - type: INTEGER
+                      name: show_lines
+                      value: '100'
+                - type: item
+                  name: 'Selected item'
+                  x: '18'
+                  'y': '12'
+                  width: '18'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: itemid._reference
+                      value: PVCE1._itemid
+                    - type: INTEGER
+                      name: show.1
+                      value: '1'
+                    - type: INTEGER
+                      name: show.2
+                      value: '2'
+                    - type: INTEGER
+                      name: show.3
+                      value: '3'
+                - type: honeycomb
+                  name: 'Ceph pool utilization'
+                  x: '36'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Ceph pool * utilization'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '1'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: Ceph
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: Pool
+                    - type: STRING
+                      name: primary_label
+                      value: '{ITEM.NAME}'
+                    - type: STRING
+                      name: reference
+                      value: PVCE3
+                - type: graph
+                  name: 'History of selected item'
+                  x: '36'
+                  'y': '12'
+                  width: '36'
+                  height: '8'
+                  fields:
+                    - type: STRING
+                      name: itemid._reference
+                      value: PVCE1._itemid
+                    - type: INTEGER
+                      name: source_type
+                      value: '1'
+      valuemaps:
+        - uuid: 4f48a8938054422b8cf484adaec102ee
+          name: 'Backup job enabled'
+          mappings:
+            - value: '0'
+              newvalue: disabled
+            - value: '1'
+              newvalue: enabled
+        - uuid: 10d3deb6c50a46f7852da7680deba0e1
+          name: 'Ceph availability'
+          mappings:
+            - value: '0'
+              newvalue: 'not available'
+            - value: '1'
+              newvalue: available
+        - uuid: 5bc687fbcc704444bc7327bc44f31833
+          name: 'Ceph health'
+          mappings:
+            - value: '0'
+              newvalue: HEALTH_OK
+            - value: '1'
+              newvalue: HEALTH_WARN
+            - value: '2'
+              newvalue: HEALTH_ERR
+        - uuid: 248a59f093cc419d9086c1052b4c9c60
+          name: 'Ceph OSD in'
+          mappings:
+            - value: '0'
+              newvalue: out
+            - value: '1'
+              newvalue: in
+        - uuid: 4f9af911f2d4433b91c80a435693cfae
+          name: 'Ceph OSD status'
+          mappings:
+            - value: '0'
+              newvalue: down
+            - value: '1'
+              newvalue: up
+        - uuid: dd3c4133c6ef47b5bcefc8e68eaeee27
+          name: 'Node status'
+          mappings:
+            - value: '0'
+              newvalue: offline
+            - value: '1'
+              newvalue: online
+            - value: '2'
+              newvalue: unknown
+        - uuid: 6ce95767698f4713adfa2dcf4618d86b
+          name: 'User status'
+          mappings:
+            - value: '0'
+              newvalue: disabled
+            - value: '1'
+              newvalue: enabled
+        - uuid: 052ad39480884912aebd6a34a8c2ff51
+          name: 'VM  and LXC status'
+          mappings:
+            - value: '0'
+              newvalue: stopped
+            - value: '1'
+              newvalue: running
+            - value: '2'
+              newvalue: paused
+            - value: '3'
+              newvalue: unknown
+    - uuid: 1c59365f955547989d4c8657034d9415
+      template: 'Proxmox VE Node by REST API'
+      name: 'Proxmox VE Node by REST API'
+      description: |
+        Node part of the Proxmox VE monitoring over the REST API. Link it to one Zabbix host per PVE node and set {$PVE_NODE} and {$PVE_IP} to that node: status, CPU, memory, disks and SMART, ZFS, storage, network, services, tasks, backups, replication, certificates, APT and subscription.
+        
+        Requires a PVEAuditor API token. See the README for setup.
+      groups:
+        - name: Templates/Virtualization
+      items:
+        - uuid: 3069a46f22c441fc8a6023daf9e0ac6d
+          name: 'PVE manager package version'
+          type: DEPENDENT
+          key: pve.apt.manager.version
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Installed pve-manager version. Source: /nodes/{node}/apt/versions.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[?(@.Package=="pve-manager")].Version.first()'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.apt.versions.raw
+          tags:
+            - tag: PVE
+              value: APT
+        - uuid: d48cb1cbc9984b0c895b49e21a41756f
+          name: 'APT repository errors'
+          type: DEPENDENT
+          key: pve.apt.repos.errors
+          delay: '0'
+          history: 7d
+          description: 'Number of unparsable APT repository files. Source: /nodes/{node}/apt/repositories.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.errors.length()
+          master_item:
+            key: pve.apt.repos.raw
+          tags:
+            - tag: PVE
+              value: APT
+          triggers:
+            - uuid: 427dab4dc45f4dee92ea748e2d8476d9
+              expression: 'last(/Proxmox VE Node by REST API/pve.apt.repos.errors)>{$PVE.APT.REPO.ERRORS.MAX}'
+              name: 'APT repository files are broken on {HOST.NAME}'
+              opdata: 'Broken files: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'At least one APT repository file cannot be parsed. Updates will fail until this is fixed.'
+        - uuid: d8c14e0b75db44b08f50d67e41644875
+          name: 'PVE APT repositories raw'
+          type: HTTP_AGENT
+          key: pve.apt.repos.raw
+          delay: '3600'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/apt/repositories. Requires Sys.Audit on /nodes/{node}.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/apt/repositories'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 5543e26f183241e48eb528b395b3e5df
+          name: 'APT repository warnings'
+          type: DEPENDENT
+          key: pve.apt.repos.warnings
+          delay: '0'
+          history: 7d
+          description: 'Number of APT repository warnings, for example the enterprise repository being enabled without a subscription. Source: /nodes/{node}/apt/repositories.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data.infos[?(@.kind=="warning")].length()'
+          master_item:
+            key: pve.apt.repos.raw
+          tags:
+            - tag: PVE
+              value: APT
+          triggers:
+            - uuid: 22ffcc10b8f84e25baa6b2e475585867
+              expression: 'last(/Proxmox VE Node by REST API/pve.apt.repos.warnings)>{$PVE.APT.REPO.WARN.MAX}'
+              name: 'APT repository configuration has warnings on {HOST.NAME}'
+              opdata: 'Warnings: {ITEM.LASTVALUE1}'
+              priority: INFO
+              description: 'PVE reports a problem with the repository configuration, for example the enterprise repository being enabled without a subscription. A host on the no-subscription repository reports one warning permanently, raise {$PVE.APT.REPO.WARN.MAX} to 1 there.'
+              manual_close: 'YES'
+        - uuid: c0d3f09f282745c8b14ed3ec0261ea4d
+          name: 'Running kernel (proxmox-ve)'
+          type: DEPENDENT
+          key: pve.apt.running.kernel
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Kernel release the node is currently booted into. Source: /nodes/{node}/apt/versions, package proxmox-ve.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[?(@.Package=="proxmox-ve")].RunningKernel.first()'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.apt.versions.raw
+          tags:
+            - tag: PVE
+              value: APT
+        - uuid: 420ffd2b294542afa9dc700520f0d1e0
+          name: 'PVE APT pending updates raw'
+          type: HTTP_AGENT
+          key: pve.apt.update.raw
+          delay: '3600'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          status: DISABLED
+          description: 'Master item. Raw JSON from /nodes/{node}/apt/update. DISABLED by default: this endpoint requires Sys.Modify on /nodes/{node}, which PVEAuditor does not grant. Enable only if you accept giving the monitoring token write level permissions.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/apt/update'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 172e6ad9dd024e959aaf9516fe8a6646
+          name: 'APT pending updates'
+          type: DEPENDENT
+          key: pve.apt.updates.count
+          delay: '0'
+          history: 7d
+          status: DISABLED
+          description: 'Number of pending package updates. DISABLED by default because the master item requires Sys.Modify.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.length()
+          master_item:
+            key: pve.apt.update.raw
+          tags:
+            - tag: PVE
+              value: APT
+          triggers:
+            - uuid: a777c3b8e7cf4c31aa434ff6d335d3b1
+              expression: 'last(/Proxmox VE Node by REST API/pve.apt.updates.count)>{$PVE.APT.UPDATES.MAX}'
+              name: '{ITEM.LASTVALUE} package update(s) pending on {HOST.NAME}'
+              status: DISABLED
+              priority: INFO
+              description: 'Disabled by default, like the item it depends on. The master item needs Sys.Modify, which PVEAuditor does not grant.'
+              manual_close: 'YES'
+        - uuid: 5f423ad7231447a7aa5c9be006c7dd7e
+          name: 'PVE APT versions raw'
+          type: HTTP_AGENT
+          key: pve.apt.versions.raw
+          delay: '3600'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/apt/versions. Requires Sys.Audit on /nodes/{node}.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/apt/versions'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: c4fcd7fc00ca42f88ffae1335c6b9c57
+          name: 'PVE backup active raw'
+          type: HTTP_AGENT
+          key: pve.backup.active.raw
+          delay: '60'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/tasks with source=active and typefilter=vzdump, so it carries only backup tasks that are running right now. The task list defaults to source=archive, where a task appears only once it has finished, which is why a running backup is invisible to pve.backup.raw and why a backup that never finishes produces no signal there at all. Returns an empty list while no backup runs. Requires Sys.Audit on /nodes/{node}.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/tasks?source=active&typefilter=vzdump'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 2d3053255eb744ba9e056c071e8e2fdc
+          name: 'PVE backup raw'
+          type: HTTP_AGENT
+          key: pve.backup.raw
+          delay: '300'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/tasks?typefilter=vzdump, so only backup tasks are listed and other tasks cannot push them out of the 50 entries PVE returns. JavaScript preprocessing keeps the most recent run per guest.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Zabbix JS preprocessing: Extract and group backup tasks (VZDUMP/PBS) from task feed (ES5.1)
+                  try {
+                      var obj = (typeof value === 'string') ? JSON.parse(value) : value;
+                  
+                      // 0) Determine data source
+                      var dataArr = [];
+                      if (obj && obj.data && obj.data instanceof Array) {
+                          dataArr = obj.data;
+                      } else if (obj && obj.body && obj.body.data && obj.body.data instanceof Array) {
+                          dataArr = obj.body.data;
+                      }
+                      if (!dataArr || !dataArr.length) {
+                          return JSON.stringify({ total: 0, data: [] });
+                      }
+                  
+                      // Helper functions
+                      function firstDefined(a, b, c, d) {
+                          if (a !== null && a !== undefined) return a;
+                          if (b !== null && b !== undefined) return b;
+                          if (c !== null && c !== undefined) return c;
+                          if (d !== null && d !== undefined) return d;
+                          return null;
+                      }
+                  
+                      // Robust timestamp conversion: supports epoch (sec/ms), numeric strings, ISO and "YYYY-MM-DD HH:mm:ss"
+                      function toEpochMs(v) {
+                          if (v === null || v === undefined) return -Infinity;
+                          if (typeof v === "number") return v < 1000000000000 ? v * 1000 : v; // sec → ms
+                  
+                          if (typeof v === "string") {
+                              var s = v.trim();
+                  
+                              // Treat purely numeric strings as numbers
+                              if (/^\d+(\.\d+)?$/.test(s)) {
+                                  var n = parseFloat(s);
+                                  return n < 1000000000000 ? n * 1000 : n;
+                              }
+                  
+                              // Parse "YYYY-MM-DD HH:mm:ss" (optional AM/PM)
+                              var m = s.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\s*(AM|PM))?$/i);
+                              if (m) {
+                                  var H = parseInt(m[4], 10), ampm = (m[7] || "").toUpperCase();
+                                  if (ampm) { if (ampm === "PM" && H < 12) H += 12; if (ampm === "AM" && H === 12) H = 0; }
+                                  return Date.UTC(+m[1], +m[2] - 1, +m[3], H, +m[5], +m[6]);
+                              }
+                  
+                              // Fallback: parse as ISO-compatible string
+                              var p = Date.parse(s.replace(/\s+/, "T"));
+                              return isNaN(p) ? -Infinity : p;
+                          }
+                          return -Infinity;
+                      }
+                      
+                  
+                      // Broad backup type matcher
+                      var reVzdump = /vzdump/i;
+                      var reBackup = /backup/i;              // generic (PBS/Proxmox Backup)
+                      var rePbs    = /\bpbs\b/i;             // "pbs" as a whole word
+                      var rePmxb   = /proxmox[- ]?backup/i;  // "proxmox-backup" or "proxmox backup"
+                  
+                      function isBackup(e) {
+                          if (!e) return false;
+                          var t = (e.type != null) ? String(e.type) : "";
+                          var u = (typeof e.upid === "string") ? e.upid : "";
+                          if (reVzdump.test(t) || reBackup.test(t) || rePbs.test(t) || rePmxb.test(t)) return true;
+                          if (reVzdump.test(u) || reBackup.test(u) || rePbs.test(u) || rePmxb.test(u)) return true;
+                          return false;
+                      }
+                  
+                      // 1) Filter backup entries and normalise timestamps
+                      var dumps = [];
+                      for (var i = 0; i < dataArr.length; i++) {
+                          var e = dataArr[i];
+                          if (!isBackup(e)) continue;
+                  
+                          var startRaw = firstDefined(e.starttime, e.start, e.begin, e.pstart);
+                          var endRaw   = firstDefined(e.endtime, e.end, null, null);
+                  
+                          var copy = {};
+                          for (var k in e) { if (e.hasOwnProperty(k)) copy[k] = e[k]; }
+                          copy._startMs = toEpochMs(startRaw);
+                          copy._endMs   = toEpochMs(endRaw);
+                          dumps.push(copy);
+                      }
+                  
+                      if (!dumps.length) {
+                          // No backup entries found in the feed
+                          return JSON.stringify({ total: 0, data: [] });
+                      }
+                  
+                      // 2) Sort by start time
+                      dumps.sort(function(a, b) { return a._startMs - b._startMs; });
+                  
+                      // 3) Replace missing/empty ID with "pve"
+                      for (i = 0; i < dumps.length; i++) {
+                          if (dumps[i].id === null || dumps[i].id === undefined || String(dumps[i].id) === "") {
+                              dumps[i].id = "pve";
+                          }
+                      }
+                  
+                      // 4) Group by id, keep only the most recent run per id (highest _startMs)
+                      var groups = {};
+                      for (i = 0; i < dumps.length; i++) {
+                          var e2 = dumps[i];
+                          var key = String(e2.id);
+                  
+                          if (!groups[key] || e2._startMs > groups[key]._startMs) {
+                              groups[key] = {
+                                  id:        key,
+                                  node:      e2.node,
+                                  status:    e2.status,
+                                  pid:       e2.pid,
+                                  upid:      e2.upid,
+                                  starttime: e2.starttime,
+                                  endtime:   e2.endtime,
+                                  _startMs:  e2._startMs,
+                                  _endMs:    e2._endMs
+                              };
+                          }
+                      }
+                      
+                  
+                      // 5) Sort IDs numerically (numeric first), "pve" last
+                      var ids = [];
+                      for (var id in groups) { if (groups.hasOwnProperty(id)) ids.push(id); }
+                      ids.sort(function(a, b) {
+                          if (a === "pve" && b !== "pve") return 1;
+                          if (b === "pve" && a !== "pve") return -1;
+                          var na = parseFloat(a), nb = parseFloat(b);
+                          var aNum = isFinite(na), bNum = isFinite(nb);
+                          if (aNum && bNum) return na - nb;
+                          if (aNum) return -1;
+                          if (bNum) return 1;
+                          a = String(a); b = String(b);
+                          if (a < b) return -1;
+                          if (a > b) return 1;
+                          return 0;
+                      });
+                  
+                      // 6) Build result
+                      var resultData = [];
+                      for (i = 0; i < ids.length; i++) {
+                          var g2 = groups[ids[i]];
+                          // Remove internal fields
+                          delete g2._startMs; delete g2._endMs;
+                          g2.bckpid = g2.id;
+                          resultData.push(g2);
+                      }
+                  
+                      return JSON.stringify({ total: resultData.length, data: resultData });
+                  
+                  } catch (err) {
+                      return JSON.stringify({ error: "Parsing failed", detail: String(err && err.message || err) });
+                  }
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/tasks?typefilter=vzdump'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          output_format: JSON
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 85a1eb044f3947cba21117d8cba24f66
+          name: 'Backup running'
+          type: DEPENDENT
+          key: pve.backup.running
+          delay: '0'
+          trends: '0'
+          description: 'Number of backup tasks running on this node right now, normally 0 or 1. The value is a counter rather than a forced 0 or 1: if two vzdump tasks ever overlap the item shows 2 and stays readable, only the value map has no entry for it. Source: /nodes/{node}/tasks with source=active.'
+          valuemap:
+            name: 'Backup running'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.length()
+          master_item:
+            key: pve.backup.active.raw
+          tags:
+            - tag: PVE
+              value: Backup
+          triggers:
+            - uuid: 82705bfa82b1405a89f112de9c2ae28b
+              expression: 'min(/Proxmox VE Node by REST API/pve.backup.running,{$PVE.BACKUP.RUN.MAX})>0'
+              name: 'Backup has been running for more than {$PVE.BACKUP.RUN.MAX} on {HOST.NAME}'
+              opdata: 'Running since: {ITEM.LASTVALUE1}'
+              priority: AVERAGE
+              description: 'A backup task has been running without interruption for the whole period. This is the one backup failure the task archive cannot show: a run that never finishes never reaches the archive, so the status, end time and message items keep reporting the previous successful run and nothing else would ever fire. Check the running task in the PVE task viewer and the target storage.'
+              manual_close: 'YES'
+        - uuid: e07f7e74bd484582b32671977eed6726
+          name: 'Backup running since'
+          type: DEPENDENT
+          key: pve.backup.running.since
+          delay: '0'
+          value_type: FLOAT
+          trends: '0'
+          units: unixtime
+          description: 'Start time of the backup that is running right now, available the moment it starts. Zero means no backup is running: the source list is then empty, the JSONPath finds nothing, and the error handler supplies the zero. This is the real start time, unlike Backup starttime, which only moves once the run has finished and reached the task archive. A trend over a Unix timestamp carries no meaning, so trends stay off.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*].starttime.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+          master_item:
+            key: pve.backup.active.raw
+          tags:
+            - tag: PVE
+              value: Backup
+        - uuid: 87cef13bf7ab476ea76bce4f222f9041
+          name: 'PVE certificates raw'
+          type: HTTP_AGENT
+          key: pve.certificates.raw
+          delay: '3600'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/certificates/info. Needs no special permission.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/certificates/info'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: b2fdee8ad2d446bfb7008d9945e5bcc4
+          name: 'PVE CPU cores'
+          type: DEPENDENT
+          key: pve.cores
+          delay: '0'
+          trends: '0'
+          units: '!Cores'
+          description: 'Number of physical CPU cores on the PVE host. Source: /nodes/{node}/status → data.cpuinfo.cores.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.cpuinfo.cores
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: 209521248ee041ff96878318f523ab06
+          name: 'PVE CPU utilization'
+          type: DEPENDENT
+          key: pve.cpu.utilization
+          delay: '0'
+          history: 7d
+          value_type: FLOAT
+          units: '%'
+          description: 'CPU utilization of the PVE host in percent (0-100). Source: /nodes/{node}/status → data.cpu * 100.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.cpu
+            - type: MULTIPLIER
+              parameters:
+                - '100'
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+          triggers:
+            - uuid: 9b505ccdb1fa4b97937ade1b672701f2
+              expression: 'min(/Proxmox VE Node by REST API/pve.cpu.utilization,300)>{$NODE.CPU.UTIL.MAX}'
+              name: 'High CPU usage on {HOST.NAME} (>{$NODE.CPU.UTIL.MAX}%)'
+              opdata: 'CPU utilization: {ITEM.LASTVALUE1}'
+              priority: AVERAGE
+        - uuid: 29414e0fb6b1475c8a9e115ad5867544
+          name: 'PVE CPU info'
+          type: DEPENDENT
+          key: pve.cpuinfo
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'CPU model name string of the PVE host. Source: /nodes/{node}/status → data.cpuinfo.model.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.cpuinfo.model
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: 8553ce7c800c4b19b4fee13f474cdc67
+          name: 'PVE CPU threads'
+          type: DEPENDENT
+          key: pve.cpus
+          delay: '0'
+          trends: '0'
+          units: '!Threads'
+          description: 'Total number of logical CPU threads (vCPUs) on the PVE host. Source: /nodes/{node}/status → data.cpuinfo.cpus.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.cpuinfo.cpus
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: cb7951f01bdd48d7b913f468bd25d95c
+          name: 'PVE current kernel'
+          type: DEPENDENT
+          key: pve.current.kernel
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Running Linux kernel release string (e.g. 6.8.12-5-pve). Source: /nodes/{node}/status → data["current-kernel"].release.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data["current-kernel"].release'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Kernel
+        - uuid: 8942c1ce2a534b28b5dec5b3b31d224e
+          name: 'PVE disks raw'
+          type: HTTP_AGENT
+          key: pve.disks.raw
+          delay: '3600'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/disks/list. Used for physical disk discovery and SMART health monitoring. Requires Sys.Audit permission on the node.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/disks/list'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Disk
+        - uuid: 89edde254438495ca9a2bb64d19bfd83
+          name: 'PVE load average (15 min)'
+          type: DEPENDENT
+          key: pve.loadaverage.fifteen
+          delay: '0'
+          history: 7d
+          value_type: FLOAT
+          description: 'System load average over the last 15 minutes. Source: /nodes/{node}/status → data.loadavg[2].'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data.loadavg[2]'
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: 24d7734a0f944483b689078d6bfb046a
+          name: 'PVE load average (5 min)'
+          type: DEPENDENT
+          key: pve.loadaverage.fiveminute
+          delay: '0'
+          history: 7d
+          value_type: FLOAT
+          description: 'System load average over the last 5 minutes. Source: /nodes/{node}/status → data.loadavg[1].'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data.loadavg[1]'
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: 51b9d6c166124fd79742c9955390d7c9
+          name: 'PVE load average (1 min)'
+          type: DEPENDENT
+          key: pve.loadaverage.oneminute
+          delay: '0'
+          history: 7d
+          value_type: FLOAT
+          description: 'System load average over the last 1 minute. Source: /nodes/{node}/status → data.loadavg[0].'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data.loadavg[0]'
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: bbea8297bac34a2db928ee0faf130ac3
+          name: 'PVE localtime'
+          type: DEPENDENT
+          key: pve.localtime
+          delay: '0'
+          trends: '0'
+          units: unixtime
+          description: 'Current Unix timestamp on the PVE host. Source: /nodes/{node}/time → data.localtime.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.localtime
+          master_item:
+            key: pve.time.raw
+          tags:
+            - tag: PVE
+              value: Localtime
+        - uuid: 504287ef92ba490a8556df77218c0f5f
+          name: 'PVE machine type'
+          type: DEPENDENT
+          key: pve.machine.type
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Host kernel machine architecture (e.g. x86_64). Source: /nodes/{node}/status → data["current-kernel"].machine.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data["current-kernel"].machine'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Kernel
+        - uuid: b93a24e173824db2a8422a5023f877dd
+          name: 'PVE memory available'
+          type: DEPENDENT
+          key: pve.memory.free
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'RAM available for new workloads on the PVE host in bytes, cache and reclaimable memory included. Source: /nodes/{node}/status → data.memory.available. Together with the used value this adds up to the installed total, which data.memory.free does not.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.memory.available
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: 56dc42c2fe27451192793a1e52e6f807
+          name: 'PVE memory total'
+          type: DEPENDENT
+          key: pve.memory.total
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Total installed RAM on the PVE host in bytes. Source: /nodes/{node}/status → data.memory.total.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.memory.total
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: 6e293138bf5a44fcbcce62a215dfa299
+          name: 'PVE memory used'
+          type: DEPENDENT
+          key: pve.memory.used
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Used RAM on the PVE host in bytes. Source: /nodes/{node}/status → data.memory.used.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.memory.used
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: fdc7c84644eb4c8695242253245e6301
+          name: 'PVE memory utilization'
+          type: CALCULATED
+          key: pve.memory.util
+          delay: '60'
+          history: 7d
+          value_type: FLOAT
+          units: '%'
+          params: '(last(/{HOST.HOST}/pve.memory.used) / last(/{HOST.HOST}/pve.memory.total)) * 100'
+          description: 'Memory utilization of the PVE host in percent, derived from pve.memory.used and pve.memory.total.'
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: 18307b7cd70d4dba9de74dbe66fa0908
+          name: 'PVE CPU MHz'
+          type: DEPENDENT
+          key: pve.mhz
+          delay: '0'
+          value_type: FLOAT
+          trends: '0'
+          units: '!MHz'
+          description: 'CPU clock speed in MHz of the PVE host processor. Source: /nodes/{node}/status → data.cpuinfo.mhz.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.cpuinfo.mhz
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: 47c47cb9777a42f1897bbe4769d1f16d
+          name: 'PVE network raw'
+          type: HTTP_AGENT
+          key: pve.nodes.network.raw
+          delay: '300'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/network. Used for host network interface discovery.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/network'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Network
+        - uuid: fe1e2188f9c64bcfba8dd9866fcc82a2
+          name: 'PVE replication raw'
+          type: HTTP_AGENT
+          key: pve.replication.raw
+          delay: '300'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/replication. The list endpoint already carries the job state (last_sync, fail_count, error, duration), so no extra call per job is needed. Requires VM.Audit on the guests.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/replication'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 7d39927cb6b946f88d188d87de358c27
+          name: 'Disk rootfs avail'
+          type: DEPENDENT
+          key: pve.rootfs.avail
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Available free space on the PVE root filesystem (/) in bytes. Source: /nodes/{node}/status → data.rootfs.avail.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.rootfs.avail
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Disk
+        - uuid: fb359a78092d42058f3e1806b1043d2d
+          name: 'Disk rootfs size'
+          type: DEPENDENT
+          key: pve.rootfs.size
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Total size of the PVE root filesystem (/) in bytes. Source: /nodes/{node}/status → data.rootfs.total.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.rootfs.total
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Disk
+        - uuid: 67c36e0c37734c929573fb493a2a713e
+          name: 'Disk rootfs used'
+          type: DEPENDENT
+          key: pve.rootfs.used
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Used space on the PVE root filesystem (/) in bytes. Source: /nodes/{node}/status → data.rootfs.used.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.rootfs.used
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Disk
+        - uuid: d0a625fdcbb244158377964037f508ef
+          name: 'Disk rootfs utilization'
+          type: CALCULATED
+          key: pve.rootfs.util
+          delay: '60'
+          history: 7d
+          value_type: FLOAT
+          units: '%'
+          params: '(last(/{HOST.HOST}/pve.rootfs.used) / last(/{HOST.HOST}/pve.rootfs.size)) * 100'
+          description: 'Root filesystem utilization of the PVE host in percent, derived from pve.rootfs.used and pve.rootfs.size.'
+          tags:
+            - tag: PVE
+              value: Filesystem
+        - uuid: 05280836cd714144b39824854c84ffdd
+          name: 'PVE services raw'
+          type: HTTP_AGENT
+          key: pve.services.raw
+          delay: '60'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/services. Requires Sys.Audit on /nodes/{node}.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/services'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: f66a04532b684ec1b02127ba05466b0e
+          name: 'PVE CPU sockets'
+          type: DEPENDENT
+          key: pve.sockets
+          delay: '0'
+          trends: '0'
+          units: '!Sockets'
+          description: 'Number of physical CPU sockets on the PVE host. Source: /nodes/{node}/status → data.cpuinfo.sockets.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.cpuinfo.sockets
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: b0528b094c1e4e0d8fbb0428a1904f3f
+          name: 'PVE status raw'
+          type: HTTP_AGENT
+          key: pve.status
+          delay: '60'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/status. Used as source for all PVE host dependent items (CPU, memory, disk, kernel, uptime, etc.).'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/status'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 357ab7b347874237ba05a41c77a23ff8
+          name: 'PVE storage raw'
+          type: HTTP_AGENT
+          key: pve.storage.raw
+          delay: '60'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/storage. Used as source for all storage discovery rules and dependent items.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/storage'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 6cae341ba9a647a2babb62923e8204d7
+          name: 'Subscription level'
+          type: DEPENDENT
+          key: pve.subscription.level
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Subscription level code. Absent without a subscription, the value is then discarded instead of turning the item unsupported.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.level
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.subscription.raw
+          tags:
+            - tag: PVE
+              value: Subscription
+        - uuid: bd8804ef9fbc449f801054e6f8af4b90
+          name: 'Subscription next due date'
+          type: DEPENDENT
+          key: pve.subscription.nextduedate
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Next due date as reported by PVE, a plain date string. The numeric form for alerting is in pve.subscription.nextduedate.epoch.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.nextduedate
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.subscription.raw
+          tags:
+            - tag: PVE
+              value: Subscription
+        - uuid: b4b1c5b0d9d94fc2b3481695a27e911d
+          name: 'Subscription expiry'
+          type: DEPENDENT
+          key: pve.subscription.nextduedate.epoch
+          delay: '0'
+          value_type: FLOAT
+          trends: '0'
+          units: unixtime
+          description: 'Subscription due date as Unix time, 0 when the node has no subscription and PVE therefore reports no due date.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.nextduedate
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // 0 means: no subscription, so PVE reports no due date.
+                  if (value === '0') {
+                      return 0;
+                  }
+                  // PVE reports nextduedate as YYYY-MM-DD. Anchored to UTC so the
+                  // result does not shift with the server timezone. An unexpected
+                  // format throws, which turns the item visibly unsupported instead
+                  // of silently producing a wrong date.
+                  var t = Date.parse(value + 'T00:00:00Z');
+                  if (isNaN(t)) {
+                      throw 'unexpected nextduedate format: ' + value;
+                  }
+                  return Math.floor(t / 1000);
+          master_item:
+            key: pve.subscription.raw
+          tags:
+            - tag: PVE
+              value: Subscription
+          triggers:
+            - uuid: 9aaf123605424ccbb594a797dc819b5b
+              expression: 'last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)>0 and last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)-now()<{$PVE.SUBSCRIPTION.EXPIRE.DAYS}'
+              name: 'PVE subscription expires in less than {$PVE.SUBSCRIPTION.EXPIRE.DAYS} on {HOST.NAME}'
+              opdata: 'Expires on: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'Advance warning before the subscription runs out, so it can be renewed in time. Depends on the expired trigger, so only one of the two is open at a time.'
+              dependencies:
+                - name: 'PVE subscription has expired on {HOST.NAME}'
+                  expression: 'last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)>0 and last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)<now()'
+            - uuid: a70cecf225f4474f9de3cfa41173f55e
+              expression: 'last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)>0 and last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)<now()'
+              name: 'PVE subscription has expired on {HOST.NAME}'
+              opdata: 'Expired on: {ITEM.LASTVALUE1}'
+              priority: AVERAGE
+              description: 'The subscription period has ended. Access to the enterprise repository is gone, updates from it will fail. Hosts without a subscription report a due date of 0, which the trigger ignores.'
+        - uuid: 84118fad0bba4ce5bffb48112cdcf428
+          name: 'PVE subscription raw'
+          type: HTTP_AGENT
+          key: pve.subscription.raw
+          delay: '3600'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/subscription. Needs no special permission. Without a subscription the endpoint returns HTTP 200 and status notfound.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/subscription'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 0849be5b5a23405784c11020bb2fa335
+          name: 'Subscription status'
+          type: DEPENDENT
+          key: pve.subscription.status
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Subscription status: active, notfound, invalid, expired or suspended. Source: /nodes/{node}/subscription.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.status
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.subscription.raw
+          tags:
+            - tag: PVE
+              value: Subscription
+          triggers:
+            - uuid: ad9a7f6a1c124e7db461f40afed8ad33
+              expression: 'last(/Proxmox VE Node by REST API/pve.subscription.status)<>"active" and {$PVE.SUBSCRIPTION.ALERT}=1'
+              name: 'PVE subscription is not active on {HOST.NAME} ({ITEM.LASTVALUE})'
+              priority: WARNING
+              description: 'Status is notfound, invalid, expired or suspended. Off by default, set {$PVE.SUBSCRIPTION.ALERT}=1 on hosts that are meant to carry a subscription. Depends on the expired trigger so a lapsed subscription raises one problem, not two.'
+              dependencies:
+                - name: 'PVE subscription has expired on {HOST.NAME}'
+                  expression: 'last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)>0 and last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)<now()'
+        - uuid: 695362344c134354a6cc113a26628ff4
+          name: 'PVE swap free'
+          type: DEPENDENT
+          key: pve.swap.free
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Free swap space on the PVE host in bytes. Source: /nodes/{node}/status → data.swap.free. Reports 0 on hosts without swap.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.swap.free
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: 0b20519bcedf48809fce4475ef78e003
+          name: 'PVE swap total'
+          type: DEPENDENT
+          key: pve.swap.total
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Configured swap space on the PVE host in bytes. Source: /nodes/{node}/status → data.swap.total. Reports 0 on hosts without swap.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.swap.total
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: 98f9d9a8ae5f4acb96f4d304083e21e6
+          name: 'PVE swap used'
+          type: DEPENDENT
+          key: pve.swap.used
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Used swap space on the PVE host in bytes. Source: /nodes/{node}/status → data.swap.used. Swap filling up while memory is not tight usually means pages were evicted during an earlier peak and never came back.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.swap.used
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: 80475185f9604d8cb3d65657d5449c54
+          name: 'PVE boot mode'
+          type: DEPENDENT
+          key: pve.system.boot.mode
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Boot mode of the PVE host (e.g. efi, legacy-bios). Source: /nodes/{node}/status → data["boot-info"].mode.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data["boot-info"].mode'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Boot
+        - uuid: b50e9be8992c463c82d4b755ee305983
+          name: 'PVE secureboot'
+          type: DEPENDENT
+          key: pve.system.boot.secureboot
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Secure Boot status on the PVE host. 0 = disabled, 1 = enabled. Source: /nodes/{node}/status → data["boot-info"].secureboot.'
+          valuemap:
+            name: 'PVE secureboot'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data["boot-info"].secureboot'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Boot
+        - uuid: 33adc7da9f614d0592fcec4873639b7a
+          name: 'PVE tasks raw'
+          type: HTTP_AGENT
+          key: pve.tasks.raw
+          delay: '60'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/tasks, processed by JavaScript preprocessing to deduplicate tasks (keeps most recent run per id+type pair, excludes backup tasks handled by pve.backup.raw).'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  try {
+                      var obj = (typeof value === 'string') ? JSON.parse(value) : value;
+                      if (!obj || !obj.body || !Array.isArray(obj.body.data)) {
+                          return JSON.stringify({ error: "Invalid structure" });
+                      }
+                  
+                      var records = obj.body.data;
+                      var grouped = {};
+                  
+                      // Helper: normalise timestamp value to milliseconds
+                      // Robust time parsing: numeric strings, ISO, "YYYY-MM-DD HH:mm:ss"
+                      function normTime(v) {
+                          if (v === null || v === undefined) return -Infinity;
+                          if (typeof v === "number") return v < 1000000000000 ? v * 1000 : v;
+                          if (typeof v === "string") {
+                              var s = v.trim();
+                  
+                              // Treat purely numeric strings as numbers
+                              if (/^\d+(\.\d+)?$/.test(s)) {
+                                  var n = parseFloat(s);
+                                  return n < 1000000000000 ? n * 1000 : n;
+                              }
+                  
+                              // Parse "YYYY-MM-DD HH:mm:ss" (optional AM/PM)
+                              var m = s.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\s*(AM|PM))?$/i);
+                              if (m) {
+                                  var H = parseInt(m[4], 10), ampm = (m[7] || "").toUpperCase();
+                                  if (ampm) { if (ampm === "PM" && H < 12) H += 12; if (ampm === "AM" && H === 12) H = 0; }
+                                  return Date.UTC(+m[1], +m[2]-1, +m[3], H, +m[5], +m[6]);
+                              }
+                  
+                              // Fallback: parse as ISO-compatible string (Leerraum → 'T')
+                              var p = Date.parse(s.replace(/\s+/, "T"));
+                              return isNaN(p) ? -Infinity : p;
+                          }
+                          return -Infinity;
+                      }
+                      
+                  
+                      // Process task records
+                      for (var i = 0; i < records.length; i++) {
+                          var e = records[i];
+                          if (!e || !e.id || !e.type) continue;
+                  
+                          var key = e.id + "|" + e.type;
+                  
+                          // Normalise timestamps
+                          var copy = {};
+                          for (var k in e) if (e.hasOwnProperty(k)) copy[k] = e[k];
+                          copy._start = normTime(e.starttime || e.pstart || e.start);
+                  
+                          var existing = grouped[key];
+                          if (!existing || copy._start > existing._rep) {
+                              copy._rep = copy._start;
+                              grouped[key] = copy;
+                          }
+                      }
+                  
+                      // Build result list
+                      var resultList = [];
+                      for (var k in grouped) {
+                          var g = grouped[k];
+                          delete g._start;
+                          delete g._rep;
+                          g.grpid = g.id;
+                          resultList.push(g);
+                      }
+                  
+                      // Sort by ID
+                      // Sort: numeric IDs first, then lexicographic
+                      resultList.sort(function(a, b) {
+                          var aNum = /^\d+$/.test(String(a.id));
+                          var bNum = /^\d+$/.test(String(b.id));
+                          if (aNum && bNum) return Number(a.id) - Number(b.id);
+                          if (aNum && !bNum) return -1;
+                          if (!aNum && bNum) return 1;
+                          return (String(a.id) || "").localeCompare(String(b.id) || "");
+                      });
+                      
+                  
+                      obj.body.data = resultList;
+                      obj.body.total = resultList.length;
+                  
+                      return JSON.stringify(obj);
+                  
+                  } catch (err) {
+                      return JSON.stringify({ error: "Parsing failed", detail: err.message });
+                  }
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/tasks'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          output_format: JSON
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 9d414ebbce7e4d50b70ce6cf2bc8dddf
+          name: 'PVE time raw'
+          type: HTTP_AGENT
+          key: pve.time.raw
+          delay: 5m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/time. Used for timezone and localtime dependent items.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/time'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Time
+        - uuid: 7f2a227581b44e9fb9be9919f44f912e
+          name: 'PVE timezone'
+          type: DEPENDENT
+          key: pve.timezone
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Timezone configured on the PVE host (e.g. Europe/Berlin). Source: /nodes/{node}/time → data.timezone.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.timezone
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.time.raw
+          tags:
+            - tag: PVE
+              value: Timezone
+        - uuid: d88f124c7cb944bfa1c049428c864173
+          name: 'PVE uptime'
+          type: DEPENDENT
+          key: pve.uptime
+          delay: '0'
+          trends: '0'
+          units: s
+          description: 'Uptime of the PVE host in seconds since last boot. Source: /nodes/{node}/status → data.uptime.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.uptime
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Uptime
+          triggers:
+            - uuid: 7c6c07fb18584005923902ed297efd60
+              expression: 'nodata(/Proxmox VE Node by REST API/pve.uptime,300)=1'
+              name: 'PVE API not reachable on {HOST.NAME}'
+              opdata: 'No data for 5 minutes'
+              priority: HIGH
+              description: 'The Proxmox VE REST API has not returned data for 5 minutes. Check connectivity, API token, and PVE service status. Evaluated on "pve.uptime", because nodata() cannot read items that keep no history, such as the raw API item.'
+              manual_close: 'YES'
+        - uuid: 9320ab31c2704c7ab38e3c403762cc34
+          name: 'PVE version'
+          type: DEPENDENT
+          key: pve.version
+          delay: '0'
+          history: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Proxmox VE version string, for example 9.2.10. Source: /nodes/{node}/status → data.pveversion, which carries it as pve-manager/9.2.10/<repoid>. Read from the host status instead of the separate version endpoint, so no extra request per interval is needed.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.pveversion
+            - type: REGEX
+              parameters:
+                - 'pve-manager/([0-9][0-9.]*)'
+                - \1
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Version
+        - uuid: a1a88263c8e14ca1a7dcac5d20cb8eeb
+          name: 'PVE ZFS pools raw'
+          type: HTTP_AGENT
+          key: pve.zfs.raw
+          delay: '300'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/disks/zfs. Requires Sys.Audit on / (not on /nodes/{node}).'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/disks/zfs'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+      discovery_rules:
+        - uuid: ed09ff1436ff403a93e2390b8ebcadbd
+          name: 'Discover backup'
+          type: DEPENDENT
+          key: discover.backup
+          delay: '0'
+          lifetime_type: DELETE_IMMEDIATELY
+          lifetime: '0'
+          item_prototypes:
+            - uuid: e60e270792a24f269e131fd4d1bb4793
+              name: 'Backup duration {#ID}'
+              type: CALCULATED
+              key: 'backup.duration[{#BCKPID}]'
+              delay: '300'
+              history: 7d
+              value_type: FLOAT
+              units: s
+              params: 'last(/{HOST.HOST}/backup.endtime[{#BCKPID}]) - last(/{HOST.HOST}/backup.starttime[{#BCKPID}])'
+              description: 'How long the last finished backup of {#ID} took, in seconds. Derived from the end and start timestamps of the same run, both of which arrive together when the task reaches the archive. The value therefore describes the last completed run, never the one in progress.'
+              preprocessing:
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              tags:
+                - tag: PVE
+                  value: Backup
+                - tag: PVE
+                  value: '{#BCKPID}'
+                - tag: vmid
+                  value: '{#BCKPID}'
+            - uuid: 81828c7d71c8491fbc51fc952b12413d
+              name: 'Backup endtime {#ID}'
+              type: DEPENDENT
+              key: 'backup.endtime[{#BCKPID}]'
+              delay: '0'
+              history: 7d
+              units: unixtime
+              description: 'Unix timestamp of the last backup job end time for VM/CT {#ID}. Source: pve.backup.raw → data[bckpid].endtime.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.bckpid=="{#BCKPID}")].endtime.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.backup.raw
+              tags:
+                - tag: PVE
+                  value: Backup
+                - tag: PVE
+                  value: '{#BCKPID}'
+                - tag: vmid
+                  value: '{#BCKPID}'
+            - uuid: 6c2e7ea8e839464e9364f26b364f47db
+              name: 'Backup message {#ID}'
+              type: DEPENDENT
+              key: 'backup.message[{#BCKPID}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Status text of the last backup job for VM/CT {#BCKPID}, exactly as Proxmox VE reports it. A successful job reports OK, a failed one reports the error message itself. The numeric item Backup status maps only a fixed set of known texts, so this item carries the real cause of a failure.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.bckpid=="{#BCKPID}")].status.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.backup.raw
+              tags:
+                - tag: PVE
+                  value: Backup
+                - tag: vmid
+                  value: '{#BCKPID}'
+            - uuid: 354a2fa167f64c1db36e580548e3b166
+              name: 'Backup starttime {#ID}'
+              type: DEPENDENT
+              key: 'backup.starttime[{#BCKPID}]'
+              delay: '0'
+              history: 7d
+              units: unixtime
+              description: 'Unix timestamp of the last backup job start time for VM/CT {#ID}. Source: pve.backup.raw → data[bckpid].starttime.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.bckpid=="{#BCKPID}")].starttime.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.backup.raw
+              tags:
+                - tag: PVE
+                  value: Backup
+                - tag: PVE
+                  value: '{#BCKPID}'
+                - tag: vmid
+                  value: '{#BCKPID}'
+            - uuid: 4df227340b60403ba2f0aa919a7b002e
+              name: 'Backup status {#ID}'
+              type: DEPENDENT
+              key: 'backup.status[{#BCKPID}]'
+              delay: '0'
+              history: 7d
+              description: 'Status of the last backup job for VM/CT {#ID}. 0=OK, 1=running, 2=stopped, 3=error, 4=unknown error.'
+              valuemap:
+                name: 'Backup status'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.bckpid=="{#BCKPID}")].status.first()'
+                  error_handler: DISCARD_VALUE
+                - type: REGEX
+                  parameters:
+                    - ^(OK|running|stopped|error)$
+                    - \0
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '4'
+                - type: STR_REPLACE
+                  parameters:
+                    - OK
+                    - '0'
+                - type: STR_REPLACE
+                  parameters:
+                    - running
+                    - '1'
+                - type: STR_REPLACE
+                  parameters:
+                    - stopped
+                    - '2'
+                - type: STR_REPLACE
+                  parameters:
+                    - error
+                    - '3'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.backup.raw
+              tags:
+                - tag: PVE
+                  value: Backup
+                - tag: PVE
+                  value: '{#BCKPID}'
+                - tag: vmid
+                  value: '{#BCKPID}'
+          trigger_prototypes:
+            - uuid: 0762db69afb046c29dff36b0ff991aa8
+              expression: 'last(/Proxmox VE Node by REST API/backup.status[{#BCKPID}])>=2 and {$ENABLE_BACKUP_ALERT:"{#BCKPID}"}=1 and fuzzytime(/Proxmox VE Node by REST API/backup.endtime[{#BCKPID}],{$BACKUP.ALERT.WINDOW})=1'
+              name: 'Backup for {#ID} failed'
+              event_name: 'Backup for {#ID} failed: {?last(//backup.message[{#BCKPID}])}'
+              opdata: 'Backup status: {ITEM.LASTVALUE}'
+              priority: HIGH
+              description: |
+                0. OK: All clear, no errors detected
+                1. running: VM/CT is currently active
+                2. stopped: VM/CT has been shut down
+                3. error: General execution failure; check logs for details
+                4. unknown error: Cannot classify status, please check Proxmox for details
+              manual_close: 'YES'
+          graph_prototypes:
+            - uuid: 3911ea69cf744a0ca14fcd2dfc00c546
+              name: 'Backup status {#ID}'
+              graph_items:
+                - color: 8E24AA
+                  calc_fnc: ALL
+                  item:
+                    host: 'Proxmox VE Node by REST API'
+                    key: 'backup.status[{#BCKPID}]'
+          master_item:
+            key: pve.backup.raw
+          lld_macro_paths:
+            - lld_macro: '{#BCKPID}'
+              path: $.bckpid
+            - lld_macro: '{#ID}'
+              path: $.id
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: cb389126c8a3488fa7159353a7752517
+          name: 'Discover certificates'
+          type: DEPENDENT
+          key: discover.certificates
+          delay: '0'
+          description: 'Discovers the certificates of the node: pve-root-ca.pem, pve-ssl.pem and, if configured, pveproxy-ssl.pem from a custom or ACME certificate.'
+          item_prototypes:
+            - uuid: ed6a2bcdb1d146f198cd13b29f6974ed
+              name: 'Certificate issuer {#CERT_FILE}'
+              type: DEPENDENT
+              key: 'cert.issuer[{#CERT_FILE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Certificate issuer name.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.filename=="{#CERT_FILE}")].issuer.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.certificates.raw
+              tags:
+                - tag: PVE
+                  value: Certificate
+                - tag: PVE
+                  value: '{#CERT_FILE}'
+            - uuid: bf18104609214d4ca9f0b40324ab58d5
+              name: 'Certificate expiry {#CERT_FILE}'
+              type: DEPENDENT
+              key: 'cert.notafter[{#CERT_FILE}]'
+              delay: '0'
+              value_type: FLOAT
+              trends: '0'
+              units: unixtime
+              description: 'notAfter timestamp. PVE already delivers a Unix epoch, so no conversion is needed.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.filename=="{#CERT_FILE}")].notafter.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.certificates.raw
+              tags:
+                - tag: PVE
+                  value: Certificate
+                - tag: PVE
+                  value: '{#CERT_FILE}'
+              trigger_prototypes:
+                - uuid: 32fda78924934bd3bef32d616e773369
+                  expression: 'last(/Proxmox VE Node by REST API/cert.notafter[{#CERT_FILE}])-now()<{$PVE.CERT.EXPIRE.DAYS}'
+                  name: 'Certificate {#CERT_FILE} expires in less than {$PVE.CERT.EXPIRE.DAYS} on {HOST.NAME}'
+                  priority: WARNING
+                  description: 'Applies to pve-ssl.pem, pve-root-ca.pem and any custom or ACME certificate. The cluster CA runs for 50 years, the node certificate for two.'
+                  dependencies:
+                    - name: 'Certificate {#CERT_FILE} has expired on {HOST.NAME}'
+                      expression: 'last(/Proxmox VE Node by REST API/cert.notafter[{#CERT_FILE}])-now()<0'
+                - uuid: 4f5a5e9a676b4f4da919f85d37d0319b
+                  expression: 'last(/Proxmox VE Node by REST API/cert.notafter[{#CERT_FILE}])-now()<0'
+                  name: 'Certificate {#CERT_FILE} has expired on {HOST.NAME}'
+                  priority: AVERAGE
+                  description: 'The certificate is past its notAfter date. Clients and the web interface reject it, and API clients that verify the chain stop connecting. The advance warning depends on this trigger, so only one of the two is open at a time.'
+            - uuid: 421975e714f1410db04024c135b92764
+              name: 'Certificate subject {#CERT_FILE}'
+              type: DEPENDENT
+              key: 'cert.subject[{#CERT_FILE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Certificate subject name.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.filename=="{#CERT_FILE}")].subject.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.certificates.raw
+              tags:
+                - tag: PVE
+                  value: Certificate
+                - tag: PVE
+                  value: '{#CERT_FILE}'
+          master_item:
+            key: pve.certificates.raw
+          lld_macro_paths:
+            - lld_macro: '{#CERT_FILE}'
+              path: $.filename
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: d3ff98aa62014bd19d46c2b230b97a53
+          name: 'Discover disks'
+          type: DEPENDENT
+          key: discover.disks
+          delay: '0'
+          description: 'Discovers physical disks from /nodes/{node}/disks/list. Covers every disk type Proxmox VE reports, including SATA, SAS and NVMe. The wearout item is skipped for rotating disks, which do not expose that value.'
+          item_prototypes:
+            - uuid: e7fdc211cf1c462db6907db3af8ccb77
+              name: 'Disk {#DISK_DEV} health'
+              type: DEPENDENT
+              key: 'disk.health[{#DISK_DEV}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'SMART health status of disk {#DISK_DEV} ({#DISK_MODEL}). Values: PASSED, FAILED, UNKNOWN. Source: /nodes/{node}/disks/list, which reports the same overall health assessment as the dedicated SMART endpoint, so no extra request per disk is needed.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.devpath=="{#DISK_DEV}")].health.first()'
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: UNKNOWN
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.disks.raw
+              tags:
+                - tag: PVE
+                  value: Disk
+                - tag: PVE
+                  value: '{#DISK_DEV}'
+              trigger_prototypes:
+                - uuid: 1f006ac693614abf9740f0cf63997be4
+                  expression: |
+                    last(/Proxmox VE Node by REST API/disk.health[{#DISK_DEV}])<>"PASSED"
+                    and last(/Proxmox VE Node by REST API/disk.health[{#DISK_DEV}])<>"OK"
+                    and last(/Proxmox VE Node by REST API/disk.health[{#DISK_DEV}])<>"UNKNOWN"
+                    and last(/Proxmox VE Node by REST API/disk.health[{#DISK_DEV}])<>"SMART Disabled"
+                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) SMART health not PASSED on {HOST.NAME}'
+                  priority: HIGH
+                  description: 'SMART health check for disk {#DISK_DEV} returned a failed status. PASSED and OK are the healthy verdicts. UNKNOWN and SMART Disabled mean the disk reports no assessment at all and are not treated as a failure.'
+                  manual_close: 'YES'
+            - uuid: 1cc10c9ca58a4528b8e48e4e6cdaa815
+              name: 'Disk {#DISK_DEV} size'
+              type: DEPENDENT
+              key: 'disk.size[{#DISK_DEV}]'
+              delay: '0'
+              history: 7d
+              units: Bytes
+              description: 'Total size of physical disk {#DISK_DEV} ({#DISK_MODEL}) in bytes. Source: /nodes/{node}/disks/list.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.devpath=="{#DISK_DEV}")].size.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: pve.disks.raw
+              tags:
+                - tag: PVE
+                  value: Disk
+                - tag: PVE
+                  value: '{#DISK_DEV}'
+              trigger_prototypes:
+                - uuid: 90a3a0700d1f4faaa8a441fb9c0d2255
+                  expression: 'nodata(/Proxmox VE Node by REST API/disk.size[{#DISK_DEV}],{$DISK.MISSING.TIME})=1'
+                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) is no longer reported by {HOST.NAME}'
+                  priority: AVERAGE
+                  description: 'Proxmox VE has stopped listing this disk. Either the disk was removed on purpose or it dropped off the bus. The disk list is refreshed hourly, so {$DISK.MISSING.TIME} must stay well above one hour.'
+                  manual_close: 'YES'
+            - uuid: 8fbe418d241d44e0a885e4956306d57e
+              name: 'Disk {#DISK_DEV} SMART raw'
+              type: HTTP_AGENT
+              key: 'disk.smart.raw[{#DISK_DEV}]'
+              delay: '3600'
+              history: '0'
+              value_type: TEXT
+              trends: '0'
+              description: 'Master item. Raw JSON from /nodes/{node}/disks/smart for disk {#DISK_DEV}. Proxmox VE answers in two shapes: type=ata carries a list of numbered SMART attributes, type=text carries the raw smartctl output used for NVMe and SAS. Source for the disk temperature item.'
+              timeout: 20s
+              url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/disks/smart?disk={#DISK_DEV}'
+              headers:
+                - name: Authorization
+                  value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+                - name: Accept
+                  value: application/json
+              tags:
+                - tag: PVE
+                  value: Raw
+                - tag: PVE
+                  value: '{#DISK_DEV}'
+            - uuid: 2837e1e2414649fc976e82db6eb24966
+              name: 'Disk {#DISK_DEV} temperature'
+              type: DEPENDENT
+              key: 'disk.temp[{#DISK_DEV}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: '!°C'
+              description: 'Temperature of disk {#DISK_DEV} ({#DISK_MODEL}) in degrees Celsius. Read from the SMART payload of the disk. SATA and SAS disks report it as attribute 194, or 190 on drives that only expose an airflow sensor. NVMe disks report it in the composite Temperature line of the smartctl output. Disks that expose no temperature at all deliver no value.'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      // Proxmox returns two different SMART shapes, so both are handled here.
+                      // type=ata  -> numbered attribute list, temperature is id 194 (or 190)
+                      // type=text -> raw smartctl output, temperature is the composite line
+                      var d = JSON.parse(value).data;
+                      if (!d) {
+                          throw 'no SMART payload';
+                      }
+                      if (d.attributes) {
+                          var wanted = ['194', '190'];
+                          for (var w = 0; w < wanted.length; w++) {
+                              for (var i = 0; i < d.attributes.length; i++) {
+                                  var a = d.attributes[i];
+                                  // Proxmox keeps the attribute id as a space padded string
+                                  if (String(a.id).replace(/\s/g, '') !== wanted[w]) {
+                                      continue;
+                                  }
+                                  // the raw column may carry trailing text such as "38 (Min/Max 20/45)"
+                                  var r = String(a.raw).match(/\d+/);
+                                  if (r) {
+                                      return r[0];
+                                  }
+                              }
+                          }
+                      }
+                      if (typeof d.text === 'string') {
+                          var t = d.text.match(/^\s*Temperature:\s+(\d+)\s+Celsius/m);
+                          if (!t) {
+                              t = d.text.match(/^\s*Temperature Sensor 1:\s+(\d+)\s+Celsius/m);
+                          }
+                          if (t) {
+                              return t[1];
+                          }
+                      }
+                      throw 'no temperature in SMART data';
+              master_item:
+                key: 'disk.smart.raw[{#DISK_DEV}]'
+              tags:
+                - tag: PVE
+                  value: Disk
+                - tag: PVE
+                  value: '{#DISK_DEV}'
+              trigger_prototypes:
+                - uuid: f3a9973e8bb54de0bbc26e3164b49e8c
+                  expression: 'min(/Proxmox VE Node by REST API/disk.temp[{#DISK_DEV}],10m)>{$DISK.TEMP.MAX:"{#DISK_DEV}"}'
+                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) temperature above {$DISK.TEMP.MAX:"{#DISK_DEV}"} C on {HOST.NAME}'
+                  opdata: 'Temperature: {ITEM.LASTVALUE1}'
+                  priority: WARNING
+                  description: 'The disk has stayed above the temperature threshold for 10 minutes. Set {$DISK.TEMP.MAX:"{#DISK_DEV}"} to raise the threshold for a single disk.'
+                  manual_close: 'YES'
+            - uuid: bd29254423524861920b89e93861adba
+              name: 'Disk {#DISK_DEV} wearout'
+              type: DEPENDENT
+              key: 'disk.wearout[{#DISK_DEV}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: '%'
+              description: 'SSD wearout indicator for disk {#DISK_DEV} in percent remaining life (100% = new, 0% = worn out). Only meaningful for SSDs and NVMe, rotating disks report N/A and are discarded. Source: /nodes/{node}/disks/list. The SMART endpoint does not return this value.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.devpath=="{#DISK_DEV}")].wearout.first()'
+                  error_handler: DISCARD_VALUE
+                - type: MATCHES_REGEX
+                  parameters:
+                    - '^[0-9]+(\.[0-9]+)?$'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.disks.raw
+              tags:
+                - tag: PVE
+                  value: Disk
+                - tag: PVE
+                  value: '{#DISK_DEV}'
+              trigger_prototypes:
+                - uuid: 24dcd5cd84574b3b994614279613ed6b
+                  expression: 'last(/Proxmox VE Node by REST API/disk.wearout[{#DISK_DEV}])<{$DISK.WEAROUT.MIN}'
+                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) wearout below {$DISK.WEAROUT.MIN}% on {HOST.NAME}'
+                  priority: WARNING
+                  description: 'SSD wearout for disk {#DISK_DEV} is below threshold. Consider replacement planning.'
+                  manual_close: 'YES'
+          master_item:
+            key: pve.disks.raw
+          lld_macro_paths:
+            - lld_macro: '{#DISK_DEV}'
+              path: $.devpath
+            - lld_macro: '{#DISK_MODEL}'
+              path: $.model
+            - lld_macro: '{#DISK_SERIAL}'
+              path: $.serial
+            - lld_macro: '{#DISK_TYPE}'
+              path: $.type
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+          overrides:
+            - name: 'No wearout on rotating disks'
+              step: '1'
+              filter:
+                conditions:
+                  - macro: '{#DISK_TYPE}'
+                    value: ^hdd$
+                    formulaid: A
+              operations:
+                - operationobject: ITEM_PROTOTYPE
+                  operator: LIKE
+                  value: wearout
+                  discover: NO_DISCOVER
+        - uuid: 0d60456d6e6b468bbfb52d9cf9790f7b
+          name: 'Discover network interfaces'
+          type: DEPENDENT
+          key: discover.network
+          delay: '0'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#IFACE}'
+                value: '{$IFACE.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: A
+              - macro: '{#IFACE_TYPE}'
+                value: '^(bridge|bond|eth|en|vlan).*'
+                formulaid: B
+          description: 'Discovers host network interfaces from /nodes/{node}/network. Filters to relevant types (bridge, bond, eth/en*, vlan) and excludes the interface names matching {$IFACE.NOT_MATCHES}, which by default drops the per-guest interfaces Proxmox creates for VMs and containers.'
+          item_prototypes:
+            - uuid: 2af0a73539a441eabb7fa95c50860028
+              name: 'Network interface {#IFACE} active'
+              type: DEPENDENT
+              key: 'iface.active[{#IFACE}]'
+              delay: '0'
+              history: 7d
+              description: 'Active/link state of network interface {#IFACE} on the PVE host. 1 = active, 0 = inactive.'
+              valuemap:
+                name: 'Network interface active'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.iface=="{#IFACE}")].active.first()'
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: pve.nodes.network.raw
+              tags:
+                - tag: PVE
+                  value: Network
+                - tag: PVE
+                  value: '{#IFACE}'
+            - uuid: 0a1d67360d8b46678ecd5ab5becbb953
+              name: 'Network interface {#IFACE} autostart'
+              type: DEPENDENT
+              key: 'iface.autostart[{#IFACE}]'
+              delay: '0'
+              history: 7d
+              description: 'Configured admin state of network interface {#IFACE}. 1 = the interface has an "auto" entry in /etc/network/interfaces and is expected to be up, 0 = not configured for automatic start. If the API does not report the field at all the item falls back to 1, so that the interface down trigger keeps working and is decided by the activity condition alone.'
+              valuemap:
+                name: 'Network interface autostart'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.iface=="{#IFACE}")].autostart.first()'
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.nodes.network.raw
+              tags:
+                - tag: PVE
+                  value: Network
+                - tag: PVE
+                  value: '{#IFACE}'
+            - uuid: 1ea674dcd2f047368f2b79669f9d487c
+              name: 'Network interface {#IFACE} type'
+              type: DEPENDENT
+              key: 'iface.type[{#IFACE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Type/driver of network interface {#IFACE} (e.g. bridge, bond, eth). Source: /nodes/{node}/network.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.iface=="{#IFACE}")].type.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.nodes.network.raw
+              tags:
+                - tag: PVE
+                  value: Network
+                - tag: PVE
+                  value: '{#IFACE}'
+          trigger_prototypes:
+            - uuid: 0ae879b4c62241ce8c60669258989a83
+              expression: 'last(/Proxmox VE Node by REST API/iface.active[{#IFACE}])=0 and last(/Proxmox VE Node by REST API/iface.autostart[{#IFACE}])=1 and max(/Proxmox VE Node by REST API/iface.active[{#IFACE}],{$IFACE.ACTIVE.WINDOW})=1'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'last(/Proxmox VE Node by REST API/iface.active[{#IFACE}])=1'
+              name: 'Network interface {#IFACE} is down on {HOST.NAME}'
+              priority: AVERAGE
+              description: 'Host network interface {#IFACE} is no longer active/up. All three conditions must hold: the interface is down, it is configured to start automatically, and it was active at least once within {$IFACE.ACTIVE.WINDOW}. Interfaces that are configured but were never actually up do not raise this trigger.'
+              manual_close: 'YES'
+          graph_prototypes:
+            - uuid: 0cb677adb6c44968b501eee74d09d286
+              name: 'Network interface {#IFACE} status'
+              graph_items:
+                - color: 1976D2
+                  calc_fnc: ALL
+                  item:
+                    host: 'Proxmox VE Node by REST API'
+                    key: 'iface.active[{#IFACE}]'
+          master_item:
+            key: pve.nodes.network.raw
+          lld_macro_paths:
+            - lld_macro: '{#IFACE_TYPE}'
+              path: $.type
+            - lld_macro: '{#IFACE}'
+              path: $.iface
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: 29c7208a3d0b4248aa0c899d0803734c
+          name: 'Discover PVE services'
+          type: DEPENDENT
+          key: discover.pve.services
+          delay: '0'
+          filter:
+            conditions:
+              - macro: '{#SERVICE}'
+                value: '{$PVE.SERVICE.MATCHES}'
+                formulaid: A
+          description: 'Discovers the systemd units PVE manages. The default filter covers the services every node runs, standalone or clustered, including the HA managers and the scheduler that starts backup and replication jobs. corosync is excluded by default because it only runs once the node is part of a cluster; add it to {$PVE.SERVICE.MATCHES} on cluster nodes.'
+          item_prototypes:
+            - uuid: 312bcd7b99194954a4858e4d0ba2a6dd
+              name: 'Service active state {#SERVICE}'
+              type: DEPENDENT
+              key: 'pve.service.active_state[{#SERVICE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Systemd ActiveState: active, inactive or failed.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.service=="{#SERVICE}")]["active-state"].first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.services.raw
+              tags:
+                - tag: PVE
+                  value: Service
+                - tag: PVE
+                  value: '{#SERVICE}'
+            - uuid: 7389a5ef4bb143c582b405caab67bcc2
+              name: 'Service state {#SERVICE}'
+              type: DEPENDENT
+              key: 'pve.service.state[{#SERVICE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Systemd SubState, for example running, dead or exited.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.service=="{#SERVICE}")].state.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.services.raw
+              tags:
+                - tag: PVE
+                  value: Service
+                - tag: PVE
+                  value: '{#SERVICE}'
+              trigger_prototypes:
+                - uuid: 6db1d0a05f554aee9ce81d2510bc4d0d
+                  expression: 'last(/Proxmox VE Node by REST API/pve.service.state[{#SERVICE}])<>"running" and {$PVE.SERVICE.STATE.ALERT:"{#SERVICE}"}=1'
+                  name: 'PVE service {#SERVICE} is not running on {HOST.NAME}'
+                  priority: AVERAGE
+                  description: 'Systemd SubState of the service is no longer running. Use {$PVE.SERVICE.STATE.ALERT:"<service>"}=0 to silence a single service, and {$PVE.SERVICE.MATCHES} to control which services are discovered at all.'
+            - uuid: 52ff1662c40147808ce0803144ae228e
+              name: 'Service unit state {#SERVICE}'
+              type: DEPENDENT
+              key: 'pve.service.unit_state[{#SERVICE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Systemd UnitFileState: enabled, disabled, masked or static.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.service=="{#SERVICE}")]["unit-state"].first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.services.raw
+              tags:
+                - tag: PVE
+                  value: Service
+                - tag: PVE
+                  value: '{#SERVICE}'
+          master_item:
+            key: pve.services.raw
+          lld_macro_paths:
+            - lld_macro: '{#SERVICE}'
+              path: $.service
+            - lld_macro: '{#SVC_DESC}'
+              path: $.desc
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: bee58b896c914c6fb7e61162fc8f1b7c
+          name: 'Discover replication jobs'
+          type: DEPENDENT
+          key: discover.replication
+          delay: '0'
+          description: 'Discovers ZFS replication jobs. The list endpoint already carries the job state, so no extra request per job is required. Yields nothing on nodes without replication.'
+          item_prototypes:
+            - uuid: 7e952e95a11446faae086e6d17965bae
+              name: 'Replication duration {#REPL_ID}'
+              type: DEPENDENT
+              key: 'repl.duration[{#REPL_ID}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: s
+              description: 'Duration of the last run in seconds.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.id=="{#REPL_ID}")].duration.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: pve.replication.raw
+              tags:
+                - tag: PVE
+                  value: Replication
+                - tag: PVE
+                  value: '{#REPL_ID}'
+            - uuid: ec1159d285064fb99b747961b65a295a
+              name: 'Replication error {#REPL_ID}'
+              type: DEPENDENT
+              key: 'repl.error[{#REPL_ID}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Error message of the last failed run. Absent while the job is healthy, the value is then discarded instead of turning the item unsupported.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.id=="{#REPL_ID}")].error.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.replication.raw
+              tags:
+                - tag: PVE
+                  value: Replication
+                - tag: PVE
+                  value: '{#REPL_ID}'
+            - uuid: 8e1d7e7e6baf449192b2664314fd749a
+              name: 'Replication fail count {#REPL_ID}'
+              type: DEPENDENT
+              key: 'repl.fail_count[{#REPL_ID}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              description: 'Consecutive failures of this job. Absent before the first run.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.id=="{#REPL_ID}")].fail_count.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: pve.replication.raw
+              tags:
+                - tag: PVE
+                  value: Replication
+                - tag: PVE
+                  value: '{#REPL_ID}'
+              trigger_prototypes:
+                - uuid: fea4a41ab7274895b1c16139bd723538
+                  expression: 'last(/Proxmox VE Node by REST API/repl.fail_count[{#REPL_ID}])>{$PVE.REPL.FAIL.MAX}'
+                  name: 'Replication job {#REPL_ID} failing on {HOST.NAME}'
+                  event_name: 'Replication job {#REPL_ID} failing: {?last(//repl.error[{#REPL_ID}])}'
+                  priority: AVERAGE
+                  description: 'PVE counts consecutive failures of this replication job. The event name carries the error message PVE reported for the last run.'
+            - uuid: 2e6541fdc04f44be9cd07871ba8647d9
+              name: 'Replication last sync {#REPL_ID}'
+              type: DEPENDENT
+              key: 'repl.last_sync[{#REPL_ID}]'
+              delay: '0'
+              value_type: FLOAT
+              trends: '0'
+              units: unixtime
+              description: 'Timestamp of the last successful sync. Absent before the first successful run.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.id=="{#REPL_ID}")].last_sync.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: pve.replication.raw
+              tags:
+                - tag: PVE
+                  value: Replication
+                - tag: PVE
+                  value: '{#REPL_ID}'
+              trigger_prototypes:
+                - uuid: 1a817ea389f749eca3c025cfa0290bfe
+                  expression: 'fuzzytime(/Proxmox VE Node by REST API/repl.last_sync[{#REPL_ID}],{$PVE.REPL.LAG})=0'
+                  name: 'Replication job {#REPL_ID} has not synced for {$PVE.REPL.LAG}'
+                  priority: WARNING
+                  description: 'Last successful sync is older than {$PVE.REPL.LAG}. Raise the macro for jobs with a wide schedule, it must stay above the replication interval.'
+            - uuid: 2444dfedd7d047c485739195925b4e29
+              name: 'Replication last try {#REPL_ID}'
+              type: DEPENDENT
+              key: 'repl.last_try[{#REPL_ID}]'
+              delay: '0'
+              value_type: FLOAT
+              trends: '0'
+              units: unixtime
+              description: 'Timestamp of the last attempt, successful or not.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.id=="{#REPL_ID}")].last_try.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: pve.replication.raw
+              tags:
+                - tag: PVE
+                  value: Replication
+                - tag: PVE
+                  value: '{#REPL_ID}'
+          master_item:
+            key: pve.replication.raw
+          lld_macro_paths:
+            - lld_macro: '{#REPL_GUEST}'
+              path: $.guest
+            - lld_macro: '{#REPL_ID}'
+              path: $.id
+            - lld_macro: '{#REPL_TARGET}'
+              path: $.target
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: fa0d182630c144688682159e68e1edba
+          name: 'Discover storage'
+          type: DEPENDENT
+          key: discover.storage
+          delay: '0'
+          enabled_lifetime_type: DISABLE_AFTER
+          enabled_lifetime: 2d
+          item_prototypes:
+            - uuid: 1a4657a92c014216ac5ae940506975d0
+              name: 'Storage active status {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.active[{#STORAGE_NAME}]'
+              delay: '0'
+              history: 7d
+              description: 'Availability status of storage pool {#STORAGE_NAME}. 1 = active/available, 0 = inactive/not mounted.'
+              valuemap:
+                name: 'Storage active status'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].active.first()'
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+              trigger_prototypes:
+                - uuid: ef1d0e4ac74946eb88d5d06bd9cb9b67
+                  expression: 'min(/Proxmox VE Node by REST API/storage.active[{#STORAGE_NAME}],900)=0 and {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=1'
+                  name: 'Storage [{#STORAGE_NAME}] not available'
+                  priority: AVERAGE
+                  description: |
+                    Use the following host macros to control the "Storage not available" trigger for each storage:
+                    {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=1 enables the "Storage not available" trigger
+                    {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=0 disables (suppresses) the "Storage not available" trigger
+            - uuid: 367ac90904914198b8696d9578542c51
+              name: 'Storage available {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.avail[{#STORAGE_NAME}]'
+              delay: '0'
+              history: 7d
+              units: Bytes
+              description: 'Free space available on storage pool {#STORAGE_NAME} in bytes. Source: /nodes/{node}/storage.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].avail.first()'
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+            - uuid: bc43ad91389e4d05949fb2001bc078e3
+              name: 'Storage content {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.content[{#STORAGE_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Content types supported by storage pool {#STORAGE_NAME} (e.g. images,backup,iso). Source: /nodes/{node}/storage → data[storage].content.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].content.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+            - uuid: 7f7c921aad664fc0a01ddd01b467d4e2
+              name: 'Storage type {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.name[{#STORAGE_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Storage backend type/driver of {#STORAGE_NAME} (e.g. dir, zfspool, lvm, nfs). Source: /nodes/{node}/storage → data[storage].type.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].type.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+            - uuid: a1eabf828c9c4218878486802f25b10b
+              name: 'Storage shared status {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.shared[{#STORAGE_NAME}]'
+              delay: '0'
+              trends: '0'
+              description: 'Indicates whether the storage {#STORAGE_NAME} is shared across the cluster (Shared = 1) or available only locally (Not Shared = 0).'
+              valuemap:
+                name: 'Storage shared status'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].shared.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+            - uuid: 5b24f6e722db4d56b54861e1ce9bba54
+              name: 'Storage total {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.size[{#STORAGE_NAME}]'
+              delay: '0'
+              history: 7d
+              units: Bytes
+              description: 'Total capacity of storage pool {#STORAGE_NAME} in bytes. Source: /nodes/{node}/storage.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].total.first()'
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+            - uuid: c63cf494a0414e70b14d3328fc690362
+              name: 'Storage used {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.used[{#STORAGE_NAME}]'
+              delay: '0'
+              history: 7d
+              units: Bytes
+              description: 'Used space on storage pool {#STORAGE_NAME} in bytes. Source: /nodes/{node}/storage.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].used.first()'
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+            - uuid: 488d0f54d2ab40079726991ac0558f26
+              name: 'Storage utilization {#STORAGE_NAME} (%)'
+              type: CALCULATED
+              key: 'storage.util[{#STORAGE_NAME}]'
+              delay: '60'
+              history: 7d
+              value_type: FLOAT
+              units: '%'
+              params: 'last(/{HOST.HOST}/storage.used[{#STORAGE_NAME}]) / last(/{HOST.HOST}/storage.size[{#STORAGE_NAME}]) * 100'
+              description: 'Storage utilization as percentage of total size.'
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+              trigger_prototypes:
+                - uuid: 085598f426c344bb92dbdc9e489ff307
+                  expression: 'last(/Proxmox VE Node by REST API/storage.util[{#STORAGE_NAME}]) > {$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"} and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
+                  name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} >{$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"}%)'
+                  opdata: 'Used: {ITEM.LASTVALUE1}'
+                  priority: HIGH
+                  description: |
+                    Storage utilization exceeded the critical threshold {$STORAGE.UTIL.CRIT}%.
+                    Use context macro {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=0 to suppress.
+                - uuid: 0288a8909ea64885a6cfcf2184d2667b
+                  expression: 'last(/Proxmox VE Node by REST API/storage.util[{#STORAGE_NAME}]) > {$STORAGE.UTIL.WARN:"{#STORAGE_NAME}"} and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
+                  name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} >{$STORAGE.UTIL.WARN:"{#STORAGE_NAME}"}%)'
+                  opdata: 'Used: {ITEM.LASTVALUE1}'
+                  priority: AVERAGE
+                  description: |
+                    Storage utilization exceeded the warning threshold {$STORAGE.UTIL.WARN}%.
+                    Use context macro {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=0 to suppress.
+                  dependencies:
+                    - name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} >{$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"}%)'
+                      expression: 'last(/Proxmox VE Node by REST API/storage.util[{#STORAGE_NAME}]) > {$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"} and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
+          graph_prototypes:
+            - uuid: a847e130161449f2b25dbab05cea1eff
+              name: 'Storage active state {#STORAGE_NAME}'
+              graph_items:
+                - color: 00FF00
+                  calc_fnc: ALL
+                  item:
+                    host: 'Proxmox VE Node by REST API'
+                    key: 'storage.active[{#STORAGE_NAME}]'
+            - uuid: 0c4f3e988aa34cb4b01ec10034c6dd79
+              name: 'Storage usage {#STORAGE_NAME}'
+              yaxismax: '0'
+              show_work_period: 'NO'
+              show_triggers: 'NO'
+              type: EXPLODED
+              graph_items:
+                - color: 0040FF
+                  calc_fnc: LAST
+                  item:
+                    host: 'Proxmox VE Node by REST API'
+                    key: 'storage.used[{#STORAGE_NAME}]'
+                - sortorder: '1'
+                  color: 388E3C
+                  calc_fnc: LAST
+                  item:
+                    host: 'Proxmox VE Node by REST API'
+                    key: 'storage.avail[{#STORAGE_NAME}]'
+            - uuid: 548642fe23df4b6ab249aeea43240b48
+              name: 'Storage utilization % {#STORAGE_NAME}'
+              graph_items:
+                - color: E53935
+                  item:
+                    host: 'Proxmox VE Node by REST API'
+                    key: 'storage.util[{#STORAGE_NAME}]'
+          master_item:
+            key: pve.storage.raw
+          lld_macro_paths:
+            - lld_macro: '{#STORAGE_NAME}'
+              path: $.storage
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: 86716f0957ef407a989e62872f387448
+          name: 'Discover tasks'
+          type: DEPENDENT
+          key: discover.tasks
+          delay: '0'
+          filter:
+            conditions:
+              - macro: '{#TYPE}'
+                value: '.*\bvzdump\b.*'
+                operator: NOT_MATCHES_REGEX
+                formulaid: A
+          lifetime_type: DELETE_IMMEDIATELY
+          lifetime: '0'
+          item_prototypes:
+            - uuid: 019142c8682949208dc78347bfd3afc2
+              name: 'Task endtime {#TYPE} {#ID}'
+              type: DEPENDENT
+              key: 'task.endtime[{#GRPID},{#TYPE}]'
+              delay: '0'
+              trends: '0'
+              units: unixtime
+              description: 'Unix timestamp of the last end time for task type {#TYPE} on VM/CT {#GRPID}. Source: pve.tasks.raw.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].endtime.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.tasks.raw
+              tags:
+                - tag: PVE
+                  value: Tasks
+                - tag: vmid
+                  value: '{#GRPID}'
+            - uuid: 1cd2547e6faa43bcad9cad800978870d
+              name: 'Task message {#TYPE} {#ID}'
+              type: DEPENDENT
+              key: 'task.message[{#GRPID},{#TYPE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Status text of the last task of type {#TYPE} for VM/CT {#GRPID}, exactly as Proxmox VE reports it. A successful task reports OK, a failed one reports the error message itself. The numeric item Task Status maps only a fixed set of known texts, so this item carries the real cause of a failure.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].status.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.tasks.raw
+              tags:
+                - tag: PVE
+                  value: Tasks
+                - tag: vmid
+                  value: '{#GRPID}'
+            - uuid: ed9ca245a6a14cf6b74f4de14203fdac
+              name: 'Task starttime {#TYPE} {#ID}'
+              type: DEPENDENT
+              key: 'task.starttime[{#GRPID},{#TYPE}]'
+              delay: '0'
+              trends: '0'
+              units: unixtime
+              description: 'Unix timestamp of the last start time for task type {#TYPE} on VM/CT {#GRPID}. Source: pve.tasks.raw.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].starttime.first()'
+                  error_handler: DISCARD_VALUE
+                - type: LTRIM
+                  parameters:
+                    - '["'
+                - type: RTRIM
+                  parameters:
+                    - '"]'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.tasks.raw
+              tags:
+                - tag: PVE
+                  value: Tasks
+                - tag: vmid
+                  value: '{#GRPID}'
+            - uuid: 759cf8e0fc9a450a8ace0d37b393db70
+              name: 'Task Status: {#TYPE} {#ID}'
+              type: DEPENDENT
+              key: 'task.status[{#GRPID},{#TYPE}]'
+              delay: '0'
+              trends: '0'
+              description: |
+                0. OK: All clear, no errors detected.
+                1. running: VM/CT is currently active.
+                2. stopped: VM/CT has been shut down.
+                3. error: General execution failure; check logs for details.
+                4. unexpected status: Returned state not anticipated by the script/API.
+                5. CT locked (disk): Container's disk is locked (e.g. during backup or migration).
+                6. timeout waiting on system: Operation exceeded its time limit and was aborted.
+                7. Failed to run vncproxy.: Unable to start the VNC proxy process.
+                8. unable to read tail (got 0 b): Failed to read log tail; zero bytes returned.
+                9. interrupted by signal: Process was terminated by a signal (e.g. SIGINT/SIGTERM).
+                10. unknown error: Cannot classify status, please check Proxmox for details
+              valuemap:
+                name: 'Tasks status'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].status.first()'
+                  error_handler: DISCARD_VALUE
+                - type: REGEX
+                  parameters:
+                    - '^(OK|running|stopped|error|unexpected status|CT is locked \(disk\)|timeout waiting on systemd|Failed to run vncproxy\.|unable to read tail \(got 0 bytes\)|interrupted by signal)$'
+                    - \0
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '10'
+                - type: STR_REPLACE
+                  parameters:
+                    - OK
+                    - '0'
+                - type: STR_REPLACE
+                  parameters:
+                    - running
+                    - '1'
+                - type: STR_REPLACE
+                  parameters:
+                    - stopped
+                    - '2'
+                - type: STR_REPLACE
+                  parameters:
+                    - error
+                    - '3'
+                - type: STR_REPLACE
+                  parameters:
+                    - 'unexpected status'
+                    - '4'
+                - type: STR_REPLACE
+                  parameters:
+                    - 'CT is locked (disk)'
+                    - '5'
+                - type: STR_REPLACE
+                  parameters:
+                    - 'timeout waiting on systemd'
+                    - '6'
+                - type: STR_REPLACE
+                  parameters:
+                    - 'Failed to run vncproxy.'
+                    - '7'
+                - type: STR_REPLACE
+                  parameters:
+                    - 'unable to read tail (got 0 bytes)'
+                    - '8'
+                - type: STR_REPLACE
+                  parameters:
+                    - 'interrupted by signal'
+                    - '9'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.tasks.raw
+              tags:
+                - tag: PVE
+                  value: Tasks
+                - tag: vmid
+                  value: '{#GRPID}'
+          trigger_prototypes:
+            - uuid: 687c925cfc7545189a76f433492b9052
+              expression: 'last(/Proxmox VE Node by REST API/task.status[{#GRPID},{#TYPE}])>1 and {$ENABLE_TASK_ALERT:"{#GRPID}"}=1 and fuzzytime(/Proxmox VE Node by REST API/task.endtime[{#GRPID},{#TYPE}],{$TASK.ALERT.WINDOW})=1'
+              name: 'Proxmox task {#TYPE} {#ID} failed'
+              event_name: 'Proxmox task {#TYPE} {#ID} failed: {ITEM.VALUE}'
+              opdata: 'Current task status: {ITEM.LASTVALUE}'
+              priority: WARNING
+              description: |
+                A task of type {#TYPE} for VM/CT {#ID} finished with a status other than OK.
+                The problem clears as soon as a later task of the same id and type succeeds, and it expires on its own once the failure is older than {$TASK.ALERT.WINDOW}, because Proxmox VE only keeps the most recent tasks in its task list.
+                Use context macro to suppress per-task:
+                {$ENABLE_TASK_ALERT:"{#GRPID}"}=0 suppresses this trigger for a specific task.
+                {$ENABLE_TASK_ALERT}=0 disables all task failure alerts globally.
+              manual_close: 'YES'
+          graph_prototypes:
+            - uuid: b95ce02f2d0f4170a89762f91822c25a
+              name: 'Task status {#TYPE} {#ID}'
+              graph_items:
+                - color: 00897B
+                  calc_fnc: ALL
+                  item:
+                    host: 'Proxmox VE Node by REST API'
+                    key: 'task.status[{#GRPID},{#TYPE}]'
+          master_item:
+            key: pve.tasks.raw
+          lld_macro_paths:
+            - lld_macro: '{#GRPID}'
+              path: $.grpid
+            - lld_macro: '{#ID}'
+              path: $.id
+            - lld_macro: '{#TYPE}'
+              path: $.type
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.body.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: a2299a539f4b4bb883faf5454666d326
+          name: 'Discover ZFS pools'
+          type: DEPENDENT
+          key: discover.zfs.pools
+          delay: '0'
+          description: 'Discovers local ZFS pools. Yields nothing on nodes without ZFS. The master item needs Sys.Audit on / and turns unsupported with HTTP 403 otherwise.'
+          item_prototypes:
+            - uuid: a2cbf6a1215947098eec5ab28298a79a
+              name: 'ZFS pool allocated {#ZPOOL}'
+              type: DEPENDENT
+              key: 'zfs.alloc[{#ZPOOL}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: Bytes
+              description: 'Allocated bytes in the pool.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.name=="{#ZPOOL}")].alloc.first()'
+              master_item:
+                key: pve.zfs.raw
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+            - uuid: e033edf6a5d34bdf9783bf16a1160bf3
+              name: 'ZFS pool dedup ratio {#ZPOOL}'
+              type: DEPENDENT
+              key: 'zfs.dedup[{#ZPOOL}]'
+              delay: '0'
+              value_type: FLOAT
+              trends: '0'
+              description: 'Deduplication ratio, 1.0 when dedup is off.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.name=="{#ZPOOL}")].dedup.first()'
+              master_item:
+                key: pve.zfs.raw
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+            - uuid: 0085e84d5e534d009d99a9fe84aac2c7
+              name: 'ZFS pool fragmentation {#ZPOOL}'
+              type: DEPENDENT
+              key: 'zfs.frag[{#ZPOOL}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: '%'
+              description: 'Free space fragmentation in percent.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.name=="{#ZPOOL}")].frag.first()'
+              master_item:
+                key: pve.zfs.raw
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+            - uuid: 2614bfe6a3c54005ac46166fb716cb56
+              name: 'ZFS pool free {#ZPOOL}'
+              type: DEPENDENT
+              key: 'zfs.free[{#ZPOOL}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: Bytes
+              description: 'Free bytes in the pool.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.name=="{#ZPOOL}")].free.first()'
+              master_item:
+                key: pve.zfs.raw
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+            - uuid: a395322e603543199a1f40729402f5c2
+              name: 'ZFS pool health {#ZPOOL}'
+              type: DEPENDENT
+              key: 'zfs.health[{#ZPOOL}]'
+              delay: '0'
+              history: 7d
+              description: 'zpool health as a number so it can be graphed and used on a dashboard. 0 is ONLINE, everything above is a fault. The value map turns it back into the zpool wording.'
+              valuemap:
+                name: 'ZFS pool health'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.name=="{#ZPOOL}")].health.first()'
+                - type: STR_REPLACE
+                  parameters:
+                    - ONLINE
+                    - '0'
+                - type: STR_REPLACE
+                  parameters:
+                    - DEGRADED
+                    - '1'
+                - type: STR_REPLACE
+                  parameters:
+                    - FAULTED
+                    - '2'
+                - type: STR_REPLACE
+                  parameters:
+                    - OFFLINE
+                    - '3'
+                - type: STR_REPLACE
+                  parameters:
+                    - REMOVED
+                    - '4'
+                - type: STR_REPLACE
+                  parameters:
+                    - UNAVAIL
+                    - '5'
+                - type: STR_REPLACE
+                  parameters:
+                    - SUSPENDED
+                    - '6'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.zfs.raw
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+              trigger_prototypes:
+                - uuid: f38481047bc6466faee16f63542a52a7
+                  expression: 'last(/Proxmox VE Node by REST API/zfs.health[{#ZPOOL}])=1'
+                  name: 'ZFS pool {#ZPOOL} is DEGRADED on {HOST.NAME}'
+                  priority: AVERAGE
+                  description: 'The pool still serves data but has lost redundancy, so a second failure means data loss. Check /nodes/{node}/disks/zfs/{pool} for the failing vdev, the detail endpoint reports read, write and checksum errors per device.'
+                - uuid: 0f96b8da3e2a425694d1f52b968aa141
+                  expression: 'last(/Proxmox VE Node by REST API/zfs.health[{#ZPOOL}])>=2'
+                  name: 'ZFS pool {#ZPOOL} is not usable on {HOST.NAME}'
+                  event_name: 'ZFS pool {#ZPOOL} is {ITEM.VALUE1} on {HOST.NAME}'
+                  priority: HIGH
+                  description: 'The pool is FAULTED, OFFLINE, REMOVED, UNAVAIL or SUSPENDED, so it no longer serves data. DEGRADED is reported separately at a lower severity because the pool keeps running. Check /nodes/{node}/disks/zfs/{pool} for the failing vdev, the detail endpoint reports read, write and checksum errors per device.'
+            - uuid: bc93b908353e4dffbfcc1c490f466fbd
+              name: 'ZFS pool size {#ZPOOL}'
+              type: DEPENDENT
+              key: 'zfs.size[{#ZPOOL}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: Bytes
+              description: 'Total pool size in bytes.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.name=="{#ZPOOL}")].size.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.zfs.raw
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+            - uuid: 9bf2068742ca4a55981b0e398a5115ff
+              name: 'ZFS pool utilization {#ZPOOL}'
+              type: CALCULATED
+              key: 'zfs.util[{#ZPOOL}]'
+              delay: '300'
+              history: 7d
+              value_type: FLOAT
+              units: '%'
+              params: '100*last(//zfs.alloc[{#ZPOOL}])/last(//zfs.size[{#ZPOOL}])'
+              description: 'Allocated share of the pool. Calculated from alloc and size, PVE does not report a percentage.'
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+              trigger_prototypes:
+                - uuid: 59bd89d3aede483c950005cfc6ebb168
+                  expression: 'last(/Proxmox VE Node by REST API/zfs.util[{#ZPOOL}])>{$ZFS.UTIL.CRIT:"{#ZPOOL}"}'
+                  name: 'ZFS pool {#ZPOOL} usage above {$ZFS.UTIL.CRIT:"{#ZPOOL}"}% on {HOST.NAME}'
+                  priority: HIGH
+                  description: 'ZFS performance degrades sharply once a pool fills up. Keep pools below 80%.'
+                - uuid: 4037a5aac12246b2b4a0670482010837
+                  expression: 'last(/Proxmox VE Node by REST API/zfs.util[{#ZPOOL}])>{$ZFS.UTIL.WARN:"{#ZPOOL}"}'
+                  name: 'ZFS pool {#ZPOOL} usage above {$ZFS.UTIL.WARN:"{#ZPOOL}"}% on {HOST.NAME}'
+                  priority: AVERAGE
+                  description: 'ZFS performance degrades sharply once a pool fills up. Keep pools below 80%.'
+                  dependencies:
+                    - name: 'ZFS pool {#ZPOOL} usage above {$ZFS.UTIL.CRIT:"{#ZPOOL}"}% on {HOST.NAME}'
+                      expression: 'last(/Proxmox VE Node by REST API/zfs.util[{#ZPOOL}])>{$ZFS.UTIL.CRIT:"{#ZPOOL}"}'
+          trigger_prototypes:
+            - uuid: abe3b298885b44efbd1b856566a1aa51
+              expression: 'last(/Proxmox VE Node by REST API/zfs.frag[{#ZPOOL}])>{$ZFS.FRAG.WARN:"{#ZPOOL}"} and last(/Proxmox VE Node by REST API/zfs.util[{#ZPOOL}])>{$ZFS.FRAG.UTIL.MIN:"{#ZPOOL}"}'
+              name: 'ZFS pool {#ZPOOL} free space is fragmented on {HOST.NAME}'
+              priority: WARNING
+              description: 'Fragmentation describes the free space, not the stored data, so on its own it costs nothing. It starts to hurt once the pool is also fairly full, because the allocator then has to satisfy writes from ever smaller free segments. The trigger therefore requires both {$ZFS.FRAG.WARN} and {$ZFS.FRAG.UTIL.MIN} to be exceeded. Freeing space and removing old snapshots helps, defragmenting a zpool is not possible.'
+          master_item:
+            key: pve.zfs.raw
+          lld_macro_paths:
+            - lld_macro: '{#ZPOOL}'
+              path: $.name
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+      macros:
+        - macro: '{$BACKUP.ALERT.WINDOW}'
+          value: 24h
+          description: 'How long a failed backup keeps alerting. The problem clears earlier if a later backup of the same guest succeeds. The value must include a time unit, for example 24h or 2d.'
+        - macro: '{$DISK.MISSING.TIME}'
+          value: 3h
+          description: 'How long a disk may be absent from the Proxmox disk list before the missing disk trigger fires. The list is refreshed once per hour, so keep this well above 1h. The value must include a time unit.'
+        - macro: '{$DISK.TEMP.MAX}'
+          value: '60'
+          description: 'Temperature threshold for physical disks in degrees Celsius. Use the context form {$DISK.TEMP.MAX:"/dev/sda"} to raise it for a single disk.'
+        - macro: '{$DISK.WEAROUT.MIN}'
+          value: '20'
+          description: 'Minimum SSD wearout remaining (%) before triggering a warning. Default: 20%.'
+        - macro: '{$ENABLE_BACKUP_ALERT}'
+          value: '1'
+          description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
+        - macro: '{$ENABLE_STORAGE_AVAILABLE_ALERT}'
+          value: '1'
+          description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
+        - macro: '{$ENABLE_STORAGE_INACTIVE_ALERT}'
+          value: '1'
+          description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
+        - macro: '{$ENABLE_TASK_ALERT}'
+          value: '1'
+          description: 'To enable task failure alerts set to 1. Use context macro {$ENABLE_TASK_ALERT:"{#GRPID}"}=0 to suppress alerts for individual tasks.'
+        - macro: '{$IFACE.ACTIVE.WINDOW}'
+          value: 7d
+          description: 'Lookback window for the network interface down trigger. The interface must have been active at least once within this period, otherwise it is treated as configured but never used and does not alert. The value must include a time unit (e.g. 7d, 24h).'
+        - macro: '{$IFACE.NOT_MATCHES}'
+          value: ^(tap|veth|fwbr|fwpr|fwln)
+          description: 'LLD filter: host network interface names to exclude (regex). The default drops the per-guest interfaces Proxmox creates for VMs and containers, which appear and disappear together with the guest.'
+        - macro: '{$MEMORY.UTIL.MAX}'
+          value: '90'
+          description: 'Warning threshold for memory utilization of the PVE host itself (%). Guest memory is not covered by this macro.'
+        - macro: '{$NODE.CPU.UTIL.MAX}'
+          value: '90'
+          description: 'Node CPU utilization (%) before the high CPU trigger fires. The threshold used to be hardcoded in the trigger expression.'
+        - macro: '{$PVE.APT.REPO.ERRORS.MAX}'
+          value: '0'
+          description: 'Tolerated number of unparsable APT repository files before alerting.'
+        - macro: '{$PVE.APT.REPO.WARN.MAX}'
+          value: '0'
+          description: 'Tolerated number of APT repository warnings. A host on the no-subscription repository permanently reports one warning, set this to 1 there.'
+        - macro: '{$PVE.APT.UPDATES.MAX}'
+          value: '0'
+          description: 'Tolerated number of pending package updates. Only relevant if the disabled apt/update items are switched on.'
+        - macro: '{$PVE.BACKUP.RUN.MAX}'
+          value: 3h
+          description: 'How long a backup may run before it is treated as stuck. The value must include a time unit, for example 3h or 90m, and must stay above the normal runtime of the longest job, otherwise the trigger fires during every regular run.'
+        - macro: '{$PVE.CERT.EXPIRE.DAYS}'
+          value: 21d
+          description: 'Lead time before certificate expiry. Must include a time unit, for example 21d.'
+        - macro: '{$PVE.REPL.FAIL.MAX}'
+          value: '0'
+          description: 'Tolerated consecutive failures of a replication job. Use the context form {$PVE.REPL.FAIL.MAX:"105-0"} for a single job.'
+        - macro: '{$PVE.REPL.LAG}'
+          value: 2h
+          description: 'Maximum age of the last successful replication. Must stay above the replication schedule, otherwise the trigger fires between two runs. Must include a time unit.'
+        - macro: '{$PVE.SERVICE.MATCHES}'
+          value: ^(pve-cluster|pvedaemon|pveproxy|pvestatd|pve-firewall|pvescheduler|pve-ha-crm|pve-ha-lrm)$
+          description: 'Services to discover. corosync is left out because it only runs on cluster members; add it there.'
+        - macro: '{$PVE.SERVICE.STATE.ALERT}'
+          value: '1'
+          description: 'Enables the service state trigger. Use the context form {$PVE.SERVICE.STATE.ALERT:"pveproxy"}=0 to silence a single service.'
+        - macro: '{$PVE.SUBSCRIPTION.ALERT}'
+          value: '0'
+          description: 'Set to 1 on hosts that are meant to carry a subscription. Off by default so community hosts do not alert on status notfound.'
+        - macro: '{$PVE.SUBSCRIPTION.EXPIRE.DAYS}'
+          value: 30d
+          description: 'Lead time before the subscription expires. Must include a time unit, for example 30d. The expiry triggers need no enable macro: hosts without a subscription report no due date, so the item stays empty.'
+        - macro: '{$PVE_API_TOKEN}'
+          type: SECRET_TEXT
+          description: 'The API token secret used to authenticate with the Proxmox VE REST API.'
+        - macro: '{$PVE_API_TOKEN_ID}'
+          value: Zabbix
+          description: 'The identifier (name) of the Proxmox VE API token.'
+        - macro: '{$PVE_API_USER}'
+          value: root@pam
+          description: 'The Proxmox VE username (including realm, e.g. "root@pam") for API authentication.'
+        - macro: '{$PVE_IP}'
+          value: localhost
+          description: 'The IP address or hostname of the Proxmox VE API server.'
+        - macro: '{$PVE_NODE}'
+          value: pve
+          description: 'The Proxmox VE node identifier (e.g. "pve") used in API endpoint paths.'
+        - macro: '{$PVE_PORT}'
+          value: '8006'
+          description: 'The TCP port number on which the Proxmox VE API listens (default: 8006).'
+        - macro: '{$ROOTFS.UTIL.CRIT}'
+          value: '95'
+          description: 'Critical threshold for root filesystem utilization (%).'
+        - macro: '{$ROOTFS.UTIL.WARN}'
+          value: '90'
+          description: 'Warning threshold for root filesystem utilization (%).'
+        - macro: '{$STORAGE.UTIL.CRIT}'
+          value: '90'
+          description: 'Critical threshold for storage utilization (%). Triggers when storage used exceeds this value.'
+        - macro: '{$STORAGE.UTIL.WARN}'
+          value: '80'
+          description: 'Warning threshold for storage utilization (%). Triggers when storage used exceeds this value.'
+        - macro: '{$SWAP.UTIL.MAX}'
+          value: '80'
+          description: 'Warning threshold for swap utilization of the PVE host (%). The trigger stays silent on hosts that have no swap configured.'
+        - macro: '{$TASK.ALERT.WINDOW}'
+          value: 1h
+          description: 'How long a failed task keeps alerting. The problem clears earlier if a later task of the same id and type succeeds. Proxmox VE only keeps the most recent tasks in its task list, so without this window a one-off failure would alert forever. The value must include a time unit, for example 1h or 30m.'
+        - macro: '{$ZFS.FRAG.UTIL.MIN}'
+          value: '70'
+          description: 'Pool usage (%) that must be reached before the fragmentation warning fires. Fragmented free space only costs write performance on a pool that is also filling up. Use the context form {$ZFS.FRAG.UTIL.MIN:"rpool"} per pool.'
+        - macro: '{$ZFS.FRAG.WARN}'
+          value: '60'
+          description: 'ZFS free space fragmentation (%) before warning. Use the context form {$ZFS.FRAG.WARN:"rpool"} per pool.'
+        - macro: '{$ZFS.UTIL.CRIT}'
+          value: '90'
+          description: 'ZFS pool usage (%) for the high severity trigger. Use the context form {$ZFS.UTIL.CRIT:"rpool"} per pool.'
+        - macro: '{$ZFS.UTIL.WARN}'
+          value: '80'
+          description: 'ZFS pool usage (%) for the average severity trigger. ZFS performance degrades noticeably above 80%.'
+      dashboards:
+        - uuid: b6525e87712e4f5daddd32156aff0551
+          name: 'Proxmox VE node'
+          auto_start: 'NO'
+          pages:
+            - name: Overview
+              widgets:
+                - type: item
+                  name: Uptime
+                  width: '18'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Proxmox VE Node by REST API'
+                        key: pve.uptime
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: gauge
+                  name: 'CPU utilization'
+                  'y': '2'
+                  width: '24'
+                  height: '5'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Proxmox VE Node by REST API'
+                        key: pve.cpu.utilization
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFBF59
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E45959
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: svggraph
+                  name: 'CPU utilization'
+                  'y': '7'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 1976D2
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'PVE CPU utilization'
+                    - type: INTEGER
+                      name: ds.0.type
+                      value: '0'
+                    - type: STRING
+                      name: reference
+                      value: PVOV1
+                - type: problems
+                  name: Problems
+                  'y': '13'
+                  width: '72'
+                  height: '8'
+                - type: item
+                  name: Kernel
+                  x: '18'
+                  width: '18'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Proxmox VE Node by REST API'
+                        key: pve.current.kernel
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: gauge
+                  name: 'Memory utilization'
+                  x: '24'
+                  'y': '2'
+                  width: '24'
+                  height: '5'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Proxmox VE Node by REST API'
+                        key: pve.memory.util
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFBF59
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E45959
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: item
+                  name: 'Boot mode'
+                  x: '36'
+                  width: '18'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Proxmox VE Node by REST API'
+                        key: pve.system.boot.mode
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: piechart
+                  name: Memory
+                  x: '36'
+                  'y': '7'
+                  width: '18'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E45959
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'PVE memory used'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 00C48C
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'PVE memory available'
+                - type: gauge
+                  name: 'Root filesystem'
+                  x: '48'
+                  'y': '2'
+                  width: '24'
+                  height: '5'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Proxmox VE Node by REST API'
+                        key: pve.rootfs.util
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFBF59
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E45959
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: item
+                  name: Subscription
+                  x: '54'
+                  width: '18'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Proxmox VE Node by REST API'
+                        key: pve.subscription.status
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: piechart
+                  name: 'Root filesystem'
+                  x: '54'
+                  'y': '7'
+                  width: '18'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E45959
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'Disk rootfs used'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 00C48C
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'Disk rootfs avail'
             - name: 'Storage and disks'
               widgets:
                 - type: honeycomb
@@ -5373,130 +7438,7 @@ zabbix_export:
                     - type: STRING
                       name: thresholds.1.threshold
                       value: '60'
-            - name: 'Nodes and HA'
-              widgets:
-                - type: honeycomb
-                  name: 'Node status'
-                  width: '36'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: items.0
-                      value: 'Node status *'
-                    - type: INTEGER
-                      name: item_tags.0.operator
-                      value: '1'
-                    - type: STRING
-                      name: item_tags.0.tag
-                      value: PVE
-                    - type: STRING
-                      name: item_tags.0.value
-                      value: Node
-                    - type: STRING
-                      name: primary_label
-                      value: '{ITEM.NAME}'
-                    - type: STRING
-                      name: reference
-                      value: PVND1
-                - type: item
-                  name: 'HA manager'
-                  'y': '6'
-                  width: '18'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Template Proxmox VE REST API'
-                        key: pve.ha.manager.status
-                    - type: INTEGER
-                      name: show.1
-                      value: '2'
-                    - type: INTEGER
-                      name: show.2
-                      value: '3'
-                - type: item
-                  name: 'Nodes offline'
-                  x: '18'
-                  'y': '6'
-                  width: '18'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Template Proxmox VE REST API'
-                        key: pve.cluster.nodes.offline
-                    - type: INTEGER
-                      name: show.1
-                      value: '2'
-                    - type: INTEGER
-                      name: show.2
-                      value: '3'
-                - type: honeycomb
-                  name: 'HA resource states'
-                  x: '36'
-                  width: '36'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: items.0
-                      value: 'HA state of *'
-                    - type: INTEGER
-                      name: item_tags.0.operator
-                      value: '1'
-                    - type: STRING
-                      name: item_tags.0.tag
-                      value: PVE
-                    - type: STRING
-                      name: item_tags.0.value
-                      value: HA
-                    - type: STRING
-                      name: primary_label
-                      value: '{ITEM.NAME}'
-                    - type: STRING
-                      name: reference
-                      value: PVND2
-                - type: item
-                  name: Kernel
-                  x: '36'
-                  'y': '6'
-                  width: '18'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Template Proxmox VE REST API'
-                        key: pve.current.kernel
-                    - type: INTEGER
-                      name: show.1
-                      value: '2'
-                    - type: INTEGER
-                      name: show.2
-                      value: '3'
-                - type: item
-                  name: 'Boot mode'
-                  x: '54'
-                  'y': '6'
-                  width: '18'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Template Proxmox VE REST API'
-                        key: pve.system.boot.mode
-                    - type: INTEGER
-                      name: show.1
-                      value: '2'
-                    - type: INTEGER
-                      name: show.2
-                      value: '3'
       valuemaps:
-        - uuid: 4f48a8938054422b8cf484adaec102ee
-          name: 'Backup job enabled'
-          mappings:
-            - value: '0'
-              newvalue: disabled
-            - value: '1'
-              newvalue: enabled
         - uuid: eec173da961c4f238887a1f4e0356a3e
           name: 'Backup running'
           mappings:
@@ -5531,13 +7473,6 @@ zabbix_export:
               newvalue: disabled
             - value: '1'
               newvalue: enabled
-        - uuid: dd3c4133c6ef47b5bcefc8e68eaeee27
-          name: 'Node status'
-          mappings:
-            - value: '0'
-              newvalue: offline
-            - value: '1'
-              newvalue: online
         - uuid: 0c2c3eccf2504239a1bb1d01c84aa41f
           name: 'PVE secureboot'
           mappings:
@@ -5584,24 +7519,6 @@ zabbix_export:
               newvalue: 'interrupted by signal'
             - value: '10'
               newvalue: 'unknown error'
-        - uuid: 6ce95767698f4713adfa2dcf4618d86b
-          name: 'User status'
-          mappings:
-            - value: '0'
-              newvalue: disabled
-            - value: '1'
-              newvalue: enabled
-        - uuid: 052ad39480884912aebd6a34a8c2ff51
-          name: 'VM  and LXC status'
-          mappings:
-            - value: '0'
-              newvalue: stopped
-            - value: '1'
-              newvalue: running
-            - value: '2'
-              newvalue: paused
-            - value: '3'
-              newvalue: unknown
         - uuid: 4edeb346d0d64155ad2e8063d7a4cab8
           name: 'ZFS pool health'
           mappings:
@@ -5620,81 +7537,81 @@ zabbix_export:
             - value: '6'
               newvalue: SUSPENDED
   triggers:
-    - uuid: bdaeac3c76ec44ef96bf78ca83ba0dad
-      expression: 'min(/Template Proxmox VE REST API/pve.loadaverage.oneminute,900) >= last(/Template Proxmox VE REST API/pve.cpus)'
+    - uuid: 298e5b9546ae4affa7da313f24345dd0
+      expression: 'min(/Proxmox VE Node by REST API/pve.loadaverage.oneminute,900) >= last(/Proxmox VE Node by REST API/pve.cpus)'
       name: 'High CPU average'
       opdata: 'Current cpu average: {ITEM.LASTVALUE1}'
       priority: WARNING
-    - uuid: d7b8381cedda4cd0bcb28053cd731ddf
-      expression: '(last(/Template Proxmox VE REST API/pve.memory.used) / last(/Template Proxmox VE REST API/pve.memory.total)) * 100 > {$MEMORY.UTIL.MAX}'
+    - uuid: d776d07e5a4a44c2adc9ec00e48d4775
+      expression: '(last(/Proxmox VE Node by REST API/pve.memory.used) / last(/Proxmox VE Node by REST API/pve.memory.total)) * 100 > {$MEMORY.UTIL.MAX}'
       name: 'High memory usage on {HOST.NAME} (>{$MEMORY.UTIL.MAX}%)'
       opdata: 'Memory used: {ITEM.LASTVALUE1}'
       priority: WARNING
-    - uuid: d621a5f2dbce40c5a96d7f5573ede065
-      expression: '((last(/Template Proxmox VE REST API/pve.rootfs.used) / last(/Template Proxmox VE REST API/pve.rootfs.size)) * 100) > {$ROOTFS.UTIL.CRIT}'
+    - uuid: c6ab86e160c04bb9a65c960800ecdb3a
+      expression: '((last(/Proxmox VE Node by REST API/pve.rootfs.used) / last(/Proxmox VE Node by REST API/pve.rootfs.size)) * 100) > {$ROOTFS.UTIL.CRIT}'
       name: 'High root filesystem usage on {HOST.NAME} (>{$ROOTFS.UTIL.CRIT}%)'
       opdata: 'Disk usage: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
       priority: HIGH
-    - uuid: 6ec8009a0c62481d85fb57b7eb83e6f2
-      expression: '((last(/Template Proxmox VE REST API/pve.rootfs.used) / last(/Template Proxmox VE REST API/pve.rootfs.size)) * 100) > {$ROOTFS.UTIL.WARN}'
+    - uuid: dd19bc681d1d492397398e8cb0320bb1
+      expression: '((last(/Proxmox VE Node by REST API/pve.rootfs.used) / last(/Proxmox VE Node by REST API/pve.rootfs.size)) * 100) > {$ROOTFS.UTIL.WARN}'
       name: 'High root filesystem usage on {HOST.NAME} (>{$ROOTFS.UTIL.WARN}%)'
       opdata: 'Disk usage: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
       priority: AVERAGE
       dependencies:
         - name: 'High root filesystem usage on {HOST.NAME} (>{$ROOTFS.UTIL.CRIT}%)'
-          expression: '((last(/Template Proxmox VE REST API/pve.rootfs.used) / last(/Template Proxmox VE REST API/pve.rootfs.size)) * 100) > {$ROOTFS.UTIL.CRIT}'
-    - uuid: e63733b354ef41c4aa800990b8f2ae73
+          expression: '((last(/Proxmox VE Node by REST API/pve.rootfs.used) / last(/Proxmox VE Node by REST API/pve.rootfs.size)) * 100) > {$ROOTFS.UTIL.CRIT}'
+    - uuid: cd414163ecbb49f8ba059c9e9fd15677
       expression: |
-        last(/Template Proxmox VE REST API/pve.swap.total)>0
-        and last(/Template Proxmox VE REST API/pve.swap.used) / last(/Template Proxmox VE REST API/pve.swap.total) * 100 > {$SWAP.UTIL.MAX}
+        last(/Proxmox VE Node by REST API/pve.swap.total)>0
+        and last(/Proxmox VE Node by REST API/pve.swap.used) / last(/Proxmox VE Node by REST API/pve.swap.total) * 100 > {$SWAP.UTIL.MAX}
       name: 'High swap usage on {HOST.NAME} (>{$SWAP.UTIL.MAX}%)'
       opdata: 'Swap used: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
       priority: WARNING
       description: 'Swap on the PVE host is filling up. The first condition keeps the trigger silent on hosts without swap instead of turning it unsupported.'
       manual_close: 'YES'
     - uuid: 429391e580264ef398145055ff85100a
-      expression: 'last(/Template Proxmox VE REST API/pve.cluster.vms.running)<last(/Template Proxmox VE REST API/pve.cluster.vms.total)'
+      expression: 'last(/Proxmox VE Cluster by REST API/pve.cluster.vms.running)<last(/Proxmox VE Cluster by REST API/pve.cluster.vms.total)'
       name: '{ITEM.LASTVALUE} of {?last(//pve.cluster.vms.total)} VMs/LXC running'
       priority: INFO
       description: 'One or more VMs or LXC containers are not in running state.'
       manual_close: 'YES'
   graphs:
-    - uuid: bbdef5c2775146b4ad30ac91ad877624
+    - uuid: 42635f8a35574da09b6d3f0b5b5c17fb
       name: 'Load average'
       type: STACKED
       graph_items:
         - color: 1A7C11
           calc_fnc: MIN
           item:
-            host: 'Template Proxmox VE REST API'
+            host: 'Proxmox VE Node by REST API'
             key: pve.loadaverage.oneminute
         - sortorder: '1'
           color: '274482'
           calc_fnc: MIN
           item:
-            host: 'Template Proxmox VE REST API'
+            host: 'Proxmox VE Node by REST API'
             key: pve.loadaverage.fiveminute
         - sortorder: '2'
           color: 9C27B0
           calc_fnc: MIN
           item:
-            host: 'Template Proxmox VE REST API'
+            host: 'Proxmox VE Node by REST API'
             key: pve.loadaverage.fifteen
-    - uuid: 0fc25cb79f674267825c8f5c3e87869e
+    - uuid: c90ade9ed259462a8df2d6749c65077e
       name: 'PVE Memory utilization'
       graph_items:
         - color: 2E7D32
           calc_fnc: ALL
           item:
-            host: 'Template Proxmox VE REST API'
+            host: 'Proxmox VE Node by REST API'
             key: pve.memory.total
         - sortorder: '1'
           color: 1565C0
           calc_fnc: ALL
           item:
-            host: 'Template Proxmox VE REST API'
+            host: 'Proxmox VE Node by REST API'
             key: pve.memory.used
-    - uuid: bb1b46e208df4f429e6e28e9c6627687
+    - uuid: b2293f0e41694d8fad82c7af3069872d
       name: 'Rootfs usage'
       yaxismax: '0'
       show_work_period: 'NO'
@@ -5704,11 +7621,11 @@ zabbix_export:
         - color: 0040FF
           calc_fnc: MIN
           item:
-            host: 'Template Proxmox VE REST API'
+            host: 'Proxmox VE Node by REST API'
             key: pve.rootfs.used
         - sortorder: '1'
           color: 388E3C
           calc_fnc: MIN
           item:
-            host: 'Template Proxmox VE REST API'
+            host: 'Proxmox VE Node by REST API'
             key: pve.rootfs.avail

--- a/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/template_proxmox-ve-rest-api.yaml
+++ b/Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/template_proxmox-ve-rest-api.yaml
@@ -5,15 +5,208 @@ zabbix_export:
       name: Templates/Virtualization
   templates:
     - uuid: 512de161946b46af952076320eb2b366
-      template: 'Proxmox VE Cluster by REST API'
-      name: 'Proxmox VE Cluster by REST API'
+      template: 'Template Proxmox VE REST API'
+      name: 'Template Proxmox VE REST API'
       description: |
-        Cluster-wide part of the Proxmox VE monitoring over the REST API. Link it to exactly one Zabbix host per cluster (or per standalone node): guests on all nodes, node states, HA, backup jobs, users, SDN and, when present, Ceph. Pair it with "Proxmox VE Node by REST API" on one host per node.
+        Zabbix template for monitoring Proxmox VE virtual machines using the REST API. No Zabbix agent is required inside the VMs.
         
-        Requires a PVEAuditor API token. See the README for setup.
+        Created by Thomas Rzen.  
+        For documentation, updates, and source code, visit:  
+        https://github.com/Garfieldttt/Zabbix-Template-Proxmox-VE-REST-API
       groups:
         - name: Templates/Virtualization
       items:
+        - uuid: c45a577215ad485082a40f8e6c0597bc
+          name: 'PVE manager package version'
+          type: DEPENDENT
+          key: pve.apt.manager.version
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Installed pve-manager version. Source: /nodes/{node}/apt/versions.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[?(@.Package=="pve-manager")].Version.first()'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.apt.versions.raw
+          tags:
+            - tag: PVE
+              value: APT
+        - uuid: 4c6198e8bdf14a628f46026f0286317d
+          name: 'APT repository errors'
+          type: DEPENDENT
+          key: pve.apt.repos.errors
+          delay: '0'
+          history: 7d
+          description: 'Number of unparsable APT repository files. Source: /nodes/{node}/apt/repositories.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.errors.length()
+          master_item:
+            key: pve.apt.repos.raw
+          tags:
+            - tag: PVE
+              value: APT
+          triggers:
+            - uuid: 6cd0c610281c42a3b32c3b1a18f204f7
+              expression: 'last(/Template Proxmox VE REST API/pve.apt.repos.errors)>{$PVE.APT.REPO.ERRORS.MAX}'
+              name: 'APT repository files are broken on {HOST.NAME}'
+              opdata: 'Broken files: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'At least one APT repository file cannot be parsed. Updates will fail until this is fixed.'
+        - uuid: b5b24417bef745dd8b8bfe73cd670974
+          name: 'PVE APT repositories raw'
+          type: HTTP_AGENT
+          key: pve.apt.repos.raw
+          delay: '3600'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/apt/repositories. Requires Sys.Audit on /nodes/{node}.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/apt/repositories'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: ed86ccf27d174856b34603273da954dd
+          name: 'APT repository warnings'
+          type: DEPENDENT
+          key: pve.apt.repos.warnings
+          delay: '0'
+          history: 7d
+          description: 'Number of APT repository warnings, for example the enterprise repository being enabled without a subscription. Source: /nodes/{node}/apt/repositories.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data.infos[?(@.kind=="warning")].length()'
+          master_item:
+            key: pve.apt.repos.raw
+          tags:
+            - tag: PVE
+              value: APT
+          triggers:
+            - uuid: 5fe993f6929a4e05ab7bca6e61c8b631
+              expression: 'last(/Template Proxmox VE REST API/pve.apt.repos.warnings)>{$PVE.APT.REPO.WARN.MAX}'
+              name: 'APT repository configuration has warnings on {HOST.NAME}'
+              opdata: 'Warnings: {ITEM.LASTVALUE1}'
+              priority: INFO
+              description: 'PVE reports a problem with the repository configuration, for example the enterprise repository being enabled without a subscription. A host on the no-subscription repository reports one warning permanently, raise {$PVE.APT.REPO.WARN.MAX} to 1 there.'
+              manual_close: 'YES'
+        - uuid: 5525d09ef8c84b9abcd6bccfa90ecf5b
+          name: 'Running kernel (proxmox-ve)'
+          type: DEPENDENT
+          key: pve.apt.running.kernel
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Kernel release the node is currently booted into. Source: /nodes/{node}/apt/versions, package proxmox-ve.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[?(@.Package=="proxmox-ve")].RunningKernel.first()'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.apt.versions.raw
+          tags:
+            - tag: PVE
+              value: APT
+        - uuid: 2d333630c4b0498b94ce00a7cd35fc47
+          name: 'PVE APT pending updates raw'
+          type: HTTP_AGENT
+          key: pve.apt.update.raw
+          delay: '3600'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          status: DISABLED
+          description: 'Master item. Raw JSON from /nodes/{node}/apt/update. DISABLED by default: this endpoint requires Sys.Modify on /nodes/{node}, which PVEAuditor does not grant. Enable only if you accept giving the monitoring token write level permissions.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/apt/update'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 184a3ada22ad4082a7bddc6f3d6a0abe
+          name: 'APT pending updates'
+          type: DEPENDENT
+          key: pve.apt.updates.count
+          delay: '0'
+          history: 7d
+          status: DISABLED
+          description: 'Number of pending package updates. DISABLED by default because the master item requires Sys.Modify.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.length()
+          master_item:
+            key: pve.apt.update.raw
+          tags:
+            - tag: PVE
+              value: APT
+          triggers:
+            - uuid: 516ffe6de3804b97aa29d41e333deba3
+              expression: 'last(/Template Proxmox VE REST API/pve.apt.updates.count)>{$PVE.APT.UPDATES.MAX}'
+              name: '{ITEM.LASTVALUE} package update(s) pending on {HOST.NAME}'
+              status: DISABLED
+              priority: INFO
+              description: 'Disabled by default, like the item it depends on. The master item needs Sys.Modify, which PVEAuditor does not grant.'
+              manual_close: 'YES'
+        - uuid: 123ab12e63c04426a943c63fc1539230
+          name: 'PVE APT versions raw'
+          type: HTTP_AGENT
+          key: pve.apt.versions.raw
+          delay: '3600'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/apt/versions. Requires Sys.Audit on /nodes/{node}.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/apt/versions'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 95c94b814aa84f569872151d7249b7a0
+          name: 'PVE backup active raw'
+          type: HTTP_AGENT
+          key: pve.backup.active.raw
+          delay: '60'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/tasks with source=active and typefilter=vzdump, so it carries only backup tasks that are running right now. The task list defaults to source=archive, where a task appears only once it has finished, which is why a running backup is invisible to pve.backup.raw and why a backup that never finishes produces no signal there at all. Returns an empty list while no backup runs. Requires Sys.Audit on /nodes/{node}.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/tasks?source=active&typefilter=vzdump'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
         - uuid: 4b7c777084034f50803f8c03d363b265
           name: 'Backup jobs configured'
           type: DEPENDENT
@@ -32,7 +225,7 @@ zabbix_export:
               value: Backup
           triggers:
             - uuid: 27abcc86c4424e11b36b25b92f9fdf0b
-              expression: 'last(/Proxmox VE Cluster by REST API/pve.backup.jobs.count)<{$PVE.BACKUP.JOBS.MIN}'
+              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.backup.jobs.count)<{$PVE.BACKUP.JOBS.MIN})'
               name: 'Fewer backup jobs configured than expected on {HOST.NAME}'
               opdata: 'Configured jobs: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -47,6 +240,11 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /cluster/backup, the configured vzdump backup job definitions. This is the job side of backup monitoring: pve.backup.raw watches the runs, this item watches whether a job exists at all, is enabled and is still being scheduled. A job that was switched off or is no longer advanced by the scheduler starts no run, so it produces no failed task and would otherwise stay invisible. Requires Sys.Audit on /.'
+          preprocessing:
+            - type: NOT_MATCHES_REGEX
+              parameters:
+                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+              error_handler: DISCARD_VALUE
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/backup'
           headers:
@@ -57,7 +255,231 @@ zabbix_export:
           tags:
             - tag: PVE
               value: Raw
-        - uuid: c79be6cf81a7437ca5692b9953a838a1
+        - uuid: 9a98e0c1e615419d8c3fc835aba5b216
+          name: 'PVE backup raw'
+          type: HTTP_AGENT
+          key: pve.backup.raw
+          delay: '300'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/tasks?typefilter=vzdump, so only backup tasks are listed and other tasks cannot push them out of the 50 entries PVE returns. JavaScript preprocessing keeps the most recent run per guest.'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // Zabbix JS preprocessing: Extract and group backup tasks (VZDUMP/PBS) from task feed (ES5.1)
+                  try {
+                      var obj = (typeof value === 'string') ? JSON.parse(value) : value;
+                  
+                      // 0) Determine data source
+                      var dataArr = [];
+                      if (obj && obj.data && obj.data instanceof Array) {
+                          dataArr = obj.data;
+                      } else if (obj && obj.body && obj.body.data && obj.body.data instanceof Array) {
+                          dataArr = obj.body.data;
+                      }
+                      if (!dataArr || !dataArr.length) {
+                          return JSON.stringify({ total: 0, data: [] });
+                      }
+                  
+                      // Helper functions
+                      function firstDefined(a, b, c, d) {
+                          if (a !== null && a !== undefined) return a;
+                          if (b !== null && b !== undefined) return b;
+                          if (c !== null && c !== undefined) return c;
+                          if (d !== null && d !== undefined) return d;
+                          return null;
+                      }
+                  
+                      // Robust timestamp conversion: supports epoch (sec/ms), numeric strings, ISO and "YYYY-MM-DD HH:mm:ss"
+                      function toEpochMs(v) {
+                          if (v === null || v === undefined) return -Infinity;
+                          if (typeof v === "number") return v < 1000000000000 ? v * 1000 : v; // sec → ms
+                  
+                          if (typeof v === "string") {
+                              var s = v.trim();
+                  
+                              // Treat purely numeric strings as numbers
+                              if (/^\d+(\.\d+)?$/.test(s)) {
+                                  var n = parseFloat(s);
+                                  return n < 1000000000000 ? n * 1000 : n;
+                              }
+                  
+                              // Parse "YYYY-MM-DD HH:mm:ss" (optional AM/PM)
+                              var m = s.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\s*(AM|PM))?$/i);
+                              if (m) {
+                                  var H = parseInt(m[4], 10), ampm = (m[7] || "").toUpperCase();
+                                  if (ampm) { if (ampm === "PM" && H < 12) H += 12; if (ampm === "AM" && H === 12) H = 0; }
+                                  return Date.UTC(+m[1], +m[2] - 1, +m[3], H, +m[5], +m[6]);
+                              }
+                  
+                              // Fallback: parse as ISO-compatible string
+                              var p = Date.parse(s.replace(/\s+/, "T"));
+                              return isNaN(p) ? -Infinity : p;
+                          }
+                          return -Infinity;
+                      }
+                      
+                  
+                      // Broad backup type matcher
+                      var reVzdump = /vzdump/i;
+                      var reBackup = /backup/i;              // generic (PBS/Proxmox Backup)
+                      var rePbs    = /\bpbs\b/i;             // "pbs" as a whole word
+                      var rePmxb   = /proxmox[- ]?backup/i;  // "proxmox-backup" or "proxmox backup"
+                  
+                      function isBackup(e) {
+                          if (!e) return false;
+                          var t = (e.type != null) ? String(e.type) : "";
+                          var u = (typeof e.upid === "string") ? e.upid : "";
+                          if (reVzdump.test(t) || reBackup.test(t) || rePbs.test(t) || rePmxb.test(t)) return true;
+                          if (reVzdump.test(u) || reBackup.test(u) || rePbs.test(u) || rePmxb.test(u)) return true;
+                          return false;
+                      }
+                  
+                      // 1) Filter backup entries and normalise timestamps
+                      var dumps = [];
+                      for (var i = 0; i < dataArr.length; i++) {
+                          var e = dataArr[i];
+                          if (!isBackup(e)) continue;
+                  
+                          var startRaw = firstDefined(e.starttime, e.start, e.begin, e.pstart);
+                          var endRaw   = firstDefined(e.endtime, e.end, null, null);
+                  
+                          var copy = {};
+                          for (var k in e) { if (e.hasOwnProperty(k)) copy[k] = e[k]; }
+                          copy._startMs = toEpochMs(startRaw);
+                          copy._endMs   = toEpochMs(endRaw);
+                          dumps.push(copy);
+                      }
+                  
+                      if (!dumps.length) {
+                          // No backup entries found in the feed
+                          return JSON.stringify({ total: 0, data: [] });
+                      }
+                  
+                      // 2) Sort by start time
+                      dumps.sort(function(a, b) { return a._startMs - b._startMs; });
+                  
+                      // 3) Replace missing/empty ID with "pve"
+                      for (i = 0; i < dumps.length; i++) {
+                          if (dumps[i].id === null || dumps[i].id === undefined || String(dumps[i].id) === "") {
+                              dumps[i].id = "pve";
+                          }
+                      }
+                  
+                      // 4) Group by id, keep only the most recent run per id (highest _startMs)
+                      var groups = {};
+                      for (i = 0; i < dumps.length; i++) {
+                          var e2 = dumps[i];
+                          var key = String(e2.id);
+                  
+                          if (!groups[key] || e2._startMs > groups[key]._startMs) {
+                              groups[key] = {
+                                  id:        key,
+                                  node:      e2.node,
+                                  status:    e2.status,
+                                  pid:       e2.pid,
+                                  upid:      e2.upid,
+                                  starttime: e2.starttime,
+                                  endtime:   e2.endtime,
+                                  _startMs:  e2._startMs,
+                                  _endMs:    e2._endMs
+                              };
+                          }
+                      }
+                      
+                  
+                      // 5) Sort IDs numerically (numeric first), "pve" last
+                      var ids = [];
+                      for (var id in groups) { if (groups.hasOwnProperty(id)) ids.push(id); }
+                      ids.sort(function(a, b) {
+                          if (a === "pve" && b !== "pve") return 1;
+                          if (b === "pve" && a !== "pve") return -1;
+                          var na = parseFloat(a), nb = parseFloat(b);
+                          var aNum = isFinite(na), bNum = isFinite(nb);
+                          if (aNum && bNum) return na - nb;
+                          if (aNum) return -1;
+                          if (bNum) return 1;
+                          a = String(a); b = String(b);
+                          if (a < b) return -1;
+                          if (a > b) return 1;
+                          return 0;
+                      });
+                  
+                      // 6) Build result
+                      var resultData = [];
+                      for (i = 0; i < ids.length; i++) {
+                          var g2 = groups[ids[i]];
+                          // Remove internal fields
+                          delete g2._startMs; delete g2._endMs;
+                          g2.bckpid = g2.id;
+                          resultData.push(g2);
+                      }
+                  
+                      return JSON.stringify({ total: resultData.length, data: resultData });
+                  
+                  } catch (err) {
+                      return JSON.stringify({ error: "Parsing failed", detail: String(err && err.message || err) });
+                  }
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/tasks?typefilter=vzdump'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          output_format: JSON
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: b9d09de6571e41eb9f6b5500b510c377
+          name: 'Backup running'
+          type: DEPENDENT
+          key: pve.backup.running
+          delay: '0'
+          trends: '0'
+          description: 'Number of backup tasks running on this node right now, normally 0 or 1. The value is a counter rather than a forced 0 or 1: if two vzdump tasks ever overlap the item shows 2 and stays readable, only the value map has no entry for it. Source: /nodes/{node}/tasks with source=active.'
+          valuemap:
+            name: 'Backup running'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.length()
+          master_item:
+            key: pve.backup.active.raw
+          tags:
+            - tag: PVE
+              value: Backup
+          triggers:
+            - uuid: c94e008565344aca9077f48fdc06c951
+              expression: 'min(/Template Proxmox VE REST API/pve.backup.running,{$PVE.BACKUP.RUN.MAX})>0'
+              name: 'Backup has been running for more than {$PVE.BACKUP.RUN.MAX} on {HOST.NAME}'
+              opdata: 'Running since: {ITEM.LASTVALUE1}'
+              priority: AVERAGE
+              description: 'A backup task has been running without interruption for the whole period. This is the one backup failure the task archive cannot show: a run that never finishes never reaches the archive, so the status, end time and message items keep reporting the previous successful run and nothing else would ever fire. Check the running task in the PVE task viewer and the target storage.'
+              manual_close: 'YES'
+        - uuid: b481215ab6764b049dbbd06ead48fa94
+          name: 'Backup running since'
+          type: DEPENDENT
+          key: pve.backup.running.since
+          delay: '0'
+          value_type: FLOAT
+          trends: '0'
+          units: unixtime
+          description: 'Start time of the backup that is running right now, available the moment it starts. Zero means no backup is running: the source list is then empty, the JSONPath finds nothing, and the error handler supplies the zero. This is the real start time, unlike Backup starttime, which only moves once the run has finished and reached the task archive. A trend over a Unix timestamp carries no meaning, so trends stay off.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*].starttime.first()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+          master_item:
+            key: pve.backup.active.raw
+          tags:
+            - tag: PVE
+              value: Backup
+        - uuid: 3ce5bf61b33547bd885f2e416dacc85a
           name: 'Ceph available'
           type: DEPENDENT
           key: pve.ceph.available
@@ -81,14 +503,14 @@ zabbix_export:
             - tag: PVE
               value: Ceph
           triggers:
-            - uuid: 1a658d8982df4bac81285f578303ed59
-              expression: 'last(/Proxmox VE Cluster by REST API/pve.ceph.available)=0 and count(/Proxmox VE Cluster by REST API/pve.ceph.available,1d,"eq","1")>0'
+            - uuid: 129264f6d8c44bc58ba06e18f2ae6db1
+              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.ceph.available)=0 and count(/Template Proxmox VE REST API/pve.ceph.available,1d,"eq","1")>0)'
               name: 'Ceph status cannot be read'
               opdata: '{ITEM.LASTVALUE1}'
               priority: HIGH
               description: 'Ceph was readable within the last day and the API now returns no status. The reason is in the item "Ceph API message"; a common one is lost monitor quorum, which blocks all Ceph I/O. On a cluster where Ceph was removed on purpose the problem resolves itself after a day.'
               manual_close: 'YES'
-        - uuid: 5cebfd8295f241e9a6b9208bd974b241
+        - uuid: 8c40a405e20c4eb9a7d9c5a567fbe538
           name: 'Ceph API message'
           type: DEPENDENT
           key: pve.ceph.message
@@ -110,7 +532,7 @@ zabbix_export:
           tags:
             - tag: PVE
               value: Ceph
-        - uuid: c5ef7e7824d142909d6bd8e7dea78d99
+        - uuid: 5327fbaa1cf14e2392304b1b797b98d6
           name: 'PVE Ceph OSD raw'
           type: HTTP_AGENT
           key: pve.ceph.osd.raw
@@ -119,6 +541,11 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /nodes/localhost/ceph/osd: the CRUSH tree with every OSD, its state, usage and latency, plus the cluster flags. "localhost" is the node answering the API call, so the path works on every node. HTTP 500 is accepted on purpose: PVE answers every Ceph call with 500 and {"data":null,"message":...} while Ceph is not set up, which keeps this item supported on clusters without Ceph and lets the dependent items tell "no Ceph" apart from a readable status.'
+          preprocessing:
+            - type: NOT_MATCHES_REGEX
+              parameters:
+                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+              error_handler: DISCARD_VALUE
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/localhost/ceph/osd'
           status_codes: '200,500'
@@ -130,7 +557,7 @@ zabbix_export:
           tags:
             - tag: PVE
               value: Raw
-        - uuid: 9954f59493c74257ac8f25dbb3cbade5
+        - uuid: 2bda262450b24f5bbacfdd3caa4cb9ed
           name: 'PVE Ceph pools raw'
           type: HTTP_AGENT
           key: pve.ceph.pool.raw
@@ -139,6 +566,11 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /nodes/localhost/ceph/pool: every pool with size, min_size and usage. HTTP 500 is accepted on purpose: PVE answers every Ceph call with 500 and {"data":null,"message":...} while Ceph is not set up, which keeps this item supported on clusters without Ceph and lets the dependent items tell "no Ceph" apart from a readable status.'
+          preprocessing:
+            - type: NOT_MATCHES_REGEX
+              parameters:
+                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+              error_handler: DISCARD_VALUE
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/localhost/ceph/pool'
           status_codes: '200,500'
@@ -150,7 +582,7 @@ zabbix_export:
           tags:
             - tag: PVE
               value: Raw
-        - uuid: 8302d2b844a546dea0271d161bb789ca
+        - uuid: 5183e2130bdd4476a4160595025d86fc
           name: 'PVE Ceph status raw'
           type: HTTP_AGENT
           key: pve.ceph.status.raw
@@ -158,9 +590,33 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /cluster/ceph/status: health, monitor, manager, OSD and PG maps. HTTP 500 is accepted on purpose: PVE answers every Ceph call with 500 and {"data":null,"message":...} while Ceph is not set up, which keeps this item supported on clusters without Ceph and lets the dependent items tell "no Ceph" apart from a readable status.'
+          preprocessing:
+            - type: NOT_MATCHES_REGEX
+              parameters:
+                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+              error_handler: DISCARD_VALUE
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/ceph/status'
           status_codes: '200,500'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: b08a4d2843444e51a668c4b5b2a907a8
+          name: 'PVE certificates raw'
+          type: HTTP_AGENT
+          key: pve.certificates.raw
+          delay: '3600'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/certificates/info. Needs no special permission.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/certificates/info'
           headers:
             - name: Authorization
               value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
@@ -193,18 +649,25 @@ zabbix_export:
               value: Cluster
         - uuid: 76a2011e68774f12b81ba29932d115af
           name: 'Cluster nodes offline'
-          type: CALCULATED
+          type: DEPENDENT
           key: pve.cluster.nodes.offline
-          delay: '60'
+          delay: '0'
           history: 7d
-          params: 'last(/{HOST.HOST}/pve.cluster.nodes.total) - last(/{HOST.HOST}/pve.cluster.nodes.online)'
-          description: 'Number of offline cluster nodes (total minus online).'
+          description: 'Number of cluster nodes that /cluster/status lists as offline.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[?(@.type=="node" && @.online==0)].length()'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+          master_item:
+            key: pve.cluster.raw
           tags:
             - tag: PVE
               value: Cluster
           triggers:
             - uuid: 3dfb794aebe14bb89850bc56aa2f937c
-              expression: 'last(/Proxmox VE Cluster by REST API/pve.cluster.nodes.offline)>{$CLUSTER.NODES.OFFLINE.MAX}'
+              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.cluster.nodes.offline)>{$CLUSTER.NODES.OFFLINE.MAX})'
               name: '{ITEM.LASTVALUE} cluster node(s) offline'
               priority: HIGH
               description: 'One or more Proxmox VE cluster nodes are offline. Set {$CLUSTER.NODES.OFFLINE.MAX} to a higher value to tolerate planned maintenance.'
@@ -261,7 +724,7 @@ zabbix_export:
               value: Cluster
           triggers:
             - uuid: 46be8e0cb28741a1a25c826eaa7f3525
-              expression: 'last(/Proxmox VE Cluster by REST API/pve.cluster.quorum)=0'
+              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.cluster.quorum)=0)'
               name: 'Proxmox VE cluster has lost quorum'
               priority: DISASTER
               description: 'The cluster is not quorate. /etc/pve is read-only, so guests cannot be started, changed or migrated, and nodes with active HA resources fence themselves.'
@@ -277,6 +740,11 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Raw cluster status from /api2/json/cluster/status. Used as master for cluster-dependent items.'
+          preprocessing:
+            - type: NOT_MATCHES_REGEX
+              parameters:
+                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+              error_handler: DISCARD_VALUE
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/status'
           headers:
@@ -296,6 +764,11 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /cluster/resources. Aggregated view of all VMs, LXC containers, storage and nodes across the cluster.'
+          preprocessing:
+            - type: NOT_MATCHES_REGEX
+              parameters:
+                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+              error_handler: DISCARD_VALUE
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/resources'
           headers:
@@ -338,14 +811,132 @@ zabbix_export:
           tags:
             - tag: PVE
               value: Cluster
+        - uuid: 8dc9614f15df4bd2914b15a03731dc02
+          name: 'PVE CPU cores'
+          type: DEPENDENT
+          key: pve.cores
+          delay: '0'
+          trends: '0'
+          units: '!Cores'
+          description: 'Number of physical CPU cores on the PVE host. Source: /nodes/{node}/status → data.cpuinfo.cores.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.cpuinfo.cores
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: 6a0405792aa8410c8c87b82f66659827
+          name: 'PVE CPU utilization'
+          type: DEPENDENT
+          key: pve.cpu.utilization
+          delay: '0'
+          history: 7d
+          value_type: FLOAT
+          units: '%'
+          description: 'CPU utilization of the PVE host in percent (0-100). Source: /nodes/{node}/status → data.cpu * 100.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.cpu
+            - type: MULTIPLIER
+              parameters:
+                - '100'
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
           triggers:
-            - uuid: efea0dc15fc74f80b8ff7805792bc444
-              expression: 'nodata(/Proxmox VE Cluster by REST API/pve.cluster.vms.total,300)=1'
-              name: 'PVE cluster API not reachable on {HOST.NAME}'
-              opdata: 'No data for 5 minutes'
-              priority: HIGH
-              description: 'The cluster-wide API calls have returned nothing for 5 minutes. Guest, HA, backup job and Ceph data are stale. Check {$PVE_IP}, the API token and pveproxy on that node. Evaluated on "pve.cluster.vms.total", because nodata() cannot read items that keep no history, such as the raw API item.'
-              manual_close: 'YES'
+            - uuid: 9551ed5e07264f4a90f57a8b8f2c8530
+              expression: 'min(/Template Proxmox VE REST API/pve.cpu.utilization,300)>{$NODE.CPU.UTIL.MAX}'
+              name: 'High CPU usage on {HOST.NAME} (>{$NODE.CPU.UTIL.MAX}%)'
+              opdata: 'CPU utilization: {ITEM.LASTVALUE1}'
+              priority: AVERAGE
+        - uuid: 8d7c1e46d5444b06ad419ffab9415d44
+          name: 'PVE CPU info'
+          type: DEPENDENT
+          key: pve.cpuinfo
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'CPU model name string of the PVE host. Source: /nodes/{node}/status → data.cpuinfo.model.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.cpuinfo.model
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: aff51cdfad424764ab637ceec7b54ff3
+          name: 'PVE CPU threads'
+          type: DEPENDENT
+          key: pve.cpus
+          delay: '0'
+          trends: '0'
+          units: '!Threads'
+          description: 'Total number of logical CPU threads (vCPUs) on the PVE host. Source: /nodes/{node}/status → data.cpuinfo.cpus.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.cpuinfo.cpus
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: bfca65a711d34b0d9543249fe9174097
+          name: 'PVE current kernel'
+          type: DEPENDENT
+          key: pve.current.kernel
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Running Linux kernel release string (e.g. 6.8.12-5-pve). Source: /nodes/{node}/status → data["current-kernel"].release.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data["current-kernel"].release'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Kernel
+        - uuid: 406db2d98a024857bc7bc617c702901a
+          name: 'PVE disks raw'
+          type: HTTP_AGENT
+          key: pve.disks.raw
+          delay: '3600'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/disks/list. Used for physical disk discovery and SMART health monitoring. Requires Sys.Audit permission on the node.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/disks/list'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Disk
         - uuid: 570cf6c8fa37488e8165b4ce032e7b24
           name: 'PVE HA manager status'
           type: DEPENDENT
@@ -375,14 +966,14 @@ zabbix_export:
             - tag: PVE
               value: HA
           triggers:
-            - uuid: a5a94355cec64a03b0101bc79d1b44af
-              expression: 'last(/Proxmox VE Cluster by REST API/pve.ha.manager.status)="old timestamp - dead?"'
+            - uuid: f2ebf17802504d13a6d8c17509ce36a6
+              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.ha.manager.status)="old timestamp - dead?")'
               name: 'HA manager (CRM) has stopped updating its status'
               priority: HIGH
               description: 'The CRM master has not written its status for more than 30 seconds. HA resources are no longer managed: failed guests are not recovered and fencing decisions are not made. Check pve-ha-crm on the node named in the HA status.'
               manual_close: 'YES'
-            - uuid: b659321a83a741a5892054c30732be4a
-              expression: 'last(/Proxmox VE Cluster by REST API/pve.ha.manager.status)="detected time drift!"'
+            - uuid: 0ff77987c4ff444cb70e80a80def1602
+              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.ha.manager.status)="detected time drift!")'
               name: 'HA manager (CRM) reports time drift'
               priority: WARNING
               description: 'The CRM status timestamp lies in the future. The cluster nodes disagree on the time, which disturbs HA decisions. Check the time synchronisation on all nodes.'
@@ -396,6 +987,11 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /cluster/ha/status/current. Contains one entry per quorum, CRM master, LRM and HA-managed service. Used for HA manager status and HA resource discovery. Note that /cluster/ha/status without /current is only a directory index and carries no status data.'
+          preprocessing:
+            - type: NOT_MATCHES_REGEX
+              parameters:
+                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+              error_handler: DISCARD_VALUE
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/ha/status/current'
           headers:
@@ -406,6 +1002,199 @@ zabbix_export:
           tags:
             - tag: PVE
               value: HA
+        - uuid: ee746cfba83e43e0af3053d86bcb2c9c
+          name: 'PVE load average (15 min)'
+          type: DEPENDENT
+          key: pve.loadaverage.fifteen
+          delay: '0'
+          history: 7d
+          value_type: FLOAT
+          description: 'System load average over the last 15 minutes. Source: /nodes/{node}/status → data.loadavg[2].'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data.loadavg[2]'
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: b0e142359bce47d288156cac52b3cda0
+          name: 'PVE load average (5 min)'
+          type: DEPENDENT
+          key: pve.loadaverage.fiveminute
+          delay: '0'
+          history: 7d
+          value_type: FLOAT
+          description: 'System load average over the last 5 minutes. Source: /nodes/{node}/status → data.loadavg[1].'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data.loadavg[1]'
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: e30e7acbdeb144f1a9b2ef6147df229b
+          name: 'PVE load average (1 min)'
+          type: DEPENDENT
+          key: pve.loadaverage.oneminute
+          delay: '0'
+          history: 7d
+          value_type: FLOAT
+          description: 'System load average over the last 1 minute. Source: /nodes/{node}/status → data.loadavg[0].'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data.loadavg[0]'
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: 86a2555f26f04ef99e267d5045947de1
+          name: 'PVE localtime'
+          type: DEPENDENT
+          key: pve.localtime
+          delay: '0'
+          trends: '0'
+          units: unixtime
+          description: 'Current Unix timestamp on the PVE host. Source: /nodes/{node}/time → data.localtime.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.localtime
+          master_item:
+            key: pve.time.raw
+          tags:
+            - tag: PVE
+              value: Localtime
+        - uuid: 05dec93dcbcc4c4c8db9642f51016ee0
+          name: 'PVE machine type'
+          type: DEPENDENT
+          key: pve.machine.type
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Host kernel machine architecture (e.g. x86_64). Source: /nodes/{node}/status → data["current-kernel"].machine.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data["current-kernel"].machine'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Kernel
+        - uuid: 7a0e1ff3f96c4695a2642bf3aa80e092
+          name: 'PVE memory available'
+          type: DEPENDENT
+          key: pve.memory.free
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'RAM available for new workloads on the PVE host in bytes, cache and reclaimable memory included. Source: /nodes/{node}/status → data.memory.available. Together with the used value this adds up to the installed total, which data.memory.free does not.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.memory.available
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: e61c53e9214544d5ba50d64223564aad
+          name: 'PVE memory total'
+          type: DEPENDENT
+          key: pve.memory.total
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Total installed RAM on the PVE host in bytes. Source: /nodes/{node}/status → data.memory.total.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.memory.total
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: ab8adc650a764a7f81847578f9360f63
+          name: 'PVE memory used'
+          type: DEPENDENT
+          key: pve.memory.used
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Used RAM on the PVE host in bytes. Source: /nodes/{node}/status → data.memory.used.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.memory.used
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: 7fe8daafaf8f423dbf3410fef13b850f
+          name: 'PVE memory utilization'
+          type: CALCULATED
+          key: pve.memory.util
+          delay: '60'
+          history: 7d
+          value_type: FLOAT
+          units: '%'
+          params: '(last(/{HOST.HOST}/pve.memory.used) / last(/{HOST.HOST}/pve.memory.total)) * 100'
+          description: 'Memory utilization of the PVE host in percent, derived from pve.memory.used and pve.memory.total.'
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: ce497662bfd34c9da21c071e7b9b95ce
+          name: 'PVE CPU MHz'
+          type: DEPENDENT
+          key: pve.mhz
+          delay: '0'
+          value_type: FLOAT
+          trends: '0'
+          units: '!MHz'
+          description: 'CPU clock speed in MHz of the PVE host processor. Source: /nodes/{node}/status → data.cpuinfo.mhz.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.cpuinfo.mhz
+              error_handler: DISCARD_VALUE
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: 34f01ffa2b17450490d7015da7759c17
+          name: 'PVE network raw'
+          type: HTTP_AGENT
+          key: pve.nodes.network.raw
+          delay: '300'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/network. Used for host network interface discovery.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/network'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Network
         - uuid: 294f426f0a9a492598bbf7ea7ba46d9d
           name: 'PVE nodes raw'
           type: HTTP_AGENT
@@ -415,6 +1204,11 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /nodes. Used as source for cluster node discovery and node status items.'
+          preprocessing:
+            - type: NOT_MATCHES_REGEX
+              parameters:
+                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+              error_handler: DISCARD_VALUE
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes'
           headers:
@@ -443,7 +1237,7 @@ zabbix_export:
               value: Backup
           triggers:
             - uuid: f93aea89718e469ea4c5468ca601fbed
-              expression: 'last(/Proxmox VE Cluster by REST API/pve.notbackedup.count)>{$PVE.NOTBACKEDUP.MAX}'
+              expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.notbackedup.count)>{$PVE.NOTBACKEDUP.MAX})'
               name: '{ITEM.LASTVALUE} guest(s) not covered by any backup job'
               opdata: 'Guests without backup: {ITEM.LASTVALUE1}'
               priority: WARNING
@@ -458,6 +1252,11 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /cluster/backup-info/not-backed-up, the guests not covered by any backup job. Requires Sys.Audit on /.'
+          preprocessing:
+            - type: NOT_MATCHES_REGEX
+              parameters:
+                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+              error_handler: DISCARD_VALUE
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/cluster/backup-info/not-backed-up'
           headers:
@@ -468,6 +1267,585 @@ zabbix_export:
           tags:
             - tag: PVE
               value: Raw
+        - uuid: 5be835074ad9406abcf7ed723dffc949
+          name: 'PVE replication raw'
+          type: HTTP_AGENT
+          key: pve.replication.raw
+          delay: '300'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/replication. The list endpoint already carries the job state (last_sync, fail_count, error, duration), so no extra call per job is needed. Requires VM.Audit on the guests.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/replication'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 8ffa4568f4d4410dad143171f541d544
+          name: 'Disk rootfs avail'
+          type: DEPENDENT
+          key: pve.rootfs.avail
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Available free space on the PVE root filesystem (/) in bytes. Source: /nodes/{node}/status → data.rootfs.avail.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.rootfs.avail
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Disk
+        - uuid: a3091fd210f446c68cef528c2151b2be
+          name: 'Disk rootfs size'
+          type: DEPENDENT
+          key: pve.rootfs.size
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Total size of the PVE root filesystem (/) in bytes. Source: /nodes/{node}/status → data.rootfs.total.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.rootfs.total
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Disk
+        - uuid: e9857891ed7b4259b5accd82e4ef59d9
+          name: 'Disk rootfs used'
+          type: DEPENDENT
+          key: pve.rootfs.used
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Used space on the PVE root filesystem (/) in bytes. Source: /nodes/{node}/status → data.rootfs.used.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.rootfs.used
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Disk
+        - uuid: 4284e670220b4548a3d0e2b71e205e74
+          name: 'Disk rootfs utilization'
+          type: CALCULATED
+          key: pve.rootfs.util
+          delay: '60'
+          history: 7d
+          value_type: FLOAT
+          units: '%'
+          params: '(last(/{HOST.HOST}/pve.rootfs.used) / last(/{HOST.HOST}/pve.rootfs.size)) * 100'
+          description: 'Root filesystem utilization of the PVE host in percent, derived from pve.rootfs.used and pve.rootfs.size.'
+          tags:
+            - tag: PVE
+              value: Filesystem
+        - uuid: fc58a4bcb2ad418ca5948dbee16cecbb
+          name: 'PVE services raw'
+          type: HTTP_AGENT
+          key: pve.services.raw
+          delay: '60'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/services. Requires Sys.Audit on /nodes/{node}.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/services'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 6e6cfbb1bd554a6c94e3c712a4387900
+          name: 'PVE CPU sockets'
+          type: DEPENDENT
+          key: pve.sockets
+          delay: '0'
+          trends: '0'
+          units: '!Sockets'
+          description: 'Number of physical CPU sockets on the PVE host. Source: /nodes/{node}/status → data.cpuinfo.sockets.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.cpuinfo.sockets
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: CPU
+        - uuid: 894e2a471b4e441e9cf76143b1961e21
+          name: 'PVE status raw'
+          type: HTTP_AGENT
+          key: pve.status
+          delay: '60'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/status. Used as source for all PVE host dependent items (CPU, memory, disk, kernel, uptime, etc.).'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/status'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: e7ccf26004ff4d73b849ec2f0ba9f3a5
+          name: 'PVE storage raw'
+          type: HTTP_AGENT
+          key: pve.storage.raw
+          delay: '60'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/storage. Used as source for all storage discovery rules and dependent items.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/storage'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: dd8b6f60eee343af828ed3b496e69a06
+          name: 'Subscription level'
+          type: DEPENDENT
+          key: pve.subscription.level
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Subscription level code. Absent without a subscription, the value is then discarded instead of turning the item unsupported.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.level
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.subscription.raw
+          tags:
+            - tag: PVE
+              value: Subscription
+        - uuid: a900f847f83843e6b93f9e12feb050d4
+          name: 'Subscription next due date'
+          type: DEPENDENT
+          key: pve.subscription.nextduedate
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Next due date as reported by PVE, a plain date string. The numeric form for alerting is in pve.subscription.nextduedate.epoch.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.nextduedate
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.subscription.raw
+          tags:
+            - tag: PVE
+              value: Subscription
+        - uuid: d3ed6d06a2194635b5580d04303e143d
+          name: 'Subscription expiry'
+          type: DEPENDENT
+          key: pve.subscription.nextduedate.epoch
+          delay: '0'
+          value_type: FLOAT
+          trends: '0'
+          units: unixtime
+          description: 'Subscription due date as Unix time, 0 when the node has no subscription and PVE therefore reports no due date.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.nextduedate
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '0'
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  // 0 means: no subscription, so PVE reports no due date.
+                  if (value === '0') {
+                      return 0;
+                  }
+                  // PVE reports nextduedate as YYYY-MM-DD. Anchored to UTC so the
+                  // result does not shift with the server timezone. An unexpected
+                  // format throws, which turns the item visibly unsupported instead
+                  // of silently producing a wrong date.
+                  var t = Date.parse(value + 'T00:00:00Z');
+                  if (isNaN(t)) {
+                      throw 'unexpected nextduedate format: ' + value;
+                  }
+                  return Math.floor(t / 1000);
+          master_item:
+            key: pve.subscription.raw
+          tags:
+            - tag: PVE
+              value: Subscription
+          triggers:
+            - uuid: 3e3366874a4d4191a88632af4344bcce
+              expression: 'last(/Template Proxmox VE REST API/pve.subscription.nextduedate.epoch)>0 and last(/Template Proxmox VE REST API/pve.subscription.nextduedate.epoch)-now()<{$PVE.SUBSCRIPTION.EXPIRE.DAYS}'
+              name: 'PVE subscription expires in less than {$PVE.SUBSCRIPTION.EXPIRE.DAYS} on {HOST.NAME}'
+              opdata: 'Expires on: {ITEM.LASTVALUE1}'
+              priority: WARNING
+              description: 'Advance warning before the subscription runs out, so it can be renewed in time. Depends on the expired trigger, so only one of the two is open at a time.'
+              dependencies:
+                - name: 'PVE subscription has expired on {HOST.NAME}'
+                  expression: 'last(/Template Proxmox VE REST API/pve.subscription.nextduedate.epoch)>0 and last(/Template Proxmox VE REST API/pve.subscription.nextduedate.epoch)<now()'
+            - uuid: 7350199fa4884df6bf61d5797c37cf4a
+              expression: 'last(/Template Proxmox VE REST API/pve.subscription.nextduedate.epoch)>0 and last(/Template Proxmox VE REST API/pve.subscription.nextduedate.epoch)<now()'
+              name: 'PVE subscription has expired on {HOST.NAME}'
+              opdata: 'Expired on: {ITEM.LASTVALUE1}'
+              priority: AVERAGE
+              description: 'The subscription period has ended. Access to the enterprise repository is gone, updates from it will fail. Hosts without a subscription report a due date of 0, which the trigger ignores.'
+        - uuid: 31d2b788dfcc4fcfbe0fd4e02294b579
+          name: 'PVE subscription raw'
+          type: HTTP_AGENT
+          key: pve.subscription.raw
+          delay: '3600'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/subscription. Needs no special permission. Without a subscription the endpoint returns HTTP 200 and status notfound.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/subscription'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: c9a7c697ce26494a9eb98d233d41862f
+          name: 'Subscription status'
+          type: DEPENDENT
+          key: pve.subscription.status
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Subscription status: active, notfound, invalid, expired or suspended. Source: /nodes/{node}/subscription.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.status
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.subscription.raw
+          tags:
+            - tag: PVE
+              value: Subscription
+          triggers:
+            - uuid: 57b2f7fad21f4672874712a66208931a
+              expression: 'last(/Template Proxmox VE REST API/pve.subscription.status)<>"active" and {$PVE.SUBSCRIPTION.ALERT}=1'
+              name: 'PVE subscription is not active on {HOST.NAME} ({ITEM.LASTVALUE})'
+              priority: WARNING
+              description: 'Status is notfound, invalid, expired or suspended. Off by default, set {$PVE.SUBSCRIPTION.ALERT}=1 on hosts that are meant to carry a subscription. Depends on the expired trigger so a lapsed subscription raises one problem, not two.'
+              dependencies:
+                - name: 'PVE subscription has expired on {HOST.NAME}'
+                  expression: 'last(/Template Proxmox VE REST API/pve.subscription.nextduedate.epoch)>0 and last(/Template Proxmox VE REST API/pve.subscription.nextduedate.epoch)<now()'
+        - uuid: b3016c59c0024f8fa5306198d1d1b73b
+          name: 'PVE swap free'
+          type: DEPENDENT
+          key: pve.swap.free
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Free swap space on the PVE host in bytes. Source: /nodes/{node}/status → data.swap.free. Reports 0 on hosts without swap.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.swap.free
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: f2ae0c9f82084184954595f19a9ed722
+          name: 'PVE swap total'
+          type: DEPENDENT
+          key: pve.swap.total
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Configured swap space on the PVE host in bytes. Source: /nodes/{node}/status → data.swap.total. Reports 0 on hosts without swap.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.swap.total
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: 9d49a6ae2695427a84790e829970669d
+          name: 'PVE swap used'
+          type: DEPENDENT
+          key: pve.swap.used
+          delay: '0'
+          history: 7d
+          units: Bytes
+          description: 'Used swap space on the PVE host in bytes. Source: /nodes/{node}/status → data.swap.used. Swap filling up while memory is not tight usually means pages were evicted during an earlier peak and never came back.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.swap.used
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Memory
+        - uuid: fc7f8aba309848fe818a194eae131210
+          name: 'PVE boot mode'
+          type: DEPENDENT
+          key: pve.system.boot.mode
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Boot mode of the PVE host (e.g. efi, legacy-bios). Source: /nodes/{node}/status → data["boot-info"].mode.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data["boot-info"].mode'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Boot
+        - uuid: 6d8d3b4ace0349838ddb4681d733df82
+          name: 'PVE secureboot'
+          type: DEPENDENT
+          key: pve.system.boot.secureboot
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Secure Boot status on the PVE host. 0 = disabled, 1 = enabled. Source: /nodes/{node}/status → data["boot-info"].secureboot.'
+          valuemap:
+            name: 'PVE secureboot'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data["boot-info"].secureboot'
+              error_handler: DISCARD_VALUE
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Boot
+        - uuid: 8cbc645bf73d4654afa40ff9245ac67c
+          name: 'PVE tasks raw'
+          type: HTTP_AGENT
+          key: pve.tasks.raw
+          delay: '60'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/tasks, processed by JavaScript preprocessing to deduplicate tasks (keeps most recent run per id+type pair, excludes backup tasks handled by pve.backup.raw).'
+          preprocessing:
+            - type: JAVASCRIPT
+              parameters:
+                - |
+                  try {
+                      var obj = (typeof value === 'string') ? JSON.parse(value) : value;
+                      if (!obj || !obj.body || !Array.isArray(obj.body.data)) {
+                          return JSON.stringify({ error: "Invalid structure" });
+                      }
+                  
+                      var records = obj.body.data;
+                      var grouped = {};
+                  
+                      // Helper: normalise timestamp value to milliseconds
+                      // Robust time parsing: numeric strings, ISO, "YYYY-MM-DD HH:mm:ss"
+                      function normTime(v) {
+                          if (v === null || v === undefined) return -Infinity;
+                          if (typeof v === "number") return v < 1000000000000 ? v * 1000 : v;
+                          if (typeof v === "string") {
+                              var s = v.trim();
+                  
+                              // Treat purely numeric strings as numbers
+                              if (/^\d+(\.\d+)?$/.test(s)) {
+                                  var n = parseFloat(s);
+                                  return n < 1000000000000 ? n * 1000 : n;
+                              }
+                  
+                              // Parse "YYYY-MM-DD HH:mm:ss" (optional AM/PM)
+                              var m = s.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\s*(AM|PM))?$/i);
+                              if (m) {
+                                  var H = parseInt(m[4], 10), ampm = (m[7] || "").toUpperCase();
+                                  if (ampm) { if (ampm === "PM" && H < 12) H += 12; if (ampm === "AM" && H === 12) H = 0; }
+                                  return Date.UTC(+m[1], +m[2]-1, +m[3], H, +m[5], +m[6]);
+                              }
+                  
+                              // Fallback: parse as ISO-compatible string (Leerraum → 'T')
+                              var p = Date.parse(s.replace(/\s+/, "T"));
+                              return isNaN(p) ? -Infinity : p;
+                          }
+                          return -Infinity;
+                      }
+                      
+                  
+                      // Process task records
+                      for (var i = 0; i < records.length; i++) {
+                          var e = records[i];
+                          if (!e || !e.id || !e.type) continue;
+                  
+                          var key = e.id + "|" + e.type;
+                  
+                          // Normalise timestamps
+                          var copy = {};
+                          for (var k in e) if (e.hasOwnProperty(k)) copy[k] = e[k];
+                          copy._start = normTime(e.starttime || e.pstart || e.start);
+                  
+                          var existing = grouped[key];
+                          if (!existing || copy._start > existing._rep) {
+                              copy._rep = copy._start;
+                              grouped[key] = copy;
+                          }
+                      }
+                  
+                      // Build result list
+                      var resultList = [];
+                      for (var k in grouped) {
+                          var g = grouped[k];
+                          delete g._start;
+                          delete g._rep;
+                          g.grpid = g.id;
+                          resultList.push(g);
+                      }
+                  
+                      // Sort by ID
+                      // Sort: numeric IDs first, then lexicographic
+                      resultList.sort(function(a, b) {
+                          var aNum = /^\d+$/.test(String(a.id));
+                          var bNum = /^\d+$/.test(String(b.id));
+                          if (aNum && bNum) return Number(a.id) - Number(b.id);
+                          if (aNum && !bNum) return -1;
+                          if (!aNum && bNum) return 1;
+                          return (String(a.id) || "").localeCompare(String(b.id) || "");
+                      });
+                      
+                  
+                      obj.body.data = resultList;
+                      obj.body.total = resultList.length;
+                  
+                      return JSON.stringify(obj);
+                  
+                  } catch (err) {
+                      return JSON.stringify({ error: "Parsing failed", detail: err.message });
+                  }
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/tasks'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          output_format: JSON
+          tags:
+            - tag: PVE
+              value: Raw
+        - uuid: 9b368584e6844582a3ad0e792bdaf408
+          name: 'PVE time raw'
+          type: HTTP_AGENT
+          key: pve.time.raw
+          delay: 5m
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/time. Used for timezone and localtime dependent items.'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/time'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Time
+        - uuid: 6b6b792bf6cd4440acd22a5701f84201
+          name: 'PVE timezone'
+          type: DEPENDENT
+          key: pve.timezone
+          delay: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Timezone configured on the PVE host (e.g. Europe/Berlin). Source: /nodes/{node}/time → data.timezone.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.timezone
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          master_item:
+            key: pve.time.raw
+          tags:
+            - tag: PVE
+              value: Timezone
+        - uuid: 65168f3bf85e4d4d9c4e56b56a66ca43
+          name: 'PVE uptime'
+          type: DEPENDENT
+          key: pve.uptime
+          delay: '0'
+          trends: '0'
+          units: s
+          description: 'Uptime of the PVE host in seconds since last boot. Source: /nodes/{node}/status → data.uptime.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.uptime
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Uptime
+          triggers:
+            - uuid: 4cc6e8941efc4a3592f6dd22f2056969
+              expression: 'nodata(/Template Proxmox VE REST API/pve.uptime,300)=1'
+              name: 'PVE API not reachable on {HOST.NAME}'
+              opdata: 'No data for 5 minutes'
+              priority: HIGH
+              description: 'The Proxmox VE REST API has not returned data for 5 minutes. Check connectivity, API token, and PVE service status. Evaluated on "pve.uptime", because nodata() cannot read items that keep no history, such as the raw API item.'
+              manual_close: 'YES'
         - uuid: b23531b01ce04f8f9f96042acce215ae
           name: 'PVE user raw'
           type: HTTP_AGENT
@@ -477,6 +1855,11 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           description: 'Master item. Raw JSON from /access/users. Used as source for user discovery and account expiration monitoring.'
+          preprocessing:
+            - type: NOT_MATCHES_REGEX
+              parameters:
+                - '^(?:(?!)){{$PVE.DATACENTER.COLLECT}}'
+              error_handler: DISCARD_VALUE
           timeout: 20s
           url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/access/users'
           headers:
@@ -488,7 +1871,237 @@ zabbix_export:
           tags:
             - tag: PVE
               value: Raw
+        - uuid: 6ab7180a35904b229e889d93696c65ad
+          name: 'PVE version'
+          type: DEPENDENT
+          key: pve.version
+          delay: '0'
+          history: '0'
+          value_type: CHAR
+          trends: '0'
+          description: 'Proxmox VE version string, for example 9.2.10. Source: /nodes/{node}/status → data.pveversion, which carries it as pve-manager/9.2.10/<repoid>. Read from the host status instead of the separate version endpoint, so no extra request per interval is needed.'
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - $.data.pveversion
+            - type: REGEX
+              parameters:
+                - 'pve-manager/([0-9][0-9.]*)'
+                - \1
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          master_item:
+            key: pve.status
+          tags:
+            - tag: PVE
+              value: Version
+        - uuid: 8673bb46b5d446598493cabb23888df7
+          name: 'PVE ZFS pools raw'
+          type: HTTP_AGENT
+          key: pve.zfs.raw
+          delay: '300'
+          history: '0'
+          value_type: TEXT
+          trends: '0'
+          description: 'Master item. Raw JSON from /nodes/{node}/disks/zfs. Requires Sys.Audit on / (not on /nodes/{node}).'
+          timeout: 20s
+          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/disks/zfs'
+          headers:
+            - name: Authorization
+              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+            - name: Accept
+              value: application/json
+          tags:
+            - tag: PVE
+              value: Raw
       discovery_rules:
+        - uuid: 91bb690f87b743cb8045704ac4a4c9e0
+          name: 'Discover backup'
+          type: DEPENDENT
+          key: discover.backup
+          delay: '0'
+          lifetime_type: DELETE_IMMEDIATELY
+          lifetime: '0'
+          item_prototypes:
+            - uuid: 92c26ec56dfd4ec9b420851f7feb5f48
+              name: 'Backup duration {#ID}'
+              type: CALCULATED
+              key: 'backup.duration[{#BCKPID}]'
+              delay: '300'
+              history: 7d
+              value_type: FLOAT
+              units: s
+              params: 'last(/{HOST.HOST}/backup.endtime[{#BCKPID}]) - last(/{HOST.HOST}/backup.starttime[{#BCKPID}])'
+              description: 'How long the last finished backup of {#ID} took, in seconds. Derived from the end and start timestamps of the same run, both of which arrive together when the task reaches the archive. The value therefore describes the last completed run, never the one in progress.'
+              preprocessing:
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              tags:
+                - tag: PVE
+                  value: Backup
+                - tag: PVE
+                  value: '{#BCKPID}'
+                - tag: vmid
+                  value: '{#BCKPID}'
+            - uuid: b4dc3c9faf174b36a46ce730a1e0953e
+              name: 'Backup endtime {#ID}'
+              type: DEPENDENT
+              key: 'backup.endtime[{#BCKPID}]'
+              delay: '0'
+              history: 7d
+              units: unixtime
+              description: 'Unix timestamp of the last backup job end time for VM/CT {#ID}. Source: pve.backup.raw → data[bckpid].endtime.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.bckpid=="{#BCKPID}")].endtime.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.backup.raw
+              tags:
+                - tag: PVE
+                  value: Backup
+                - tag: PVE
+                  value: '{#BCKPID}'
+                - tag: vmid
+                  value: '{#BCKPID}'
+            - uuid: 44259cf2a2344ca09ff4a808dafc42cf
+              name: 'Backup message {#ID}'
+              type: DEPENDENT
+              key: 'backup.message[{#BCKPID}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Status text of the last backup job for VM/CT {#BCKPID}, exactly as Proxmox VE reports it. A successful job reports OK, a failed one reports the error message itself. The numeric item Backup status maps only a fixed set of known texts, so this item carries the real cause of a failure.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.bckpid=="{#BCKPID}")].status.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.backup.raw
+              tags:
+                - tag: PVE
+                  value: Backup
+                - tag: vmid
+                  value: '{#BCKPID}'
+            - uuid: 44af4c4fba8a485ca2d6076bed9e01b4
+              name: 'Backup starttime {#ID}'
+              type: DEPENDENT
+              key: 'backup.starttime[{#BCKPID}]'
+              delay: '0'
+              history: 7d
+              units: unixtime
+              description: 'Unix timestamp of the last backup job start time for VM/CT {#ID}. Source: pve.backup.raw → data[bckpid].starttime.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.bckpid=="{#BCKPID}")].starttime.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.backup.raw
+              tags:
+                - tag: PVE
+                  value: Backup
+                - tag: PVE
+                  value: '{#BCKPID}'
+                - tag: vmid
+                  value: '{#BCKPID}'
+            - uuid: a43334f185c049cb9b1eb4a6b3e813d5
+              name: 'Backup status {#ID}'
+              type: DEPENDENT
+              key: 'backup.status[{#BCKPID}]'
+              delay: '0'
+              history: 7d
+              description: 'Status of the last backup job for VM/CT {#ID}. 0=OK, 1=running, 2=stopped, 3=error, 4=unknown error.'
+              valuemap:
+                name: 'Backup status'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.bckpid=="{#BCKPID}")].status.first()'
+                  error_handler: DISCARD_VALUE
+                - type: REGEX
+                  parameters:
+                    - ^(OK|running|stopped|error)$
+                    - \0
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '4'
+                - type: STR_REPLACE
+                  parameters:
+                    - OK
+                    - '0'
+                - type: STR_REPLACE
+                  parameters:
+                    - running
+                    - '1'
+                - type: STR_REPLACE
+                  parameters:
+                    - stopped
+                    - '2'
+                - type: STR_REPLACE
+                  parameters:
+                    - error
+                    - '3'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.backup.raw
+              tags:
+                - tag: PVE
+                  value: Backup
+                - tag: PVE
+                  value: '{#BCKPID}'
+                - tag: vmid
+                  value: '{#BCKPID}'
+          trigger_prototypes:
+            - uuid: 6c0aa697138548fe8407c82d28d31a4a
+              expression: 'last(/Template Proxmox VE REST API/backup.status[{#BCKPID}])>=2 and {$ENABLE_BACKUP_ALERT:"{#BCKPID}"}=1 and fuzzytime(/Template Proxmox VE REST API/backup.endtime[{#BCKPID}],{$BACKUP.ALERT.WINDOW})=1'
+              name: 'Backup for {#ID} failed'
+              event_name: 'Backup for {#ID} failed: {?last(//backup.message[{#BCKPID}])}'
+              opdata: 'Backup status: {ITEM.LASTVALUE}'
+              priority: HIGH
+              description: |
+                0. OK: All clear, no errors detected
+                1. running: VM/CT is currently active
+                2. stopped: VM/CT has been shut down
+                3. error: General execution failure; check logs for details
+                4. unknown error: Cannot classify status, please check Proxmox for details
+              manual_close: 'YES'
+          graph_prototypes:
+            - uuid: 1f9f9b88b6394562ae09774bf5190e68
+              name: 'Backup status {#ID}'
+              graph_items:
+                - color: 8E24AA
+                  calc_fnc: ALL
+                  item:
+                    host: 'Template Proxmox VE REST API'
+                    key: 'backup.status[{#BCKPID}]'
+          master_item:
+            key: pve.backup.raw
+          lld_macro_paths:
+            - lld_macro: '{#BCKPID}'
+              path: $.bckpid
+            - lld_macro: '{#ID}'
+              path: $.id
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
         - uuid: d82f27394dbb4634a7802e256d63d054
           name: 'Discover backup jobs'
           type: DEPENDENT
@@ -522,7 +2135,7 @@ zabbix_export:
                   value: '{#BACKUP_JOB_ID}'
               trigger_prototypes:
                 - uuid: 9213166e3c774322a4bc6e31d87b4198
-                  expression: 'last(/Proxmox VE Cluster by REST API/backup.job.enabled[{#BACKUP_JOB_ID}])=0 and {$PVE.BACKUP.JOB.ALERT:"{#BACKUP_JOB_ID}"}=1'
+                  expression: 'last(/Template Proxmox VE REST API/backup.job.enabled[{#BACKUP_JOB_ID}])=0 and {$PVE.BACKUP.JOB.ALERT:"{#BACKUP_JOB_ID}"}=1'
                   name: 'Backup job {#BACKUP_JOB_ID} is disabled on {HOST.NAME}'
                   opdata: 'Schedule: {#BACKUP_JOB_SCHEDULE}, storage: {#BACKUP_JOB_STORAGE}'
                   priority: WARNING
@@ -554,7 +2167,7 @@ zabbix_export:
                   value: '{#BACKUP_JOB_ID}'
           trigger_prototypes:
             - uuid: 6279740f47ca48d3adf8795d408d722c
-              expression: 'nodata(/Proxmox VE Cluster by REST API/backup.job.nextrun[{#BACKUP_JOB_ID}],{$PVE.BACKUP.JOB.STALE})=1 and last(/Proxmox VE Cluster by REST API/backup.job.enabled[{#BACKUP_JOB_ID}])=1'
+              expression: 'nodata(/Template Proxmox VE REST API/backup.job.nextrun[{#BACKUP_JOB_ID}],{$PVE.BACKUP.JOB.STALE})=1 and last(/Template Proxmox VE REST API/backup.job.enabled[{#BACKUP_JOB_ID}])=1'
               name: 'Backup job {#BACKUP_JOB_ID} has not been rescheduled for {$PVE.BACKUP.JOB.STALE}'
               opdata: 'Next run: {ITEM.LASTVALUE1}, schedule: {#BACKUP_JOB_SCHEDULE}'
               priority: AVERAGE
@@ -575,7 +2188,7 @@ zabbix_export:
                 - '$.data[*]'
               error_handler: CUSTOM_VALUE
               error_handler_params: '[]'
-        - uuid: 4b6688341e0b4a1b9944368464cb3967
+        - uuid: 41c0fb6e4fe3477ea292ae1b26ea6e5d
           name: 'Discover Ceph cluster'
           type: DEPENDENT
           key: discover.ceph.cluster
@@ -584,7 +2197,7 @@ zabbix_export:
           enabled_lifetime: 1d
           description: 'Creates the Ceph items only when /cluster/ceph/status returns a Ceph status. On clusters without Ceph it discovers nothing, so no Ceph item exists and nothing is evaluated.'
           item_prototypes:
-            - uuid: 1fce79ca0fde478cbaeaedffbc7266d3
+            - uuid: 02daa4b3b12048b68b4bff33943491ec
               name: 'Ceph raw capacity available'
               type: DEPENDENT
               key: 'ceph.bytes.avail[{#FSID}]'
@@ -601,7 +2214,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: adccff89e39145578ac82a5cb31ba6ef
+            - uuid: b00b49a29df54059b4bf4d799af43110
               name: 'Ceph raw capacity total'
               type: DEPENDENT
               key: 'ceph.bytes.total[{#FSID}]'
@@ -621,7 +2234,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 2a900ec1d37c4074ab2df018faecfdb4
+            - uuid: d102d94df1a1492c985b0d459327b53a
               name: 'Ceph raw capacity used'
               type: DEPENDENT
               key: 'ceph.bytes.used[{#FSID}]'
@@ -638,7 +2251,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 9e86fd152f894a6a93de3313ba0e5b42
+            - uuid: 52f573eec3e145fd82bb34f0358410a8
               name: 'Ceph OSD flags'
               type: DEPENDENT
               key: 'ceph.flags[{#FSID}]'
@@ -660,14 +2273,14 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: c73f0805cd1b4f28b092576b5d6eb26c
+            - uuid: f6b09b3ddb994a788d01529bf6ea08e1
               name: 'Ceph health checks'
               type: DEPENDENT
               key: 'ceph.health.checks[{#FSID}]'
               delay: '0'
               value_type: TEXT
               trends: '0'
-              description: 'Summary messages of all active Ceph health checks, "none" while there are none.'
+              description: 'Summary messages of all active Ceph health checks, "none" while there are none. Zabbix shortens item values to 20 characters in trigger texts, so the full list is only here.'
               preprocessing:
                 - type: JSONPATH
                   parameters:
@@ -682,7 +2295,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: b36e1250d643426eb604c3ff260d6e6d
+            - uuid: a5d9dd21ae4f4d3ab21c4c6713f13d51
               name: 'Ceph health'
               type: DEPENDENT
               key: 'ceph.health[{#FSID}]'
@@ -713,22 +2326,22 @@ zabbix_export:
                 - tag: PVE
                   value: Ceph
               trigger_prototypes:
-                - uuid: 178e40d95d8743f3a898ac1ebb48b10d
-                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.health[{#FSID}])=2'
+                - uuid: 5305f3c7f76e4430bdc40813f3ff662e
+                  expression: 'last(/Template Proxmox VE REST API/ceph.health[{#FSID}])=2'
                   name: 'Ceph cluster health is HEALTH_ERR'
                   priority: HIGH
                   description: 'Ceph reports HEALTH_ERR. Data may be unavailable or at risk. The active health checks are in the item "Ceph health checks".'
                   manual_close: 'YES'
-                - uuid: 2aac4387212943e9ab407173e31b33c9
-                  expression: 'min(/Proxmox VE Cluster by REST API/ceph.health[{#FSID}],{$CEPH.HEALTH.WARN.PERIOD})>=1'
+                - uuid: 36ef062b9cb74ebfb569ddc49e95cbd5
+                  expression: 'min(/Template Proxmox VE REST API/ceph.health[{#FSID}],{$CEPH.HEALTH.WARN.PERIOD})>=1'
                   name: 'Ceph cluster health is not OK for {$CEPH.HEALTH.WARN.PERIOD}'
                   priority: WARNING
                   description: 'Ceph has reported at least HEALTH_WARN for the whole period. Short warnings, for example during a restart, do not fire. The active health checks are in the item "Ceph health checks".'
                   manual_close: 'YES'
                   dependencies:
                     - name: 'Ceph cluster health is HEALTH_ERR'
-                      expression: 'last(/Proxmox VE Cluster by REST API/ceph.health[{#FSID}])=2'
-            - uuid: 827de8b97ea34736ac840036c30b8ff5
+                      expression: 'last(/Template Proxmox VE REST API/ceph.health[{#FSID}])=2'
+            - uuid: 94f0b288d34640eda6af29999d15d364
               name: 'Ceph manager available'
               type: DEPENDENT
               key: 'ceph.mgr.available[{#FSID}]'
@@ -753,13 +2366,13 @@ zabbix_export:
                 - tag: PVE
                   value: Ceph
               trigger_prototypes:
-                - uuid: d780ff7e44b54f9ca587af71d3e5f892
-                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.mgr.available[{#FSID}])=0'
+                - uuid: 9565bd6d09f14fcca736dc911b838382
+                  expression: 'last(/Template Proxmox VE REST API/ceph.mgr.available[{#FSID}])=0'
                   name: 'Ceph: no active manager'
                   priority: HIGH
                   description: 'No Ceph manager is active. Statistics, the dashboard and orchestration stop, and PG statistics go stale.'
                   manual_close: 'YES'
-            - uuid: 501c083532b74a44a6c85dc260b3264a
+            - uuid: 5319295d668e4cddb72aaf201917a97a
               name: 'Ceph manager standbys'
               type: DEPENDENT
               key: 'ceph.mgr.standbys[{#FSID}]'
@@ -780,7 +2393,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 56a4e1a2fd1b42339883e4128c0e624a
+            - uuid: 43691267ccd041b3855032a3cdfc2d03
               name: 'Ceph monitors in quorum'
               type: DEPENDENT
               key: 'ceph.mons.quorum[{#FSID}]'
@@ -799,7 +2412,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 52ab2191852541dc9bd8d859534d59ad
+            - uuid: aafe7518e9be472ca56ff4b14f3d030f
               name: 'Ceph monitors total'
               type: DEPENDENT
               key: 'ceph.mons.total[{#FSID}]'
@@ -818,7 +2431,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 5197066e9abb4c4990a6b8f3a13bb892
+            - uuid: 1e79f7414de64826b6be29d36faa4cf9
               name: 'Ceph objects degraded'
               type: DEPENDENT
               key: 'ceph.objects.degraded[{#FSID}]'
@@ -836,7 +2449,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 4bfe2b04f12548f1b6dde1a65b136e04
+            - uuid: 45f4b285b6c948d1add664839f2ce9bf
               name: 'Ceph objects misplaced'
               type: DEPENDENT
               key: 'ceph.objects.misplaced[{#FSID}]'
@@ -854,7 +2467,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 1410e6fd150548e88d188ef77fca575f
+            - uuid: 098fa4df416b46d6af094dd060c32295
               name: 'Ceph objects unfound'
               type: DEPENDENT
               key: 'ceph.objects.unfound[{#FSID}]'
@@ -873,14 +2486,14 @@ zabbix_export:
                 - tag: PVE
                   value: Ceph
               trigger_prototypes:
-                - uuid: 44951557f91a4bd9a899a338f91dcad8
-                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.objects.unfound[{#FSID}])>0'
+                - uuid: 1f54ac85ee624b648d8dce59b4853e2e
+                  expression: 'last(/Template Proxmox VE REST API/ceph.objects.unfound[{#FSID}])>0'
                   name: 'Ceph: unfound objects'
                   opdata: '{ITEM.LASTVALUE1} objects'
                   priority: HIGH
                   description: 'Ceph knows objects exist but cannot find any copy. I/O to them blocks, and data loss is possible if the OSDs holding them do not come back.'
                   manual_close: 'YES'
-            - uuid: 2adf09093ddf41b7aef8c0ba32ee7198
+            - uuid: fac485651d294501a6a56683e4cf7736
               name: 'Ceph OSDs in'
               type: DEPENDENT
               key: 'ceph.osds.in[{#FSID}]'
@@ -899,7 +2512,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 854eaeba5cfa4541b85a2ace64370b6d
+            - uuid: a1596bb4fd264f5bbce4b91d61c11fb9
               name: 'Ceph OSDs total'
               type: DEPENDENT
               key: 'ceph.osds.total[{#FSID}]'
@@ -918,7 +2531,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: a789d15450a245069b1c07b5317807bc
+            - uuid: 4b000e282ce44dc3ae6cba3298df32a6
               name: 'Ceph OSDs up'
               type: DEPENDENT
               key: 'ceph.osds.up[{#FSID}]'
@@ -937,7 +2550,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 55cfbd82a2b14cdbb8d8b81c99b5ca42
+            - uuid: 51cbba2f71ea483095ffb1874a40abdf
               name: 'Ceph PGs active+clean'
               type: DEPENDENT
               key: 'ceph.pgs.clean[{#FSID}]'
@@ -955,7 +2568,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 0d3e06c09560434087cfda670af87c96
+            - uuid: 62255580391a4e50abad89a743569398
               name: 'Ceph PGs total'
               type: DEPENDENT
               key: 'ceph.pgs.total[{#FSID}]'
@@ -974,7 +2587,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: d0dbed744cee451a93e574eb86a4d60f
+            - uuid: 084a609a7b114d85a105d24e9758d946
               name: 'Ceph client read'
               type: DEPENDENT
               key: 'ceph.read.bps[{#FSID}]'
@@ -993,7 +2606,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 91912d2f86604871bbfabcb66fe32c16
+            - uuid: 3c08e400869045bfbe57bcf188c8607c
               name: 'Ceph client read operations'
               type: DEPENDENT
               key: 'ceph.read.iops[{#FSID}]'
@@ -1012,7 +2625,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 08b573745e0e4421aba3709ba3527c53
+            - uuid: 828624248da64faabaf2aeb0fe6b424c
               name: 'Ceph recovery throughput'
               type: DEPENDENT
               key: 'ceph.recovery.bps[{#FSID}]'
@@ -1031,7 +2644,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 05d393c5ebab4950b2af56c3178ba4e0
+            - uuid: 4622508a6c0f4b3b944ca0996393b8f7
               name: 'Ceph raw capacity utilization'
               type: CALCULATED
               key: 'ceph.util[{#FSID}]'
@@ -1044,15 +2657,15 @@ zabbix_export:
                 - tag: PVE
                   value: Ceph
               trigger_prototypes:
-                - uuid: e9d4d5ac2b08462b85c14a73d3734931
-                  expression: 'min(/Proxmox VE Cluster by REST API/ceph.util[{#FSID}],5m)>{$CEPH.UTIL.CRIT}'
+                - uuid: 00f34097ac5c4b2fbf507d6f225332ce
+                  expression: 'min(/Template Proxmox VE REST API/ceph.util[{#FSID}],5m)>{$CEPH.UTIL.CRIT}'
                   name: 'Ceph raw capacity is over {$CEPH.UTIL.CRIT}%'
                   opdata: '{ITEM.LASTVALUE1}'
                   priority: HIGH
                   description: 'The raw capacity of the Ceph cluster is almost used up. OSDs refuse writes once they reach the full ratio, and the first OSD fills up before the cluster average does.'
                   manual_close: 'YES'
-                - uuid: daa5908e05c24b74bb8c94dc9e941c75
-                  expression: 'min(/Proxmox VE Cluster by REST API/ceph.util[{#FSID}],5m)>{$CEPH.UTIL.WARN}'
+                - uuid: 9a40c4ef65a84ac3b564a484d5e35a50
+                  expression: 'min(/Template Proxmox VE REST API/ceph.util[{#FSID}],5m)>{$CEPH.UTIL.WARN}'
                   name: 'Ceph raw capacity is over {$CEPH.UTIL.WARN}%'
                   opdata: '{ITEM.LASTVALUE1}'
                   priority: WARNING
@@ -1060,8 +2673,8 @@ zabbix_export:
                   manual_close: 'YES'
                   dependencies:
                     - name: 'Ceph raw capacity is over {$CEPH.UTIL.CRIT}%'
-                      expression: 'min(/Proxmox VE Cluster by REST API/ceph.util[{#FSID}],5m)>{$CEPH.UTIL.CRIT}'
-            - uuid: e0c48680b284451cb38b3862d5329267
+                      expression: 'min(/Template Proxmox VE REST API/ceph.util[{#FSID}],5m)>{$CEPH.UTIL.CRIT}'
+            - uuid: b841c1f540f745d2b0dd7c1c44b5a89c
               name: 'Ceph client write'
               type: DEPENDENT
               key: 'ceph.write.bps[{#FSID}]'
@@ -1080,7 +2693,7 @@ zabbix_export:
               tags:
                 - tag: PVE
                   value: Ceph
-            - uuid: 6fefa5a4d3b74807bf4adbbd15dfac11
+            - uuid: 78c72a99153d42d6aef4ca0c5e574b8c
               name: 'Ceph client write operations'
               type: DEPENDENT
               key: 'ceph.write.iops[{#FSID}]'
@@ -1100,77 +2713,77 @@ zabbix_export:
                 - tag: PVE
                   value: Ceph
           trigger_prototypes:
-            - uuid: 23fa4140dd5941acb9a040e5c09561a3
-              expression: 'last(/Proxmox VE Cluster by REST API/ceph.mons.quorum[{#FSID}])<last(/Proxmox VE Cluster by REST API/ceph.mons.total[{#FSID}])'
+            - uuid: 8daf7f9034554910a24ef6baf8c0c506
+              expression: 'last(/Template Proxmox VE REST API/ceph.mons.quorum[{#FSID}])<last(/Template Proxmox VE REST API/ceph.mons.total[{#FSID}])'
               name: 'Ceph: monitor(s) out of quorum'
               opdata: 'In quorum: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
               priority: AVERAGE
               description: 'At least one Ceph monitor is not part of the quorum. Losing one more may cost the quorum and stop all Ceph I/O.'
               manual_close: 'YES'
-            - uuid: 0e5b80522e994ff0b0e79d515cc669a4
-              expression: 'last(/Proxmox VE Cluster by REST API/ceph.osds.up[{#FSID}])<last(/Proxmox VE Cluster by REST API/ceph.osds.total[{#FSID}])'
+            - uuid: 9720ba49deb049348fea7107ca45790c
+              expression: 'last(/Template Proxmox VE REST API/ceph.osds.up[{#FSID}])<last(/Template Proxmox VE REST API/ceph.osds.total[{#FSID}])'
               name: 'Ceph: one or more OSDs are down'
               opdata: 'Up: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
               priority: AVERAGE
               description: 'Ceph marks the affected OSDs out after a while and starts to rebalance. The OSD discovery shows which OSD is down.'
               manual_close: 'YES'
-            - uuid: cc1eebd702744e68a9d40ef71668c7d4
-              expression: 'last(/Proxmox VE Cluster by REST API/ceph.osds.in[{#FSID}])<last(/Proxmox VE Cluster by REST API/ceph.osds.total[{#FSID}])'
+            - uuid: 9bcf528b1e344d1fbdc4c21ce3a3b6b4
+              expression: 'last(/Template Proxmox VE REST API/ceph.osds.in[{#FSID}])<last(/Template Proxmox VE REST API/ceph.osds.total[{#FSID}])'
               name: 'Ceph: one or more OSDs are out'
               opdata: 'In: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
               priority: WARNING
               description: 'OSDs that are out hold no data; the cluster runs with reduced capacity and redundancy until they are back in or removed.'
               manual_close: 'YES'
-            - uuid: 349c4191aff84e5d8257861987945260
-              expression: 'max(/Proxmox VE Cluster by REST API/ceph.pgs.clean[{#FSID}],{$CEPH.PG.NOT_CLEAN.PERIOD})<last(/Proxmox VE Cluster by REST API/ceph.pgs.total[{#FSID}])'
+            - uuid: 817e1296e2ad447cbcedbfa4266a338f
+              expression: 'max(/Template Proxmox VE REST API/ceph.pgs.clean[{#FSID}],{$CEPH.PG.NOT_CLEAN.PERIOD})<last(/Template Proxmox VE REST API/ceph.pgs.total[{#FSID}])'
               name: 'Ceph: placement groups not active+clean for {$CEPH.PG.NOT_CLEAN.PERIOD}'
               opdata: 'Clean: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
               priority: WARNING
               description: 'Some placement groups have not been active+clean at any point of the period. Recovery or backfill is stuck or the cluster lacks OSDs to restore redundancy.'
               manual_close: 'YES'
           graph_prototypes:
-            - uuid: 62ea53723ce443d494d8265098f177ca
+            - uuid: 22801be025b742ea8ff5b3341af45612
               name: 'Ceph client operations'
               graph_items:
                 - color: 1976D2
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'ceph.read.iops[{#FSID}]'
                 - sortorder: '1'
                   color: FF8F00
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'ceph.write.iops[{#FSID}]'
-            - uuid: c2b159575594448abe65ba2532089b0a
+            - uuid: b31e1896f4734671bd3139a5746a3b51
               name: 'Ceph client throughput'
               graph_items:
                 - color: 1976D2
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'ceph.read.bps[{#FSID}]'
                 - sortorder: '1'
                   color: FF8F00
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'ceph.write.bps[{#FSID}]'
                 - sortorder: '2'
                   color: 8E24AA
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'ceph.recovery.bps[{#FSID}]'
-            - uuid: 52f6428700fc451c976ded0e63e72908
+            - uuid: 617a422cd5de4c8da524e1445e654fdd
               name: 'Ceph raw capacity'
               graph_items:
                 - drawtype: FILLED_REGION
                   color: E45959
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'ceph.bytes.used[{#FSID}]'
                 - sortorder: '1'
                   drawtype: FILLED_REGION
                   color: 00C48C
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'ceph.bytes.avail[{#FSID}]'
           master_item:
             key: pve.ceph.status.raw
@@ -1183,7 +2796,7 @@ zabbix_export:
                 - '$[?(@.fsid)]'
               error_handler: CUSTOM_VALUE
               error_handler_params: '[]'
-        - uuid: af70c6046bbd4fb69a1bf98eba508c8e
+        - uuid: 38786fee8d3843279cd3e58a7ba06e88
           name: 'Discover Ceph OSDs'
           type: DEPENDENT
           key: discover.ceph.osd
@@ -1192,7 +2805,7 @@ zabbix_export:
           enabled_lifetime: 1d
           description: 'Discovers every OSD in the CRUSH tree of /nodes/localhost/ceph/osd. Discovers nothing on clusters without Ceph.'
           item_prototypes:
-            - uuid: 5ca75d7030da4ae480c5bde9627b835e
+            - uuid: 3e754961e3f44170bdc4e919f3fc6833
               name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: in'
               type: DEPENDENT
               key: 'ceph.osd.in[{#OSD_ID}]'
@@ -1218,7 +2831,7 @@ zabbix_export:
                   value: Ceph
                 - tag: PVE
                   value: '{#OSD_HOST}'
-            - uuid: 99f03db18cf740aea3b468b09daccf9e
+            - uuid: 6abbb87bb8fc4c1d832ed6336e0ee883
               name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: apply latency'
               type: DEPENDENT
               key: 'ceph.osd.latency.apply[{#OSD_ID}]'
@@ -1244,7 +2857,7 @@ zabbix_export:
                   value: Ceph
                 - tag: PVE
                   value: '{#OSD_HOST}'
-            - uuid: aba4d66025b145eb84bdecbf7d0cfa06
+            - uuid: 66b1e3e7ef5840a1a2e05383e07ce5a5
               name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: commit latency'
               type: DEPENDENT
               key: 'ceph.osd.latency.commit[{#OSD_ID}]'
@@ -1271,14 +2884,14 @@ zabbix_export:
                 - tag: PVE
                   value: '{#OSD_HOST}'
               trigger_prototypes:
-                - uuid: d1467778baba4841992335f3e9d9fb82
-                  expression: 'min(/Proxmox VE Cluster by REST API/ceph.osd.latency.commit[{#OSD_ID}],{$CEPH.OSD.LATENCY.PERIOD})>{$CEPH.OSD.LATENCY.MAX}'
+                - uuid: dd54c345289e42d6b35b720fac6198fc
+                  expression: 'min(/Template Proxmox VE REST API/ceph.osd.latency.commit[{#OSD_ID}],{$CEPH.OSD.LATENCY.PERIOD})>{$CEPH.OSD.LATENCY.MAX}'
                   name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: commit latency over {$CEPH.OSD.LATENCY.MAX}s'
                   opdata: '{ITEM.LASTVALUE1}'
                   priority: WARNING
                   description: 'The OSD has been slow for the whole period. A failing or overloaded disk slows down every pool it serves.'
                   manual_close: 'YES'
-            - uuid: dee4b7cd4e034069a6ec0ab98871ad6d
+            - uuid: 66ebf328534d4bbabcbea7044decc8ac
               name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: placement groups'
               type: DEPENDENT
               key: 'ceph.osd.pgs[{#OSD_ID}]'
@@ -1299,7 +2912,7 @@ zabbix_export:
                   value: Ceph
                 - tag: PVE
                   value: '{#OSD_HOST}'
-            - uuid: fa11df6d1fb943139c7fb6f4711c5247
+            - uuid: 84b92a1e2b224c2aa0cf404178d97fc9
               name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: status'
               type: DEPENDENT
               key: 'ceph.osd.up[{#OSD_ID}]'
@@ -1334,13 +2947,13 @@ zabbix_export:
                 - tag: PVE
                   value: '{#OSD_HOST}'
               trigger_prototypes:
-                - uuid: a0f2b17145724977a4cc66d3e4966fe6
-                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.osd.up[{#OSD_ID}])=0'
+                - uuid: 9f8f794b6d60448d8b45c6b1b9cdf289
+                  expression: 'last(/Template Proxmox VE REST API/ceph.osd.up[{#OSD_ID}])=0'
                   name: 'Ceph {#OSD_NAME} on {#OSD_HOST} is down'
                   priority: AVERAGE
                   description: 'The OSD daemon is not running or cannot reach the monitors. Check ceph-osd@{#OSD_ID} on {#OSD_HOST} and the disk behind it.'
                   manual_close: 'YES'
-            - uuid: c1df354baa8743f6849cf53326fbaf3e
+            - uuid: 7364c68b0d5b45cbbb5ec666428b790c
               name: 'Ceph {#OSD_NAME} on {#OSD_HOST}: utilization'
               type: DEPENDENT
               key: 'ceph.osd.util[{#OSD_ID}]'
@@ -1364,15 +2977,15 @@ zabbix_export:
                 - tag: PVE
                   value: '{#OSD_HOST}'
               trigger_prototypes:
-                - uuid: 638b17ed15004ab7aafd9b4d576df1b9
-                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.osd.util[{#OSD_ID}])>{$CEPH.OSD.UTIL.CRIT}'
+                - uuid: 277f0758d25d48e8a653dce5148cb4ed
+                  expression: 'last(/Template Proxmox VE REST API/ceph.osd.util[{#OSD_ID}])>{$CEPH.OSD.UTIL.CRIT}'
                   name: 'Ceph {#OSD_NAME} on {#OSD_HOST} is over {$CEPH.OSD.UTIL.CRIT}% full'
                   opdata: '{ITEM.LASTVALUE1}'
                   priority: HIGH
                   description: 'Ceph blocks writes to the whole pool once a single OSD reaches the full ratio (95% by default). Rebalance with reweight or add capacity.'
                   manual_close: 'YES'
-                - uuid: e9fffc5d11804c62aeaa58bac2ad1ebe
-                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.osd.util[{#OSD_ID}])>{$CEPH.OSD.UTIL.WARN}'
+                - uuid: ae43ff43bea1427d8344e0f07e103b4a
+                  expression: 'last(/Template Proxmox VE REST API/ceph.osd.util[{#OSD_ID}])>{$CEPH.OSD.UTIL.WARN}'
                   name: 'Ceph {#OSD_NAME} on {#OSD_HOST} is over {$CEPH.OSD.UTIL.WARN}% full'
                   opdata: '{ITEM.LASTVALUE1}'
                   priority: WARNING
@@ -1380,7 +2993,7 @@ zabbix_export:
                   manual_close: 'YES'
                   dependencies:
                     - name: 'Ceph {#OSD_NAME} on {#OSD_HOST} is over {$CEPH.OSD.UTIL.CRIT}% full'
-                      expression: 'last(/Proxmox VE Cluster by REST API/ceph.osd.util[{#OSD_ID}])>{$CEPH.OSD.UTIL.CRIT}'
+                      expression: 'last(/Template Proxmox VE REST API/ceph.osd.util[{#OSD_ID}])>{$CEPH.OSD.UTIL.CRIT}'
           master_item:
             key: pve.ceph.osd.raw
           lld_macro_paths:
@@ -1396,7 +3009,7 @@ zabbix_export:
                 - '$.data.root..children[?(@.type=="osd")]'
               error_handler: CUSTOM_VALUE
               error_handler_params: '[]'
-        - uuid: 18f88b7d53de4b81be456c01a8b5c369
+        - uuid: d6b89f68f426497e9d9094fc6a8c4422
           name: 'Discover Ceph pools'
           type: DEPENDENT
           key: discover.ceph.pools
@@ -1411,7 +3024,7 @@ zabbix_export:
           enabled_lifetime: 1d
           description: 'Discovers the Ceph pools from /nodes/localhost/ceph/pool. Discovers nothing on clusters without Ceph. Items are keyed by pool id; the name is in the item name and tags.'
           item_prototypes:
-            - uuid: bda878b967e540cca8bde0babb6594d7
+            - uuid: 1fb33747160e49d2bb133ac324c70a23
               name: 'Ceph pool {#POOL}: min_size'
               type: DEPENDENT
               key: 'ceph.pool.min_size[{#POOL_ID}]'
@@ -1435,7 +3048,7 @@ zabbix_export:
                   value: '{#POOL}'
                 - tag: PVE
                   value: Ceph
-            - uuid: c7a2377d7e4545958482504a688fd4a6
+            - uuid: f5a4af8f16ec4e068accc3e0ee78a724
               name: 'Ceph pool {#POOL}: size'
               type: DEPENDENT
               key: 'ceph.pool.size[{#POOL_ID}]'
@@ -1459,7 +3072,7 @@ zabbix_export:
                   value: '{#POOL}'
                 - tag: PVE
                   value: Ceph
-            - uuid: 0ab62b28f4d04106b38efd2ab40bd8e6
+            - uuid: f40e484a4eb544f8ac149d1e785db0d8
               name: 'Ceph pool {#POOL}: used'
               type: DEPENDENT
               key: 'ceph.pool.used[{#POOL_ID}]'
@@ -1481,7 +3094,7 @@ zabbix_export:
                   value: '{#POOL}'
                 - tag: PVE
                   value: Ceph
-            - uuid: c4fc3424825a424897ac1f8a46daf098
+            - uuid: 628894262fed4cfc974f1cd5c30991d4
               name: 'Ceph pool {#POOL}: utilization'
               type: DEPENDENT
               key: 'ceph.pool.util[{#POOL_ID}]'
@@ -1508,15 +3121,15 @@ zabbix_export:
                 - tag: PVE
                   value: Ceph
               trigger_prototypes:
-                - uuid: 200f52e8661c4d74b0c228d882b30035
-                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.pool.util[{#POOL_ID}])>{$CEPH.POOL.UTIL.CRIT}'
+                - uuid: 9695c451c930432e801650e48b096829
+                  expression: 'last(/Template Proxmox VE REST API/ceph.pool.util[{#POOL_ID}])>{$CEPH.POOL.UTIL.CRIT}'
                   name: 'Ceph pool {#POOL} is over {$CEPH.POOL.UTIL.CRIT}% full'
                   opdata: '{ITEM.LASTVALUE1}'
                   priority: HIGH
                   description: 'The pool is close to its usable capacity. Ceph stops writes to the pool once it is full.'
                   manual_close: 'YES'
-                - uuid: 0c91dde314d348ac9f4ad348c3a884c0
-                  expression: 'last(/Proxmox VE Cluster by REST API/ceph.pool.util[{#POOL_ID}])>{$CEPH.POOL.UTIL.WARN}'
+                - uuid: c30e5615a2d14afeab4f90b331fac519
+                  expression: 'last(/Template Proxmox VE REST API/ceph.pool.util[{#POOL_ID}])>{$CEPH.POOL.UTIL.WARN}'
                   name: 'Ceph pool {#POOL} is over {$CEPH.POOL.UTIL.WARN}% full'
                   opdata: '{ITEM.LASTVALUE1}'
                   priority: WARNING
@@ -1524,10 +3137,10 @@ zabbix_export:
                   manual_close: 'YES'
                   dependencies:
                     - name: 'Ceph pool {#POOL} is over {$CEPH.POOL.UTIL.CRIT}% full'
-                      expression: 'last(/Proxmox VE Cluster by REST API/ceph.pool.util[{#POOL_ID}])>{$CEPH.POOL.UTIL.CRIT}'
+                      expression: 'last(/Template Proxmox VE REST API/ceph.pool.util[{#POOL_ID}])>{$CEPH.POOL.UTIL.CRIT}'
           trigger_prototypes:
-            - uuid: e5ed8415c37c4ce89740ed1d4140cb56
-              expression: 'last(/Proxmox VE Cluster by REST API/ceph.pool.min_size[{#POOL_ID}])=1 and last(/Proxmox VE Cluster by REST API/ceph.pool.size[{#POOL_ID}])>1'
+            - uuid: f2a24bf0fad8464fb784a936ff1e6e89
+              expression: 'last(/Template Proxmox VE REST API/ceph.pool.min_size[{#POOL_ID}])=1 and last(/Template Proxmox VE REST API/ceph.pool.size[{#POOL_ID}])>1'
               name: 'Ceph pool {#POOL} accepts writes with a single copy (min_size 1)'
               priority: WARNING
               description: 'With min_size 1 the pool keeps writing while only one copy is left. A second failure then loses data. Set min_size to 2 for size 3.'
@@ -1544,7 +3157,325 @@ zabbix_export:
                 - '$.data[*]'
               error_handler: CUSTOM_VALUE
               error_handler_params: '[]'
-        - uuid: 7495dfbf4ad940b9a04c3150e802f97d
+        - uuid: fc425a072e654624bdcb690f816894f9
+          name: 'Discover certificates'
+          type: DEPENDENT
+          key: discover.certificates
+          delay: '0'
+          description: 'Discovers the certificates of the node: pve-root-ca.pem, pve-ssl.pem and, if configured, pveproxy-ssl.pem from a custom or ACME certificate.'
+          item_prototypes:
+            - uuid: 6cc4542bb31644218df1ab33e8a59cbd
+              name: 'Certificate issuer {#CERT_FILE}'
+              type: DEPENDENT
+              key: 'cert.issuer[{#CERT_FILE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Certificate issuer name.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.filename=="{#CERT_FILE}")].issuer.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.certificates.raw
+              tags:
+                - tag: PVE
+                  value: Certificate
+                - tag: PVE
+                  value: '{#CERT_FILE}'
+            - uuid: 34c34d3714f642caa995220ac55d4cbc
+              name: 'Certificate expiry {#CERT_FILE}'
+              type: DEPENDENT
+              key: 'cert.notafter[{#CERT_FILE}]'
+              delay: '0'
+              value_type: FLOAT
+              trends: '0'
+              units: unixtime
+              description: 'notAfter timestamp. PVE already delivers a Unix epoch, so no conversion is needed.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.filename=="{#CERT_FILE}")].notafter.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.certificates.raw
+              tags:
+                - tag: PVE
+                  value: Certificate
+                - tag: PVE
+                  value: '{#CERT_FILE}'
+              trigger_prototypes:
+                - uuid: f259a1bd684b48ec89304dafcd4cb29f
+                  expression: 'last(/Template Proxmox VE REST API/cert.notafter[{#CERT_FILE}])-now()<{$PVE.CERT.EXPIRE.DAYS}'
+                  name: 'Certificate {#CERT_FILE} expires in less than {$PVE.CERT.EXPIRE.DAYS} on {HOST.NAME}'
+                  priority: WARNING
+                  description: 'Applies to pve-ssl.pem, pve-root-ca.pem and any custom or ACME certificate. The cluster CA runs for 50 years, the node certificate for two.'
+                  dependencies:
+                    - name: 'Certificate {#CERT_FILE} has expired on {HOST.NAME}'
+                      expression: 'last(/Template Proxmox VE REST API/cert.notafter[{#CERT_FILE}])-now()<0'
+                - uuid: 1a30b199323f48aea3f672c249264da5
+                  expression: 'last(/Template Proxmox VE REST API/cert.notafter[{#CERT_FILE}])-now()<0'
+                  name: 'Certificate {#CERT_FILE} has expired on {HOST.NAME}'
+                  priority: AVERAGE
+                  description: 'The certificate is past its notAfter date. Clients and the web interface reject it, and API clients that verify the chain stop connecting. The advance warning depends on this trigger, so only one of the two is open at a time.'
+            - uuid: 89ee399fb63440c4b39c734fab870ac2
+              name: 'Certificate subject {#CERT_FILE}'
+              type: DEPENDENT
+              key: 'cert.subject[{#CERT_FILE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Certificate subject name.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.filename=="{#CERT_FILE}")].subject.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.certificates.raw
+              tags:
+                - tag: PVE
+                  value: Certificate
+                - tag: PVE
+                  value: '{#CERT_FILE}'
+          master_item:
+            key: pve.certificates.raw
+          lld_macro_paths:
+            - lld_macro: '{#CERT_FILE}'
+              path: $.filename
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: b3effaa7e8414b4b80f82b301646e7a2
+          name: 'Discover disks'
+          type: DEPENDENT
+          key: discover.disks
+          delay: '0'
+          description: 'Discovers physical disks from /nodes/{node}/disks/list. Covers every disk type Proxmox VE reports, including SATA, SAS and NVMe. The wearout item is skipped for rotating disks, which do not expose that value.'
+          item_prototypes:
+            - uuid: 34f801ed3d4f492bb997c571addb024a
+              name: 'Disk {#DISK_DEV} health'
+              type: DEPENDENT
+              key: 'disk.health[{#DISK_DEV}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'SMART health status of disk {#DISK_DEV} ({#DISK_MODEL}). Values: PASSED, FAILED, UNKNOWN. Source: /nodes/{node}/disks/list, which reports the same overall health assessment as the dedicated SMART endpoint, so no extra request per disk is needed.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.devpath=="{#DISK_DEV}")].health.first()'
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: UNKNOWN
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.disks.raw
+              tags:
+                - tag: PVE
+                  value: Disk
+                - tag: PVE
+                  value: '{#DISK_DEV}'
+              trigger_prototypes:
+                - uuid: e1ea4b0beadb4577a6b71421c12761a1
+                  expression: |
+                    last(/Template Proxmox VE REST API/disk.health[{#DISK_DEV}])<>"PASSED"
+                    and last(/Template Proxmox VE REST API/disk.health[{#DISK_DEV}])<>"OK"
+                    and last(/Template Proxmox VE REST API/disk.health[{#DISK_DEV}])<>"UNKNOWN"
+                    and last(/Template Proxmox VE REST API/disk.health[{#DISK_DEV}])<>"SMART Disabled"
+                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) SMART health not PASSED on {HOST.NAME}'
+                  priority: HIGH
+                  description: 'SMART health check for disk {#DISK_DEV} returned a failed status. PASSED and OK are the healthy verdicts. UNKNOWN and SMART Disabled mean the disk reports no assessment at all and are not treated as a failure.'
+                  manual_close: 'YES'
+            - uuid: 8f6a409c8d1c40dd8ddb78d029f7dcbc
+              name: 'Disk {#DISK_DEV} size'
+              type: DEPENDENT
+              key: 'disk.size[{#DISK_DEV}]'
+              delay: '0'
+              history: 7d
+              units: Bytes
+              description: 'Total size of physical disk {#DISK_DEV} ({#DISK_MODEL}) in bytes. Source: /nodes/{node}/disks/list.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.devpath=="{#DISK_DEV}")].size.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: pve.disks.raw
+              tags:
+                - tag: PVE
+                  value: Disk
+                - tag: PVE
+                  value: '{#DISK_DEV}'
+              trigger_prototypes:
+                - uuid: 273bb1dc1ff74d379f4c7b1c88c82fcf
+                  expression: 'nodata(/Template Proxmox VE REST API/disk.size[{#DISK_DEV}],{$DISK.MISSING.TIME})=1'
+                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) is no longer reported by {HOST.NAME}'
+                  priority: AVERAGE
+                  description: 'Proxmox VE has stopped listing this disk. Either the disk was removed on purpose or it dropped off the bus. The disk list is refreshed hourly, so {$DISK.MISSING.TIME} must stay well above one hour.'
+                  manual_close: 'YES'
+            - uuid: 57d697c2516d49aaadeca4f761b082dc
+              name: 'Disk {#DISK_DEV} SMART raw'
+              type: HTTP_AGENT
+              key: 'disk.smart.raw[{#DISK_DEV}]'
+              delay: '3600'
+              history: '0'
+              value_type: TEXT
+              trends: '0'
+              description: 'Master item. Raw JSON from /nodes/{node}/disks/smart for disk {#DISK_DEV}. Proxmox VE answers in two shapes: type=ata carries a list of numbered SMART attributes, type=text carries the raw smartctl output used for NVMe and SAS. Source for the disk temperature item.'
+              timeout: 20s
+              url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/disks/smart?disk={#DISK_DEV}'
+              headers:
+                - name: Authorization
+                  value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
+                - name: Accept
+                  value: application/json
+              tags:
+                - tag: PVE
+                  value: Raw
+                - tag: PVE
+                  value: '{#DISK_DEV}'
+            - uuid: ffcc0cce9a074f4c8061e99dda3f325b
+              name: 'Disk {#DISK_DEV} temperature'
+              type: DEPENDENT
+              key: 'disk.temp[{#DISK_DEV}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: '!°C'
+              description: 'Temperature of disk {#DISK_DEV} ({#DISK_MODEL}) in degrees Celsius. Read from the SMART payload of the disk. SATA and SAS disks report it as attribute 194, or 190 on drives that only expose an airflow sensor. NVMe disks report it in the composite Temperature line of the smartctl output. Disks that expose no temperature at all deliver no value.'
+              preprocessing:
+                - type: JAVASCRIPT
+                  parameters:
+                    - |
+                      // Proxmox returns two different SMART shapes, so both are handled here.
+                      // type=ata  -> numbered attribute list, temperature is id 194 (or 190)
+                      // type=text -> raw smartctl output, temperature is the composite line
+                      var d = JSON.parse(value).data;
+                      if (!d) {
+                          throw 'no SMART payload';
+                      }
+                      if (d.attributes) {
+                          var wanted = ['194', '190'];
+                          for (var w = 0; w < wanted.length; w++) {
+                              for (var i = 0; i < d.attributes.length; i++) {
+                                  var a = d.attributes[i];
+                                  // Proxmox keeps the attribute id as a space padded string
+                                  if (String(a.id).replace(/\s/g, '') !== wanted[w]) {
+                                      continue;
+                                  }
+                                  // the raw column may carry trailing text such as "38 (Min/Max 20/45)"
+                                  var r = String(a.raw).match(/\d+/);
+                                  if (r) {
+                                      return r[0];
+                                  }
+                              }
+                          }
+                      }
+                      if (typeof d.text === 'string') {
+                          var t = d.text.match(/^\s*Temperature:\s+(\d+)\s+Celsius/m);
+                          if (!t) {
+                              t = d.text.match(/^\s*Temperature Sensor 1:\s+(\d+)\s+Celsius/m);
+                          }
+                          if (t) {
+                              return t[1];
+                          }
+                      }
+                      throw 'no temperature in SMART data';
+              master_item:
+                key: 'disk.smart.raw[{#DISK_DEV}]'
+              tags:
+                - tag: PVE
+                  value: Disk
+                - tag: PVE
+                  value: '{#DISK_DEV}'
+              trigger_prototypes:
+                - uuid: a407b65ce7b44bfebd0a2f343dc0300d
+                  expression: 'min(/Template Proxmox VE REST API/disk.temp[{#DISK_DEV}],10m)>{$DISK.TEMP.MAX:"{#DISK_DEV}"}'
+                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) temperature above {$DISK.TEMP.MAX:"{#DISK_DEV}"} C on {HOST.NAME}'
+                  opdata: 'Temperature: {ITEM.LASTVALUE1}'
+                  priority: WARNING
+                  description: 'The disk has stayed above the temperature threshold for 10 minutes. Set {$DISK.TEMP.MAX:"{#DISK_DEV}"} to raise the threshold for a single disk.'
+                  manual_close: 'YES'
+            - uuid: 11439521679e47f8a1e96261a5e98e4d
+              name: 'Disk {#DISK_DEV} wearout'
+              type: DEPENDENT
+              key: 'disk.wearout[{#DISK_DEV}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: '%'
+              description: 'SSD wearout indicator for disk {#DISK_DEV} in percent remaining life (100% = new, 0% = worn out). Only meaningful for SSDs and NVMe, rotating disks report N/A and are discarded. Source: /nodes/{node}/disks/list. The SMART endpoint does not return this value.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.devpath=="{#DISK_DEV}")].wearout.first()'
+                  error_handler: DISCARD_VALUE
+                - type: MATCHES_REGEX
+                  parameters:
+                    - '^[0-9]+(\.[0-9]+)?$'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.disks.raw
+              tags:
+                - tag: PVE
+                  value: Disk
+                - tag: PVE
+                  value: '{#DISK_DEV}'
+              trigger_prototypes:
+                - uuid: c5f1c17c33624781a843ccea415667e3
+                  expression: 'last(/Template Proxmox VE REST API/disk.wearout[{#DISK_DEV}])<{$DISK.WEAROUT.MIN}'
+                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) wearout below {$DISK.WEAROUT.MIN}% on {HOST.NAME}'
+                  priority: WARNING
+                  description: 'SSD wearout for disk {#DISK_DEV} is below threshold. Consider replacement planning.'
+                  manual_close: 'YES'
+          master_item:
+            key: pve.disks.raw
+          lld_macro_paths:
+            - lld_macro: '{#DISK_DEV}'
+              path: $.devpath
+            - lld_macro: '{#DISK_MODEL}'
+              path: $.model
+            - lld_macro: '{#DISK_SERIAL}'
+              path: $.serial
+            - lld_macro: '{#DISK_TYPE}'
+              path: $.type
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+          overrides:
+            - name: 'No wearout on rotating disks'
+              step: '1'
+              filter:
+                conditions:
+                  - macro: '{#DISK_TYPE}'
+                    value: ^hdd$
+                    formulaid: A
+              operations:
+                - operationobject: ITEM_PROTOTYPE
+                  operator: LIKE
+                  value: wearout
+                  discover: NO_DISCOVER
+        - uuid: d0da0a6c105544acb457ce5634a677cd
           name: 'Discover HA local resource managers'
           type: DEPENDENT
           key: discover.ha.lrm
@@ -1553,7 +3484,7 @@ zabbix_export:
           enabled_lifetime: 1d
           description: 'Discovers one local resource manager (LRM) per node from the type=lrm entries of /cluster/ha/status/current. PVE lists LRMs only once HA has been configured.'
           item_prototypes:
-            - uuid: 3ff0636454ba45b39598c3348ddff777
+            - uuid: e43ad8eebabf4dc5af41accc7e621ae3
               name: 'HA LRM state on {#HA_NODE}'
               type: DEPENDENT
               key: 'ha.lrm.state[{#HA_NODE}]'
@@ -1583,14 +3514,14 @@ zabbix_export:
                 - tag: PVE
                   value: '{#HA_NODE}'
               trigger_prototypes:
-                - uuid: 08f71fc8ee0d46698a0acd10a9c7670a
-                  expression: 'last(/Proxmox VE Cluster by REST API/ha.lrm.state[{#HA_NODE}])="old timestamp - dead?" or last(/Proxmox VE Cluster by REST API/ha.lrm.state[{#HA_NODE}])="unable to read lrm status" or last(/Proxmox VE Cluster by REST API/ha.lrm.state[{#HA_NODE}])="lost_agent_lock"'
+                - uuid: 3fef64da785b4f3a8c6aef5029dedee5
+                  expression: 'last(/Template Proxmox VE REST API/ha.lrm.state[{#HA_NODE}])="old timestamp - dead?" or last(/Template Proxmox VE REST API/ha.lrm.state[{#HA_NODE}])="unable to read lrm status" or last(/Template Proxmox VE REST API/ha.lrm.state[{#HA_NODE}])="lost_agent_lock"'
                   name: 'HA LRM on {#HA_NODE} is not working'
                   priority: HIGH
                   description: 'The local resource manager on {#HA_NODE} is dead, unreadable or has lost its agent lock. HA guests on this node are not managed, and a node that lost its lock will be fenced.'
                   manual_close: 'YES'
-                - uuid: 7fc106669cf549c39184c8972d0ddf61
-                  expression: 'last(/Proxmox VE Cluster by REST API/ha.lrm.state[{#HA_NODE}])="maintenance mode"'
+                - uuid: 3c1f508cb70a4c13927ac6199c9644c6
+                  expression: 'last(/Template Proxmox VE REST API/ha.lrm.state[{#HA_NODE}])="maintenance mode"'
                   name: 'HA node {#HA_NODE} is in maintenance mode'
                   priority: INFO
                   description: 'The node has been put into HA maintenance mode. HA resources are migrated away and it does not take part in recovery.'
@@ -1637,14 +3568,14 @@ zabbix_export:
                 - tag: PVE
                   value: '{#HA_SID}'
               trigger_prototypes:
-                - uuid: b757e20efadd49ac9b193183c1f24867
-                  expression: 'last(/Proxmox VE Cluster by REST API/ha.resource.state[{#HA_SID}])="fence" or last(/Proxmox VE Cluster by REST API/ha.resource.state[{#HA_SID}])="recovery"'
+                - uuid: 90a5858d5a2f4e0d9525aad8d8c90bde
+                  expression: 'last(/Template Proxmox VE REST API/ha.resource.state[{#HA_SID}])="fence" or last(/Template Proxmox VE REST API/ha.resource.state[{#HA_SID}])="recovery"'
                   name: 'HA resource {#HA_SID} is being fenced or recovered'
                   priority: HIGH
                   description: 'The node running {#HA_SID} has failed. The CRM is fencing that node (state fence) or moving the resource to another node (state recovery). The guest is down until recovery completes.'
                   manual_close: 'YES'
                 - uuid: 1e1ce9abf20f4d0eb649fbfe8d50d884
-                  expression: 'last(/Proxmox VE Cluster by REST API/ha.resource.state[{#HA_SID}])="error"'
+                  expression: 'last(/Template Proxmox VE REST API/ha.resource.state[{#HA_SID}])="error"'
                   name: 'HA resource {#HA_SID} is in error state'
                   priority: HIGH
                   description: 'The HA-managed resource {#HA_SID} has entered error state. Check the PVE HA log for details.'
@@ -1696,16 +3627,16 @@ zabbix_export:
                   value: '{#VMID}'
               trigger_prototypes:
                 - uuid: 4e5c59fc6d1a4a1da537b354b2696a5d
-                  expression: 'min(/Proxmox VE Cluster by REST API/lxc.cpuusage[{#VMID}],300)>{$LXC.CPU.HIGH:"{#VMID}"}'
+                  expression: 'min(/Template Proxmox VE REST API/lxc.cpuusage[{#VMID}],300)>{$LXC.CPU.HIGH:"{#VMID}"}'
                   name: 'CPU usage of LXC {#VMID} over {$LXC.CPU.HIGH:"{#VMID}"}% for 5 minutes'
                   priority: AVERAGE
                 - uuid: cce7280e51c24bd9965f4ea5eb783c87
-                  expression: 'min(/Proxmox VE Cluster by REST API/lxc.cpuusage[{#VMID}],300)>{$LXC.CPU.WARN:"{#VMID}"}'
+                  expression: 'min(/Template Proxmox VE REST API/lxc.cpuusage[{#VMID}],300)>{$LXC.CPU.WARN:"{#VMID}"}'
                   name: 'CPU usage of LXC {#VMID} over {$LXC.CPU.WARN:"{#VMID}"}% for 5 minutes'
                   priority: WARNING
                   dependencies:
                     - name: 'CPU usage of LXC {#VMID} over {$LXC.CPU.HIGH:"{#VMID}"}% for 5 minutes'
-                      expression: 'min(/Proxmox VE Cluster by REST API/lxc.cpuusage[{#VMID}],300)>{$LXC.CPU.HIGH:"{#VMID}"}'
+                      expression: 'min(/Template Proxmox VE REST API/lxc.cpuusage[{#VMID}],300)>{$LXC.CPU.HIGH:"{#VMID}"}'
             - uuid: 392f03aa5456439e84c89e9f57ecc832
               name: 'Disk read rate of {#VMID}'
               type: DEPENDENT
@@ -2043,7 +3974,7 @@ zabbix_export:
                   value: '{#VMID}'
               trigger_prototypes:
                 - uuid: 5609a6c57fb342308e04beab00d469ee
-                  expression: 'change(/Proxmox VE Cluster by REST API/lxc.node[{#VMID}])<>0'
+                  expression: 'change(/Template Proxmox VE REST API/lxc.node[{#VMID}])<>0'
                   name: 'LXC {#VMID} has been migrated to another node'
                   priority: INFO
                   description: 'The cluster node running LXC {#VMID} changed since the previous check, which indicates a migration.'
@@ -2113,11 +4044,11 @@ zabbix_export:
               trigger_prototypes:
                 - uuid: ff83e8f239e246b0a1c385029fe3941d
                   expression: |
-                    max(/Proxmox VE Cluster by REST API/lxc.status[{#VMID}],900)=0
+                    max(/Template Proxmox VE REST API/lxc.status[{#VMID}],900)=0
                     and {$ENABLE_VM_STOP_ALERT:"{#VMID}"}=1
-                    and count(/Proxmox VE Cluster by REST API/lxc.status[{#VMID}],24h,"eq","1")>0
+                    and count(/Template Proxmox VE REST API/lxc.status[{#VMID}],24h,"eq","1")>0
                   recovery_mode: RECOVERY_EXPRESSION
-                  recovery_expression: 'last(/Proxmox VE Cluster by REST API/lxc.status[{#VMID}])=1'
+                  recovery_expression: 'last(/Template Proxmox VE REST API/lxc.status[{#VMID}])=1'
                   name: 'LXC {#VMID} status is stopped'
                   priority: HIGH
                   description: |
@@ -2196,7 +4127,7 @@ zabbix_export:
                   value: '{#VMID}'
           trigger_prototypes:
             - uuid: 2dc3bee99506415d9461edbbdb9ce115
-              expression: 'last(/Proxmox VE Cluster by REST API/lxc.status[{#VMID}])=1 and last(/Proxmox VE Cluster by REST API/lxc.uptime[{#VMID}])<600'
+              expression: 'last(/Template Proxmox VE REST API/lxc.status[{#VMID}])=1 and last(/Template Proxmox VE REST API/lxc.uptime[{#VMID}])<600'
               name: 'LXC {#VMID} has been restarted (uptime < 10 min)'
               priority: INFO
               description: 'LXC container was recently started or restarted.'
@@ -2208,7 +4139,7 @@ zabbix_export:
                 - color: 0D47A1
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.cpuusage[{#VMID}]'
             - uuid: 1879f420b8344b57829327af81fe59e6
               name: 'LXC Cumulative network input/output since {#VMID} start'
@@ -2216,13 +4147,13 @@ zabbix_export:
                 - color: 1A7C11
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.netin[{#VMID}]'
                 - sortorder: '1'
                   color: '274482'
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.netout[{#VMID}]'
             - uuid: db5004ac56a648cba11ccc852f4aeede
               name: 'LXC Current network input/output {#VMID}'
@@ -2230,25 +4161,25 @@ zabbix_export:
                 - color: 1A7C11
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.netin.current[{#VMID}]'
                 - sortorder: '1'
                   color: '274482'
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.netout.current[{#VMID}]'
             - uuid: 04ce547c02f9405899376372dffa6aff
               name: 'LXC Disk I/O rate {#VMID}'
               graph_items:
                 - color: E65100
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.diskread.rate[{#VMID}]'
                 - sortorder: '1'
                   color: 1565C0
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.diskwrite.rate[{#VMID}]'
             - uuid: d1ce123e0cda47c8b3352cac115f059e
               name: 'LXC Disk usage {#VMID}'
@@ -2260,20 +4191,20 @@ zabbix_export:
                 - color: 388E3C
                   calc_fnc: MIN
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.maxdisk[{#VMID}]'
                 - sortorder: '1'
                   color: 0040FF
                   calc_fnc: MIN
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.disk[{#VMID}]'
             - uuid: a9871fd798ba440a8dbba4e7cd325f53
               name: 'LXC Memory utilization % {#VMID}'
               graph_items:
                 - color: 1565C0
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.memutil[{#VMID}]'
             - uuid: a02d03993bbb446cae8abc6124d36330
               name: 'LXC Memory utilization {#VMID}'
@@ -2281,13 +4212,13 @@ zabbix_export:
                 - color: 1565C0
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.memusage[{#VMID}]'
                 - sortorder: '1'
                   color: 2E7D32
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.maxmem[{#VMID}]'
             - uuid: 42127aaa69bb44d5b018190469cc46ca
               name: 'LXC status {#VMID}'
@@ -2295,7 +4226,7 @@ zabbix_export:
                 - color: 5E35B1
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.status[{#VMID}]'
             - uuid: 53d79ba0d5cb428bb5100629359e18ad
               name: 'LXC Swap utilization {#VMID}'
@@ -2303,13 +4234,13 @@ zabbix_export:
                 - color: 1565C0
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.swap[{#VMID}]'
                 - sortorder: '1'
                   color: 2E7D32
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'lxc.maxswap[{#VMID}]'
           master_item:
             key: pve.cluster.resources.raw
@@ -2342,6 +4273,124 @@ zabbix_export:
                   operator: REGEXP
                   value: '(Max\ swap\ of|status\ raw|Swap\ usage\ of)'
                   discover: NO_DISCOVER
+        - uuid: cdcb64618a174622909398a4c3f2d5d1
+          name: 'Discover network interfaces'
+          type: DEPENDENT
+          key: discover.network
+          delay: '0'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#IFACE}'
+                value: '{$IFACE.NOT_MATCHES}'
+                operator: NOT_MATCHES_REGEX
+                formulaid: A
+              - macro: '{#IFACE_TYPE}'
+                value: '^(bridge|bond|eth|en|vlan).*'
+                formulaid: B
+          description: 'Discovers host network interfaces from /nodes/{node}/network. Filters to relevant types (bridge, bond, eth/en*, vlan) and excludes the interface names matching {$IFACE.NOT_MATCHES}, which by default drops the per-guest interfaces Proxmox creates for VMs and containers.'
+          item_prototypes:
+            - uuid: 6ab6551bf8354a489ebbc4bb8281b9cf
+              name: 'Network interface {#IFACE} active'
+              type: DEPENDENT
+              key: 'iface.active[{#IFACE}]'
+              delay: '0'
+              history: 7d
+              description: 'Active/link state of network interface {#IFACE} on the PVE host. 1 = active, 0 = inactive.'
+              valuemap:
+                name: 'Network interface active'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.iface=="{#IFACE}")].active.first()'
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+              master_item:
+                key: pve.nodes.network.raw
+              tags:
+                - tag: PVE
+                  value: Network
+                - tag: PVE
+                  value: '{#IFACE}'
+            - uuid: 9a5222d23474453985777d17eb16a70f
+              name: 'Network interface {#IFACE} autostart'
+              type: DEPENDENT
+              key: 'iface.autostart[{#IFACE}]'
+              delay: '0'
+              history: 7d
+              description: 'Configured admin state of network interface {#IFACE}. 1 = the interface has an "auto" entry in /etc/network/interfaces and is expected to be up, 0 = not configured for automatic start. If the API does not report the field at all the item falls back to 1, so that the interface down trigger keeps working and is decided by the activity condition alone.'
+              valuemap:
+                name: 'Network interface autostart'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.iface=="{#IFACE}")].autostart.first()'
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '0'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.nodes.network.raw
+              tags:
+                - tag: PVE
+                  value: Network
+                - tag: PVE
+                  value: '{#IFACE}'
+            - uuid: afe0f690dd654826a7fbd90e56d485c5
+              name: 'Network interface {#IFACE} type'
+              type: DEPENDENT
+              key: 'iface.type[{#IFACE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Type/driver of network interface {#IFACE} (e.g. bridge, bond, eth). Source: /nodes/{node}/network.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.iface=="{#IFACE}")].type.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.nodes.network.raw
+              tags:
+                - tag: PVE
+                  value: Network
+                - tag: PVE
+                  value: '{#IFACE}'
+          trigger_prototypes:
+            - uuid: 9ad045fbeefa4b9db50fdae75cce9a9f
+              expression: 'last(/Template Proxmox VE REST API/iface.active[{#IFACE}])=0 and last(/Template Proxmox VE REST API/iface.autostart[{#IFACE}])=1 and max(/Template Proxmox VE REST API/iface.active[{#IFACE}],{$IFACE.ACTIVE.WINDOW})=1'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'last(/Template Proxmox VE REST API/iface.active[{#IFACE}])=1'
+              name: 'Network interface {#IFACE} is down on {HOST.NAME}'
+              priority: AVERAGE
+              description: 'Host network interface {#IFACE} is no longer active/up. All three conditions must hold: the interface is down, it is configured to start automatically, and it was active at least once within {$IFACE.ACTIVE.WINDOW}. Interfaces that are configured but were never actually up do not raise this trigger.'
+              manual_close: 'YES'
+          graph_prototypes:
+            - uuid: 92d3124033794ee4ada71893d6960b9c
+              name: 'Network interface {#IFACE} status'
+              graph_items:
+                - color: 1976D2
+                  calc_fnc: ALL
+                  item:
+                    host: 'Template Proxmox VE REST API'
+                    key: 'iface.active[{#IFACE}]'
+          master_item:
+            key: pve.nodes.network.raw
+          lld_macro_paths:
+            - lld_macro: '{#IFACE_TYPE}'
+              path: $.type
+            - lld_macro: '{#IFACE}'
+              path: $.iface
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
         - uuid: 83905502b5b94a61b6ec0e5811338fcb
           name: 'Discover nodes'
           type: DEPENDENT
@@ -2412,8 +4461,8 @@ zabbix_export:
               trigger_prototypes:
                 - uuid: e85b8277a1824f2daf365df1a8ce8de2
                   expression: |
-                    (min(/Proxmox VE Cluster by REST API/node.status[{#NODE_NAME}],900)=0
-                    or max(/Proxmox VE Cluster by REST API/node.status[{#NODE_NAME}],900)=2)
+                    (min(/Template Proxmox VE REST API/node.status[{#NODE_NAME}],900)=0
+                    or max(/Template Proxmox VE REST API/node.status[{#NODE_NAME}],900)=2)
                     and {$ENABLE_NODE_STATUS_ALERT:"{#NODE_NAME}"}=1
                   name: 'Node status {#NODE_NAME} not online'
                   priority: HIGH
@@ -2453,7 +4502,7 @@ zabbix_export:
                 - color: 1A7C11
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'node.status[{#NODE_NAME}]'
             - uuid: 4ba4071765ef4551b01cd57a588d8bff
               name: 'Node uptime {#NODE_NAME}'
@@ -2461,13 +4510,112 @@ zabbix_export:
                 - color: 0040FF
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'node.uptime[{#NODE_NAME}]'
           master_item:
             key: pve.nodes.raw
           lld_macro_paths:
             - lld_macro: '{#NODE_NAME}'
               path: $.node
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: 387f61cb46f74e369013f9cfe29b9868
+          name: 'Discover PVE services'
+          type: DEPENDENT
+          key: discover.pve.services
+          delay: '0'
+          filter:
+            conditions:
+              - macro: '{#SERVICE}'
+                value: '{$PVE.SERVICE.MATCHES}'
+                formulaid: A
+          description: 'Discovers the systemd units PVE manages. The default filter covers the services every node runs, standalone or clustered, including the HA managers and the scheduler that starts backup and replication jobs. corosync is excluded by default because it only runs once the node is part of a cluster; add it to {$PVE.SERVICE.MATCHES} on cluster nodes.'
+          item_prototypes:
+            - uuid: b1c4f04ea721446b9e0886c5e663b7f3
+              name: 'Service active state {#SERVICE}'
+              type: DEPENDENT
+              key: 'pve.service.active_state[{#SERVICE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Systemd ActiveState: active, inactive or failed.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.service=="{#SERVICE}")]["active-state"].first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.services.raw
+              tags:
+                - tag: PVE
+                  value: Service
+                - tag: PVE
+                  value: '{#SERVICE}'
+            - uuid: d8c668d940794d55bd3730acf2066a54
+              name: 'Service state {#SERVICE}'
+              type: DEPENDENT
+              key: 'pve.service.state[{#SERVICE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Systemd SubState, for example running, dead or exited.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.service=="{#SERVICE}")].state.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.services.raw
+              tags:
+                - tag: PVE
+                  value: Service
+                - tag: PVE
+                  value: '{#SERVICE}'
+              trigger_prototypes:
+                - uuid: 13832b562b7b4ef8a7faa050c9e025c2
+                  expression: 'last(/Template Proxmox VE REST API/pve.service.state[{#SERVICE}])<>"running" and {$PVE.SERVICE.STATE.ALERT:"{#SERVICE}"}=1'
+                  name: 'PVE service {#SERVICE} is not running on {HOST.NAME}'
+                  priority: AVERAGE
+                  description: 'Systemd SubState of the service is no longer running. Use {$PVE.SERVICE.STATE.ALERT:"<service>"}=0 to silence a single service, and {$PVE.SERVICE.MATCHES} to control which services are discovered at all.'
+            - uuid: e5b0f194a5474cd5bd603c870316dfbc
+              name: 'Service unit state {#SERVICE}'
+              type: DEPENDENT
+              key: 'pve.service.unit_state[{#SERVICE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Systemd UnitFileState: enabled, disabled, masked or static.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.service=="{#SERVICE}")]["unit-state"].first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.services.raw
+              tags:
+                - tag: PVE
+                  value: Service
+                - tag: PVE
+                  value: '{#SERVICE}'
+          master_item:
+            key: pve.services.raw
+          lld_macro_paths:
+            - lld_macro: '{#SERVICE}'
+              path: $.service
+            - lld_macro: '{#SVC_DESC}'
+              path: $.desc
           preprocessing:
             - type: JSONPATH
               parameters:
@@ -2537,7 +4685,7 @@ zabbix_export:
                   value: '{#VMID}'
               trigger_prototypes:
                 - uuid: e1ed112879054da082fbcaeac3de5830
-                  expression: 'min(/Proxmox VE Cluster by REST API/vm.cpuusage[{#VMID}],300)>{$CPU_USAGE_AVERAGE:"{#VMID}"}'
+                  expression: 'min(/Template Proxmox VE REST API/vm.cpuusage[{#VMID}],300)>{$CPU_USAGE_AVERAGE:"{#VMID}"}'
                   name: 'CPU usage of VM {#VMID} over {$CPU_USAGE_AVERAGE:"{#VMID}"}% for 5 minutes'
                   priority: WARNING
                   description: |
@@ -2545,9 +4693,9 @@ zabbix_export:
                     Use the context form to change it for a single guest, for example {$CPU_USAGE_AVERAGE:"{#VMID}"}=95, or set it to 100 to silence that guest.
                   dependencies:
                     - name: 'CPU usage of VM {#VMID} over {$CPU_USAGE_HIGH:"{#VMID}"}% for 5 minutes'
-                      expression: 'min(/Proxmox VE Cluster by REST API/vm.cpuusage[{#VMID}],300)>{$CPU_USAGE_HIGH:"{#VMID}"}'
+                      expression: 'min(/Template Proxmox VE REST API/vm.cpuusage[{#VMID}],300)>{$CPU_USAGE_HIGH:"{#VMID}"}'
                 - uuid: 4205c0d40f154884b9cdc12210a0d566
-                  expression: 'min(/Proxmox VE Cluster by REST API/vm.cpuusage[{#VMID}],300)>{$CPU_USAGE_HIGH:"{#VMID}"}'
+                  expression: 'min(/Template Proxmox VE REST API/vm.cpuusage[{#VMID}],300)>{$CPU_USAGE_HIGH:"{#VMID}"}'
                   name: 'CPU usage of VM {#VMID} over {$CPU_USAGE_HIGH:"{#VMID}"}% for 5 minutes'
                   priority: AVERAGE
                   description: |
@@ -2843,7 +4991,7 @@ zabbix_export:
                   value: '{#VMID}'
               trigger_prototypes:
                 - uuid: 0906752ddc0b419593430b655042ce2f
-                  expression: 'change(/Proxmox VE Cluster by REST API/vm.node[{#VMID}])<>0'
+                  expression: 'change(/Template Proxmox VE REST API/vm.node[{#VMID}])<>0'
                   name: 'VM {#VMID} has been migrated to another node'
                   priority: INFO
                   description: 'The cluster node running VM {#VMID} changed since the previous check, which indicates a migration.'
@@ -2939,11 +5087,11 @@ zabbix_export:
               trigger_prototypes:
                 - uuid: ac085aa97edb40dcb08272e859a39e36
                   expression: |
-                    max(/Proxmox VE Cluster by REST API/vm.status[{#VMID}],900)=0
+                    max(/Template Proxmox VE REST API/vm.status[{#VMID}],900)=0
                     and {$ENABLE_VM_STOP_ALERT:"{#VMID}"}=1
-                    and count(/Proxmox VE Cluster by REST API/vm.status[{#VMID}],24h,"eq","1")>0
+                    and count(/Template Proxmox VE REST API/vm.status[{#VMID}],24h,"eq","1")>0
                   recovery_mode: RECOVERY_EXPRESSION
-                  recovery_expression: 'last(/Proxmox VE Cluster by REST API/vm.status[{#VMID}])=1'
+                  recovery_expression: 'last(/Template Proxmox VE REST API/vm.status[{#VMID}])=1'
                   name: 'VM {#VMID} status is stopped'
                   priority: HIGH
                   description: |
@@ -3006,7 +5154,7 @@ zabbix_export:
                   value: '{#VMID}'
           trigger_prototypes:
             - uuid: 4b7ca0a0681a43a4a10eb0647292cc90
-              expression: 'last(/Proxmox VE Cluster by REST API/vm.status[{#VMID}])=1 and last(/Proxmox VE Cluster by REST API/vm.uptime[{#VMID}])<600'
+              expression: 'last(/Template Proxmox VE REST API/vm.status[{#VMID}])=1 and last(/Template Proxmox VE REST API/vm.uptime[{#VMID}])<600'
               name: 'VM {#VMID} has been restarted (uptime < 10 min)'
               priority: INFO
               description: 'VM was recently started or restarted.'
@@ -3018,7 +5166,7 @@ zabbix_export:
                 - color: 0D47A1
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'vm.cpuusage[{#VMID}]'
             - uuid: a9fbf2a1b5554bbf81e0b11d2b5ac957
               name: 'VM Cumulative network input/output, since {#VMID} start'
@@ -3026,13 +5174,13 @@ zabbix_export:
                 - color: 1A7C11
                   calc_fnc: MAX
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'vm.netin[{#VMID}]'
                 - sortorder: '1'
                   color: '274482'
                   calc_fnc: MAX
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'vm.netout[{#VMID}]'
             - uuid: 9a01fe6c5b9b43c3bf5287caa9453e47
               name: 'VM Current network input/output {#VMID}'
@@ -3040,32 +5188,32 @@ zabbix_export:
                 - color: 1A7C11
                   calc_fnc: MAX
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'vm.netin.current[{#VMID}]'
                 - sortorder: '1'
                   color: '274482'
                   calc_fnc: MAX
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'vm.netout.current[{#VMID}]'
             - uuid: a04ab78377214299bb04b20f8e41e0a1
               name: 'VM Disk I/O rate {#VMID}'
               graph_items:
                 - color: E65100
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'vm.diskread.rate[{#VMID}]'
                 - sortorder: '1'
                   color: 1565C0
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'vm.diskwrite.rate[{#VMID}]'
             - uuid: 28cab029b5e44a8f996321a5ac97c1ce
               name: 'VM Memory utilization % {#VMID}'
               graph_items:
                 - color: 1565C0
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'vm.memutil[{#VMID}]'
             - uuid: 4a78e07a7bf04c50b779ed61e65c39d8
               name: 'VM Memory utilization {#VMID}'
@@ -3073,13 +5221,13 @@ zabbix_export:
                 - color: 1565C0
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'vm.memusage[{#VMID}]'
                 - sortorder: '1'
                   color: 2E7D32
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'vm.maxmem[{#VMID}]'
             - uuid: 23fbf7d228b544d58f95ccb0cd8230f5
               name: 'VM status {#VMID}'
@@ -3087,7 +5235,7 @@ zabbix_export:
                 - color: 5E35B1
                   calc_fnc: ALL
                   item:
-                    host: 'Proxmox VE Cluster by REST API'
+                    host: 'Template Proxmox VE REST API'
                     key: 'vm.status[{#VMID}]'
           master_item:
             key: pve.cluster.resources.raw
@@ -3120,7 +5268,148 @@ zabbix_export:
                   operator: REGEXP
                   value: '(status\ raw|Balloon\ memory|Machine\ type\ of)'
                   discover: NO_DISCOVER
-        - uuid: 66e47c9a611949818be58f7cbb1a2164
+        - uuid: fb81ff142f814e40b1b0f850dd5280e6
+          name: 'Discover replication jobs'
+          type: DEPENDENT
+          key: discover.replication
+          delay: '0'
+          description: 'Discovers ZFS replication jobs. The list endpoint already carries the job state, so no extra request per job is required. Yields nothing on nodes without replication.'
+          item_prototypes:
+            - uuid: e7d91ba232e8415d9e262e3fd052a184
+              name: 'Replication duration {#REPL_ID}'
+              type: DEPENDENT
+              key: 'repl.duration[{#REPL_ID}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: s
+              description: 'Duration of the last run in seconds.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.id=="{#REPL_ID}")].duration.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: pve.replication.raw
+              tags:
+                - tag: PVE
+                  value: Replication
+                - tag: PVE
+                  value: '{#REPL_ID}'
+            - uuid: ce87dde3040a4b73ae078022a2a81cea
+              name: 'Replication error {#REPL_ID}'
+              type: DEPENDENT
+              key: 'repl.error[{#REPL_ID}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Error message of the last failed run. Absent while the job is healthy, the value is then discarded instead of turning the item unsupported.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.id=="{#REPL_ID}")].error.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.replication.raw
+              tags:
+                - tag: PVE
+                  value: Replication
+                - tag: PVE
+                  value: '{#REPL_ID}'
+            - uuid: 9ea05f2ef30b49c783cfb5f5516c2a3e
+              name: 'Replication fail count {#REPL_ID}'
+              type: DEPENDENT
+              key: 'repl.fail_count[{#REPL_ID}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              description: 'Consecutive failures of this job. Absent before the first run.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.id=="{#REPL_ID}")].fail_count.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: pve.replication.raw
+              tags:
+                - tag: PVE
+                  value: Replication
+                - tag: PVE
+                  value: '{#REPL_ID}'
+              trigger_prototypes:
+                - uuid: 9d0695a301e54a4dbb9590dd62e79a37
+                  expression: 'last(/Template Proxmox VE REST API/repl.fail_count[{#REPL_ID}])>{$PVE.REPL.FAIL.MAX}'
+                  name: 'Replication job {#REPL_ID} failing on {HOST.NAME}'
+                  event_name: 'Replication job {#REPL_ID} failing: {?last(//repl.error[{#REPL_ID}])}'
+                  priority: AVERAGE
+                  description: 'PVE counts consecutive failures of this replication job. The event name carries the error message PVE reported for the last run.'
+            - uuid: 40786cb4039d42c8bc5703ca03635c1e
+              name: 'Replication last sync {#REPL_ID}'
+              type: DEPENDENT
+              key: 'repl.last_sync[{#REPL_ID}]'
+              delay: '0'
+              value_type: FLOAT
+              trends: '0'
+              units: unixtime
+              description: 'Timestamp of the last successful sync. Absent before the first successful run.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.id=="{#REPL_ID}")].last_sync.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: pve.replication.raw
+              tags:
+                - tag: PVE
+                  value: Replication
+                - tag: PVE
+                  value: '{#REPL_ID}'
+              trigger_prototypes:
+                - uuid: 19f563e0e5ff48de8c738f2c1ca160c0
+                  expression: 'fuzzytime(/Template Proxmox VE REST API/repl.last_sync[{#REPL_ID}],{$PVE.REPL.LAG})=0'
+                  name: 'Replication job {#REPL_ID} has not synced for {$PVE.REPL.LAG}'
+                  priority: WARNING
+                  description: 'Last successful sync is older than {$PVE.REPL.LAG}. Raise the macro for jobs with a wide schedule, it must stay above the replication interval.'
+            - uuid: 3021e56037464324a99f53e163a34b53
+              name: 'Replication last try {#REPL_ID}'
+              type: DEPENDENT
+              key: 'repl.last_try[{#REPL_ID}]'
+              delay: '0'
+              value_type: FLOAT
+              trends: '0'
+              units: unixtime
+              description: 'Timestamp of the last attempt, successful or not.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.id=="{#REPL_ID}")].last_try.first()'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: pve.replication.raw
+              tags:
+                - tag: PVE
+                  value: Replication
+                - tag: PVE
+                  value: '{#REPL_ID}'
+          master_item:
+            key: pve.replication.raw
+          lld_macro_paths:
+            - lld_macro: '{#REPL_GUEST}'
+              path: $.guest
+            - lld_macro: '{#REPL_ID}'
+              path: $.id
+            - lld_macro: '{#REPL_TARGET}'
+              path: $.target
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: a1cc411292224352a13a2dcbcf900517
           name: 'Discover SDN zones'
           type: DEPENDENT
           key: discover.sdn
@@ -3129,7 +5418,7 @@ zabbix_export:
           enabled_lifetime: 1d
           description: 'Discovers the SDN entries (zones and, from PVE 9, fabrics) per node from the type=network entries of /cluster/resources. PVE 8 lists them as type=sdn, which this rule does not cover.'
           item_prototypes:
-            - uuid: 2320714ee3674baf98f9f80241f71ae7
+            - uuid: 0e2eb7104e0040ef9c34abfe29295e5e
               name: 'SDN {#SDN_TYPE} {#SDN} on {#NODE}: status'
               type: DEPENDENT
               key: 'sdn.status[{#SDN_ID}]'
@@ -3153,8 +5442,8 @@ zabbix_export:
                 - tag: PVE
                   value: '{#NODE}'
               trigger_prototypes:
-                - uuid: 99bc5f68eaf342f0949adc5e5763e731
-                  expression: 'last(/Proxmox VE Cluster by REST API/sdn.status[{#SDN_ID}])="error"'
+                - uuid: 2c77421da08e4db481fed5e3b08bac6d
+                  expression: 'last(/Template Proxmox VE REST API/sdn.status[{#SDN_ID}])="error"'
                   name: 'SDN {#SDN_TYPE} {#SDN} on {#NODE} is in error state'
                   priority: WARNING
                   description: 'The SDN configuration could not be applied on {#NODE}. Guests attached to it may have no network. Check Datacenter > SDN and the node syslog.'
@@ -3174,6 +5463,455 @@ zabbix_export:
             - type: JSONPATH
               parameters:
                 - '$.data[?(@.type=="network")]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: 14efa82386b54af18a8e26377422dd57
+          name: 'Discover storage'
+          type: DEPENDENT
+          key: discover.storage
+          delay: '0'
+          enabled_lifetime_type: DISABLE_AFTER
+          enabled_lifetime: 2d
+          item_prototypes:
+            - uuid: 07551137b00f485bbbe712b675cf2b75
+              name: 'Storage active status {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.active[{#STORAGE_NAME}]'
+              delay: '0'
+              history: 7d
+              description: 'Availability status of storage pool {#STORAGE_NAME}. 1 = active/available, 0 = inactive/not mounted.'
+              valuemap:
+                name: 'Storage active status'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].active.first()'
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+              trigger_prototypes:
+                - uuid: cf31e839babb4b8a90b395ad3df47023
+                  expression: 'min(/Template Proxmox VE REST API/storage.active[{#STORAGE_NAME}],900)=0 and {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=1'
+                  name: 'Storage [{#STORAGE_NAME}] not available'
+                  priority: AVERAGE
+                  description: |
+                    Use the following host macros to control the "Storage not available" trigger for each storage:
+                    {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=1 enables the "Storage not available" trigger
+                    {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=0 disables (suppresses) the "Storage not available" trigger
+            - uuid: 8e1de775d9524b27b37ad414ce961d9b
+              name: 'Storage available {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.avail[{#STORAGE_NAME}]'
+              delay: '0'
+              history: 7d
+              units: Bytes
+              description: 'Free space available on storage pool {#STORAGE_NAME} in bytes. Source: /nodes/{node}/storage.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].avail.first()'
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+            - uuid: 7f8d7a2cbdab48f097d46c92b870bb1b
+              name: 'Storage content {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.content[{#STORAGE_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Content types supported by storage pool {#STORAGE_NAME} (e.g. images,backup,iso). Source: /nodes/{node}/storage → data[storage].content.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].content.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+            - uuid: 4f6028533a65470ca71894fdfd256d20
+              name: 'Storage type {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.name[{#STORAGE_NAME}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Storage backend type/driver of {#STORAGE_NAME} (e.g. dir, zfspool, lvm, nfs). Source: /nodes/{node}/storage → data[storage].type.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].type.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+            - uuid: 37b0fd0f4af0451c9b4b6bae31ed0ab2
+              name: 'Storage shared status {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.shared[{#STORAGE_NAME}]'
+              delay: '0'
+              trends: '0'
+              description: 'Indicates whether the storage {#STORAGE_NAME} is shared across the cluster (Shared = 1) or available only locally (Not Shared = 0).'
+              valuemap:
+                name: 'Storage shared status'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].shared.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+            - uuid: 1d760dcaa1124491a918f1b73f20c6d3
+              name: 'Storage total {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.size[{#STORAGE_NAME}]'
+              delay: '0'
+              history: 7d
+              units: Bytes
+              description: 'Total capacity of storage pool {#STORAGE_NAME} in bytes. Source: /nodes/{node}/storage.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].total.first()'
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+            - uuid: 68f65c17913043368ffbe2db02887a10
+              name: 'Storage used {#STORAGE_NAME}'
+              type: DEPENDENT
+              key: 'storage.used[{#STORAGE_NAME}]'
+              delay: '0'
+              history: 7d
+              units: Bytes
+              description: 'Used space on storage pool {#STORAGE_NAME} in bytes. Source: /nodes/{node}/storage.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].used.first()'
+              master_item:
+                key: pve.storage.raw
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+            - uuid: 4f1446c1a3f1407b8b796e47b9208321
+              name: 'Storage utilization {#STORAGE_NAME} (%)'
+              type: CALCULATED
+              key: 'storage.util[{#STORAGE_NAME}]'
+              delay: '60'
+              history: 7d
+              value_type: FLOAT
+              units: '%'
+              params: 'last(/{HOST.HOST}/storage.used[{#STORAGE_NAME}]) / last(/{HOST.HOST}/storage.size[{#STORAGE_NAME}]) * 100'
+              description: 'Storage utilization as percentage of total size.'
+              tags:
+                - tag: PVE
+                  value: Storage
+                - tag: PVE
+                  value: '{#STORAGE_NAME}'
+              trigger_prototypes:
+                - uuid: 2b032af2b5d54593a4f5910d6ae3f912
+                  expression: 'last(/Template Proxmox VE REST API/storage.util[{#STORAGE_NAME}]) > {$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"} and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
+                  name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} >{$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"}%)'
+                  opdata: 'Used: {ITEM.LASTVALUE1}'
+                  priority: HIGH
+                  description: |
+                    Storage utilization exceeded the critical threshold {$STORAGE.UTIL.CRIT}%.
+                    Use context macro {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=0 to suppress.
+                - uuid: 3827182fb0fe498d8e4c09401168d998
+                  expression: 'last(/Template Proxmox VE REST API/storage.util[{#STORAGE_NAME}]) > {$STORAGE.UTIL.WARN:"{#STORAGE_NAME}"} and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
+                  name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} >{$STORAGE.UTIL.WARN:"{#STORAGE_NAME}"}%)'
+                  opdata: 'Used: {ITEM.LASTVALUE1}'
+                  priority: AVERAGE
+                  description: |
+                    Storage utilization exceeded the warning threshold {$STORAGE.UTIL.WARN}%.
+                    Use context macro {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=0 to suppress.
+                  dependencies:
+                    - name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} >{$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"}%)'
+                      expression: 'last(/Template Proxmox VE REST API/storage.util[{#STORAGE_NAME}]) > {$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"} and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
+          graph_prototypes:
+            - uuid: e49e5464b78446aabd4313abefda14c1
+              name: 'Storage active state {#STORAGE_NAME}'
+              graph_items:
+                - color: 00FF00
+                  calc_fnc: ALL
+                  item:
+                    host: 'Template Proxmox VE REST API'
+                    key: 'storage.active[{#STORAGE_NAME}]'
+            - uuid: b5e6a1f14c5b4752a18926ed9a269f9f
+              name: 'Storage usage {#STORAGE_NAME}'
+              yaxismax: '0'
+              show_work_period: 'NO'
+              show_triggers: 'NO'
+              type: EXPLODED
+              graph_items:
+                - color: 0040FF
+                  calc_fnc: LAST
+                  item:
+                    host: 'Template Proxmox VE REST API'
+                    key: 'storage.used[{#STORAGE_NAME}]'
+                - sortorder: '1'
+                  color: 388E3C
+                  calc_fnc: LAST
+                  item:
+                    host: 'Template Proxmox VE REST API'
+                    key: 'storage.avail[{#STORAGE_NAME}]'
+            - uuid: dc57dfa3ca394ee38c6fe9b13804d1b8
+              name: 'Storage utilization % {#STORAGE_NAME}'
+              graph_items:
+                - color: E53935
+                  item:
+                    host: 'Template Proxmox VE REST API'
+                    key: 'storage.util[{#STORAGE_NAME}]'
+          master_item:
+            key: pve.storage.raw
+          lld_macro_paths:
+            - lld_macro: '{#STORAGE_NAME}'
+              path: $.storage
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
+        - uuid: eb63de9ec0e6489e9da820ee39cd1f00
+          name: 'Discover tasks'
+          type: DEPENDENT
+          key: discover.tasks
+          delay: '0'
+          filter:
+            conditions:
+              - macro: '{#TYPE}'
+                value: '.*\bvzdump\b.*'
+                operator: NOT_MATCHES_REGEX
+                formulaid: A
+          lifetime_type: DELETE_IMMEDIATELY
+          lifetime: '0'
+          item_prototypes:
+            - uuid: be929b6a65ab46109a509d6f96b2348b
+              name: 'Task endtime {#TYPE} {#ID}'
+              type: DEPENDENT
+              key: 'task.endtime[{#GRPID},{#TYPE}]'
+              delay: '0'
+              trends: '0'
+              units: unixtime
+              description: 'Unix timestamp of the last end time for task type {#TYPE} on VM/CT {#GRPID}. Source: pve.tasks.raw.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].endtime.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.tasks.raw
+              tags:
+                - tag: PVE
+                  value: Tasks
+                - tag: vmid
+                  value: '{#GRPID}'
+            - uuid: 5dda8b03514e474cbe5879096a17c133
+              name: 'Task message {#TYPE} {#ID}'
+              type: DEPENDENT
+              key: 'task.message[{#GRPID},{#TYPE}]'
+              delay: '0'
+              value_type: CHAR
+              trends: '0'
+              description: 'Status text of the last task of type {#TYPE} for VM/CT {#GRPID}, exactly as Proxmox VE reports it. A successful task reports OK, a failed one reports the error message itself. The numeric item Task Status maps only a fixed set of known texts, so this item carries the real cause of a failure.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].status.first()'
+                  error_handler: DISCARD_VALUE
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.tasks.raw
+              tags:
+                - tag: PVE
+                  value: Tasks
+                - tag: vmid
+                  value: '{#GRPID}'
+            - uuid: 1b938d0bb1b542e281b2d554d24225b4
+              name: 'Task starttime {#TYPE} {#ID}'
+              type: DEPENDENT
+              key: 'task.starttime[{#GRPID},{#TYPE}]'
+              delay: '0'
+              trends: '0'
+              units: unixtime
+              description: 'Unix timestamp of the last start time for task type {#TYPE} on VM/CT {#GRPID}. Source: pve.tasks.raw.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].starttime.first()'
+                  error_handler: DISCARD_VALUE
+                - type: LTRIM
+                  parameters:
+                    - '["'
+                - type: RTRIM
+                  parameters:
+                    - '"]'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.tasks.raw
+              tags:
+                - tag: PVE
+                  value: Tasks
+                - tag: vmid
+                  value: '{#GRPID}'
+            - uuid: 07fbf01babe4452487bcc8fa7de63d1e
+              name: 'Task Status: {#TYPE} {#ID}'
+              type: DEPENDENT
+              key: 'task.status[{#GRPID},{#TYPE}]'
+              delay: '0'
+              trends: '0'
+              description: |
+                0. OK: All clear, no errors detected.
+                1. running: VM/CT is currently active.
+                2. stopped: VM/CT has been shut down.
+                3. error: General execution failure; check logs for details.
+                4. unexpected status: Returned state not anticipated by the script/API.
+                5. CT locked (disk): Container's disk is locked (e.g. during backup or migration).
+                6. timeout waiting on system: Operation exceeded its time limit and was aborted.
+                7. Failed to run vncproxy.: Unable to start the VNC proxy process.
+                8. unable to read tail (got 0 b): Failed to read log tail; zero bytes returned.
+                9. interrupted by signal: Process was terminated by a signal (e.g. SIGINT/SIGTERM).
+                10. unknown error: Cannot classify status, please check Proxmox for details
+              valuemap:
+                name: 'Tasks status'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].status.first()'
+                  error_handler: DISCARD_VALUE
+                - type: REGEX
+                  parameters:
+                    - '^(OK|running|stopped|error|unexpected status|CT is locked \(disk\)|timeout waiting on systemd|Failed to run vncproxy\.|unable to read tail \(got 0 bytes\)|interrupted by signal)$'
+                    - \0
+                  error_handler: CUSTOM_VALUE
+                  error_handler_params: '10'
+                - type: STR_REPLACE
+                  parameters:
+                    - OK
+                    - '0'
+                - type: STR_REPLACE
+                  parameters:
+                    - running
+                    - '1'
+                - type: STR_REPLACE
+                  parameters:
+                    - stopped
+                    - '2'
+                - type: STR_REPLACE
+                  parameters:
+                    - error
+                    - '3'
+                - type: STR_REPLACE
+                  parameters:
+                    - 'unexpected status'
+                    - '4'
+                - type: STR_REPLACE
+                  parameters:
+                    - 'CT is locked (disk)'
+                    - '5'
+                - type: STR_REPLACE
+                  parameters:
+                    - 'timeout waiting on systemd'
+                    - '6'
+                - type: STR_REPLACE
+                  parameters:
+                    - 'Failed to run vncproxy.'
+                    - '7'
+                - type: STR_REPLACE
+                  parameters:
+                    - 'unable to read tail (got 0 bytes)'
+                    - '8'
+                - type: STR_REPLACE
+                  parameters:
+                    - 'interrupted by signal'
+                    - '9'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.tasks.raw
+              tags:
+                - tag: PVE
+                  value: Tasks
+                - tag: vmid
+                  value: '{#GRPID}'
+          trigger_prototypes:
+            - uuid: 19e5d067d25941169192a9ff6461b787
+              expression: 'last(/Template Proxmox VE REST API/task.status[{#GRPID},{#TYPE}])>1 and {$ENABLE_TASK_ALERT:"{#GRPID}"}=1 and fuzzytime(/Template Proxmox VE REST API/task.endtime[{#GRPID},{#TYPE}],{$TASK.ALERT.WINDOW})=1'
+              name: 'Proxmox task {#TYPE} {#ID} failed'
+              event_name: 'Proxmox task {#TYPE} {#ID} failed: {ITEM.VALUE}'
+              opdata: 'Current task status: {ITEM.LASTVALUE}'
+              priority: WARNING
+              description: |
+                A task of type {#TYPE} for VM/CT {#ID} finished with a status other than OK.
+                The problem clears as soon as a later task of the same id and type succeeds, and it expires on its own once the failure is older than {$TASK.ALERT.WINDOW}, because Proxmox VE only keeps the most recent tasks in its task list.
+                Use context macro to suppress per-task:
+                {$ENABLE_TASK_ALERT:"{#GRPID}"}=0 suppresses this trigger for a specific task.
+                {$ENABLE_TASK_ALERT}=0 disables all task failure alerts globally.
+              manual_close: 'YES'
+          graph_prototypes:
+            - uuid: 3d3673ff518e45a2979ecfbb6aa8b5e6
+              name: 'Task status {#TYPE} {#ID}'
+              graph_items:
+                - color: 00897B
+                  calc_fnc: ALL
+                  item:
+                    host: 'Template Proxmox VE REST API'
+                    key: 'task.status[{#GRPID},{#TYPE}]'
+          master_item:
+            key: pve.tasks.raw
+          lld_macro_paths:
+            - lld_macro: '{#GRPID}'
+              path: $.grpid
+            - lld_macro: '{#ID}'
+              path: $.id
+            - lld_macro: '{#TYPE}'
+              path: $.type
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.body.data[*]'
               error_handler: CUSTOM_VALUE
               error_handler_params: '[]'
         - uuid: c16a8fe279a84b10bc7f06f3ab2bca76
@@ -3232,7 +5970,7 @@ zabbix_export:
                   value: '{#USERID}'
               trigger_prototypes:
                 - uuid: 749e797e101a40abb81a572dcd08bc06
-                  expression: 'last(/Proxmox VE Cluster by REST API/user.expiration[{#USERID}])>0 and last(/Proxmox VE Cluster by REST API/user.expiration[{#USERID}])-now()<{$PVE.USER.EXPIRE.TIME:"{#USERID}"}'
+                  expression: 'last(/Template Proxmox VE REST API/user.expiration[{#USERID}])>0 and last(/Template Proxmox VE REST API/user.expiration[{#USERID}])-now()<{$PVE.USER.EXPIRE.TIME:"{#USERID}"}'
                   name: 'User {#USERID} account expires soon on {HOST.NAME}'
                   priority: WARNING
                   description: |
@@ -3343,7 +6081,228 @@ zabbix_export:
                 - '$.body.data[*]'
               error_handler: CUSTOM_VALUE
               error_handler_params: '[]'
+        - uuid: 92df286f4a31496c887b1992534efb2c
+          name: 'Discover ZFS pools'
+          type: DEPENDENT
+          key: discover.zfs.pools
+          delay: '0'
+          description: 'Discovers local ZFS pools. Yields nothing on nodes without ZFS. The master item needs Sys.Audit on / and turns unsupported with HTTP 403 otherwise.'
+          item_prototypes:
+            - uuid: f29490ff777948a2a8dbca4014d8fbfd
+              name: 'ZFS pool allocated {#ZPOOL}'
+              type: DEPENDENT
+              key: 'zfs.alloc[{#ZPOOL}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: Bytes
+              description: 'Allocated bytes in the pool.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.name=="{#ZPOOL}")].alloc.first()'
+              master_item:
+                key: pve.zfs.raw
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+            - uuid: 2167f0fa32e24ac9803b5aa3cd346bbe
+              name: 'ZFS pool dedup ratio {#ZPOOL}'
+              type: DEPENDENT
+              key: 'zfs.dedup[{#ZPOOL}]'
+              delay: '0'
+              value_type: FLOAT
+              trends: '0'
+              description: 'Deduplication ratio, 1.0 when dedup is off.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.name=="{#ZPOOL}")].dedup.first()'
+              master_item:
+                key: pve.zfs.raw
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+            - uuid: 673b04f727fa43ddaec262e4b73edb20
+              name: 'ZFS pool fragmentation {#ZPOOL}'
+              type: DEPENDENT
+              key: 'zfs.frag[{#ZPOOL}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: '%'
+              description: 'Free space fragmentation in percent.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.name=="{#ZPOOL}")].frag.first()'
+              master_item:
+                key: pve.zfs.raw
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+            - uuid: 65fb9ba3975e4f7bb54ff6991aa9a2b2
+              name: 'ZFS pool free {#ZPOOL}'
+              type: DEPENDENT
+              key: 'zfs.free[{#ZPOOL}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: Bytes
+              description: 'Free bytes in the pool.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.name=="{#ZPOOL}")].free.first()'
+              master_item:
+                key: pve.zfs.raw
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+            - uuid: 9dbc38322f79490b8e0e76c7c015ddbb
+              name: 'ZFS pool health {#ZPOOL}'
+              type: DEPENDENT
+              key: 'zfs.health[{#ZPOOL}]'
+              delay: '0'
+              history: 7d
+              description: 'zpool health as a number so it can be graphed and used on a dashboard. 0 is ONLINE, everything above is a fault. The value map turns it back into the zpool wording.'
+              valuemap:
+                name: 'ZFS pool health'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.name=="{#ZPOOL}")].health.first()'
+                - type: STR_REPLACE
+                  parameters:
+                    - ONLINE
+                    - '0'
+                - type: STR_REPLACE
+                  parameters:
+                    - DEGRADED
+                    - '1'
+                - type: STR_REPLACE
+                  parameters:
+                    - FAULTED
+                    - '2'
+                - type: STR_REPLACE
+                  parameters:
+                    - OFFLINE
+                    - '3'
+                - type: STR_REPLACE
+                  parameters:
+                    - REMOVED
+                    - '4'
+                - type: STR_REPLACE
+                  parameters:
+                    - UNAVAIL
+                    - '5'
+                - type: STR_REPLACE
+                  parameters:
+                    - SUSPENDED
+                    - '6'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.zfs.raw
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+              trigger_prototypes:
+                - uuid: 8b079af5e75b46a8a6e974087ca2f097
+                  expression: 'last(/Template Proxmox VE REST API/zfs.health[{#ZPOOL}])=1'
+                  name: 'ZFS pool {#ZPOOL} is DEGRADED on {HOST.NAME}'
+                  priority: AVERAGE
+                  description: 'The pool still serves data but has lost redundancy, so a second failure means data loss. Check /nodes/{node}/disks/zfs/{pool} for the failing vdev, the detail endpoint reports read, write and checksum errors per device.'
+                - uuid: d65a4e365c134cea9cf48cfca9c173dc
+                  expression: 'last(/Template Proxmox VE REST API/zfs.health[{#ZPOOL}])>=2'
+                  name: 'ZFS pool {#ZPOOL} is not usable on {HOST.NAME}'
+                  event_name: 'ZFS pool {#ZPOOL} is {ITEM.VALUE1} on {HOST.NAME}'
+                  priority: HIGH
+                  description: 'The pool is FAULTED, OFFLINE, REMOVED, UNAVAIL or SUSPENDED, so it no longer serves data. DEGRADED is reported separately at a lower severity because the pool keeps running. Check /nodes/{node}/disks/zfs/{pool} for the failing vdev, the detail endpoint reports read, write and checksum errors per device.'
+            - uuid: 60c15d2ea06e465897ef285127da047c
+              name: 'ZFS pool size {#ZPOOL}'
+              type: DEPENDENT
+              key: 'zfs.size[{#ZPOOL}]'
+              delay: '0'
+              history: 7d
+              value_type: FLOAT
+              units: Bytes
+              description: 'Total pool size in bytes.'
+              preprocessing:
+                - type: JSONPATH
+                  parameters:
+                    - '$.data[?(@.name=="{#ZPOOL}")].size.first()'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: pve.zfs.raw
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+            - uuid: 609a0e36820844edb94bfd9d3d8d6ff6
+              name: 'ZFS pool utilization {#ZPOOL}'
+              type: CALCULATED
+              key: 'zfs.util[{#ZPOOL}]'
+              delay: '300'
+              history: 7d
+              value_type: FLOAT
+              units: '%'
+              params: '100*last(//zfs.alloc[{#ZPOOL}])/last(//zfs.size[{#ZPOOL}])'
+              description: 'Allocated share of the pool. Calculated from alloc and size, PVE does not report a percentage.'
+              tags:
+                - tag: PVE
+                  value: ZFS
+                - tag: PVE
+                  value: '{#ZPOOL}'
+              trigger_prototypes:
+                - uuid: 21550648e49a43e6ae6580a431bf048f
+                  expression: 'last(/Template Proxmox VE REST API/zfs.util[{#ZPOOL}])>{$ZFS.UTIL.CRIT:"{#ZPOOL}"}'
+                  name: 'ZFS pool {#ZPOOL} usage above {$ZFS.UTIL.CRIT:"{#ZPOOL}"}% on {HOST.NAME}'
+                  priority: HIGH
+                  description: 'ZFS performance degrades sharply once a pool fills up. Keep pools below 80%.'
+                - uuid: 875ee85867384cefac96493b00c8559e
+                  expression: 'last(/Template Proxmox VE REST API/zfs.util[{#ZPOOL}])>{$ZFS.UTIL.WARN:"{#ZPOOL}"}'
+                  name: 'ZFS pool {#ZPOOL} usage above {$ZFS.UTIL.WARN:"{#ZPOOL}"}% on {HOST.NAME}'
+                  priority: AVERAGE
+                  description: 'ZFS performance degrades sharply once a pool fills up. Keep pools below 80%.'
+                  dependencies:
+                    - name: 'ZFS pool {#ZPOOL} usage above {$ZFS.UTIL.CRIT:"{#ZPOOL}"}% on {HOST.NAME}'
+                      expression: 'last(/Template Proxmox VE REST API/zfs.util[{#ZPOOL}])>{$ZFS.UTIL.CRIT:"{#ZPOOL}"}'
+          trigger_prototypes:
+            - uuid: ed2b6ba1d4cb4b029e7b75c0ff414ea0
+              expression: 'last(/Template Proxmox VE REST API/zfs.frag[{#ZPOOL}])>{$ZFS.FRAG.WARN:"{#ZPOOL}"} and last(/Template Proxmox VE REST API/zfs.util[{#ZPOOL}])>{$ZFS.FRAG.UTIL.MIN:"{#ZPOOL}"}'
+              name: 'ZFS pool {#ZPOOL} free space is fragmented on {HOST.NAME}'
+              priority: WARNING
+              description: 'Fragmentation describes the free space, not the stored data, so on its own it costs nothing. It starts to hurt once the pool is also fairly full, because the allocator then has to satisfy writes from ever smaller free segments. The trigger therefore requires both {$ZFS.FRAG.WARN} and {$ZFS.FRAG.UTIL.MIN} to be exceeded. Freeing space and removing old snapshots helps, defragmenting a zpool is not possible.'
+          master_item:
+            key: pve.zfs.raw
+          lld_macro_paths:
+            - lld_macro: '{#ZPOOL}'
+              path: $.name
+          preprocessing:
+            - type: JSONPATH
+              parameters:
+                - '$.data[*]'
+              error_handler: CUSTOM_VALUE
+              error_handler_params: '[]'
       macros:
+        - macro: '{$BACKUP.ALERT.WINDOW}'
+          value: 24h
+          description: 'How long a failed backup keeps alerting. The problem clears earlier if a later backup of the same guest succeeds. The value must include a time unit, for example 24h or 2d.'
         - macro: '{$CEPH.HEALTH.WARN.PERIOD}'
           value: 15m
           description: 'How long Ceph must stay in HEALTH_WARN or worse before the warning fires.'
@@ -3386,18 +6345,60 @@ zabbix_export:
         - macro: '{$CPU_USAGE_HIGH}'
           value: '99'
           description: 'High CPU usage threshold (%) for warning level trigger'
+        - macro: '{$DISK.MISSING.TIME}'
+          value: 3h
+          description: 'How long a disk may be absent from the Proxmox disk list before the missing disk trigger fires. The list is refreshed once per hour, so keep this well above 1h. The value must include a time unit.'
+        - macro: '{$DISK.TEMP.MAX}'
+          value: '60'
+          description: 'Temperature threshold for physical disks in degrees Celsius. Use the context form {$DISK.TEMP.MAX:"/dev/sda"} to raise it for a single disk.'
+        - macro: '{$DISK.WEAROUT.MIN}'
+          value: '20'
+          description: 'Minimum SSD wearout remaining (%) before triggering a warning. Default: 20%.'
+        - macro: '{$ENABLE_BACKUP_ALERT}'
+          value: '1'
+          description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
         - macro: '{$ENABLE_NODE_STATUS_ALERT}'
           value: '1'
           description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
+        - macro: '{$ENABLE_STORAGE_AVAILABLE_ALERT}'
+          value: '1'
+          description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
+        - macro: '{$ENABLE_STORAGE_INACTIVE_ALERT}'
+          value: '1'
+          description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
+        - macro: '{$ENABLE_TASK_ALERT}'
+          value: '1'
+          description: 'To enable task failure alerts set to 1. Use context macro {$ENABLE_TASK_ALERT:"{#GRPID}"}=0 to suppress alerts for individual tasks.'
         - macro: '{$ENABLE_VM_STOP_ALERT}'
           value: '1'
           description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
+        - macro: '{$IFACE.ACTIVE.WINDOW}'
+          value: 7d
+          description: 'Lookback window for the network interface down trigger. The interface must have been active at least once within this period, otherwise it is treated as configured but never used and does not alert. The value must include a time unit (e.g. 7d, 24h).'
+        - macro: '{$IFACE.NOT_MATCHES}'
+          value: ^(tap|veth|fwbr|fwpr|fwln)
+          description: 'LLD filter: host network interface names to exclude (regex). The default drops the per-guest interfaces Proxmox creates for VMs and containers, which appear and disappear together with the guest.'
         - macro: '{$LXC.CPU.HIGH}'
           value: '99'
           description: 'Critical threshold for LXC CPU utilization (%) over 5 minutes.'
         - macro: '{$LXC.CPU.WARN}'
           value: '85'
           description: 'Warning threshold for LXC CPU utilization (%) over 5 minutes.'
+        - macro: '{$MEMORY.UTIL.MAX}'
+          value: '90'
+          description: 'Warning threshold for memory utilization of the PVE host itself (%). Guest memory is not covered by this macro.'
+        - macro: '{$NODE.CPU.UTIL.MAX}'
+          value: '90'
+          description: 'Node CPU utilization (%) before the high CPU trigger fires. The threshold used to be hardcoded in the trigger expression.'
+        - macro: '{$PVE.APT.REPO.ERRORS.MAX}'
+          value: '0'
+          description: 'Tolerated number of unparsable APT repository files before alerting.'
+        - macro: '{$PVE.APT.REPO.WARN.MAX}'
+          value: '0'
+          description: 'Tolerated number of APT repository warnings. A host on the no-subscription repository permanently reports one warning, set this to 1 there.'
+        - macro: '{$PVE.APT.UPDATES.MAX}'
+          value: '0'
+          description: 'Tolerated number of pending package updates. Only relevant if the disabled apt/update items are switched on.'
         - macro: '{$PVE.BACKUP.JOB.ALERT}'
           value: '1'
           description: 'Disabled backup job trigger. Set to 0 to suppress it everywhere, or use the context form {$PVE.BACKUP.JOB.ALERT:"backup-a5c9d88a-bc0e"}=0 to silence one job that is switched off on purpose.'
@@ -3407,6 +6408,15 @@ zabbix_export:
         - macro: '{$PVE.BACKUP.JOBS.MIN}'
           value: '1'
           description: 'Minimum number of vzdump backup job definitions expected on this cluster. Set to 0 on hosts that are deliberately backed up from somewhere else.'
+        - macro: '{$PVE.BACKUP.RUN.MAX}'
+          value: 3h
+          description: 'How long a backup may run before it is treated as stuck. The value must include a time unit, for example 3h or 90m, and must stay above the normal runtime of the longest job, otherwise the trigger fires during every regular run.'
+        - macro: '{$PVE.CERT.EXPIRE.DAYS}'
+          value: 21d
+          description: 'Lead time before certificate expiry. Must include a time unit, for example 21d.'
+        - macro: '{$PVE.DATACENTER.COLLECT}'
+          value: '1'
+          description: 'Collect the datacenter-wide data on this host: guests on all nodes, node states, quorum, HA, backup jobs, users, SDN and Ceph. In a cluster keep 1 on one host and set 0 on the others, so this data is not collected and alerted once per node.'
         - macro: '{$PVE.GUEST.DETAIL.INTERVAL}'
           value: 10m
           description: 'Interval of the per guest status request (balloon, machine type, LXC swap). One request per guest, so keep it long in large clusters.'
@@ -3416,6 +6426,24 @@ zabbix_export:
         - macro: '{$PVE.NOTBACKEDUP.MAX}'
           value: '0'
           description: 'Tolerated number of guests without a backup job. Raise it if some guests are deliberately excluded from backup.'
+        - macro: '{$PVE.REPL.FAIL.MAX}'
+          value: '0'
+          description: 'Tolerated consecutive failures of a replication job. Use the context form {$PVE.REPL.FAIL.MAX:"105-0"} for a single job.'
+        - macro: '{$PVE.REPL.LAG}'
+          value: 2h
+          description: 'Maximum age of the last successful replication. Must stay above the replication schedule, otherwise the trigger fires between two runs. Must include a time unit.'
+        - macro: '{$PVE.SERVICE.MATCHES}'
+          value: ^(pve-cluster|pvedaemon|pveproxy|pvestatd|pve-firewall|pvescheduler|pve-ha-crm|pve-ha-lrm)$
+          description: 'Services to discover. corosync is left out because it only runs on cluster members; add it there.'
+        - macro: '{$PVE.SERVICE.STATE.ALERT}'
+          value: '1'
+          description: 'Enables the service state trigger. Use the context form {$PVE.SERVICE.STATE.ALERT:"pveproxy"}=0 to silence a single service.'
+        - macro: '{$PVE.SUBSCRIPTION.ALERT}'
+          value: '0'
+          description: 'Set to 1 on hosts that are meant to carry a subscription. Off by default so community hosts do not alert on status notfound.'
+        - macro: '{$PVE.SUBSCRIPTION.EXPIRE.DAYS}'
+          value: 30d
+          description: 'Lead time before the subscription expires. Must include a time unit, for example 30d. The expiry triggers need no enable macro: hosts without a subscription report no due date, so the item stays empty.'
         - macro: '{$PVE.USER.EXPIRE.TIME}'
           value: '172800'
           description: 'Seconds before user account expiration to trigger warning (default 172800 = 2 days).'
@@ -3431,12 +6459,45 @@ zabbix_export:
         - macro: '{$PVE_IP}'
           value: localhost
           description: 'The IP address or hostname of the Proxmox VE API server.'
+        - macro: '{$PVE_NODE}'
+          value: pve
+          description: 'The Proxmox VE node identifier (e.g. "pve") used in API endpoint paths.'
         - macro: '{$PVE_PORT}'
           value: '8006'
           description: 'The TCP port number on which the Proxmox VE API listens (default: 8006).'
+        - macro: '{$ROOTFS.UTIL.CRIT}'
+          value: '95'
+          description: 'Critical threshold for root filesystem utilization (%).'
+        - macro: '{$ROOTFS.UTIL.WARN}'
+          value: '90'
+          description: 'Warning threshold for root filesystem utilization (%).'
+        - macro: '{$STORAGE.UTIL.CRIT}'
+          value: '90'
+          description: 'Critical threshold for storage utilization (%). Triggers when storage used exceeds this value.'
+        - macro: '{$STORAGE.UTIL.WARN}'
+          value: '80'
+          description: 'Warning threshold for storage utilization (%). Triggers when storage used exceeds this value.'
+        - macro: '{$SWAP.UTIL.MAX}'
+          value: '80'
+          description: 'Warning threshold for swap utilization of the PVE host (%). The trigger stays silent on hosts that have no swap configured.'
+        - macro: '{$TASK.ALERT.WINDOW}'
+          value: 1h
+          description: 'How long a failed task keeps alerting. The problem clears earlier if a later task of the same id and type succeeds. Proxmox VE only keeps the most recent tasks in its task list, so without this window a one-off failure would alert forever. The value must include a time unit, for example 1h or 30m.'
+        - macro: '{$ZFS.FRAG.UTIL.MIN}'
+          value: '70'
+          description: 'Pool usage (%) that must be reached before the fragmentation warning fires. Fragmented free space only costs write performance on a pool that is also filling up. Use the context form {$ZFS.FRAG.UTIL.MIN:"rpool"} per pool.'
+        - macro: '{$ZFS.FRAG.WARN}'
+          value: '60'
+          description: 'ZFS free space fragmentation (%) before warning. Use the context form {$ZFS.FRAG.WARN:"rpool"} per pool.'
+        - macro: '{$ZFS.UTIL.CRIT}'
+          value: '90'
+          description: 'ZFS pool usage (%) for the high severity trigger. Use the context form {$ZFS.UTIL.CRIT:"rpool"} per pool.'
+        - macro: '{$ZFS.UTIL.WARN}'
+          value: '80'
+          description: 'ZFS pool usage (%) for the average severity trigger. ZFS performance degrades noticeably above 80%.'
       dashboards:
         - uuid: a6999e1b8414408ab403f86cba2b272b
-          name: 'Proxmox VE cluster'
+          name: 'Proxmox VE - Monitoring Dashboard'
           auto_start: 'NO'
           pages:
             - name: Overview
@@ -3448,7 +6509,7 @@ zabbix_export:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Proxmox VE Cluster by REST API'
+                        host: 'Template Proxmox VE REST API'
                         key: pve.cluster.name
                     - type: INTEGER
                       name: show.1
@@ -3456,25 +6517,59 @@ zabbix_export:
                     - type: INTEGER
                       name: show.2
                       value: '3'
-                - type: item
-                  name: 'HA manager'
+                - type: gauge
+                  name: 'CPU utilization'
                   'y': '2'
                   width: '24'
+                  height: '5'
                   fields:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Proxmox VE Cluster by REST API'
-                        key: pve.ha.manager.status
+                        host: 'Template Proxmox VE REST API'
+                        key: pve.cpu.utilization
                     - type: INTEGER
-                      name: show.1
-                      value: '2'
+                      name: max
+                      value: '100'
                     - type: INTEGER
-                      name: show.2
-                      value: '3'
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFBF59
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E45959
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: svggraph
+                  name: 'CPU utilization'
+                  'y': '7'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: 1976D2
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'PVE CPU utilization'
+                    - type: INTEGER
+                      name: ds.0.type
+                      value: '0'
+                    - type: STRING
+                      name: reference
+                      value: PVOV1
                 - type: problems
                   name: Problems
-                  'y': '4'
+                  'y': '13'
                   width: '72'
                   height: '8'
                 - type: item
@@ -3485,7 +6580,7 @@ zabbix_export:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Proxmox VE Cluster by REST API'
+                        host: 'Template Proxmox VE REST API'
                         key: pve.cluster.quorum
                     - type: INTEGER
                       name: show.1
@@ -3501,7 +6596,7 @@ zabbix_export:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Proxmox VE Cluster by REST API'
+                        host: 'Template Proxmox VE REST API'
                         key: pve.cluster.nodes.online
                     - type: INTEGER
                       name: show.1
@@ -3509,48 +6604,48 @@ zabbix_export:
                     - type: INTEGER
                       name: show.2
                       value: '3'
-                - type: item
-                  name: Ceph
+                - type: gauge
+                  name: 'Memory utilization'
                   x: '24'
                   'y': '2'
                   width: '24'
+                  height: '5'
                   fields:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Proxmox VE Cluster by REST API'
-                        key: pve.ceph.available
+                        host: 'Template Proxmox VE REST API'
+                        key: pve.memory.util
                     - type: INTEGER
-                      name: show.1
-                      value: '2'
+                      name: max
+                      value: '100'
                     - type: INTEGER
-                      name: show.2
-                      value: '3'
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFBF59
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E45959
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
                 - type: item
-                  name: 'Nodes offline'
+                  name: 'Guests running'
                   x: '36'
                   width: '12'
                   fields:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Proxmox VE Cluster by REST API'
-                        key: pve.cluster.nodes.offline
-                    - type: INTEGER
-                      name: show.1
-                      value: '2'
-                    - type: INTEGER
-                      name: show.2
-                      value: '3'
-                - type: item
-                  name: 'Guests running'
-                  x: '48'
-                  width: '12'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Proxmox VE Cluster by REST API'
+                        host: 'Template Proxmox VE REST API'
                         key: pve.cluster.vms.running
                     - type: INTEGER
                       name: show.1
@@ -3558,33 +6653,103 @@ zabbix_export:
                     - type: INTEGER
                       name: show.2
                       value: '3'
+                - type: piechart
+                  name: Memory
+                  x: '36'
+                  'y': '7'
+                  width: '18'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E45959
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'PVE memory used'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 00C48C
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'PVE memory available'
                 - type: item
-                  name: 'Guests without backup job'
+                  name: 'Guests total'
                   x: '48'
-                  'y': '2'
-                  width: '24'
+                  width: '12'
                   fields:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Proxmox VE Cluster by REST API'
-                        key: pve.notbackedup.count
+                        host: 'Template Proxmox VE REST API'
+                        key: pve.cluster.vms.total
                     - type: INTEGER
                       name: show.1
                       value: '2'
                     - type: INTEGER
                       name: show.2
                       value: '3'
+                - type: gauge
+                  name: 'Root filesystem'
+                  x: '48'
+                  'y': '2'
+                  width: '24'
+                  height: '5'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template Proxmox VE REST API'
+                        key: pve.rootfs.util
+                    - type: INTEGER
+                      name: max
+                      value: '100'
+                    - type: INTEGER
+                      name: min
+                      value: '0'
+                    - type: STRING
+                      name: thresholds.0.color
+                      value: FFBF59
+                    - type: STRING
+                      name: thresholds.0.threshold
+                      value: '80'
+                    - type: STRING
+                      name: thresholds.1.color
+                      value: E45959
+                    - type: STRING
+                      name: thresholds.1.threshold
+                      value: '90'
+                    - type: STRING
+                      name: units
+                      value: '%'
+                - type: piechart
+                  name: 'Root filesystem'
+                  x: '54'
+                  'y': '7'
+                  width: '18'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: ds.0.color
+                      value: E45959
+                    - type: STRING
+                      name: ds.0.items.0
+                      value: 'Disk rootfs used'
+                    - type: STRING
+                      name: ds.1.color
+                      value: 00C48C
+                    - type: STRING
+                      name: ds.1.items.0
+                      value: 'Disk rootfs avail'
                 - type: item
-                  name: 'Guests total'
+                  name: Uptime
                   x: '60'
                   width: '12'
                   fields:
                     - type: ITEM
                       name: itemid.0
                       value:
-                        host: 'Proxmox VE Cluster by REST API'
-                        key: pve.cluster.vms.total
+                        host: 'Template Proxmox VE REST API'
+                        key: pve.uptime
                     - type: INTEGER
                       name: show.1
                       value: '2'
@@ -3765,3551 +6930,6 @@ zabbix_export:
                     - type: INTEGER
                       name: source_type
                       value: '1'
-            - name: 'Nodes and HA'
-              widgets:
-                - type: honeycomb
-                  name: 'Node status'
-                  width: '36'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: items.0
-                      value: 'Node status *'
-                    - type: INTEGER
-                      name: item_tags.0.operator
-                      value: '1'
-                    - type: STRING
-                      name: item_tags.0.tag
-                      value: PVE
-                    - type: STRING
-                      name: item_tags.0.value
-                      value: Node
-                    - type: STRING
-                      name: primary_label
-                      value: '{ITEM.NAME}'
-                    - type: STRING
-                      name: reference
-                      value: PVND1
-                - type: item
-                  name: 'HA manager'
-                  'y': '6'
-                  width: '18'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Proxmox VE Cluster by REST API'
-                        key: pve.ha.manager.status
-                    - type: INTEGER
-                      name: show.1
-                      value: '2'
-                    - type: INTEGER
-                      name: show.2
-                      value: '3'
-                - type: honeycomb
-                  name: 'HA local resource managers'
-                  'y': '8'
-                  width: '36'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: items.0
-                      value: 'HA LRM state on *'
-                    - type: INTEGER
-                      name: item_tags.0.operator
-                      value: '1'
-                    - type: STRING
-                      name: item_tags.0.tag
-                      value: PVE
-                    - type: STRING
-                      name: item_tags.0.value
-                      value: HA
-                    - type: STRING
-                      name: primary_label
-                      value: '{ITEM.NAME}'
-                    - type: STRING
-                      name: reference
-                      value: PVHA1
-                - type: item
-                  name: 'Nodes offline'
-                  x: '18'
-                  'y': '6'
-                  width: '18'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Proxmox VE Cluster by REST API'
-                        key: pve.cluster.nodes.offline
-                    - type: INTEGER
-                      name: show.1
-                      value: '2'
-                    - type: INTEGER
-                      name: show.2
-                      value: '3'
-                - type: honeycomb
-                  name: 'HA resource states'
-                  x: '36'
-                  width: '36'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: items.0
-                      value: 'HA state of *'
-                    - type: INTEGER
-                      name: item_tags.0.operator
-                      value: '1'
-                    - type: STRING
-                      name: item_tags.0.tag
-                      value: PVE
-                    - type: STRING
-                      name: item_tags.0.value
-                      value: HA
-                    - type: STRING
-                      name: primary_label
-                      value: '{ITEM.NAME}'
-                    - type: STRING
-                      name: reference
-                      value: PVND2
-            - name: Ceph
-              widgets:
-                - type: honeycomb
-                  name: 'Ceph OSD status'
-                  width: '36'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: items.0
-                      value: 'Ceph * status'
-                    - type: INTEGER
-                      name: item_tags.0.operator
-                      value: '1'
-                    - type: STRING
-                      name: item_tags.0.tag
-                      value: Ceph
-                    - type: STRING
-                      name: item_tags.0.value
-                      value: OSD
-                    - type: STRING
-                      name: primary_label
-                      value: '{ITEM.NAME}'
-                    - type: STRING
-                      name: reference
-                      value: PVCE2
-                - type: itemnavigator
-                  name: 'Browse Ceph items'
-                  'y': '6'
-                  width: '18'
-                  height: '14'
-                  fields:
-                    - type: INTEGER
-                      name: group_by.0.attribute
-                      value: '3'
-                    - type: STRING
-                      name: group_by.0.tag_name
-                      value: Ceph
-                    - type: STRING
-                      name: items.0
-                      value: '*'
-                    - type: INTEGER
-                      name: item_tags.0.operator
-                      value: '0'
-                    - type: STRING
-                      name: item_tags.0.tag
-                      value: PVE
-                    - type: STRING
-                      name: item_tags.0.value
-                      value: Ceph
-                    - type: STRING
-                      name: reference
-                      value: PVCE1
-                    - type: INTEGER
-                      name: show_lines
-                      value: '100'
-                - type: item
-                  name: 'Selected item'
-                  x: '18'
-                  'y': '12'
-                  width: '18'
-                  height: '4'
-                  fields:
-                    - type: STRING
-                      name: itemid._reference
-                      value: PVCE1._itemid
-                    - type: INTEGER
-                      name: show.1
-                      value: '1'
-                    - type: INTEGER
-                      name: show.2
-                      value: '2'
-                    - type: INTEGER
-                      name: show.3
-                      value: '3'
-                - type: honeycomb
-                  name: 'Ceph pool utilization'
-                  x: '36'
-                  width: '36'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: items.0
-                      value: 'Ceph pool * utilization'
-                    - type: INTEGER
-                      name: item_tags.0.operator
-                      value: '1'
-                    - type: STRING
-                      name: item_tags.0.tag
-                      value: Ceph
-                    - type: STRING
-                      name: item_tags.0.value
-                      value: Pool
-                    - type: STRING
-                      name: primary_label
-                      value: '{ITEM.NAME}'
-                    - type: STRING
-                      name: reference
-                      value: PVCE3
-                - type: graph
-                  name: 'History of selected item'
-                  x: '36'
-                  'y': '12'
-                  width: '36'
-                  height: '8'
-                  fields:
-                    - type: STRING
-                      name: itemid._reference
-                      value: PVCE1._itemid
-                    - type: INTEGER
-                      name: source_type
-                      value: '1'
-      valuemaps:
-        - uuid: 4f48a8938054422b8cf484adaec102ee
-          name: 'Backup job enabled'
-          mappings:
-            - value: '0'
-              newvalue: disabled
-            - value: '1'
-              newvalue: enabled
-        - uuid: 10d3deb6c50a46f7852da7680deba0e1
-          name: 'Ceph availability'
-          mappings:
-            - value: '0'
-              newvalue: 'not available'
-            - value: '1'
-              newvalue: available
-        - uuid: 5bc687fbcc704444bc7327bc44f31833
-          name: 'Ceph health'
-          mappings:
-            - value: '0'
-              newvalue: HEALTH_OK
-            - value: '1'
-              newvalue: HEALTH_WARN
-            - value: '2'
-              newvalue: HEALTH_ERR
-        - uuid: 248a59f093cc419d9086c1052b4c9c60
-          name: 'Ceph OSD in'
-          mappings:
-            - value: '0'
-              newvalue: out
-            - value: '1'
-              newvalue: in
-        - uuid: 4f9af911f2d4433b91c80a435693cfae
-          name: 'Ceph OSD status'
-          mappings:
-            - value: '0'
-              newvalue: down
-            - value: '1'
-              newvalue: up
-        - uuid: dd3c4133c6ef47b5bcefc8e68eaeee27
-          name: 'Node status'
-          mappings:
-            - value: '0'
-              newvalue: offline
-            - value: '1'
-              newvalue: online
-            - value: '2'
-              newvalue: unknown
-        - uuid: 6ce95767698f4713adfa2dcf4618d86b
-          name: 'User status'
-          mappings:
-            - value: '0'
-              newvalue: disabled
-            - value: '1'
-              newvalue: enabled
-        - uuid: 052ad39480884912aebd6a34a8c2ff51
-          name: 'VM  and LXC status'
-          mappings:
-            - value: '0'
-              newvalue: stopped
-            - value: '1'
-              newvalue: running
-            - value: '2'
-              newvalue: paused
-            - value: '3'
-              newvalue: unknown
-    - uuid: 1c59365f955547989d4c8657034d9415
-      template: 'Proxmox VE Node by REST API'
-      name: 'Proxmox VE Node by REST API'
-      description: |
-        Node part of the Proxmox VE monitoring over the REST API. Link it to one Zabbix host per PVE node and set {$PVE_NODE} and {$PVE_IP} to that node: status, CPU, memory, disks and SMART, ZFS, storage, network, services, tasks, backups, replication, certificates, APT and subscription.
-        
-        Requires a PVEAuditor API token. See the README for setup.
-      groups:
-        - name: Templates/Virtualization
-      items:
-        - uuid: 3069a46f22c441fc8a6023daf9e0ac6d
-          name: 'PVE manager package version'
-          type: DEPENDENT
-          key: pve.apt.manager.version
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Installed pve-manager version. Source: /nodes/{node}/apt/versions.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[?(@.Package=="pve-manager")].Version.first()'
-              error_handler: DISCARD_VALUE
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.apt.versions.raw
-          tags:
-            - tag: PVE
-              value: APT
-        - uuid: d48cb1cbc9984b0c895b49e21a41756f
-          name: 'APT repository errors'
-          type: DEPENDENT
-          key: pve.apt.repos.errors
-          delay: '0'
-          history: 7d
-          description: 'Number of unparsable APT repository files. Source: /nodes/{node}/apt/repositories.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.errors.length()
-          master_item:
-            key: pve.apt.repos.raw
-          tags:
-            - tag: PVE
-              value: APT
-          triggers:
-            - uuid: 427dab4dc45f4dee92ea748e2d8476d9
-              expression: 'last(/Proxmox VE Node by REST API/pve.apt.repos.errors)>{$PVE.APT.REPO.ERRORS.MAX}'
-              name: 'APT repository files are broken on {HOST.NAME}'
-              opdata: 'Broken files: {ITEM.LASTVALUE1}'
-              priority: WARNING
-              description: 'At least one APT repository file cannot be parsed. Updates will fail until this is fixed.'
-        - uuid: d8c14e0b75db44b08f50d67e41644875
-          name: 'PVE APT repositories raw'
-          type: HTTP_AGENT
-          key: pve.apt.repos.raw
-          delay: '3600'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/apt/repositories. Requires Sys.Audit on /nodes/{node}.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/apt/repositories'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 5543e26f183241e48eb528b395b3e5df
-          name: 'APT repository warnings'
-          type: DEPENDENT
-          key: pve.apt.repos.warnings
-          delay: '0'
-          history: 7d
-          description: 'Number of APT repository warnings, for example the enterprise repository being enabled without a subscription. Source: /nodes/{node}/apt/repositories.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data.infos[?(@.kind=="warning")].length()'
-          master_item:
-            key: pve.apt.repos.raw
-          tags:
-            - tag: PVE
-              value: APT
-          triggers:
-            - uuid: 22ffcc10b8f84e25baa6b2e475585867
-              expression: 'last(/Proxmox VE Node by REST API/pve.apt.repos.warnings)>{$PVE.APT.REPO.WARN.MAX}'
-              name: 'APT repository configuration has warnings on {HOST.NAME}'
-              opdata: 'Warnings: {ITEM.LASTVALUE1}'
-              priority: INFO
-              description: 'PVE reports a problem with the repository configuration, for example the enterprise repository being enabled without a subscription. A host on the no-subscription repository reports one warning permanently, raise {$PVE.APT.REPO.WARN.MAX} to 1 there.'
-              manual_close: 'YES'
-        - uuid: c0d3f09f282745c8b14ed3ec0261ea4d
-          name: 'Running kernel (proxmox-ve)'
-          type: DEPENDENT
-          key: pve.apt.running.kernel
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Kernel release the node is currently booted into. Source: /nodes/{node}/apt/versions, package proxmox-ve.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[?(@.Package=="proxmox-ve")].RunningKernel.first()'
-              error_handler: DISCARD_VALUE
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.apt.versions.raw
-          tags:
-            - tag: PVE
-              value: APT
-        - uuid: 420ffd2b294542afa9dc700520f0d1e0
-          name: 'PVE APT pending updates raw'
-          type: HTTP_AGENT
-          key: pve.apt.update.raw
-          delay: '3600'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          status: DISABLED
-          description: 'Master item. Raw JSON from /nodes/{node}/apt/update. DISABLED by default: this endpoint requires Sys.Modify on /nodes/{node}, which PVEAuditor does not grant. Enable only if you accept giving the monitoring token write level permissions.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/apt/update'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 172e6ad9dd024e959aaf9516fe8a6646
-          name: 'APT pending updates'
-          type: DEPENDENT
-          key: pve.apt.updates.count
-          delay: '0'
-          history: 7d
-          status: DISABLED
-          description: 'Number of pending package updates. DISABLED by default because the master item requires Sys.Modify.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.length()
-          master_item:
-            key: pve.apt.update.raw
-          tags:
-            - tag: PVE
-              value: APT
-          triggers:
-            - uuid: a777c3b8e7cf4c31aa434ff6d335d3b1
-              expression: 'last(/Proxmox VE Node by REST API/pve.apt.updates.count)>{$PVE.APT.UPDATES.MAX}'
-              name: '{ITEM.LASTVALUE} package update(s) pending on {HOST.NAME}'
-              status: DISABLED
-              priority: INFO
-              description: 'Disabled by default, like the item it depends on. The master item needs Sys.Modify, which PVEAuditor does not grant.'
-              manual_close: 'YES'
-        - uuid: 5f423ad7231447a7aa5c9be006c7dd7e
-          name: 'PVE APT versions raw'
-          type: HTTP_AGENT
-          key: pve.apt.versions.raw
-          delay: '3600'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/apt/versions. Requires Sys.Audit on /nodes/{node}.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/apt/versions'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: c4fcd7fc00ca42f88ffae1335c6b9c57
-          name: 'PVE backup active raw'
-          type: HTTP_AGENT
-          key: pve.backup.active.raw
-          delay: '60'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/tasks with source=active and typefilter=vzdump, so it carries only backup tasks that are running right now. The task list defaults to source=archive, where a task appears only once it has finished, which is why a running backup is invisible to pve.backup.raw and why a backup that never finishes produces no signal there at all. Returns an empty list while no backup runs. Requires Sys.Audit on /nodes/{node}.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/tasks?source=active&typefilter=vzdump'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 2d3053255eb744ba9e056c071e8e2fdc
-          name: 'PVE backup raw'
-          type: HTTP_AGENT
-          key: pve.backup.raw
-          delay: '300'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/tasks?typefilter=vzdump, so only backup tasks are listed and other tasks cannot push them out of the 50 entries PVE returns. JavaScript preprocessing keeps the most recent run per guest.'
-          preprocessing:
-            - type: JAVASCRIPT
-              parameters:
-                - |
-                  // Zabbix JS preprocessing: Extract and group backup tasks (VZDUMP/PBS) from task feed (ES5.1)
-                  try {
-                      var obj = (typeof value === 'string') ? JSON.parse(value) : value;
-                  
-                      // 0) Determine data source
-                      var dataArr = [];
-                      if (obj && obj.data && obj.data instanceof Array) {
-                          dataArr = obj.data;
-                      } else if (obj && obj.body && obj.body.data && obj.body.data instanceof Array) {
-                          dataArr = obj.body.data;
-                      }
-                      if (!dataArr || !dataArr.length) {
-                          return JSON.stringify({ total: 0, data: [] });
-                      }
-                  
-                      // Helper functions
-                      function firstDefined(a, b, c, d) {
-                          if (a !== null && a !== undefined) return a;
-                          if (b !== null && b !== undefined) return b;
-                          if (c !== null && c !== undefined) return c;
-                          if (d !== null && d !== undefined) return d;
-                          return null;
-                      }
-                  
-                      // Robust timestamp conversion: supports epoch (sec/ms), numeric strings, ISO and "YYYY-MM-DD HH:mm:ss"
-                      function toEpochMs(v) {
-                          if (v === null || v === undefined) return -Infinity;
-                          if (typeof v === "number") return v < 1000000000000 ? v * 1000 : v; // sec → ms
-                  
-                          if (typeof v === "string") {
-                              var s = v.trim();
-                  
-                              // Treat purely numeric strings as numbers
-                              if (/^\d+(\.\d+)?$/.test(s)) {
-                                  var n = parseFloat(s);
-                                  return n < 1000000000000 ? n * 1000 : n;
-                              }
-                  
-                              // Parse "YYYY-MM-DD HH:mm:ss" (optional AM/PM)
-                              var m = s.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\s*(AM|PM))?$/i);
-                              if (m) {
-                                  var H = parseInt(m[4], 10), ampm = (m[7] || "").toUpperCase();
-                                  if (ampm) { if (ampm === "PM" && H < 12) H += 12; if (ampm === "AM" && H === 12) H = 0; }
-                                  return Date.UTC(+m[1], +m[2] - 1, +m[3], H, +m[5], +m[6]);
-                              }
-                  
-                              // Fallback: parse as ISO-compatible string
-                              var p = Date.parse(s.replace(/\s+/, "T"));
-                              return isNaN(p) ? -Infinity : p;
-                          }
-                          return -Infinity;
-                      }
-                      
-                  
-                      // Broad backup type matcher
-                      var reVzdump = /vzdump/i;
-                      var reBackup = /backup/i;              // generic (PBS/Proxmox Backup)
-                      var rePbs    = /\bpbs\b/i;             // "pbs" as a whole word
-                      var rePmxb   = /proxmox[- ]?backup/i;  // "proxmox-backup" or "proxmox backup"
-                  
-                      function isBackup(e) {
-                          if (!e) return false;
-                          var t = (e.type != null) ? String(e.type) : "";
-                          var u = (typeof e.upid === "string") ? e.upid : "";
-                          if (reVzdump.test(t) || reBackup.test(t) || rePbs.test(t) || rePmxb.test(t)) return true;
-                          if (reVzdump.test(u) || reBackup.test(u) || rePbs.test(u) || rePmxb.test(u)) return true;
-                          return false;
-                      }
-                  
-                      // 1) Filter backup entries and normalise timestamps
-                      var dumps = [];
-                      for (var i = 0; i < dataArr.length; i++) {
-                          var e = dataArr[i];
-                          if (!isBackup(e)) continue;
-                  
-                          var startRaw = firstDefined(e.starttime, e.start, e.begin, e.pstart);
-                          var endRaw   = firstDefined(e.endtime, e.end, null, null);
-                  
-                          var copy = {};
-                          for (var k in e) { if (e.hasOwnProperty(k)) copy[k] = e[k]; }
-                          copy._startMs = toEpochMs(startRaw);
-                          copy._endMs   = toEpochMs(endRaw);
-                          dumps.push(copy);
-                      }
-                  
-                      if (!dumps.length) {
-                          // No backup entries found in the feed
-                          return JSON.stringify({ total: 0, data: [] });
-                      }
-                  
-                      // 2) Sort by start time
-                      dumps.sort(function(a, b) { return a._startMs - b._startMs; });
-                  
-                      // 3) Replace missing/empty ID with "pve"
-                      for (i = 0; i < dumps.length; i++) {
-                          if (dumps[i].id === null || dumps[i].id === undefined || String(dumps[i].id) === "") {
-                              dumps[i].id = "pve";
-                          }
-                      }
-                  
-                      // 4) Group by id, keep only the most recent run per id (highest _startMs)
-                      var groups = {};
-                      for (i = 0; i < dumps.length; i++) {
-                          var e2 = dumps[i];
-                          var key = String(e2.id);
-                  
-                          if (!groups[key] || e2._startMs > groups[key]._startMs) {
-                              groups[key] = {
-                                  id:        key,
-                                  node:      e2.node,
-                                  status:    e2.status,
-                                  pid:       e2.pid,
-                                  upid:      e2.upid,
-                                  starttime: e2.starttime,
-                                  endtime:   e2.endtime,
-                                  _startMs:  e2._startMs,
-                                  _endMs:    e2._endMs
-                              };
-                          }
-                      }
-                      
-                  
-                      // 5) Sort IDs numerically (numeric first), "pve" last
-                      var ids = [];
-                      for (var id in groups) { if (groups.hasOwnProperty(id)) ids.push(id); }
-                      ids.sort(function(a, b) {
-                          if (a === "pve" && b !== "pve") return 1;
-                          if (b === "pve" && a !== "pve") return -1;
-                          var na = parseFloat(a), nb = parseFloat(b);
-                          var aNum = isFinite(na), bNum = isFinite(nb);
-                          if (aNum && bNum) return na - nb;
-                          if (aNum) return -1;
-                          if (bNum) return 1;
-                          a = String(a); b = String(b);
-                          if (a < b) return -1;
-                          if (a > b) return 1;
-                          return 0;
-                      });
-                  
-                      // 6) Build result
-                      var resultData = [];
-                      for (i = 0; i < ids.length; i++) {
-                          var g2 = groups[ids[i]];
-                          // Remove internal fields
-                          delete g2._startMs; delete g2._endMs;
-                          g2.bckpid = g2.id;
-                          resultData.push(g2);
-                      }
-                  
-                      return JSON.stringify({ total: resultData.length, data: resultData });
-                  
-                  } catch (err) {
-                      return JSON.stringify({ error: "Parsing failed", detail: String(err && err.message || err) });
-                  }
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/tasks?typefilter=vzdump'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          output_format: JSON
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 85a1eb044f3947cba21117d8cba24f66
-          name: 'Backup running'
-          type: DEPENDENT
-          key: pve.backup.running
-          delay: '0'
-          trends: '0'
-          description: 'Number of backup tasks running on this node right now, normally 0 or 1. The value is a counter rather than a forced 0 or 1: if two vzdump tasks ever overlap the item shows 2 and stays readable, only the value map has no entry for it. Source: /nodes/{node}/tasks with source=active.'
-          valuemap:
-            name: 'Backup running'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.length()
-          master_item:
-            key: pve.backup.active.raw
-          tags:
-            - tag: PVE
-              value: Backup
-          triggers:
-            - uuid: 82705bfa82b1405a89f112de9c2ae28b
-              expression: 'min(/Proxmox VE Node by REST API/pve.backup.running,{$PVE.BACKUP.RUN.MAX})>0'
-              name: 'Backup has been running for more than {$PVE.BACKUP.RUN.MAX} on {HOST.NAME}'
-              opdata: 'Running since: {ITEM.LASTVALUE1}'
-              priority: AVERAGE
-              description: 'A backup task has been running without interruption for the whole period. This is the one backup failure the task archive cannot show: a run that never finishes never reaches the archive, so the status, end time and message items keep reporting the previous successful run and nothing else would ever fire. Check the running task in the PVE task viewer and the target storage.'
-              manual_close: 'YES'
-        - uuid: e07f7e74bd484582b32671977eed6726
-          name: 'Backup running since'
-          type: DEPENDENT
-          key: pve.backup.running.since
-          delay: '0'
-          value_type: FLOAT
-          trends: '0'
-          units: unixtime
-          description: 'Start time of the backup that is running right now, available the moment it starts. Zero means no backup is running: the source list is then empty, the JSONPath finds nothing, and the error handler supplies the zero. This is the real start time, unlike Backup starttime, which only moves once the run has finished and reached the task archive. A trend over a Unix timestamp carries no meaning, so trends stay off.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*].starttime.first()'
-              error_handler: CUSTOM_VALUE
-              error_handler_params: '0'
-          master_item:
-            key: pve.backup.active.raw
-          tags:
-            - tag: PVE
-              value: Backup
-        - uuid: 87cef13bf7ab476ea76bce4f222f9041
-          name: 'PVE certificates raw'
-          type: HTTP_AGENT
-          key: pve.certificates.raw
-          delay: '3600'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/certificates/info. Needs no special permission.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/certificates/info'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: b2fdee8ad2d446bfb7008d9945e5bcc4
-          name: 'PVE CPU cores'
-          type: DEPENDENT
-          key: pve.cores
-          delay: '0'
-          trends: '0'
-          units: '!Cores'
-          description: 'Number of physical CPU cores on the PVE host. Source: /nodes/{node}/status → data.cpuinfo.cores.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.cpuinfo.cores
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: 209521248ee041ff96878318f523ab06
-          name: 'PVE CPU utilization'
-          type: DEPENDENT
-          key: pve.cpu.utilization
-          delay: '0'
-          history: 7d
-          value_type: FLOAT
-          units: '%'
-          description: 'CPU utilization of the PVE host in percent (0-100). Source: /nodes/{node}/status → data.cpu * 100.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.cpu
-            - type: MULTIPLIER
-              parameters:
-                - '100'
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-          triggers:
-            - uuid: 9b505ccdb1fa4b97937ade1b672701f2
-              expression: 'min(/Proxmox VE Node by REST API/pve.cpu.utilization,300)>{$NODE.CPU.UTIL.MAX}'
-              name: 'High CPU usage on {HOST.NAME} (>{$NODE.CPU.UTIL.MAX}%)'
-              opdata: 'CPU utilization: {ITEM.LASTVALUE1}'
-              priority: AVERAGE
-        - uuid: 29414e0fb6b1475c8a9e115ad5867544
-          name: 'PVE CPU info'
-          type: DEPENDENT
-          key: pve.cpuinfo
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'CPU model name string of the PVE host. Source: /nodes/{node}/status → data.cpuinfo.model.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.cpuinfo.model
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: 8553ce7c800c4b19b4fee13f474cdc67
-          name: 'PVE CPU threads'
-          type: DEPENDENT
-          key: pve.cpus
-          delay: '0'
-          trends: '0'
-          units: '!Threads'
-          description: 'Total number of logical CPU threads (vCPUs) on the PVE host. Source: /nodes/{node}/status → data.cpuinfo.cpus.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.cpuinfo.cpus
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: cb7951f01bdd48d7b913f468bd25d95c
-          name: 'PVE current kernel'
-          type: DEPENDENT
-          key: pve.current.kernel
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Running Linux kernel release string (e.g. 6.8.12-5-pve). Source: /nodes/{node}/status → data["current-kernel"].release.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data["current-kernel"].release'
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Kernel
-        - uuid: 8942c1ce2a534b28b5dec5b3b31d224e
-          name: 'PVE disks raw'
-          type: HTTP_AGENT
-          key: pve.disks.raw
-          delay: '3600'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/disks/list. Used for physical disk discovery and SMART health monitoring. Requires Sys.Audit permission on the node.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/disks/list'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Disk
-        - uuid: 89edde254438495ca9a2bb64d19bfd83
-          name: 'PVE load average (15 min)'
-          type: DEPENDENT
-          key: pve.loadaverage.fifteen
-          delay: '0'
-          history: 7d
-          value_type: FLOAT
-          description: 'System load average over the last 15 minutes. Source: /nodes/{node}/status → data.loadavg[2].'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data.loadavg[2]'
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: 24d7734a0f944483b689078d6bfb046a
-          name: 'PVE load average (5 min)'
-          type: DEPENDENT
-          key: pve.loadaverage.fiveminute
-          delay: '0'
-          history: 7d
-          value_type: FLOAT
-          description: 'System load average over the last 5 minutes. Source: /nodes/{node}/status → data.loadavg[1].'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data.loadavg[1]'
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: 51b9d6c166124fd79742c9955390d7c9
-          name: 'PVE load average (1 min)'
-          type: DEPENDENT
-          key: pve.loadaverage.oneminute
-          delay: '0'
-          history: 7d
-          value_type: FLOAT
-          description: 'System load average over the last 1 minute. Source: /nodes/{node}/status → data.loadavg[0].'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data.loadavg[0]'
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: bbea8297bac34a2db928ee0faf130ac3
-          name: 'PVE localtime'
-          type: DEPENDENT
-          key: pve.localtime
-          delay: '0'
-          trends: '0'
-          units: unixtime
-          description: 'Current Unix timestamp on the PVE host. Source: /nodes/{node}/time → data.localtime.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.localtime
-          master_item:
-            key: pve.time.raw
-          tags:
-            - tag: PVE
-              value: Localtime
-        - uuid: 504287ef92ba490a8556df77218c0f5f
-          name: 'PVE machine type'
-          type: DEPENDENT
-          key: pve.machine.type
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Host kernel machine architecture (e.g. x86_64). Source: /nodes/{node}/status → data["current-kernel"].machine.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data["current-kernel"].machine'
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Kernel
-        - uuid: b93a24e173824db2a8422a5023f877dd
-          name: 'PVE memory available'
-          type: DEPENDENT
-          key: pve.memory.free
-          delay: '0'
-          history: 7d
-          units: Bytes
-          description: 'RAM available for new workloads on the PVE host in bytes, cache and reclaimable memory included. Source: /nodes/{node}/status → data.memory.available. Together with the used value this adds up to the installed total, which data.memory.free does not.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.memory.available
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: 56dc42c2fe27451192793a1e52e6f807
-          name: 'PVE memory total'
-          type: DEPENDENT
-          key: pve.memory.total
-          delay: '0'
-          history: 7d
-          units: Bytes
-          description: 'Total installed RAM on the PVE host in bytes. Source: /nodes/{node}/status → data.memory.total.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.memory.total
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: 6e293138bf5a44fcbcce62a215dfa299
-          name: 'PVE memory used'
-          type: DEPENDENT
-          key: pve.memory.used
-          delay: '0'
-          history: 7d
-          units: Bytes
-          description: 'Used RAM on the PVE host in bytes. Source: /nodes/{node}/status → data.memory.used.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.memory.used
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: fdc7c84644eb4c8695242253245e6301
-          name: 'PVE memory utilization'
-          type: CALCULATED
-          key: pve.memory.util
-          delay: '60'
-          history: 7d
-          value_type: FLOAT
-          units: '%'
-          params: '(last(/{HOST.HOST}/pve.memory.used) / last(/{HOST.HOST}/pve.memory.total)) * 100'
-          description: 'Memory utilization of the PVE host in percent, derived from pve.memory.used and pve.memory.total.'
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: 18307b7cd70d4dba9de74dbe66fa0908
-          name: 'PVE CPU MHz'
-          type: DEPENDENT
-          key: pve.mhz
-          delay: '0'
-          value_type: FLOAT
-          trends: '0'
-          units: '!MHz'
-          description: 'CPU clock speed in MHz of the PVE host processor. Source: /nodes/{node}/status → data.cpuinfo.mhz.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.cpuinfo.mhz
-              error_handler: DISCARD_VALUE
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: 47c47cb9777a42f1897bbe4769d1f16d
-          name: 'PVE network raw'
-          type: HTTP_AGENT
-          key: pve.nodes.network.raw
-          delay: '300'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/network. Used for host network interface discovery.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/network'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Network
-        - uuid: fe1e2188f9c64bcfba8dd9866fcc82a2
-          name: 'PVE replication raw'
-          type: HTTP_AGENT
-          key: pve.replication.raw
-          delay: '300'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/replication. The list endpoint already carries the job state (last_sync, fail_count, error, duration), so no extra call per job is needed. Requires VM.Audit on the guests.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/replication'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 7d39927cb6b946f88d188d87de358c27
-          name: 'Disk rootfs avail'
-          type: DEPENDENT
-          key: pve.rootfs.avail
-          delay: '0'
-          history: 7d
-          units: Bytes
-          description: 'Available free space on the PVE root filesystem (/) in bytes. Source: /nodes/{node}/status → data.rootfs.avail.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.rootfs.avail
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Disk
-        - uuid: fb359a78092d42058f3e1806b1043d2d
-          name: 'Disk rootfs size'
-          type: DEPENDENT
-          key: pve.rootfs.size
-          delay: '0'
-          history: 7d
-          units: Bytes
-          description: 'Total size of the PVE root filesystem (/) in bytes. Source: /nodes/{node}/status → data.rootfs.total.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.rootfs.total
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Disk
-        - uuid: 67c36e0c37734c929573fb493a2a713e
-          name: 'Disk rootfs used'
-          type: DEPENDENT
-          key: pve.rootfs.used
-          delay: '0'
-          history: 7d
-          units: Bytes
-          description: 'Used space on the PVE root filesystem (/) in bytes. Source: /nodes/{node}/status → data.rootfs.used.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.rootfs.used
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Disk
-        - uuid: d0a625fdcbb244158377964037f508ef
-          name: 'Disk rootfs utilization'
-          type: CALCULATED
-          key: pve.rootfs.util
-          delay: '60'
-          history: 7d
-          value_type: FLOAT
-          units: '%'
-          params: '(last(/{HOST.HOST}/pve.rootfs.used) / last(/{HOST.HOST}/pve.rootfs.size)) * 100'
-          description: 'Root filesystem utilization of the PVE host in percent, derived from pve.rootfs.used and pve.rootfs.size.'
-          tags:
-            - tag: PVE
-              value: Filesystem
-        - uuid: 05280836cd714144b39824854c84ffdd
-          name: 'PVE services raw'
-          type: HTTP_AGENT
-          key: pve.services.raw
-          delay: '60'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/services. Requires Sys.Audit on /nodes/{node}.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/services'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: f66a04532b684ec1b02127ba05466b0e
-          name: 'PVE CPU sockets'
-          type: DEPENDENT
-          key: pve.sockets
-          delay: '0'
-          trends: '0'
-          units: '!Sockets'
-          description: 'Number of physical CPU sockets on the PVE host. Source: /nodes/{node}/status → data.cpuinfo.sockets.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.cpuinfo.sockets
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: CPU
-        - uuid: b0528b094c1e4e0d8fbb0428a1904f3f
-          name: 'PVE status raw'
-          type: HTTP_AGENT
-          key: pve.status
-          delay: '60'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/status. Used as source for all PVE host dependent items (CPU, memory, disk, kernel, uptime, etc.).'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/status'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 357ab7b347874237ba05a41c77a23ff8
-          name: 'PVE storage raw'
-          type: HTTP_AGENT
-          key: pve.storage.raw
-          delay: '60'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/storage. Used as source for all storage discovery rules and dependent items.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/storage'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 6cae341ba9a647a2babb62923e8204d7
-          name: 'Subscription level'
-          type: DEPENDENT
-          key: pve.subscription.level
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Subscription level code. Absent without a subscription, the value is then discarded instead of turning the item unsupported.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.level
-              error_handler: DISCARD_VALUE
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.subscription.raw
-          tags:
-            - tag: PVE
-              value: Subscription
-        - uuid: bd8804ef9fbc449f801054e6f8af4b90
-          name: 'Subscription next due date'
-          type: DEPENDENT
-          key: pve.subscription.nextduedate
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Next due date as reported by PVE, a plain date string. The numeric form for alerting is in pve.subscription.nextduedate.epoch.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.nextduedate
-              error_handler: DISCARD_VALUE
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.subscription.raw
-          tags:
-            - tag: PVE
-              value: Subscription
-        - uuid: b4b1c5b0d9d94fc2b3481695a27e911d
-          name: 'Subscription expiry'
-          type: DEPENDENT
-          key: pve.subscription.nextduedate.epoch
-          delay: '0'
-          value_type: FLOAT
-          trends: '0'
-          units: unixtime
-          description: 'Subscription due date as Unix time, 0 when the node has no subscription and PVE therefore reports no due date.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.nextduedate
-              error_handler: CUSTOM_VALUE
-              error_handler_params: '0'
-            - type: JAVASCRIPT
-              parameters:
-                - |
-                  // 0 means: no subscription, so PVE reports no due date.
-                  if (value === '0') {
-                      return 0;
-                  }
-                  // PVE reports nextduedate as YYYY-MM-DD. Anchored to UTC so the
-                  // result does not shift with the server timezone. An unexpected
-                  // format throws, which turns the item visibly unsupported instead
-                  // of silently producing a wrong date.
-                  var t = Date.parse(value + 'T00:00:00Z');
-                  if (isNaN(t)) {
-                      throw 'unexpected nextduedate format: ' + value;
-                  }
-                  return Math.floor(t / 1000);
-          master_item:
-            key: pve.subscription.raw
-          tags:
-            - tag: PVE
-              value: Subscription
-          triggers:
-            - uuid: 9aaf123605424ccbb594a797dc819b5b
-              expression: 'last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)>0 and last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)-now()<{$PVE.SUBSCRIPTION.EXPIRE.DAYS}'
-              name: 'PVE subscription expires in less than {$PVE.SUBSCRIPTION.EXPIRE.DAYS} on {HOST.NAME}'
-              opdata: 'Expires on: {ITEM.LASTVALUE1}'
-              priority: WARNING
-              description: 'Advance warning before the subscription runs out, so it can be renewed in time. Depends on the expired trigger, so only one of the two is open at a time.'
-              dependencies:
-                - name: 'PVE subscription has expired on {HOST.NAME}'
-                  expression: 'last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)>0 and last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)<now()'
-            - uuid: a70cecf225f4474f9de3cfa41173f55e
-              expression: 'last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)>0 and last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)<now()'
-              name: 'PVE subscription has expired on {HOST.NAME}'
-              opdata: 'Expired on: {ITEM.LASTVALUE1}'
-              priority: AVERAGE
-              description: 'The subscription period has ended. Access to the enterprise repository is gone, updates from it will fail. Hosts without a subscription report a due date of 0, which the trigger ignores.'
-        - uuid: 84118fad0bba4ce5bffb48112cdcf428
-          name: 'PVE subscription raw'
-          type: HTTP_AGENT
-          key: pve.subscription.raw
-          delay: '3600'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/subscription. Needs no special permission. Without a subscription the endpoint returns HTTP 200 and status notfound.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/subscription'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 0849be5b5a23405784c11020bb2fa335
-          name: 'Subscription status'
-          type: DEPENDENT
-          key: pve.subscription.status
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Subscription status: active, notfound, invalid, expired or suspended. Source: /nodes/{node}/subscription.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.status
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.subscription.raw
-          tags:
-            - tag: PVE
-              value: Subscription
-          triggers:
-            - uuid: ad9a7f6a1c124e7db461f40afed8ad33
-              expression: 'last(/Proxmox VE Node by REST API/pve.subscription.status)<>"active" and {$PVE.SUBSCRIPTION.ALERT}=1'
-              name: 'PVE subscription is not active on {HOST.NAME} ({ITEM.LASTVALUE})'
-              priority: WARNING
-              description: 'Status is notfound, invalid, expired or suspended. Off by default, set {$PVE.SUBSCRIPTION.ALERT}=1 on hosts that are meant to carry a subscription. Depends on the expired trigger so a lapsed subscription raises one problem, not two.'
-              dependencies:
-                - name: 'PVE subscription has expired on {HOST.NAME}'
-                  expression: 'last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)>0 and last(/Proxmox VE Node by REST API/pve.subscription.nextduedate.epoch)<now()'
-        - uuid: 695362344c134354a6cc113a26628ff4
-          name: 'PVE swap free'
-          type: DEPENDENT
-          key: pve.swap.free
-          delay: '0'
-          history: 7d
-          units: Bytes
-          description: 'Free swap space on the PVE host in bytes. Source: /nodes/{node}/status → data.swap.free. Reports 0 on hosts without swap.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.swap.free
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: 0b20519bcedf48809fce4475ef78e003
-          name: 'PVE swap total'
-          type: DEPENDENT
-          key: pve.swap.total
-          delay: '0'
-          history: 7d
-          units: Bytes
-          description: 'Configured swap space on the PVE host in bytes. Source: /nodes/{node}/status → data.swap.total. Reports 0 on hosts without swap.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.swap.total
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: 98f9d9a8ae5f4acb96f4d304083e21e6
-          name: 'PVE swap used'
-          type: DEPENDENT
-          key: pve.swap.used
-          delay: '0'
-          history: 7d
-          units: Bytes
-          description: 'Used swap space on the PVE host in bytes. Source: /nodes/{node}/status → data.swap.used. Swap filling up while memory is not tight usually means pages were evicted during an earlier peak and never came back.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.swap.used
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Memory
-        - uuid: 80475185f9604d8cb3d65657d5449c54
-          name: 'PVE boot mode'
-          type: DEPENDENT
-          key: pve.system.boot.mode
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Boot mode of the PVE host (e.g. efi, legacy-bios). Source: /nodes/{node}/status → data["boot-info"].mode.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data["boot-info"].mode'
-              error_handler: DISCARD_VALUE
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Boot
-        - uuid: b50e9be8992c463c82d4b755ee305983
-          name: 'PVE secureboot'
-          type: DEPENDENT
-          key: pve.system.boot.secureboot
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Secure Boot status on the PVE host. 0 = disabled, 1 = enabled. Source: /nodes/{node}/status → data["boot-info"].secureboot.'
-          valuemap:
-            name: 'PVE secureboot'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data["boot-info"].secureboot'
-              error_handler: DISCARD_VALUE
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Boot
-        - uuid: 33adc7da9f614d0592fcec4873639b7a
-          name: 'PVE tasks raw'
-          type: HTTP_AGENT
-          key: pve.tasks.raw
-          delay: '60'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/tasks, processed by JavaScript preprocessing to deduplicate tasks (keeps most recent run per id+type pair, excludes backup tasks handled by pve.backup.raw).'
-          preprocessing:
-            - type: JAVASCRIPT
-              parameters:
-                - |
-                  try {
-                      var obj = (typeof value === 'string') ? JSON.parse(value) : value;
-                      if (!obj || !obj.body || !Array.isArray(obj.body.data)) {
-                          return JSON.stringify({ error: "Invalid structure" });
-                      }
-                  
-                      var records = obj.body.data;
-                      var grouped = {};
-                  
-                      // Helper: normalise timestamp value to milliseconds
-                      // Robust time parsing: numeric strings, ISO, "YYYY-MM-DD HH:mm:ss"
-                      function normTime(v) {
-                          if (v === null || v === undefined) return -Infinity;
-                          if (typeof v === "number") return v < 1000000000000 ? v * 1000 : v;
-                          if (typeof v === "string") {
-                              var s = v.trim();
-                  
-                              // Treat purely numeric strings as numbers
-                              if (/^\d+(\.\d+)?$/.test(s)) {
-                                  var n = parseFloat(s);
-                                  return n < 1000000000000 ? n * 1000 : n;
-                              }
-                  
-                              // Parse "YYYY-MM-DD HH:mm:ss" (optional AM/PM)
-                              var m = s.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\s*(AM|PM))?$/i);
-                              if (m) {
-                                  var H = parseInt(m[4], 10), ampm = (m[7] || "").toUpperCase();
-                                  if (ampm) { if (ampm === "PM" && H < 12) H += 12; if (ampm === "AM" && H === 12) H = 0; }
-                                  return Date.UTC(+m[1], +m[2]-1, +m[3], H, +m[5], +m[6]);
-                              }
-                  
-                              // Fallback: parse as ISO-compatible string (Leerraum → 'T')
-                              var p = Date.parse(s.replace(/\s+/, "T"));
-                              return isNaN(p) ? -Infinity : p;
-                          }
-                          return -Infinity;
-                      }
-                      
-                  
-                      // Process task records
-                      for (var i = 0; i < records.length; i++) {
-                          var e = records[i];
-                          if (!e || !e.id || !e.type) continue;
-                  
-                          var key = e.id + "|" + e.type;
-                  
-                          // Normalise timestamps
-                          var copy = {};
-                          for (var k in e) if (e.hasOwnProperty(k)) copy[k] = e[k];
-                          copy._start = normTime(e.starttime || e.pstart || e.start);
-                  
-                          var existing = grouped[key];
-                          if (!existing || copy._start > existing._rep) {
-                              copy._rep = copy._start;
-                              grouped[key] = copy;
-                          }
-                      }
-                  
-                      // Build result list
-                      var resultList = [];
-                      for (var k in grouped) {
-                          var g = grouped[k];
-                          delete g._start;
-                          delete g._rep;
-                          g.grpid = g.id;
-                          resultList.push(g);
-                      }
-                  
-                      // Sort by ID
-                      // Sort: numeric IDs first, then lexicographic
-                      resultList.sort(function(a, b) {
-                          var aNum = /^\d+$/.test(String(a.id));
-                          var bNum = /^\d+$/.test(String(b.id));
-                          if (aNum && bNum) return Number(a.id) - Number(b.id);
-                          if (aNum && !bNum) return -1;
-                          if (!aNum && bNum) return 1;
-                          return (String(a.id) || "").localeCompare(String(b.id) || "");
-                      });
-                      
-                  
-                      obj.body.data = resultList;
-                      obj.body.total = resultList.length;
-                  
-                      return JSON.stringify(obj);
-                  
-                  } catch (err) {
-                      return JSON.stringify({ error: "Parsing failed", detail: err.message });
-                  }
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/tasks'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          output_format: JSON
-          tags:
-            - tag: PVE
-              value: Raw
-        - uuid: 9d414ebbce7e4d50b70ce6cf2bc8dddf
-          name: 'PVE time raw'
-          type: HTTP_AGENT
-          key: pve.time.raw
-          delay: 5m
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/time. Used for timezone and localtime dependent items.'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/time'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Time
-        - uuid: 7f2a227581b44e9fb9be9919f44f912e
-          name: 'PVE timezone'
-          type: DEPENDENT
-          key: pve.timezone
-          delay: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Timezone configured on the PVE host (e.g. Europe/Berlin). Source: /nodes/{node}/time → data.timezone.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.timezone
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1h
-          master_item:
-            key: pve.time.raw
-          tags:
-            - tag: PVE
-              value: Timezone
-        - uuid: d88f124c7cb944bfa1c049428c864173
-          name: 'PVE uptime'
-          type: DEPENDENT
-          key: pve.uptime
-          delay: '0'
-          trends: '0'
-          units: s
-          description: 'Uptime of the PVE host in seconds since last boot. Source: /nodes/{node}/status → data.uptime.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.uptime
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Uptime
-          triggers:
-            - uuid: 7c6c07fb18584005923902ed297efd60
-              expression: 'nodata(/Proxmox VE Node by REST API/pve.uptime,300)=1'
-              name: 'PVE API not reachable on {HOST.NAME}'
-              opdata: 'No data for 5 minutes'
-              priority: HIGH
-              description: 'The Proxmox VE REST API has not returned data for 5 minutes. Check connectivity, API token, and PVE service status. Evaluated on "pve.uptime", because nodata() cannot read items that keep no history, such as the raw API item.'
-              manual_close: 'YES'
-        - uuid: 9320ab31c2704c7ab38e3c403762cc34
-          name: 'PVE version'
-          type: DEPENDENT
-          key: pve.version
-          delay: '0'
-          history: '0'
-          value_type: CHAR
-          trends: '0'
-          description: 'Proxmox VE version string, for example 9.2.10. Source: /nodes/{node}/status → data.pveversion, which carries it as pve-manager/9.2.10/<repoid>. Read from the host status instead of the separate version endpoint, so no extra request per interval is needed.'
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - $.data.pveversion
-            - type: REGEX
-              parameters:
-                - 'pve-manager/([0-9][0-9.]*)'
-                - \1
-            - type: DISCARD_UNCHANGED_HEARTBEAT
-              parameters:
-                - 1d
-          master_item:
-            key: pve.status
-          tags:
-            - tag: PVE
-              value: Version
-        - uuid: a1a88263c8e14ca1a7dcac5d20cb8eeb
-          name: 'PVE ZFS pools raw'
-          type: HTTP_AGENT
-          key: pve.zfs.raw
-          delay: '300'
-          history: '0'
-          value_type: TEXT
-          trends: '0'
-          description: 'Master item. Raw JSON from /nodes/{node}/disks/zfs. Requires Sys.Audit on / (not on /nodes/{node}).'
-          timeout: 20s
-          url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/disks/zfs'
-          headers:
-            - name: Authorization
-              value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-            - name: Accept
-              value: application/json
-          tags:
-            - tag: PVE
-              value: Raw
-      discovery_rules:
-        - uuid: ed09ff1436ff403a93e2390b8ebcadbd
-          name: 'Discover backup'
-          type: DEPENDENT
-          key: discover.backup
-          delay: '0'
-          lifetime_type: DELETE_IMMEDIATELY
-          lifetime: '0'
-          item_prototypes:
-            - uuid: e60e270792a24f269e131fd4d1bb4793
-              name: 'Backup duration {#ID}'
-              type: CALCULATED
-              key: 'backup.duration[{#BCKPID}]'
-              delay: '300'
-              history: 7d
-              value_type: FLOAT
-              units: s
-              params: 'last(/{HOST.HOST}/backup.endtime[{#BCKPID}]) - last(/{HOST.HOST}/backup.starttime[{#BCKPID}])'
-              description: 'How long the last finished backup of {#ID} took, in seconds. Derived from the end and start timestamps of the same run, both of which arrive together when the task reaches the archive. The value therefore describes the last completed run, never the one in progress.'
-              preprocessing:
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              tags:
-                - tag: PVE
-                  value: Backup
-                - tag: PVE
-                  value: '{#BCKPID}'
-                - tag: vmid
-                  value: '{#BCKPID}'
-            - uuid: 81828c7d71c8491fbc51fc952b12413d
-              name: 'Backup endtime {#ID}'
-              type: DEPENDENT
-              key: 'backup.endtime[{#BCKPID}]'
-              delay: '0'
-              history: 7d
-              units: unixtime
-              description: 'Unix timestamp of the last backup job end time for VM/CT {#ID}. Source: pve.backup.raw → data[bckpid].endtime.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.bckpid=="{#BCKPID}")].endtime.first()'
-                  error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.backup.raw
-              tags:
-                - tag: PVE
-                  value: Backup
-                - tag: PVE
-                  value: '{#BCKPID}'
-                - tag: vmid
-                  value: '{#BCKPID}'
-            - uuid: 6c2e7ea8e839464e9364f26b364f47db
-              name: 'Backup message {#ID}'
-              type: DEPENDENT
-              key: 'backup.message[{#BCKPID}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Status text of the last backup job for VM/CT {#BCKPID}, exactly as Proxmox VE reports it. A successful job reports OK, a failed one reports the error message itself. The numeric item Backup status maps only a fixed set of known texts, so this item carries the real cause of a failure.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.bckpid=="{#BCKPID}")].status.first()'
-                  error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.backup.raw
-              tags:
-                - tag: PVE
-                  value: Backup
-                - tag: vmid
-                  value: '{#BCKPID}'
-            - uuid: 354a2fa167f64c1db36e580548e3b166
-              name: 'Backup starttime {#ID}'
-              type: DEPENDENT
-              key: 'backup.starttime[{#BCKPID}]'
-              delay: '0'
-              history: 7d
-              units: unixtime
-              description: 'Unix timestamp of the last backup job start time for VM/CT {#ID}. Source: pve.backup.raw → data[bckpid].starttime.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.bckpid=="{#BCKPID}")].starttime.first()'
-                  error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.backup.raw
-              tags:
-                - tag: PVE
-                  value: Backup
-                - tag: PVE
-                  value: '{#BCKPID}'
-                - tag: vmid
-                  value: '{#BCKPID}'
-            - uuid: 4df227340b60403ba2f0aa919a7b002e
-              name: 'Backup status {#ID}'
-              type: DEPENDENT
-              key: 'backup.status[{#BCKPID}]'
-              delay: '0'
-              history: 7d
-              description: 'Status of the last backup job for VM/CT {#ID}. 0=OK, 1=running, 2=stopped, 3=error, 4=unknown error.'
-              valuemap:
-                name: 'Backup status'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.bckpid=="{#BCKPID}")].status.first()'
-                  error_handler: DISCARD_VALUE
-                - type: REGEX
-                  parameters:
-                    - ^(OK|running|stopped|error)$
-                    - \0
-                  error_handler: CUSTOM_VALUE
-                  error_handler_params: '4'
-                - type: STR_REPLACE
-                  parameters:
-                    - OK
-                    - '0'
-                - type: STR_REPLACE
-                  parameters:
-                    - running
-                    - '1'
-                - type: STR_REPLACE
-                  parameters:
-                    - stopped
-                    - '2'
-                - type: STR_REPLACE
-                  parameters:
-                    - error
-                    - '3'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.backup.raw
-              tags:
-                - tag: PVE
-                  value: Backup
-                - tag: PVE
-                  value: '{#BCKPID}'
-                - tag: vmid
-                  value: '{#BCKPID}'
-          trigger_prototypes:
-            - uuid: 0762db69afb046c29dff36b0ff991aa8
-              expression: 'last(/Proxmox VE Node by REST API/backup.status[{#BCKPID}])>=2 and {$ENABLE_BACKUP_ALERT:"{#BCKPID}"}=1 and fuzzytime(/Proxmox VE Node by REST API/backup.endtime[{#BCKPID}],{$BACKUP.ALERT.WINDOW})=1'
-              name: 'Backup for {#ID} failed'
-              event_name: 'Backup for {#ID} failed: {?last(//backup.message[{#BCKPID}])}'
-              opdata: 'Backup status: {ITEM.LASTVALUE}'
-              priority: HIGH
-              description: |
-                0. OK: All clear, no errors detected
-                1. running: VM/CT is currently active
-                2. stopped: VM/CT has been shut down
-                3. error: General execution failure; check logs for details
-                4. unknown error: Cannot classify status, please check Proxmox for details
-              manual_close: 'YES'
-          graph_prototypes:
-            - uuid: 3911ea69cf744a0ca14fcd2dfc00c546
-              name: 'Backup status {#ID}'
-              graph_items:
-                - color: 8E24AA
-                  calc_fnc: ALL
-                  item:
-                    host: 'Proxmox VE Node by REST API'
-                    key: 'backup.status[{#BCKPID}]'
-          master_item:
-            key: pve.backup.raw
-          lld_macro_paths:
-            - lld_macro: '{#BCKPID}'
-              path: $.bckpid
-            - lld_macro: '{#ID}'
-              path: $.id
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
-              error_handler: CUSTOM_VALUE
-              error_handler_params: '[]'
-        - uuid: cb389126c8a3488fa7159353a7752517
-          name: 'Discover certificates'
-          type: DEPENDENT
-          key: discover.certificates
-          delay: '0'
-          description: 'Discovers the certificates of the node: pve-root-ca.pem, pve-ssl.pem and, if configured, pveproxy-ssl.pem from a custom or ACME certificate.'
-          item_prototypes:
-            - uuid: ed6a2bcdb1d146f198cd13b29f6974ed
-              name: 'Certificate issuer {#CERT_FILE}'
-              type: DEPENDENT
-              key: 'cert.issuer[{#CERT_FILE}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Certificate issuer name.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.filename=="{#CERT_FILE}")].issuer.first()'
-                  error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.certificates.raw
-              tags:
-                - tag: PVE
-                  value: Certificate
-                - tag: PVE
-                  value: '{#CERT_FILE}'
-            - uuid: bf18104609214d4ca9f0b40324ab58d5
-              name: 'Certificate expiry {#CERT_FILE}'
-              type: DEPENDENT
-              key: 'cert.notafter[{#CERT_FILE}]'
-              delay: '0'
-              value_type: FLOAT
-              trends: '0'
-              units: unixtime
-              description: 'notAfter timestamp. PVE already delivers a Unix epoch, so no conversion is needed.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.filename=="{#CERT_FILE}")].notafter.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.certificates.raw
-              tags:
-                - tag: PVE
-                  value: Certificate
-                - tag: PVE
-                  value: '{#CERT_FILE}'
-              trigger_prototypes:
-                - uuid: 32fda78924934bd3bef32d616e773369
-                  expression: 'last(/Proxmox VE Node by REST API/cert.notafter[{#CERT_FILE}])-now()<{$PVE.CERT.EXPIRE.DAYS}'
-                  name: 'Certificate {#CERT_FILE} expires in less than {$PVE.CERT.EXPIRE.DAYS} on {HOST.NAME}'
-                  priority: WARNING
-                  description: 'Applies to pve-ssl.pem, pve-root-ca.pem and any custom or ACME certificate. The cluster CA runs for 50 years, the node certificate for two.'
-                  dependencies:
-                    - name: 'Certificate {#CERT_FILE} has expired on {HOST.NAME}'
-                      expression: 'last(/Proxmox VE Node by REST API/cert.notafter[{#CERT_FILE}])-now()<0'
-                - uuid: 4f5a5e9a676b4f4da919f85d37d0319b
-                  expression: 'last(/Proxmox VE Node by REST API/cert.notafter[{#CERT_FILE}])-now()<0'
-                  name: 'Certificate {#CERT_FILE} has expired on {HOST.NAME}'
-                  priority: AVERAGE
-                  description: 'The certificate is past its notAfter date. Clients and the web interface reject it, and API clients that verify the chain stop connecting. The advance warning depends on this trigger, so only one of the two is open at a time.'
-            - uuid: 421975e714f1410db04024c135b92764
-              name: 'Certificate subject {#CERT_FILE}'
-              type: DEPENDENT
-              key: 'cert.subject[{#CERT_FILE}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Certificate subject name.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.filename=="{#CERT_FILE}")].subject.first()'
-                  error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.certificates.raw
-              tags:
-                - tag: PVE
-                  value: Certificate
-                - tag: PVE
-                  value: '{#CERT_FILE}'
-          master_item:
-            key: pve.certificates.raw
-          lld_macro_paths:
-            - lld_macro: '{#CERT_FILE}'
-              path: $.filename
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
-              error_handler: CUSTOM_VALUE
-              error_handler_params: '[]'
-        - uuid: d3ff98aa62014bd19d46c2b230b97a53
-          name: 'Discover disks'
-          type: DEPENDENT
-          key: discover.disks
-          delay: '0'
-          description: 'Discovers physical disks from /nodes/{node}/disks/list. Covers every disk type Proxmox VE reports, including SATA, SAS and NVMe. The wearout item is skipped for rotating disks, which do not expose that value.'
-          item_prototypes:
-            - uuid: e7fdc211cf1c462db6907db3af8ccb77
-              name: 'Disk {#DISK_DEV} health'
-              type: DEPENDENT
-              key: 'disk.health[{#DISK_DEV}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'SMART health status of disk {#DISK_DEV} ({#DISK_MODEL}). Values: PASSED, FAILED, UNKNOWN. Source: /nodes/{node}/disks/list, which reports the same overall health assessment as the dedicated SMART endpoint, so no extra request per disk is needed.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.devpath=="{#DISK_DEV}")].health.first()'
-                  error_handler: CUSTOM_VALUE
-                  error_handler_params: UNKNOWN
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.disks.raw
-              tags:
-                - tag: PVE
-                  value: Disk
-                - tag: PVE
-                  value: '{#DISK_DEV}'
-              trigger_prototypes:
-                - uuid: 1f006ac693614abf9740f0cf63997be4
-                  expression: |
-                    last(/Proxmox VE Node by REST API/disk.health[{#DISK_DEV}])<>"PASSED"
-                    and last(/Proxmox VE Node by REST API/disk.health[{#DISK_DEV}])<>"OK"
-                    and last(/Proxmox VE Node by REST API/disk.health[{#DISK_DEV}])<>"UNKNOWN"
-                    and last(/Proxmox VE Node by REST API/disk.health[{#DISK_DEV}])<>"SMART Disabled"
-                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) SMART health not PASSED on {HOST.NAME}'
-                  priority: HIGH
-                  description: 'SMART health check for disk {#DISK_DEV} returned a failed status. PASSED and OK are the healthy verdicts. UNKNOWN and SMART Disabled mean the disk reports no assessment at all and are not treated as a failure.'
-                  manual_close: 'YES'
-            - uuid: 1cc10c9ca58a4528b8e48e4e6cdaa815
-              name: 'Disk {#DISK_DEV} size'
-              type: DEPENDENT
-              key: 'disk.size[{#DISK_DEV}]'
-              delay: '0'
-              history: 7d
-              units: Bytes
-              description: 'Total size of physical disk {#DISK_DEV} ({#DISK_MODEL}) in bytes. Source: /nodes/{node}/disks/list.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.devpath=="{#DISK_DEV}")].size.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.disks.raw
-              tags:
-                - tag: PVE
-                  value: Disk
-                - tag: PVE
-                  value: '{#DISK_DEV}'
-              trigger_prototypes:
-                - uuid: 90a3a0700d1f4faaa8a441fb9c0d2255
-                  expression: 'nodata(/Proxmox VE Node by REST API/disk.size[{#DISK_DEV}],{$DISK.MISSING.TIME})=1'
-                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) is no longer reported by {HOST.NAME}'
-                  priority: AVERAGE
-                  description: 'Proxmox VE has stopped listing this disk. Either the disk was removed on purpose or it dropped off the bus. The disk list is refreshed hourly, so {$DISK.MISSING.TIME} must stay well above one hour.'
-                  manual_close: 'YES'
-            - uuid: 8fbe418d241d44e0a885e4956306d57e
-              name: 'Disk {#DISK_DEV} SMART raw'
-              type: HTTP_AGENT
-              key: 'disk.smart.raw[{#DISK_DEV}]'
-              delay: '3600'
-              history: '0'
-              value_type: TEXT
-              trends: '0'
-              description: 'Master item. Raw JSON from /nodes/{node}/disks/smart for disk {#DISK_DEV}. Proxmox VE answers in two shapes: type=ata carries a list of numbered SMART attributes, type=text carries the raw smartctl output used for NVMe and SAS. Source for the disk temperature item.'
-              timeout: 20s
-              url: 'https://{$PVE_IP}:{$PVE_PORT}/api2/json/nodes/{$PVE_NODE}/disks/smart?disk={#DISK_DEV}'
-              headers:
-                - name: Authorization
-                  value: 'PVEAPIToken={$PVE_API_USER}!{$PVE_API_TOKEN_ID}={$PVE_API_TOKEN}'
-                - name: Accept
-                  value: application/json
-              tags:
-                - tag: PVE
-                  value: Raw
-                - tag: PVE
-                  value: '{#DISK_DEV}'
-            - uuid: 2837e1e2414649fc976e82db6eb24966
-              name: 'Disk {#DISK_DEV} temperature'
-              type: DEPENDENT
-              key: 'disk.temp[{#DISK_DEV}]'
-              delay: '0'
-              history: 7d
-              value_type: FLOAT
-              units: '!°C'
-              description: 'Temperature of disk {#DISK_DEV} ({#DISK_MODEL}) in degrees Celsius. Read from the SMART payload of the disk. SATA and SAS disks report it as attribute 194, or 190 on drives that only expose an airflow sensor. NVMe disks report it in the composite Temperature line of the smartctl output. Disks that expose no temperature at all deliver no value.'
-              preprocessing:
-                - type: JAVASCRIPT
-                  parameters:
-                    - |
-                      // Proxmox returns two different SMART shapes, so both are handled here.
-                      // type=ata  -> numbered attribute list, temperature is id 194 (or 190)
-                      // type=text -> raw smartctl output, temperature is the composite line
-                      var d = JSON.parse(value).data;
-                      if (!d) {
-                          throw 'no SMART payload';
-                      }
-                      if (d.attributes) {
-                          var wanted = ['194', '190'];
-                          for (var w = 0; w < wanted.length; w++) {
-                              for (var i = 0; i < d.attributes.length; i++) {
-                                  var a = d.attributes[i];
-                                  // Proxmox keeps the attribute id as a space padded string
-                                  if (String(a.id).replace(/\s/g, '') !== wanted[w]) {
-                                      continue;
-                                  }
-                                  // the raw column may carry trailing text such as "38 (Min/Max 20/45)"
-                                  var r = String(a.raw).match(/\d+/);
-                                  if (r) {
-                                      return r[0];
-                                  }
-                              }
-                          }
-                      }
-                      if (typeof d.text === 'string') {
-                          var t = d.text.match(/^\s*Temperature:\s+(\d+)\s+Celsius/m);
-                          if (!t) {
-                              t = d.text.match(/^\s*Temperature Sensor 1:\s+(\d+)\s+Celsius/m);
-                          }
-                          if (t) {
-                              return t[1];
-                          }
-                      }
-                      throw 'no temperature in SMART data';
-              master_item:
-                key: 'disk.smart.raw[{#DISK_DEV}]'
-              tags:
-                - tag: PVE
-                  value: Disk
-                - tag: PVE
-                  value: '{#DISK_DEV}'
-              trigger_prototypes:
-                - uuid: f3a9973e8bb54de0bbc26e3164b49e8c
-                  expression: 'min(/Proxmox VE Node by REST API/disk.temp[{#DISK_DEV}],10m)>{$DISK.TEMP.MAX:"{#DISK_DEV}"}'
-                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) temperature above {$DISK.TEMP.MAX:"{#DISK_DEV}"} C on {HOST.NAME}'
-                  opdata: 'Temperature: {ITEM.LASTVALUE1}'
-                  priority: WARNING
-                  description: 'The disk has stayed above the temperature threshold for 10 minutes. Set {$DISK.TEMP.MAX:"{#DISK_DEV}"} to raise the threshold for a single disk.'
-                  manual_close: 'YES'
-            - uuid: bd29254423524861920b89e93861adba
-              name: 'Disk {#DISK_DEV} wearout'
-              type: DEPENDENT
-              key: 'disk.wearout[{#DISK_DEV}]'
-              delay: '0'
-              history: 7d
-              value_type: FLOAT
-              units: '%'
-              description: 'SSD wearout indicator for disk {#DISK_DEV} in percent remaining life (100% = new, 0% = worn out). Only meaningful for SSDs and NVMe, rotating disks report N/A and are discarded. Source: /nodes/{node}/disks/list. The SMART endpoint does not return this value.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.devpath=="{#DISK_DEV}")].wearout.first()'
-                  error_handler: DISCARD_VALUE
-                - type: MATCHES_REGEX
-                  parameters:
-                    - '^[0-9]+(\.[0-9]+)?$'
-                  error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.disks.raw
-              tags:
-                - tag: PVE
-                  value: Disk
-                - tag: PVE
-                  value: '{#DISK_DEV}'
-              trigger_prototypes:
-                - uuid: 24dcd5cd84574b3b994614279613ed6b
-                  expression: 'last(/Proxmox VE Node by REST API/disk.wearout[{#DISK_DEV}])<{$DISK.WEAROUT.MIN}'
-                  name: 'Disk {#DISK_DEV} ({#DISK_MODEL}) wearout below {$DISK.WEAROUT.MIN}% on {HOST.NAME}'
-                  priority: WARNING
-                  description: 'SSD wearout for disk {#DISK_DEV} is below threshold. Consider replacement planning.'
-                  manual_close: 'YES'
-          master_item:
-            key: pve.disks.raw
-          lld_macro_paths:
-            - lld_macro: '{#DISK_DEV}'
-              path: $.devpath
-            - lld_macro: '{#DISK_MODEL}'
-              path: $.model
-            - lld_macro: '{#DISK_SERIAL}'
-              path: $.serial
-            - lld_macro: '{#DISK_TYPE}'
-              path: $.type
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
-              error_handler: CUSTOM_VALUE
-              error_handler_params: '[]'
-          overrides:
-            - name: 'No wearout on rotating disks'
-              step: '1'
-              filter:
-                conditions:
-                  - macro: '{#DISK_TYPE}'
-                    value: ^hdd$
-                    formulaid: A
-              operations:
-                - operationobject: ITEM_PROTOTYPE
-                  operator: LIKE
-                  value: wearout
-                  discover: NO_DISCOVER
-        - uuid: 0d60456d6e6b468bbfb52d9cf9790f7b
-          name: 'Discover network interfaces'
-          type: DEPENDENT
-          key: discover.network
-          delay: '0'
-          filter:
-            evaltype: AND
-            conditions:
-              - macro: '{#IFACE}'
-                value: '{$IFACE.NOT_MATCHES}'
-                operator: NOT_MATCHES_REGEX
-                formulaid: A
-              - macro: '{#IFACE_TYPE}'
-                value: '^(bridge|bond|eth|en|vlan).*'
-                formulaid: B
-          description: 'Discovers host network interfaces from /nodes/{node}/network. Filters to relevant types (bridge, bond, eth/en*, vlan) and excludes the interface names matching {$IFACE.NOT_MATCHES}, which by default drops the per-guest interfaces Proxmox creates for VMs and containers.'
-          item_prototypes:
-            - uuid: 2af0a73539a441eabb7fa95c50860028
-              name: 'Network interface {#IFACE} active'
-              type: DEPENDENT
-              key: 'iface.active[{#IFACE}]'
-              delay: '0'
-              history: 7d
-              description: 'Active/link state of network interface {#IFACE} on the PVE host. 1 = active, 0 = inactive.'
-              valuemap:
-                name: 'Network interface active'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.iface=="{#IFACE}")].active.first()'
-                  error_handler: CUSTOM_VALUE
-                  error_handler_params: '0'
-              master_item:
-                key: pve.nodes.network.raw
-              tags:
-                - tag: PVE
-                  value: Network
-                - tag: PVE
-                  value: '{#IFACE}'
-            - uuid: 0a1d67360d8b46678ecd5ab5becbb953
-              name: 'Network interface {#IFACE} autostart'
-              type: DEPENDENT
-              key: 'iface.autostart[{#IFACE}]'
-              delay: '0'
-              history: 7d
-              description: 'Configured admin state of network interface {#IFACE}. 1 = the interface has an "auto" entry in /etc/network/interfaces and is expected to be up, 0 = not configured for automatic start. If the API does not report the field at all the item falls back to 1, so that the interface down trigger keeps working and is decided by the activity condition alone.'
-              valuemap:
-                name: 'Network interface autostart'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.iface=="{#IFACE}")].autostart.first()'
-                  error_handler: CUSTOM_VALUE
-                  error_handler_params: '0'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.nodes.network.raw
-              tags:
-                - tag: PVE
-                  value: Network
-                - tag: PVE
-                  value: '{#IFACE}'
-            - uuid: 1ea674dcd2f047368f2b79669f9d487c
-              name: 'Network interface {#IFACE} type'
-              type: DEPENDENT
-              key: 'iface.type[{#IFACE}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Type/driver of network interface {#IFACE} (e.g. bridge, bond, eth). Source: /nodes/{node}/network.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.iface=="{#IFACE}")].type.first()'
-                  error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.nodes.network.raw
-              tags:
-                - tag: PVE
-                  value: Network
-                - tag: PVE
-                  value: '{#IFACE}'
-          trigger_prototypes:
-            - uuid: 0ae879b4c62241ce8c60669258989a83
-              expression: 'last(/Proxmox VE Node by REST API/iface.active[{#IFACE}])=0 and last(/Proxmox VE Node by REST API/iface.autostart[{#IFACE}])=1 and max(/Proxmox VE Node by REST API/iface.active[{#IFACE}],{$IFACE.ACTIVE.WINDOW})=1'
-              recovery_mode: RECOVERY_EXPRESSION
-              recovery_expression: 'last(/Proxmox VE Node by REST API/iface.active[{#IFACE}])=1'
-              name: 'Network interface {#IFACE} is down on {HOST.NAME}'
-              priority: AVERAGE
-              description: 'Host network interface {#IFACE} is no longer active/up. All three conditions must hold: the interface is down, it is configured to start automatically, and it was active at least once within {$IFACE.ACTIVE.WINDOW}. Interfaces that are configured but were never actually up do not raise this trigger.'
-              manual_close: 'YES'
-          graph_prototypes:
-            - uuid: 0cb677adb6c44968b501eee74d09d286
-              name: 'Network interface {#IFACE} status'
-              graph_items:
-                - color: 1976D2
-                  calc_fnc: ALL
-                  item:
-                    host: 'Proxmox VE Node by REST API'
-                    key: 'iface.active[{#IFACE}]'
-          master_item:
-            key: pve.nodes.network.raw
-          lld_macro_paths:
-            - lld_macro: '{#IFACE_TYPE}'
-              path: $.type
-            - lld_macro: '{#IFACE}'
-              path: $.iface
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
-              error_handler: CUSTOM_VALUE
-              error_handler_params: '[]'
-        - uuid: 29c7208a3d0b4248aa0c899d0803734c
-          name: 'Discover PVE services'
-          type: DEPENDENT
-          key: discover.pve.services
-          delay: '0'
-          filter:
-            conditions:
-              - macro: '{#SERVICE}'
-                value: '{$PVE.SERVICE.MATCHES}'
-                formulaid: A
-          description: 'Discovers the systemd units PVE manages. The default filter covers the services every node runs, standalone or clustered, including the HA managers and the scheduler that starts backup and replication jobs. corosync is excluded by default because it only runs once the node is part of a cluster; add it to {$PVE.SERVICE.MATCHES} on cluster nodes.'
-          item_prototypes:
-            - uuid: 312bcd7b99194954a4858e4d0ba2a6dd
-              name: 'Service active state {#SERVICE}'
-              type: DEPENDENT
-              key: 'pve.service.active_state[{#SERVICE}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Systemd ActiveState: active, inactive or failed.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.service=="{#SERVICE}")]["active-state"].first()'
-                  error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.services.raw
-              tags:
-                - tag: PVE
-                  value: Service
-                - tag: PVE
-                  value: '{#SERVICE}'
-            - uuid: 7389a5ef4bb143c582b405caab67bcc2
-              name: 'Service state {#SERVICE}'
-              type: DEPENDENT
-              key: 'pve.service.state[{#SERVICE}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Systemd SubState, for example running, dead or exited.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.service=="{#SERVICE}")].state.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.services.raw
-              tags:
-                - tag: PVE
-                  value: Service
-                - tag: PVE
-                  value: '{#SERVICE}'
-              trigger_prototypes:
-                - uuid: 6db1d0a05f554aee9ce81d2510bc4d0d
-                  expression: 'last(/Proxmox VE Node by REST API/pve.service.state[{#SERVICE}])<>"running" and {$PVE.SERVICE.STATE.ALERT:"{#SERVICE}"}=1'
-                  name: 'PVE service {#SERVICE} is not running on {HOST.NAME}'
-                  priority: AVERAGE
-                  description: 'Systemd SubState of the service is no longer running. Use {$PVE.SERVICE.STATE.ALERT:"<service>"}=0 to silence a single service, and {$PVE.SERVICE.MATCHES} to control which services are discovered at all.'
-            - uuid: 52ff1662c40147808ce0803144ae228e
-              name: 'Service unit state {#SERVICE}'
-              type: DEPENDENT
-              key: 'pve.service.unit_state[{#SERVICE}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Systemd UnitFileState: enabled, disabled, masked or static.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.service=="{#SERVICE}")]["unit-state"].first()'
-                  error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.services.raw
-              tags:
-                - tag: PVE
-                  value: Service
-                - tag: PVE
-                  value: '{#SERVICE}'
-          master_item:
-            key: pve.services.raw
-          lld_macro_paths:
-            - lld_macro: '{#SERVICE}'
-              path: $.service
-            - lld_macro: '{#SVC_DESC}'
-              path: $.desc
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
-              error_handler: CUSTOM_VALUE
-              error_handler_params: '[]'
-        - uuid: bee58b896c914c6fb7e61162fc8f1b7c
-          name: 'Discover replication jobs'
-          type: DEPENDENT
-          key: discover.replication
-          delay: '0'
-          description: 'Discovers ZFS replication jobs. The list endpoint already carries the job state, so no extra request per job is required. Yields nothing on nodes without replication.'
-          item_prototypes:
-            - uuid: 7e952e95a11446faae086e6d17965bae
-              name: 'Replication duration {#REPL_ID}'
-              type: DEPENDENT
-              key: 'repl.duration[{#REPL_ID}]'
-              delay: '0'
-              history: 7d
-              value_type: FLOAT
-              units: s
-              description: 'Duration of the last run in seconds.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.id=="{#REPL_ID}")].duration.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.replication.raw
-              tags:
-                - tag: PVE
-                  value: Replication
-                - tag: PVE
-                  value: '{#REPL_ID}'
-            - uuid: ec1159d285064fb99b747961b65a295a
-              name: 'Replication error {#REPL_ID}'
-              type: DEPENDENT
-              key: 'repl.error[{#REPL_ID}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Error message of the last failed run. Absent while the job is healthy, the value is then discarded instead of turning the item unsupported.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.id=="{#REPL_ID}")].error.first()'
-                  error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.replication.raw
-              tags:
-                - tag: PVE
-                  value: Replication
-                - tag: PVE
-                  value: '{#REPL_ID}'
-            - uuid: 8e1d7e7e6baf449192b2664314fd749a
-              name: 'Replication fail count {#REPL_ID}'
-              type: DEPENDENT
-              key: 'repl.fail_count[{#REPL_ID}]'
-              delay: '0'
-              history: 7d
-              value_type: FLOAT
-              description: 'Consecutive failures of this job. Absent before the first run.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.id=="{#REPL_ID}")].fail_count.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.replication.raw
-              tags:
-                - tag: PVE
-                  value: Replication
-                - tag: PVE
-                  value: '{#REPL_ID}'
-              trigger_prototypes:
-                - uuid: fea4a41ab7274895b1c16139bd723538
-                  expression: 'last(/Proxmox VE Node by REST API/repl.fail_count[{#REPL_ID}])>{$PVE.REPL.FAIL.MAX}'
-                  name: 'Replication job {#REPL_ID} failing on {HOST.NAME}'
-                  event_name: 'Replication job {#REPL_ID} failing: {?last(//repl.error[{#REPL_ID}])}'
-                  priority: AVERAGE
-                  description: 'PVE counts consecutive failures of this replication job. The event name carries the error message PVE reported for the last run.'
-            - uuid: 2e6541fdc04f44be9cd07871ba8647d9
-              name: 'Replication last sync {#REPL_ID}'
-              type: DEPENDENT
-              key: 'repl.last_sync[{#REPL_ID}]'
-              delay: '0'
-              value_type: FLOAT
-              trends: '0'
-              units: unixtime
-              description: 'Timestamp of the last successful sync. Absent before the first successful run.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.id=="{#REPL_ID}")].last_sync.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.replication.raw
-              tags:
-                - tag: PVE
-                  value: Replication
-                - tag: PVE
-                  value: '{#REPL_ID}'
-              trigger_prototypes:
-                - uuid: 1a817ea389f749eca3c025cfa0290bfe
-                  expression: 'fuzzytime(/Proxmox VE Node by REST API/repl.last_sync[{#REPL_ID}],{$PVE.REPL.LAG})=0'
-                  name: 'Replication job {#REPL_ID} has not synced for {$PVE.REPL.LAG}'
-                  priority: WARNING
-                  description: 'Last successful sync is older than {$PVE.REPL.LAG}. Raise the macro for jobs with a wide schedule, it must stay above the replication interval.'
-            - uuid: 2444dfedd7d047c485739195925b4e29
-              name: 'Replication last try {#REPL_ID}'
-              type: DEPENDENT
-              key: 'repl.last_try[{#REPL_ID}]'
-              delay: '0'
-              value_type: FLOAT
-              trends: '0'
-              units: unixtime
-              description: 'Timestamp of the last attempt, successful or not.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.id=="{#REPL_ID}")].last_try.first()'
-                  error_handler: DISCARD_VALUE
-              master_item:
-                key: pve.replication.raw
-              tags:
-                - tag: PVE
-                  value: Replication
-                - tag: PVE
-                  value: '{#REPL_ID}'
-          master_item:
-            key: pve.replication.raw
-          lld_macro_paths:
-            - lld_macro: '{#REPL_GUEST}'
-              path: $.guest
-            - lld_macro: '{#REPL_ID}'
-              path: $.id
-            - lld_macro: '{#REPL_TARGET}'
-              path: $.target
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
-              error_handler: CUSTOM_VALUE
-              error_handler_params: '[]'
-        - uuid: fa0d182630c144688682159e68e1edba
-          name: 'Discover storage'
-          type: DEPENDENT
-          key: discover.storage
-          delay: '0'
-          enabled_lifetime_type: DISABLE_AFTER
-          enabled_lifetime: 2d
-          item_prototypes:
-            - uuid: 1a4657a92c014216ac5ae940506975d0
-              name: 'Storage active status {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.active[{#STORAGE_NAME}]'
-              delay: '0'
-              history: 7d
-              description: 'Availability status of storage pool {#STORAGE_NAME}. 1 = active/available, 0 = inactive/not mounted.'
-              valuemap:
-                name: 'Storage active status'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].active.first()'
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-              trigger_prototypes:
-                - uuid: ef1d0e4ac74946eb88d5d06bd9cb9b67
-                  expression: 'min(/Proxmox VE Node by REST API/storage.active[{#STORAGE_NAME}],900)=0 and {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=1'
-                  name: 'Storage [{#STORAGE_NAME}] not available'
-                  priority: AVERAGE
-                  description: |
-                    Use the following host macros to control the "Storage not available" trigger for each storage:
-                    {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=1 enables the "Storage not available" trigger
-                    {$ENABLE_STORAGE_INACTIVE_ALERT:"{#STORAGE_NAME}"}=0 disables (suppresses) the "Storage not available" trigger
-            - uuid: 367ac90904914198b8696d9578542c51
-              name: 'Storage available {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.avail[{#STORAGE_NAME}]'
-              delay: '0'
-              history: 7d
-              units: Bytes
-              description: 'Free space available on storage pool {#STORAGE_NAME} in bytes. Source: /nodes/{node}/storage.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].avail.first()'
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-            - uuid: bc43ad91389e4d05949fb2001bc078e3
-              name: 'Storage content {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.content[{#STORAGE_NAME}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Content types supported by storage pool {#STORAGE_NAME} (e.g. images,backup,iso). Source: /nodes/{node}/storage → data[storage].content.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].content.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-            - uuid: 7f7c921aad664fc0a01ddd01b467d4e2
-              name: 'Storage type {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.name[{#STORAGE_NAME}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Storage backend type/driver of {#STORAGE_NAME} (e.g. dir, zfspool, lvm, nfs). Source: /nodes/{node}/storage → data[storage].type.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].type.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-            - uuid: a1eabf828c9c4218878486802f25b10b
-              name: 'Storage shared status {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.shared[{#STORAGE_NAME}]'
-              delay: '0'
-              trends: '0'
-              description: 'Indicates whether the storage {#STORAGE_NAME} is shared across the cluster (Shared = 1) or available only locally (Not Shared = 0).'
-              valuemap:
-                name: 'Storage shared status'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].shared.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-            - uuid: 5b24f6e722db4d56b54861e1ce9bba54
-              name: 'Storage total {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.size[{#STORAGE_NAME}]'
-              delay: '0'
-              history: 7d
-              units: Bytes
-              description: 'Total capacity of storage pool {#STORAGE_NAME} in bytes. Source: /nodes/{node}/storage.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].total.first()'
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-            - uuid: c63cf494a0414e70b14d3328fc690362
-              name: 'Storage used {#STORAGE_NAME}'
-              type: DEPENDENT
-              key: 'storage.used[{#STORAGE_NAME}]'
-              delay: '0'
-              history: 7d
-              units: Bytes
-              description: 'Used space on storage pool {#STORAGE_NAME} in bytes. Source: /nodes/{node}/storage.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.storage=="{#STORAGE_NAME}")].used.first()'
-              master_item:
-                key: pve.storage.raw
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-            - uuid: 488d0f54d2ab40079726991ac0558f26
-              name: 'Storage utilization {#STORAGE_NAME} (%)'
-              type: CALCULATED
-              key: 'storage.util[{#STORAGE_NAME}]'
-              delay: '60'
-              history: 7d
-              value_type: FLOAT
-              units: '%'
-              params: 'last(/{HOST.HOST}/storage.used[{#STORAGE_NAME}]) / last(/{HOST.HOST}/storage.size[{#STORAGE_NAME}]) * 100'
-              description: 'Storage utilization as percentage of total size.'
-              tags:
-                - tag: PVE
-                  value: Storage
-                - tag: PVE
-                  value: '{#STORAGE_NAME}'
-              trigger_prototypes:
-                - uuid: 085598f426c344bb92dbdc9e489ff307
-                  expression: 'last(/Proxmox VE Node by REST API/storage.util[{#STORAGE_NAME}]) > {$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"} and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
-                  name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} >{$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"}%)'
-                  opdata: 'Used: {ITEM.LASTVALUE1}'
-                  priority: HIGH
-                  description: |
-                    Storage utilization exceeded the critical threshold {$STORAGE.UTIL.CRIT}%.
-                    Use context macro {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=0 to suppress.
-                - uuid: 0288a8909ea64885a6cfcf2184d2667b
-                  expression: 'last(/Proxmox VE Node by REST API/storage.util[{#STORAGE_NAME}]) > {$STORAGE.UTIL.WARN:"{#STORAGE_NAME}"} and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
-                  name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} >{$STORAGE.UTIL.WARN:"{#STORAGE_NAME}"}%)'
-                  opdata: 'Used: {ITEM.LASTVALUE1}'
-                  priority: AVERAGE
-                  description: |
-                    Storage utilization exceeded the warning threshold {$STORAGE.UTIL.WARN}%.
-                    Use context macro {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=0 to suppress.
-                  dependencies:
-                    - name: 'High storage usage on {HOST.NAME} ({#STORAGE_NAME} >{$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"}%)'
-                      expression: 'last(/Proxmox VE Node by REST API/storage.util[{#STORAGE_NAME}]) > {$STORAGE.UTIL.CRIT:"{#STORAGE_NAME}"} and {$ENABLE_STORAGE_AVAILABLE_ALERT:"{#STORAGE_NAME}"}=1'
-          graph_prototypes:
-            - uuid: a847e130161449f2b25dbab05cea1eff
-              name: 'Storage active state {#STORAGE_NAME}'
-              graph_items:
-                - color: 00FF00
-                  calc_fnc: ALL
-                  item:
-                    host: 'Proxmox VE Node by REST API'
-                    key: 'storage.active[{#STORAGE_NAME}]'
-            - uuid: 0c4f3e988aa34cb4b01ec10034c6dd79
-              name: 'Storage usage {#STORAGE_NAME}'
-              yaxismax: '0'
-              show_work_period: 'NO'
-              show_triggers: 'NO'
-              type: EXPLODED
-              graph_items:
-                - color: 0040FF
-                  calc_fnc: LAST
-                  item:
-                    host: 'Proxmox VE Node by REST API'
-                    key: 'storage.used[{#STORAGE_NAME}]'
-                - sortorder: '1'
-                  color: 388E3C
-                  calc_fnc: LAST
-                  item:
-                    host: 'Proxmox VE Node by REST API'
-                    key: 'storage.avail[{#STORAGE_NAME}]'
-            - uuid: 548642fe23df4b6ab249aeea43240b48
-              name: 'Storage utilization % {#STORAGE_NAME}'
-              graph_items:
-                - color: E53935
-                  item:
-                    host: 'Proxmox VE Node by REST API'
-                    key: 'storage.util[{#STORAGE_NAME}]'
-          master_item:
-            key: pve.storage.raw
-          lld_macro_paths:
-            - lld_macro: '{#STORAGE_NAME}'
-              path: $.storage
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
-              error_handler: CUSTOM_VALUE
-              error_handler_params: '[]'
-        - uuid: 86716f0957ef407a989e62872f387448
-          name: 'Discover tasks'
-          type: DEPENDENT
-          key: discover.tasks
-          delay: '0'
-          filter:
-            conditions:
-              - macro: '{#TYPE}'
-                value: '.*\bvzdump\b.*'
-                operator: NOT_MATCHES_REGEX
-                formulaid: A
-          lifetime_type: DELETE_IMMEDIATELY
-          lifetime: '0'
-          item_prototypes:
-            - uuid: 019142c8682949208dc78347bfd3afc2
-              name: 'Task endtime {#TYPE} {#ID}'
-              type: DEPENDENT
-              key: 'task.endtime[{#GRPID},{#TYPE}]'
-              delay: '0'
-              trends: '0'
-              units: unixtime
-              description: 'Unix timestamp of the last end time for task type {#TYPE} on VM/CT {#GRPID}. Source: pve.tasks.raw.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].endtime.first()'
-                  error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.tasks.raw
-              tags:
-                - tag: PVE
-                  value: Tasks
-                - tag: vmid
-                  value: '{#GRPID}'
-            - uuid: 1cd2547e6faa43bcad9cad800978870d
-              name: 'Task message {#TYPE} {#ID}'
-              type: DEPENDENT
-              key: 'task.message[{#GRPID},{#TYPE}]'
-              delay: '0'
-              value_type: CHAR
-              trends: '0'
-              description: 'Status text of the last task of type {#TYPE} for VM/CT {#GRPID}, exactly as Proxmox VE reports it. A successful task reports OK, a failed one reports the error message itself. The numeric item Task Status maps only a fixed set of known texts, so this item carries the real cause of a failure.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].status.first()'
-                  error_handler: DISCARD_VALUE
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.tasks.raw
-              tags:
-                - tag: PVE
-                  value: Tasks
-                - tag: vmid
-                  value: '{#GRPID}'
-            - uuid: ed9ca245a6a14cf6b74f4de14203fdac
-              name: 'Task starttime {#TYPE} {#ID}'
-              type: DEPENDENT
-              key: 'task.starttime[{#GRPID},{#TYPE}]'
-              delay: '0'
-              trends: '0'
-              units: unixtime
-              description: 'Unix timestamp of the last start time for task type {#TYPE} on VM/CT {#GRPID}. Source: pve.tasks.raw.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].starttime.first()'
-                  error_handler: DISCARD_VALUE
-                - type: LTRIM
-                  parameters:
-                    - '["'
-                - type: RTRIM
-                  parameters:
-                    - '"]'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.tasks.raw
-              tags:
-                - tag: PVE
-                  value: Tasks
-                - tag: vmid
-                  value: '{#GRPID}'
-            - uuid: 759cf8e0fc9a450a8ace0d37b393db70
-              name: 'Task Status: {#TYPE} {#ID}'
-              type: DEPENDENT
-              key: 'task.status[{#GRPID},{#TYPE}]'
-              delay: '0'
-              trends: '0'
-              description: |
-                0. OK: All clear, no errors detected.
-                1. running: VM/CT is currently active.
-                2. stopped: VM/CT has been shut down.
-                3. error: General execution failure; check logs for details.
-                4. unexpected status: Returned state not anticipated by the script/API.
-                5. CT locked (disk): Container's disk is locked (e.g. during backup or migration).
-                6. timeout waiting on system: Operation exceeded its time limit and was aborted.
-                7. Failed to run vncproxy.: Unable to start the VNC proxy process.
-                8. unable to read tail (got 0 b): Failed to read log tail; zero bytes returned.
-                9. interrupted by signal: Process was terminated by a signal (e.g. SIGINT/SIGTERM).
-                10. unknown error: Cannot classify status, please check Proxmox for details
-              valuemap:
-                name: 'Tasks status'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.body.data[?(@.grpid=="{#GRPID}" && @.type=="{#TYPE}")].status.first()'
-                  error_handler: DISCARD_VALUE
-                - type: REGEX
-                  parameters:
-                    - '^(OK|running|stopped|error|unexpected status|CT is locked \(disk\)|timeout waiting on systemd|Failed to run vncproxy\.|unable to read tail \(got 0 bytes\)|interrupted by signal)$'
-                    - \0
-                  error_handler: CUSTOM_VALUE
-                  error_handler_params: '10'
-                - type: STR_REPLACE
-                  parameters:
-                    - OK
-                    - '0'
-                - type: STR_REPLACE
-                  parameters:
-                    - running
-                    - '1'
-                - type: STR_REPLACE
-                  parameters:
-                    - stopped
-                    - '2'
-                - type: STR_REPLACE
-                  parameters:
-                    - error
-                    - '3'
-                - type: STR_REPLACE
-                  parameters:
-                    - 'unexpected status'
-                    - '4'
-                - type: STR_REPLACE
-                  parameters:
-                    - 'CT is locked (disk)'
-                    - '5'
-                - type: STR_REPLACE
-                  parameters:
-                    - 'timeout waiting on systemd'
-                    - '6'
-                - type: STR_REPLACE
-                  parameters:
-                    - 'Failed to run vncproxy.'
-                    - '7'
-                - type: STR_REPLACE
-                  parameters:
-                    - 'unable to read tail (got 0 bytes)'
-                    - '8'
-                - type: STR_REPLACE
-                  parameters:
-                    - 'interrupted by signal'
-                    - '9'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.tasks.raw
-              tags:
-                - tag: PVE
-                  value: Tasks
-                - tag: vmid
-                  value: '{#GRPID}'
-          trigger_prototypes:
-            - uuid: 687c925cfc7545189a76f433492b9052
-              expression: 'last(/Proxmox VE Node by REST API/task.status[{#GRPID},{#TYPE}])>1 and {$ENABLE_TASK_ALERT:"{#GRPID}"}=1 and fuzzytime(/Proxmox VE Node by REST API/task.endtime[{#GRPID},{#TYPE}],{$TASK.ALERT.WINDOW})=1'
-              name: 'Proxmox task {#TYPE} {#ID} failed'
-              event_name: 'Proxmox task {#TYPE} {#ID} failed: {ITEM.VALUE}'
-              opdata: 'Current task status: {ITEM.LASTVALUE}'
-              priority: WARNING
-              description: |
-                A task of type {#TYPE} for VM/CT {#ID} finished with a status other than OK.
-                The problem clears as soon as a later task of the same id and type succeeds, and it expires on its own once the failure is older than {$TASK.ALERT.WINDOW}, because Proxmox VE only keeps the most recent tasks in its task list.
-                Use context macro to suppress per-task:
-                {$ENABLE_TASK_ALERT:"{#GRPID}"}=0 suppresses this trigger for a specific task.
-                {$ENABLE_TASK_ALERT}=0 disables all task failure alerts globally.
-              manual_close: 'YES'
-          graph_prototypes:
-            - uuid: b95ce02f2d0f4170a89762f91822c25a
-              name: 'Task status {#TYPE} {#ID}'
-              graph_items:
-                - color: 00897B
-                  calc_fnc: ALL
-                  item:
-                    host: 'Proxmox VE Node by REST API'
-                    key: 'task.status[{#GRPID},{#TYPE}]'
-          master_item:
-            key: pve.tasks.raw
-          lld_macro_paths:
-            - lld_macro: '{#GRPID}'
-              path: $.grpid
-            - lld_macro: '{#ID}'
-              path: $.id
-            - lld_macro: '{#TYPE}'
-              path: $.type
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.body.data[*]'
-              error_handler: CUSTOM_VALUE
-              error_handler_params: '[]'
-        - uuid: a2299a539f4b4bb883faf5454666d326
-          name: 'Discover ZFS pools'
-          type: DEPENDENT
-          key: discover.zfs.pools
-          delay: '0'
-          description: 'Discovers local ZFS pools. Yields nothing on nodes without ZFS. The master item needs Sys.Audit on / and turns unsupported with HTTP 403 otherwise.'
-          item_prototypes:
-            - uuid: a2cbf6a1215947098eec5ab28298a79a
-              name: 'ZFS pool allocated {#ZPOOL}'
-              type: DEPENDENT
-              key: 'zfs.alloc[{#ZPOOL}]'
-              delay: '0'
-              history: 7d
-              value_type: FLOAT
-              units: Bytes
-              description: 'Allocated bytes in the pool.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.name=="{#ZPOOL}")].alloc.first()'
-              master_item:
-                key: pve.zfs.raw
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-            - uuid: e033edf6a5d34bdf9783bf16a1160bf3
-              name: 'ZFS pool dedup ratio {#ZPOOL}'
-              type: DEPENDENT
-              key: 'zfs.dedup[{#ZPOOL}]'
-              delay: '0'
-              value_type: FLOAT
-              trends: '0'
-              description: 'Deduplication ratio, 1.0 when dedup is off.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.name=="{#ZPOOL}")].dedup.first()'
-              master_item:
-                key: pve.zfs.raw
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-            - uuid: 0085e84d5e534d009d99a9fe84aac2c7
-              name: 'ZFS pool fragmentation {#ZPOOL}'
-              type: DEPENDENT
-              key: 'zfs.frag[{#ZPOOL}]'
-              delay: '0'
-              history: 7d
-              value_type: FLOAT
-              units: '%'
-              description: 'Free space fragmentation in percent.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.name=="{#ZPOOL}")].frag.first()'
-              master_item:
-                key: pve.zfs.raw
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-            - uuid: 2614bfe6a3c54005ac46166fb716cb56
-              name: 'ZFS pool free {#ZPOOL}'
-              type: DEPENDENT
-              key: 'zfs.free[{#ZPOOL}]'
-              delay: '0'
-              history: 7d
-              value_type: FLOAT
-              units: Bytes
-              description: 'Free bytes in the pool.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.name=="{#ZPOOL}")].free.first()'
-              master_item:
-                key: pve.zfs.raw
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-            - uuid: a395322e603543199a1f40729402f5c2
-              name: 'ZFS pool health {#ZPOOL}'
-              type: DEPENDENT
-              key: 'zfs.health[{#ZPOOL}]'
-              delay: '0'
-              history: 7d
-              description: 'zpool health as a number so it can be graphed and used on a dashboard. 0 is ONLINE, everything above is a fault. The value map turns it back into the zpool wording.'
-              valuemap:
-                name: 'ZFS pool health'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.name=="{#ZPOOL}")].health.first()'
-                - type: STR_REPLACE
-                  parameters:
-                    - ONLINE
-                    - '0'
-                - type: STR_REPLACE
-                  parameters:
-                    - DEGRADED
-                    - '1'
-                - type: STR_REPLACE
-                  parameters:
-                    - FAULTED
-                    - '2'
-                - type: STR_REPLACE
-                  parameters:
-                    - OFFLINE
-                    - '3'
-                - type: STR_REPLACE
-                  parameters:
-                    - REMOVED
-                    - '4'
-                - type: STR_REPLACE
-                  parameters:
-                    - UNAVAIL
-                    - '5'
-                - type: STR_REPLACE
-                  parameters:
-                    - SUSPENDED
-                    - '6'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.zfs.raw
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-              trigger_prototypes:
-                - uuid: f38481047bc6466faee16f63542a52a7
-                  expression: 'last(/Proxmox VE Node by REST API/zfs.health[{#ZPOOL}])=1'
-                  name: 'ZFS pool {#ZPOOL} is DEGRADED on {HOST.NAME}'
-                  priority: AVERAGE
-                  description: 'The pool still serves data but has lost redundancy, so a second failure means data loss. Check /nodes/{node}/disks/zfs/{pool} for the failing vdev, the detail endpoint reports read, write and checksum errors per device.'
-                - uuid: 0f96b8da3e2a425694d1f52b968aa141
-                  expression: 'last(/Proxmox VE Node by REST API/zfs.health[{#ZPOOL}])>=2'
-                  name: 'ZFS pool {#ZPOOL} is not usable on {HOST.NAME}'
-                  event_name: 'ZFS pool {#ZPOOL} is {ITEM.VALUE1} on {HOST.NAME}'
-                  priority: HIGH
-                  description: 'The pool is FAULTED, OFFLINE, REMOVED, UNAVAIL or SUSPENDED, so it no longer serves data. DEGRADED is reported separately at a lower severity because the pool keeps running. Check /nodes/{node}/disks/zfs/{pool} for the failing vdev, the detail endpoint reports read, write and checksum errors per device.'
-            - uuid: bc93b908353e4dffbfcc1c490f466fbd
-              name: 'ZFS pool size {#ZPOOL}'
-              type: DEPENDENT
-              key: 'zfs.size[{#ZPOOL}]'
-              delay: '0'
-              history: 7d
-              value_type: FLOAT
-              units: Bytes
-              description: 'Total pool size in bytes.'
-              preprocessing:
-                - type: JSONPATH
-                  parameters:
-                    - '$.data[?(@.name=="{#ZPOOL}")].size.first()'
-                - type: DISCARD_UNCHANGED_HEARTBEAT
-                  parameters:
-                    - 1h
-              master_item:
-                key: pve.zfs.raw
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-            - uuid: 9bf2068742ca4a55981b0e398a5115ff
-              name: 'ZFS pool utilization {#ZPOOL}'
-              type: CALCULATED
-              key: 'zfs.util[{#ZPOOL}]'
-              delay: '300'
-              history: 7d
-              value_type: FLOAT
-              units: '%'
-              params: '100*last(//zfs.alloc[{#ZPOOL}])/last(//zfs.size[{#ZPOOL}])'
-              description: 'Allocated share of the pool. Calculated from alloc and size, PVE does not report a percentage.'
-              tags:
-                - tag: PVE
-                  value: ZFS
-                - tag: PVE
-                  value: '{#ZPOOL}'
-              trigger_prototypes:
-                - uuid: 59bd89d3aede483c950005cfc6ebb168
-                  expression: 'last(/Proxmox VE Node by REST API/zfs.util[{#ZPOOL}])>{$ZFS.UTIL.CRIT:"{#ZPOOL}"}'
-                  name: 'ZFS pool {#ZPOOL} usage above {$ZFS.UTIL.CRIT:"{#ZPOOL}"}% on {HOST.NAME}'
-                  priority: HIGH
-                  description: 'ZFS performance degrades sharply once a pool fills up. Keep pools below 80%.'
-                - uuid: 4037a5aac12246b2b4a0670482010837
-                  expression: 'last(/Proxmox VE Node by REST API/zfs.util[{#ZPOOL}])>{$ZFS.UTIL.WARN:"{#ZPOOL}"}'
-                  name: 'ZFS pool {#ZPOOL} usage above {$ZFS.UTIL.WARN:"{#ZPOOL}"}% on {HOST.NAME}'
-                  priority: AVERAGE
-                  description: 'ZFS performance degrades sharply once a pool fills up. Keep pools below 80%.'
-                  dependencies:
-                    - name: 'ZFS pool {#ZPOOL} usage above {$ZFS.UTIL.CRIT:"{#ZPOOL}"}% on {HOST.NAME}'
-                      expression: 'last(/Proxmox VE Node by REST API/zfs.util[{#ZPOOL}])>{$ZFS.UTIL.CRIT:"{#ZPOOL}"}'
-          trigger_prototypes:
-            - uuid: abe3b298885b44efbd1b856566a1aa51
-              expression: 'last(/Proxmox VE Node by REST API/zfs.frag[{#ZPOOL}])>{$ZFS.FRAG.WARN:"{#ZPOOL}"} and last(/Proxmox VE Node by REST API/zfs.util[{#ZPOOL}])>{$ZFS.FRAG.UTIL.MIN:"{#ZPOOL}"}'
-              name: 'ZFS pool {#ZPOOL} free space is fragmented on {HOST.NAME}'
-              priority: WARNING
-              description: 'Fragmentation describes the free space, not the stored data, so on its own it costs nothing. It starts to hurt once the pool is also fairly full, because the allocator then has to satisfy writes from ever smaller free segments. The trigger therefore requires both {$ZFS.FRAG.WARN} and {$ZFS.FRAG.UTIL.MIN} to be exceeded. Freeing space and removing old snapshots helps, defragmenting a zpool is not possible.'
-          master_item:
-            key: pve.zfs.raw
-          lld_macro_paths:
-            - lld_macro: '{#ZPOOL}'
-              path: $.name
-          preprocessing:
-            - type: JSONPATH
-              parameters:
-                - '$.data[*]'
-              error_handler: CUSTOM_VALUE
-              error_handler_params: '[]'
-      macros:
-        - macro: '{$BACKUP.ALERT.WINDOW}'
-          value: 24h
-          description: 'How long a failed backup keeps alerting. The problem clears earlier if a later backup of the same guest succeeds. The value must include a time unit, for example 24h or 2d.'
-        - macro: '{$DISK.MISSING.TIME}'
-          value: 3h
-          description: 'How long a disk may be absent from the Proxmox disk list before the missing disk trigger fires. The list is refreshed once per hour, so keep this well above 1h. The value must include a time unit.'
-        - macro: '{$DISK.TEMP.MAX}'
-          value: '60'
-          description: 'Temperature threshold for physical disks in degrees Celsius. Use the context form {$DISK.TEMP.MAX:"/dev/sda"} to raise it for a single disk.'
-        - macro: '{$DISK.WEAROUT.MIN}'
-          value: '20'
-          description: 'Minimum SSD wearout remaining (%) before triggering a warning. Default: 20%.'
-        - macro: '{$ENABLE_BACKUP_ALERT}'
-          value: '1'
-          description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
-        - macro: '{$ENABLE_STORAGE_AVAILABLE_ALERT}'
-          value: '1'
-          description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
-        - macro: '{$ENABLE_STORAGE_INACTIVE_ALERT}'
-          value: '1'
-          description: 'To enable this trigger set to 1, to disable alerts on this trigger set value to 0'
-        - macro: '{$ENABLE_TASK_ALERT}'
-          value: '1'
-          description: 'To enable task failure alerts set to 1. Use context macro {$ENABLE_TASK_ALERT:"{#GRPID}"}=0 to suppress alerts for individual tasks.'
-        - macro: '{$IFACE.ACTIVE.WINDOW}'
-          value: 7d
-          description: 'Lookback window for the network interface down trigger. The interface must have been active at least once within this period, otherwise it is treated as configured but never used and does not alert. The value must include a time unit (e.g. 7d, 24h).'
-        - macro: '{$IFACE.NOT_MATCHES}'
-          value: ^(tap|veth|fwbr|fwpr|fwln)
-          description: 'LLD filter: host network interface names to exclude (regex). The default drops the per-guest interfaces Proxmox creates for VMs and containers, which appear and disappear together with the guest.'
-        - macro: '{$MEMORY.UTIL.MAX}'
-          value: '90'
-          description: 'Warning threshold for memory utilization of the PVE host itself (%). Guest memory is not covered by this macro.'
-        - macro: '{$NODE.CPU.UTIL.MAX}'
-          value: '90'
-          description: 'Node CPU utilization (%) before the high CPU trigger fires. The threshold used to be hardcoded in the trigger expression.'
-        - macro: '{$PVE.APT.REPO.ERRORS.MAX}'
-          value: '0'
-          description: 'Tolerated number of unparsable APT repository files before alerting.'
-        - macro: '{$PVE.APT.REPO.WARN.MAX}'
-          value: '0'
-          description: 'Tolerated number of APT repository warnings. A host on the no-subscription repository permanently reports one warning, set this to 1 there.'
-        - macro: '{$PVE.APT.UPDATES.MAX}'
-          value: '0'
-          description: 'Tolerated number of pending package updates. Only relevant if the disabled apt/update items are switched on.'
-        - macro: '{$PVE.BACKUP.RUN.MAX}'
-          value: 3h
-          description: 'How long a backup may run before it is treated as stuck. The value must include a time unit, for example 3h or 90m, and must stay above the normal runtime of the longest job, otherwise the trigger fires during every regular run.'
-        - macro: '{$PVE.CERT.EXPIRE.DAYS}'
-          value: 21d
-          description: 'Lead time before certificate expiry. Must include a time unit, for example 21d.'
-        - macro: '{$PVE.REPL.FAIL.MAX}'
-          value: '0'
-          description: 'Tolerated consecutive failures of a replication job. Use the context form {$PVE.REPL.FAIL.MAX:"105-0"} for a single job.'
-        - macro: '{$PVE.REPL.LAG}'
-          value: 2h
-          description: 'Maximum age of the last successful replication. Must stay above the replication schedule, otherwise the trigger fires between two runs. Must include a time unit.'
-        - macro: '{$PVE.SERVICE.MATCHES}'
-          value: ^(pve-cluster|pvedaemon|pveproxy|pvestatd|pve-firewall|pvescheduler|pve-ha-crm|pve-ha-lrm)$
-          description: 'Services to discover. corosync is left out because it only runs on cluster members; add it there.'
-        - macro: '{$PVE.SERVICE.STATE.ALERT}'
-          value: '1'
-          description: 'Enables the service state trigger. Use the context form {$PVE.SERVICE.STATE.ALERT:"pveproxy"}=0 to silence a single service.'
-        - macro: '{$PVE.SUBSCRIPTION.ALERT}'
-          value: '0'
-          description: 'Set to 1 on hosts that are meant to carry a subscription. Off by default so community hosts do not alert on status notfound.'
-        - macro: '{$PVE.SUBSCRIPTION.EXPIRE.DAYS}'
-          value: 30d
-          description: 'Lead time before the subscription expires. Must include a time unit, for example 30d. The expiry triggers need no enable macro: hosts without a subscription report no due date, so the item stays empty.'
-        - macro: '{$PVE_API_TOKEN}'
-          type: SECRET_TEXT
-          description: 'The API token secret used to authenticate with the Proxmox VE REST API.'
-        - macro: '{$PVE_API_TOKEN_ID}'
-          value: Zabbix
-          description: 'The identifier (name) of the Proxmox VE API token.'
-        - macro: '{$PVE_API_USER}'
-          value: root@pam
-          description: 'The Proxmox VE username (including realm, e.g. "root@pam") for API authentication.'
-        - macro: '{$PVE_IP}'
-          value: localhost
-          description: 'The IP address or hostname of the Proxmox VE API server.'
-        - macro: '{$PVE_NODE}'
-          value: pve
-          description: 'The Proxmox VE node identifier (e.g. "pve") used in API endpoint paths.'
-        - macro: '{$PVE_PORT}'
-          value: '8006'
-          description: 'The TCP port number on which the Proxmox VE API listens (default: 8006).'
-        - macro: '{$ROOTFS.UTIL.CRIT}'
-          value: '95'
-          description: 'Critical threshold for root filesystem utilization (%).'
-        - macro: '{$ROOTFS.UTIL.WARN}'
-          value: '90'
-          description: 'Warning threshold for root filesystem utilization (%).'
-        - macro: '{$STORAGE.UTIL.CRIT}'
-          value: '90'
-          description: 'Critical threshold for storage utilization (%). Triggers when storage used exceeds this value.'
-        - macro: '{$STORAGE.UTIL.WARN}'
-          value: '80'
-          description: 'Warning threshold for storage utilization (%). Triggers when storage used exceeds this value.'
-        - macro: '{$SWAP.UTIL.MAX}'
-          value: '80'
-          description: 'Warning threshold for swap utilization of the PVE host (%). The trigger stays silent on hosts that have no swap configured.'
-        - macro: '{$TASK.ALERT.WINDOW}'
-          value: 1h
-          description: 'How long a failed task keeps alerting. The problem clears earlier if a later task of the same id and type succeeds. Proxmox VE only keeps the most recent tasks in its task list, so without this window a one-off failure would alert forever. The value must include a time unit, for example 1h or 30m.'
-        - macro: '{$ZFS.FRAG.UTIL.MIN}'
-          value: '70'
-          description: 'Pool usage (%) that must be reached before the fragmentation warning fires. Fragmented free space only costs write performance on a pool that is also filling up. Use the context form {$ZFS.FRAG.UTIL.MIN:"rpool"} per pool.'
-        - macro: '{$ZFS.FRAG.WARN}'
-          value: '60'
-          description: 'ZFS free space fragmentation (%) before warning. Use the context form {$ZFS.FRAG.WARN:"rpool"} per pool.'
-        - macro: '{$ZFS.UTIL.CRIT}'
-          value: '90'
-          description: 'ZFS pool usage (%) for the high severity trigger. Use the context form {$ZFS.UTIL.CRIT:"rpool"} per pool.'
-        - macro: '{$ZFS.UTIL.WARN}'
-          value: '80'
-          description: 'ZFS pool usage (%) for the average severity trigger. ZFS performance degrades noticeably above 80%.'
-      dashboards:
-        - uuid: b6525e87712e4f5daddd32156aff0551
-          name: 'Proxmox VE node'
-          auto_start: 'NO'
-          pages:
-            - name: Overview
-              widgets:
-                - type: item
-                  name: Uptime
-                  width: '18'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Proxmox VE Node by REST API'
-                        key: pve.uptime
-                    - type: INTEGER
-                      name: show.1
-                      value: '2'
-                    - type: INTEGER
-                      name: show.2
-                      value: '3'
-                - type: gauge
-                  name: 'CPU utilization'
-                  'y': '2'
-                  width: '24'
-                  height: '5'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Proxmox VE Node by REST API'
-                        key: pve.cpu.utilization
-                    - type: INTEGER
-                      name: max
-                      value: '100'
-                    - type: INTEGER
-                      name: min
-                      value: '0'
-                    - type: STRING
-                      name: thresholds.0.color
-                      value: FFBF59
-                    - type: STRING
-                      name: thresholds.0.threshold
-                      value: '80'
-                    - type: STRING
-                      name: thresholds.1.color
-                      value: E45959
-                    - type: STRING
-                      name: thresholds.1.threshold
-                      value: '90'
-                    - type: STRING
-                      name: units
-                      value: '%'
-                - type: svggraph
-                  name: 'CPU utilization'
-                  'y': '7'
-                  width: '36'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: ds.0.color
-                      value: 1976D2
-                    - type: STRING
-                      name: ds.0.items.0
-                      value: 'PVE CPU utilization'
-                    - type: INTEGER
-                      name: ds.0.type
-                      value: '0'
-                    - type: STRING
-                      name: reference
-                      value: PVOV1
-                - type: problems
-                  name: Problems
-                  'y': '13'
-                  width: '72'
-                  height: '8'
-                - type: item
-                  name: Kernel
-                  x: '18'
-                  width: '18'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Proxmox VE Node by REST API'
-                        key: pve.current.kernel
-                    - type: INTEGER
-                      name: show.1
-                      value: '2'
-                    - type: INTEGER
-                      name: show.2
-                      value: '3'
-                - type: gauge
-                  name: 'Memory utilization'
-                  x: '24'
-                  'y': '2'
-                  width: '24'
-                  height: '5'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Proxmox VE Node by REST API'
-                        key: pve.memory.util
-                    - type: INTEGER
-                      name: max
-                      value: '100'
-                    - type: INTEGER
-                      name: min
-                      value: '0'
-                    - type: STRING
-                      name: thresholds.0.color
-                      value: FFBF59
-                    - type: STRING
-                      name: thresholds.0.threshold
-                      value: '80'
-                    - type: STRING
-                      name: thresholds.1.color
-                      value: E45959
-                    - type: STRING
-                      name: thresholds.1.threshold
-                      value: '90'
-                    - type: STRING
-                      name: units
-                      value: '%'
-                - type: item
-                  name: 'Boot mode'
-                  x: '36'
-                  width: '18'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Proxmox VE Node by REST API'
-                        key: pve.system.boot.mode
-                    - type: INTEGER
-                      name: show.1
-                      value: '2'
-                    - type: INTEGER
-                      name: show.2
-                      value: '3'
-                - type: piechart
-                  name: Memory
-                  x: '36'
-                  'y': '7'
-                  width: '18'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: ds.0.color
-                      value: E45959
-                    - type: STRING
-                      name: ds.0.items.0
-                      value: 'PVE memory used'
-                    - type: STRING
-                      name: ds.1.color
-                      value: 00C48C
-                    - type: STRING
-                      name: ds.1.items.0
-                      value: 'PVE memory available'
-                - type: gauge
-                  name: 'Root filesystem'
-                  x: '48'
-                  'y': '2'
-                  width: '24'
-                  height: '5'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Proxmox VE Node by REST API'
-                        key: pve.rootfs.util
-                    - type: INTEGER
-                      name: max
-                      value: '100'
-                    - type: INTEGER
-                      name: min
-                      value: '0'
-                    - type: STRING
-                      name: thresholds.0.color
-                      value: FFBF59
-                    - type: STRING
-                      name: thresholds.0.threshold
-                      value: '80'
-                    - type: STRING
-                      name: thresholds.1.color
-                      value: E45959
-                    - type: STRING
-                      name: thresholds.1.threshold
-                      value: '90'
-                    - type: STRING
-                      name: units
-                      value: '%'
-                - type: item
-                  name: Subscription
-                  x: '54'
-                  width: '18'
-                  fields:
-                    - type: ITEM
-                      name: itemid.0
-                      value:
-                        host: 'Proxmox VE Node by REST API'
-                        key: pve.subscription.status
-                    - type: INTEGER
-                      name: show.1
-                      value: '2'
-                    - type: INTEGER
-                      name: show.2
-                      value: '3'
-                - type: piechart
-                  name: 'Root filesystem'
-                  x: '54'
-                  'y': '7'
-                  width: '18'
-                  height: '6'
-                  fields:
-                    - type: STRING
-                      name: ds.0.color
-                      value: E45959
-                    - type: STRING
-                      name: ds.0.items.0
-                      value: 'Disk rootfs used'
-                    - type: STRING
-                      name: ds.1.color
-                      value: 00C48C
-                    - type: STRING
-                      name: ds.1.items.0
-                      value: 'Disk rootfs avail'
             - name: 'Storage and disks'
               widgets:
                 - type: honeycomb
@@ -7438,7 +7058,265 @@ zabbix_export:
                     - type: STRING
                       name: thresholds.1.threshold
                       value: '60'
+            - name: 'Nodes and HA'
+              widgets:
+                - type: honeycomb
+                  name: 'Node status'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Node status *'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '1'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: PVE
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: Node
+                    - type: STRING
+                      name: primary_label
+                      value: '{ITEM.NAME}'
+                    - type: STRING
+                      name: reference
+                      value: PVND1
+                - type: item
+                  name: 'HA manager'
+                  'y': '6'
+                  width: '18'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template Proxmox VE REST API'
+                        key: pve.ha.manager.status
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: honeycomb
+                  name: 'HA local resource managers'
+                  'y': '8'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'HA LRM state on *'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '1'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: PVE
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: HA
+                    - type: STRING
+                      name: primary_label
+                      value: '{ITEM.NAME}'
+                    - type: STRING
+                      name: reference
+                      value: PVHA1
+                - type: item
+                  name: 'Nodes offline'
+                  x: '18'
+                  'y': '6'
+                  width: '18'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template Proxmox VE REST API'
+                        key: pve.cluster.nodes.offline
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: honeycomb
+                  name: 'HA resource states'
+                  x: '36'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'HA state of *'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '1'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: PVE
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: HA
+                    - type: STRING
+                      name: primary_label
+                      value: '{ITEM.NAME}'
+                    - type: STRING
+                      name: reference
+                      value: PVND2
+                - type: item
+                  name: Kernel
+                  x: '36'
+                  'y': '6'
+                  width: '18'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template Proxmox VE REST API'
+                        key: pve.current.kernel
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+                - type: item
+                  name: 'Boot mode'
+                  x: '54'
+                  'y': '6'
+                  width: '18'
+                  fields:
+                    - type: ITEM
+                      name: itemid.0
+                      value:
+                        host: 'Template Proxmox VE REST API'
+                        key: pve.system.boot.mode
+                    - type: INTEGER
+                      name: show.1
+                      value: '2'
+                    - type: INTEGER
+                      name: show.2
+                      value: '3'
+            - name: Ceph
+              widgets:
+                - type: honeycomb
+                  name: 'Ceph OSD status'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Ceph * status'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '1'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: Ceph
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: OSD
+                    - type: STRING
+                      name: primary_label
+                      value: '{ITEM.NAME}'
+                    - type: STRING
+                      name: reference
+                      value: PVCE2
+                - type: itemnavigator
+                  name: 'Browse Ceph items'
+                  'y': '6'
+                  width: '18'
+                  height: '14'
+                  fields:
+                    - type: INTEGER
+                      name: group_by.0.attribute
+                      value: '3'
+                    - type: STRING
+                      name: group_by.0.tag_name
+                      value: Ceph
+                    - type: STRING
+                      name: items.0
+                      value: '*'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '0'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: PVE
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: Ceph
+                    - type: STRING
+                      name: reference
+                      value: PVCE1
+                    - type: INTEGER
+                      name: show_lines
+                      value: '100'
+                - type: item
+                  name: 'Selected item'
+                  x: '18'
+                  'y': '6'
+                  width: '18'
+                  height: '4'
+                  fields:
+                    - type: STRING
+                      name: itemid._reference
+                      value: PVCE1._itemid
+                    - type: INTEGER
+                      name: show.1
+                      value: '1'
+                    - type: INTEGER
+                      name: show.2
+                      value: '2'
+                    - type: INTEGER
+                      name: show.3
+                      value: '3'
+                - type: honeycomb
+                  name: 'Ceph pool utilization'
+                  x: '36'
+                  width: '36'
+                  height: '6'
+                  fields:
+                    - type: STRING
+                      name: items.0
+                      value: 'Ceph pool * utilization'
+                    - type: INTEGER
+                      name: item_tags.0.operator
+                      value: '1'
+                    - type: STRING
+                      name: item_tags.0.tag
+                      value: Ceph
+                    - type: STRING
+                      name: item_tags.0.value
+                      value: Pool
+                    - type: STRING
+                      name: primary_label
+                      value: '{ITEM.NAME}'
+                    - type: STRING
+                      name: reference
+                      value: PVCE3
+                - type: graph
+                  name: 'History of selected item'
+                  x: '36'
+                  'y': '6'
+                  width: '36'
+                  height: '8'
+                  fields:
+                    - type: STRING
+                      name: itemid._reference
+                      value: PVCE1._itemid
+                    - type: INTEGER
+                      name: source_type
+                      value: '1'
       valuemaps:
+        - uuid: 4f48a8938054422b8cf484adaec102ee
+          name: 'Backup job enabled'
+          mappings:
+            - value: '0'
+              newvalue: disabled
+            - value: '1'
+              newvalue: enabled
         - uuid: eec173da961c4f238887a1f4e0356a3e
           name: 'Backup running'
           mappings:
@@ -7459,6 +7337,36 @@ zabbix_export:
               newvalue: error
             - value: '4'
               newvalue: 'unknown error'
+        - uuid: 7af954938cb343f5a57e5f6465b9fa81
+          name: 'Ceph availability'
+          mappings:
+            - value: '0'
+              newvalue: 'not available'
+            - value: '1'
+              newvalue: available
+        - uuid: 3a752a6c666e4e9186381ff4a376e9fd
+          name: 'Ceph health'
+          mappings:
+            - value: '0'
+              newvalue: HEALTH_OK
+            - value: '1'
+              newvalue: HEALTH_WARN
+            - value: '2'
+              newvalue: HEALTH_ERR
+        - uuid: 779243f27e904fc88afe2ded8e0a7830
+          name: 'Ceph OSD in'
+          mappings:
+            - value: '0'
+              newvalue: out
+            - value: '1'
+              newvalue: in
+        - uuid: 515e1541e4f644c7aab3d63cfabf134b
+          name: 'Ceph OSD status'
+          mappings:
+            - value: '0'
+              newvalue: down
+            - value: '1'
+              newvalue: up
         - uuid: 8eaed02478a54b538161d33d26c566e5
           name: 'Network interface active'
           mappings:
@@ -7473,6 +7381,15 @@ zabbix_export:
               newvalue: disabled
             - value: '1'
               newvalue: enabled
+        - uuid: dd3c4133c6ef47b5bcefc8e68eaeee27
+          name: 'Node status'
+          mappings:
+            - value: '0'
+              newvalue: offline
+            - value: '1'
+              newvalue: online
+            - value: '2'
+              newvalue: unknown
         - uuid: 0c2c3eccf2504239a1bb1d01c84aa41f
           name: 'PVE secureboot'
           mappings:
@@ -7519,6 +7436,24 @@ zabbix_export:
               newvalue: 'interrupted by signal'
             - value: '10'
               newvalue: 'unknown error'
+        - uuid: 6ce95767698f4713adfa2dcf4618d86b
+          name: 'User status'
+          mappings:
+            - value: '0'
+              newvalue: disabled
+            - value: '1'
+              newvalue: enabled
+        - uuid: 052ad39480884912aebd6a34a8c2ff51
+          name: 'VM  and LXC status'
+          mappings:
+            - value: '0'
+              newvalue: stopped
+            - value: '1'
+              newvalue: running
+            - value: '2'
+              newvalue: paused
+            - value: '3'
+              newvalue: unknown
         - uuid: 4edeb346d0d64155ad2e8063d7a4cab8
           name: 'ZFS pool health'
           mappings:
@@ -7537,81 +7472,81 @@ zabbix_export:
             - value: '6'
               newvalue: SUSPENDED
   triggers:
-    - uuid: 298e5b9546ae4affa7da313f24345dd0
-      expression: 'min(/Proxmox VE Node by REST API/pve.loadaverage.oneminute,900) >= last(/Proxmox VE Node by REST API/pve.cpus)'
+    - uuid: bdaeac3c76ec44ef96bf78ca83ba0dad
+      expression: 'min(/Template Proxmox VE REST API/pve.loadaverage.oneminute,900) >= last(/Template Proxmox VE REST API/pve.cpus)'
       name: 'High CPU average'
       opdata: 'Current cpu average: {ITEM.LASTVALUE1}'
       priority: WARNING
-    - uuid: d776d07e5a4a44c2adc9ec00e48d4775
-      expression: '(last(/Proxmox VE Node by REST API/pve.memory.used) / last(/Proxmox VE Node by REST API/pve.memory.total)) * 100 > {$MEMORY.UTIL.MAX}'
+    - uuid: d7b8381cedda4cd0bcb28053cd731ddf
+      expression: '(last(/Template Proxmox VE REST API/pve.memory.used) / last(/Template Proxmox VE REST API/pve.memory.total)) * 100 > {$MEMORY.UTIL.MAX}'
       name: 'High memory usage on {HOST.NAME} (>{$MEMORY.UTIL.MAX}%)'
       opdata: 'Memory used: {ITEM.LASTVALUE1}'
       priority: WARNING
-    - uuid: c6ab86e160c04bb9a65c960800ecdb3a
-      expression: '((last(/Proxmox VE Node by REST API/pve.rootfs.used) / last(/Proxmox VE Node by REST API/pve.rootfs.size)) * 100) > {$ROOTFS.UTIL.CRIT}'
+    - uuid: d621a5f2dbce40c5a96d7f5573ede065
+      expression: '((last(/Template Proxmox VE REST API/pve.rootfs.used) / last(/Template Proxmox VE REST API/pve.rootfs.size)) * 100) > {$ROOTFS.UTIL.CRIT}'
       name: 'High root filesystem usage on {HOST.NAME} (>{$ROOTFS.UTIL.CRIT}%)'
       opdata: 'Disk usage: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
       priority: HIGH
-    - uuid: dd19bc681d1d492397398e8cb0320bb1
-      expression: '((last(/Proxmox VE Node by REST API/pve.rootfs.used) / last(/Proxmox VE Node by REST API/pve.rootfs.size)) * 100) > {$ROOTFS.UTIL.WARN}'
+    - uuid: 6ec8009a0c62481d85fb57b7eb83e6f2
+      expression: '((last(/Template Proxmox VE REST API/pve.rootfs.used) / last(/Template Proxmox VE REST API/pve.rootfs.size)) * 100) > {$ROOTFS.UTIL.WARN}'
       name: 'High root filesystem usage on {HOST.NAME} (>{$ROOTFS.UTIL.WARN}%)'
       opdata: 'Disk usage: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
       priority: AVERAGE
       dependencies:
         - name: 'High root filesystem usage on {HOST.NAME} (>{$ROOTFS.UTIL.CRIT}%)'
-          expression: '((last(/Proxmox VE Node by REST API/pve.rootfs.used) / last(/Proxmox VE Node by REST API/pve.rootfs.size)) * 100) > {$ROOTFS.UTIL.CRIT}'
-    - uuid: cd414163ecbb49f8ba059c9e9fd15677
+          expression: '((last(/Template Proxmox VE REST API/pve.rootfs.used) / last(/Template Proxmox VE REST API/pve.rootfs.size)) * 100) > {$ROOTFS.UTIL.CRIT}'
+    - uuid: e63733b354ef41c4aa800990b8f2ae73
       expression: |
-        last(/Proxmox VE Node by REST API/pve.swap.total)>0
-        and last(/Proxmox VE Node by REST API/pve.swap.used) / last(/Proxmox VE Node by REST API/pve.swap.total) * 100 > {$SWAP.UTIL.MAX}
+        last(/Template Proxmox VE REST API/pve.swap.total)>0
+        and last(/Template Proxmox VE REST API/pve.swap.used) / last(/Template Proxmox VE REST API/pve.swap.total) * 100 > {$SWAP.UTIL.MAX}
       name: 'High swap usage on {HOST.NAME} (>{$SWAP.UTIL.MAX}%)'
       opdata: 'Swap used: {ITEM.LASTVALUE1} of {ITEM.LASTVALUE2}'
       priority: WARNING
       description: 'Swap on the PVE host is filling up. The first condition keeps the trigger silent on hosts without swap instead of turning it unsupported.'
       manual_close: 'YES'
     - uuid: 429391e580264ef398145055ff85100a
-      expression: 'last(/Proxmox VE Cluster by REST API/pve.cluster.vms.running)<last(/Proxmox VE Cluster by REST API/pve.cluster.vms.total)'
+      expression: '{$PVE.DATACENTER.COLLECT}=1 and (last(/Template Proxmox VE REST API/pve.cluster.vms.running)<last(/Template Proxmox VE REST API/pve.cluster.vms.total))'
       name: '{ITEM.LASTVALUE} of {?last(//pve.cluster.vms.total)} VMs/LXC running'
       priority: INFO
       description: 'One or more VMs or LXC containers are not in running state.'
       manual_close: 'YES'
   graphs:
-    - uuid: 42635f8a35574da09b6d3f0b5b5c17fb
+    - uuid: bbdef5c2775146b4ad30ac91ad877624
       name: 'Load average'
       type: STACKED
       graph_items:
         - color: 1A7C11
           calc_fnc: MIN
           item:
-            host: 'Proxmox VE Node by REST API'
+            host: 'Template Proxmox VE REST API'
             key: pve.loadaverage.oneminute
         - sortorder: '1'
           color: '274482'
           calc_fnc: MIN
           item:
-            host: 'Proxmox VE Node by REST API'
+            host: 'Template Proxmox VE REST API'
             key: pve.loadaverage.fiveminute
         - sortorder: '2'
           color: 9C27B0
           calc_fnc: MIN
           item:
-            host: 'Proxmox VE Node by REST API'
+            host: 'Template Proxmox VE REST API'
             key: pve.loadaverage.fifteen
-    - uuid: c90ade9ed259462a8df2d6749c65077e
+    - uuid: 0fc25cb79f674267825c8f5c3e87869e
       name: 'PVE Memory utilization'
       graph_items:
         - color: 2E7D32
           calc_fnc: ALL
           item:
-            host: 'Proxmox VE Node by REST API'
+            host: 'Template Proxmox VE REST API'
             key: pve.memory.total
         - sortorder: '1'
           color: 1565C0
           calc_fnc: ALL
           item:
-            host: 'Proxmox VE Node by REST API'
+            host: 'Template Proxmox VE REST API'
             key: pve.memory.used
-    - uuid: b2293f0e41694d8fad82c7af3069872d
+    - uuid: bb1b46e208df4f429e6e28e9c6627687
       name: 'Rootfs usage'
       yaxismax: '0'
       show_work_period: 'NO'
@@ -7621,11 +7556,11 @@ zabbix_export:
         - color: 0040FF
           calc_fnc: MIN
           item:
-            host: 'Proxmox VE Node by REST API'
+            host: 'Template Proxmox VE REST API'
             key: pve.rootfs.used
         - sortorder: '1'
           color: 388E3C
           calc_fnc: MIN
           item:
-            host: 'Proxmox VE Node by REST API'
+            host: 'Template Proxmox VE REST API'
             key: pve.rootfs.avail


### PR DESCRIPTION
Update of the existing template in `Virtualization/template_proxmox-ve-rest-api-zabbix/7.0/`.

One template as before: `Template Proxmox VE REST API`, same UUID, same description. Every existing UUID and item key is unchanged, so an import updates the template in place and keeps the history.

## New
- Ceph: health, OSDs, monitors, managers, PGs, capacity, IO, per OSD and per pool discovery. PVE answers Ceph calls with HTTP 500 while Ceph is not set up; a gate discovery creates Ceph items only when a status is returned.
- HA local resource manager discovery; triggers for a dead CRM, time drift, dead or unreadable LRM, maintenance mode, resources in fence or recovery.
- SDN zone discovery (PVE 9).
- `{$PVE.DATACENTER.PAUSE}` for clusters: set `1-7,00:00-24:00` on all node hosts but one. The datacenter-wide requests carry the flexible interval `0/{$PVE.DATACENTER.PAUSE}`, so guests, HA, backup jobs, users, SDN and Ceph are not requested at all there instead of once per node.
- `{$PVE.GUEST.DETAIL.INTERVAL}` and `{$PVE.GUEST.DETAIL.VMID.MATCHES}` limit the per guest status request via LLD override.
- CPU I/O wait of the node, from `/nodes/{node}/status`, which is fetched anyway.

## Less load
- Storage, services, tasks and the running backup check poll every 5 minutes instead of every minute. Measured on a live PVE 9, `/nodes/{node}/storage` alone takes 1.4 s per call.
- Values that rarely change are only stored when they change. A heartbeat is kept only where graphs, `count()` over a window or `change()` triggers need it.
- Numeric history is 7 days, trends stay at 365 days.

## Fixed
- "PVE API not reachable" never fired (nodata() on an item without history).
- Backup discovery read the plain task list (only the 50 most recent tasks); now `typefilter=vzdump`.
- HTTP items without timeout fell back to 3 s, too short for `/nodes/{node}/disks/list`.
- Every discovery rule turned unsupported on an empty list.
- Subscription expiry triggers stayed UNKNOWN without a subscription.
- backup.status "unknown error" was mangled and the failure trigger went silent.
- node.status "unknown" made the item unsupported.
- disk.temp lost its DISCARD_VALUE handler; disk.health UNKNOWN / SMART Disabled raised a false SMART failure.
- Guest detail items used `{$PVE_NODE}` instead of the discovered `{#NODE}`, so guests on other nodes never got values.
- VM and LXC stopped triggers were inverted against each other.

Verified on Zabbix 7.0.30 against a live Proxmox VE 9 API, the same API with the datacenter data paused, and a mock for Ceph and HA.
