### PR TITLE
HP A5120: update SNMPv3 template for Zabbix 7.0

### DIFF
--- a/Network_Devices/HP/template_hp_a5120_switch_snmp_v3/7.0/README.md
+++ b/Network_Devices/HP/template_hp_a5120_switch_snmp_v3/7.0/README.md
@@ -1,0 +1,177 @@
+# HP A5120
+
+## Overview
+
+Template for HP A5120 switch with SNMP v3 authPriv.
+
+
+Included items:
+
+
+* CPU usage
+* Memory usage
+* Temperature
+* Fan status
+* PSU status
+* Device name, location, description, contact details
+* Interface discovery: bandwidth in/out (64-bit counters), speed, admin/operational status, CRC errors
+* Link down trigger: only fires when an interface goes from up to down while admin status is up. Interfaces that are already down or shut down by an administrator are ignored.
+* High bandwidth usage trigger: 15-minute average in or out > `{$IF.UTIL.MAX}`% (default 90%) of interface speed.
+
+
+No links to other templates.
+
+
+I use SNMP V3 with authPriv security level, SHA authentication protocol, AES privacy protocol.
+
+
+It is required to fill these variables with correct values using host macros and reference them in the SNMP interface of the host.
+
+
+* Security name: {$SNMP\_V3\_USER}
+* Authentication passphrase: {$SNMP\_V3\_AUTHPASSPHRASE}
+* Privacy passphrase: {$SNMP\_V3\_PRIVPASSPHRASE}
+
+
+ Created on Zabbix 3.0, updated for Zabbix 7.0.
+
+## Tested on
+
+Successfully tested on:
+
+* Device: HP A5120-48G EI
+* Zabbix version: 7.0.29
+
+## Interface monitoring
+
+All interface data (ifDescr, ifType, ifAdminStatus, ifOperStatus, ifName, ifHCInOctets, ifHCOutOctets,
+ifHighSpeed, ifAlias) is collected by one master item `net.if.walk` (SNMP `walk[]`, bulk request, every 1m).
+Discovery and all per-interface items are dependent items of this master item, so the admin status and
+the operational status of an interface always come from the same poll.
+
+Interfaces are filtered by ifType with macro `{$NET.IF.IFTYPE.MATCHES}`:
+
+* `6` = ethernetCsmacd (GigabitEthernet, Ten-GigabitEthernet)
+* `136` = l3ipvlan (Vlan-interface)
+* `161` = ieee8023adLag (Bridge-Aggregation)
+
+Default: `^(6|136|161)$`.
+
+### VLAN interfaces
+
+Interfaces whose ifType matches `{$NET.IF.NO_TRAFFIC.IFTYPE.MATCHES}` (default `^136$` = Vlan-interface)
+are monitored for **status only** (admin status, operational status, link down trigger).
+An LLD override disables for them:
+
+* items: Bits received, Bits sent, Speed, CRC errors
+* triggers: High bandwidth usage, CRC errors
+* graph: Network traffic
+
+To also monitor bandwidth on Vlan-interfaces, set `{$NET.IF.NO_TRAFFIC.IFTYPE.MATCHES}` to a value that
+matches nothing, for example `^$`.
+
+### Link down
+
+The link down trigger fires only when all of these are true:
+
+* admin status is `up` (1), the port is not shut down by an administrator
+* the previous operational status was `up` (1)
+* the current operational status is `down` (2)
+
+If an interface is already down when it is discovered or when the template is linked, no alert is raised.
+If an administrator shuts the port down (`shutdown`), no alert is raised.
+The problem is resolved when the interface is no longer down, or when it is shut down by an administrator.
+
+To disable the link down trigger for one interface, add a host macro with context, for example
+`{$IFCONTROL:"GigabitEthernet1/0/24"}` = `0`.
+
+### High bandwidth usage
+
+The trigger fires when the 15-minute average of inbound **or** outbound traffic is above
+`{$IF.UTIL.MAX}`% (default `90`) of the interface speed (`ifHighSpeed`).
+It is resolved when both directions drop below `{$IF.UTIL.MAX}` - 3 %.
+Interfaces reporting speed 0 are ignored.
+
+The threshold can be changed per interface, for example `{$IF.UTIL.MAX:"Ten-GigabitEthernet1/1/1"}` = `80`.
+
+## Changes for Zabbix 7.0
+
+* Export format `7.0` (`template_groups`, no `date` field).
+* Discovery uses bulk `walk[]` + `SNMP_WALK_TO_JSON` preprocessing instead of legacy `discovery[]`.
+* Removed positional macro `$1` in item prototype name (not supported since Zabbix 6.0).
+* Fixed memory trigger (it was checking CPU item instead of memory).
+* CRC item now uses `EtherLike-MIB::dot3StatsFCSErrors` (previously `dot3StatsAlignmentErrors`).
+* Temperature trigger hysteresis uses recovery expression instead of `{TRIGGER.VALUE}`.
+* `Application` tags replaced by `component` tags, `scope` tags added on triggers.
+* Value map `HH3C-LSW-DEV-ADM-MIB::DevStatus` for fan / power supply status.
+* Deprecated `{HOSTNAME}` macro replaced by `{HOST.NAME}`.
+* Removed item `Power Supply Sensor` (it polled the same OID as `Internal Power Supply 1`).
+* Added triggers for fan and power supply status `deactive` (value 2). `not-install` (value 3) does not raise an alert.
+* Added interface bandwidth (bits received / sent), speed, admin and operational status, traffic graph per interface.
+* Added link down trigger (up to down, admin status up) and high bandwidth usage trigger.
+* Vlan-interfaces are discovered by default, status only (LLD override excludes bandwidth, speed and CRC).
+
+
+
+## Author
+
+Jakub Samek
+
+## Macros used
+
+|Name|Description|Default|
+|----|-----------|-------|
+|{$IF.UTIL.MAX}|<p>Bandwidth usage threshold in % of interface speed (15-minute average, inbound or outbound). Override per interface with context, e.g. {$IF.UTIL.MAX:"Ten-GigabitEthernet1/1/1"}=80.</p>|`90`|
+|{$IFCONTROL}|<p>Link down trigger: 1 = enabled, 0 = disabled. Override per interface with context, e.g. {$IFCONTROL:"GigabitEthernet1/0/1"}=0.</p>|`1`|
+|{$NET.IF.IFTYPE.MATCHES}|<p>Regex of ifType values to discover. 6 = ethernetCsmacd, 136 = l3ipvlan (Vlan-interface), 161 = ieee8023adLag (Bridge-Aggregation).</p>|`^(6|136|161)$`|
+|{$NET.IF.NO_TRAFFIC.IFTYPE.MATCHES}|<p>Regex of ifType values that are discovered for status only: no bandwidth, speed, CRC items and no bandwidth / CRC triggers. Default 136 = l3ipvlan (Vlan-interface).</p>|`^136$`|
+
+## Template links
+
+There are no template links in this template.
+
+## Discovery rules
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|Network interfaces discovery|<p>Discovers interfaces from IF-MIB (ifDescr, ifName, ifAlias, ifType). Interfaces are filtered by ifType using macro {$NET.IF.IFTYPE.MATCHES}.</p>|`Dependent item`|net.if.discovery<p>Master item: net.if.walk</p>|
+
+
+## Items collected
+
+|Name|Description|Type|Key and additional info|
+|----|-----------|----|----|
+|Device location|<p>The physical location of this node (e.g., `telephone closet, 3rd floor'). If the location is unknown, the value is the zero-length string.</p>|`SNMP agent`|sysLocation<p>Update: 1h</p>|
+|Device name|<p>An administratively-assigned name for this managed node. By convention, this is the node's fully-qualified domain name. If the name is unknown, the value is the zero-length string.</p>|`SNMP agent`|sysName<p>Update: 1h</p>|
+|Device contact details|<p>The textual identification of the contact person for this managed node, together with information on how to contact this person. If no contact information is known, the value is the zero-length string.</p>|`SNMP agent`|sysContact<p>Update: 1h</p>|
+|Internal Power Supply 1|<p>-</p>|`SNMP agent`|Int.Power.Supply1<p>Update: 1m</p>|
+|Device description|<p>A textual description of the entity. This value should include the full name and version identification of the system's hardware type, software operating-system, and networking software.</p>|`SNMP agent`|sysDescr<p>Update: 1h</p>|
+|Memory usage|<p>-</p>|`SNMP agent`|switch.memory<p>Update: 1m</p>|
+|CPU usage|<p>-</p>|`SNMP agent`|switch.cpu<p>Update: 1m</p>|
+|SysUptime|<p>-</p>|`SNMP agent`|SysUptime<p>Update: 5m</p>|
+|External Power Supply 1|<p>-</p>|`SNMP agent`|Ext.Power.Supply<p>Update: 1m</p>|
+|Switch Temperature|<p>-</p>|`SNMP agent`|switch.temp<p>Update: 1m</p>|
+|Fan 1|<p>-</p>|`SNMP agent`|fan1.status<p>Update: 1m</p>|
+|Network interfaces: SNMP walk|<p>Master item: collects IF-MIB interface data in one bulk request. History is not stored.</p>|`SNMP agent`|net.if.walk<p>Update: 1m</p>|
+|Interface {#IFNAME}({#IFALIAS}): Admin status|<p>IF-MIB::ifAdminStatus - the desired (configured) state of the interface. down = shutdown by administrator.</p>|`Dependent item`|net.if.adminstatus[ifAdminStatus.{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFALIAS}): Operational status|<p>IF-MIB::ifOperStatus - the current operational state of the interface.</p>|`Dependent item`|net.if.status[ifOperStatus.{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFALIAS}): Bits received|<p>IF-MIB::ifHCInOctets - incoming traffic on the interface (64-bit counter).</p>|`Dependent item`|net.if.in[ifHCInOctets.{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFALIAS}): Bits sent|<p>IF-MIB::ifHCOutOctets - outgoing traffic on the interface (64-bit counter).</p>|`Dependent item`|net.if.out[ifHCOutOctets.{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFALIAS}): Speed|<p>IF-MIB::ifHighSpeed - current bandwidth of the interface (reported in Mbps, converted to bps).</p>|`Dependent item`|net.if.speed[ifHighSpeed.{#SNMPINDEX}]<p>LLD</p>|
+|Interface {#IFNAME}({#IFALIAS}): CRC errors|<p>EtherLike-MIB::dot3StatsFCSErrors - frames received that failed the FCS (CRC) check.</p>|`SNMP agent`|CRC.Errors[{#SNMPINDEX}]<p>Update: 2m</p><p>LLD</p>|
+
+
+## Triggers
+
+|Name|Description|Expression|Priority|
+|----|-----------|----------|--------|
+|CPU usage on {HOST.NAME} > 80%|<p>-</p>|<p>**Expression**: last(/HP A5120/switch.cpu)>80</p><p>**Recovery expression**: </p>|high|
+|Memory usage on {HOST.NAME} > 80%|<p>-</p>|<p>**Expression**: last(/HP A5120/switch.memory)>80</p><p>**Recovery expression**: </p>|high|
+|Temperature on {HOST.NAME} is > 45°C|<p>Temperature too high! Problem resolves when the temperature drops to 40°C or below.</p>|<p>**Expression**: last(/HP A5120/switch.temp)>45</p><p>**Recovery expression**: last(/HP A5120/switch.temp)<=40</p>|high|
+|External Power Supply 1 on {HOST.NAME} is deactive|<p>The external power supply is installed but not working (status: deactive).</p>|<p>**Expression**: last(/HP A5120/Ext.Power.Supply)=2</p><p>**Recovery expression**: </p>|high|
+|Fan 1 on {HOST.NAME} is deactive|<p>The fan is installed but not working (status: deactive).</p>|<p>**Expression**: last(/HP A5120/fan1.status)=2</p><p>**Recovery expression**: </p>|high|
+|Internal Power Supply 1 on {HOST.NAME} is deactive|<p>The internal power supply is installed but not working (status: deactive).</p>|<p>**Expression**: last(/HP A5120/Int.Power.Supply1)=2</p><p>**Recovery expression**: </p>|high|
+|{HOST.NAME} has been restarted (uptime < 10m)|<p>-</p>|<p>**Expression**: last(/HP A5120/SysUptime)<10m</p><p>**Recovery expression**: </p>|info|
+|Interface {#IFNAME}({#IFALIAS}): Link down (LLD)|<p>The interface changed from up to down while its admin status is up (not shutdown). Interfaces that were already down, or that were shut down by an administrator, are ignored.</p>|<p>**Expression**: {$IFCONTROL:"{#IFNAME}"}=1 and last(/HP A5120/net.if.adminstatus[ifAdminStatus.{#SNMPINDEX}])=1 and last(/HP A5120/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and last(/HP A5120/net.if.status[ifOperStatus.{#SNMPINDEX}],#2)=1</p><p>**Recovery expression**: last(/HP A5120/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or last(/HP A5120/net.if.adminstatus[ifAdminStatus.{#SNMPINDEX}])=2 or {$IFCONTROL:"{#IFNAME}"}=0</p>|average|
+|Interface {#IFNAME}({#IFALIAS}): High bandwidth usage (>{$IF.UTIL.MAX:"{#IFNAME}"}%) (LLD)|<p>The 15-minute average of inbound or outbound traffic exceeds {$IF.UTIL.MAX:"{#IFNAME}"}% of the interface speed. The problem is resolved when both directions drop below ({$IF.UTIL.MAX:"{#IFNAME}"} - 3)%.</p>|<p>**Expression**: (avg(/HP A5120/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/HP A5120/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) or avg(/HP A5120/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/HP A5120/net.if.speed[ifHighSpeed.{#SNMPINDEX}])) and last(/HP A5120/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0</p><p>**Recovery expression**: avg(/HP A5120/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/HP A5120/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) and avg(/HP A5120/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/HP A5120/net.if.speed[ifHighSpeed.{#SNMPINDEX}])</p>|warning|
+|Interface {#IFNAME}({#IFALIAS}): CRC errors on {HOST.NAME} (LLD)|<p>A Cyclic Redundancy Check (CRC) are a hash function designed to detect accidental changes to raw computer data. A CRC is a short binary sequence present on each block of data. When a block of data is read or received, the device repeats the calculation to check for a match. If the new CRC does not match the original CRC, then a data error is logged and the device can attempt to correct the data error by re-reading or requesting the block of data.</p>|<p>**Expression**: change(/HP A5120/CRC.Errors[{#SNMPINDEX}])>1</p><p>**Recovery expression**: </p>|average|

--- a/Network_Devices/HP/template_hp_a5120_switch_snmp_v3/7.0/template_hp_a5120_switch_snmp_v3.yaml
+++ b/Network_Devices/HP/template_hp_a5120_switch_snmp_v3/7.0/template_hp_a5120_switch_snmp_v3.yaml
@@ -1,0 +1,604 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 59ecf1b9ff1643f9bafae26e6fa2de0b
+      name: 'Template Switches'
+  templates:
+    - uuid: 3ca956ad30bb44bcb26e2ae7bad0cf17
+      template: 'HP A5120'
+      name: 'HP A5120'
+      description: |
+        ## Overview
+
+        Template for HP A5120 switch with SNMP v3 authPriv.
+
+        Included items:
+
+        * CPU usage
+        * Memory usage
+        * Temperature
+        * Fan status
+        * PSU sensor
+        * Device name, location, description, contact details
+        * Interface discovery: bandwidth in/out (64-bit counters), speed, admin/operational status, CRC errors
+        * Link down trigger: only fires when an interface goes from up to down while admin status is up.
+          Interfaces that are already down or shut down by an administrator are ignored.
+        * High bandwidth usage trigger: 15-minute average in or out > {$IF.UTIL.MAX}% (default 90%) of interface speed.
+
+        No links to other templates.
+
+        Interfaces are filtered by ifType with macro {$NET.IF.IFTYPE.MATCHES}
+        (default: 6 = ethernetCsmacd, 136 = l3ipvlan / Vlan-interface, 161 = ieee8023adLag / Bridge-Aggregation).
+        Interfaces matching {$NET.IF.NO_TRAFFIC.IFTYPE.MATCHES} (default: 136 = Vlan-interface) are monitored
+        for status / link down only: no bandwidth, speed and CRC items, triggers and graphs.
+        Link down trigger can be disabled per interface with {$IFCONTROL:"<ifName>"}=0.
+        Bandwidth threshold can be changed per interface with {$IF.UTIL.MAX:"<ifName>"}.
+
+        I use SNMP V3 with authPriv security level, SHA authentication protocol, AES privacy protocol.
+
+        It is required to fill these variables with correct values using host macros
+        and reference them in the SNMP interface of the host:
+
+        * Security name: {$SNMP_V3_USER}
+        * Authentication passphrase: {$SNMP_V3_AUTHPASSPHRASE}
+        * Privacy passphrase: {$SNMP_V3_PRIVPASSPHRASE}
+
+        Created on Zabbix 3.0, updated for Zabbix 7.0.
+
+        ## Author
+
+        Jakub Samek
+      groups:
+        - name: 'Template Switches'
+      items:
+        - uuid: 9db93e32acd94a8693c2918af1038b60
+          name: 'External Power Supply 1'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.25506.8.35.9.1.2.1.2.2
+          key: Ext.Power.Supply
+          history: 7d
+          valuemap:
+            name: 'HH3C-LSW-DEV-ADM-MIB::DevStatus'
+          tags:
+            - tag: component
+              value: power-supply
+          triggers:
+            - uuid: 334d09ff429940e38d10d0e38ffeda40
+              expression: 'last(/HP A5120/Ext.Power.Supply)=2'
+              name: 'External Power Supply 1 on {HOST.NAME} is deactive'
+              priority: HIGH
+              description: 'The external power supply is installed but not working (status: deactive).'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: a87e25dd955442ae80f7704a4c3d3bbe
+          name: 'Fan 1'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.25506.8.35.9.1.1.1.2.1
+          key: fan1.status
+          history: 7d
+          valuemap:
+            name: 'HH3C-LSW-DEV-ADM-MIB::DevStatus'
+          tags:
+            - tag: component
+              value: fan
+          triggers:
+            - uuid: bae635a4c8f545019e72546a971df6db
+              expression: 'last(/HP A5120/fan1.status)=2'
+              name: 'Fan 1 on {HOST.NAME} is deactive'
+              priority: HIGH
+              description: 'The fan is installed but not working (status: deactive).'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: ea46109a13b541a79f3ea5650f81813c
+          name: 'Internal Power Supply 1'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.25506.8.35.9.1.2.1.2.1
+          key: Int.Power.Supply1
+          history: 7d
+          valuemap:
+            name: 'HH3C-LSW-DEV-ADM-MIB::DevStatus'
+          tags:
+            - tag: component
+              value: power-supply
+          triggers:
+            - uuid: e61aeb792a76448ea1c232b7e2145dfe
+              expression: 'last(/HP A5120/Int.Power.Supply1)=2'
+              name: 'Internal Power Supply 1 on {HOST.NAME} is deactive'
+              priority: HIGH
+              description: 'The internal power supply is installed but not working (status: deactive).'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: 8a412495c85e4b11b9ad239541bd2dfd
+          name: 'CPU usage'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.25506.2.6.1.1.1.1.6.30
+          key: switch.cpu
+          history: 7d
+          units: '%'
+          tags:
+            - tag: component
+              value: cpu
+          triggers:
+            - uuid: 09f05f8997004b2088d1a85fbf54982f
+              expression: 'last(/HP A5120/switch.cpu)>80'
+              name: 'CPU usage on {HOST.NAME} > 80%'
+              priority: HIGH
+              tags:
+                - tag: scope
+                  value: performance
+        - uuid: 20bc550de0474c768e070ae0ca41d8f1
+          name: 'Memory usage'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.25506.2.6.1.1.1.1.8.30
+          key: switch.memory
+          history: 7d
+          units: '%'
+          tags:
+            - tag: component
+              value: memory
+          triggers:
+            - uuid: 89df224b9825497c9be0469db4c21851
+              expression: 'last(/HP A5120/switch.memory)>80'
+              name: 'Memory usage on {HOST.NAME} > 80%'
+              priority: HIGH
+              tags:
+                - tag: scope
+                  value: capacity
+        - uuid: 6175279f333442719b222e2cdbdf348b
+          name: 'Switch Temperature'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.4.1.25506.2.6.1.1.1.1.12.2
+          key: switch.temp
+          history: 7d
+          value_type: FLOAT
+          units: °C
+          tags:
+            - tag: component
+              value: temperature
+          triggers:
+            - uuid: ef2767a0ea464e76925b432d1a24d747
+              expression: 'last(/HP A5120/switch.temp)>45'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'last(/HP A5120/switch.temp)<=40'
+              name: 'Temperature on {HOST.NAME} is > 45°C'
+              priority: HIGH
+              description: 'Temperature too high! Problem resolves when the temperature drops to 40°C or below.'
+              tags:
+                - tag: scope
+                  value: availability
+        - uuid: fcdb80df54c64f4f856cdc1c8ee9010c
+          name: 'Device contact details'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.4.0
+          key: sysContact
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          trends: '0'
+          description: 'The textual identification of the contact person for this managed node, together with information on how to contact this person.  If no contact information is known, the value is the zero-length string.'
+          inventory_link: CONTACT
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+        - uuid: 9ba29c811cfd4ab49541ee3ef37824ef
+          name: 'Device description'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.1.0
+          key: sysDescr
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          trends: '0'
+          description: 'A textual description of the entity.  This value should include the full name and version identification of the system''s hardware type, software operating-system, and networking software.'
+          inventory_link: HARDWARE
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+        - uuid: a5fb104482174916aa01053e1ea668ce
+          name: 'Device location'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.6.0
+          key: sysLocation
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          trends: '0'
+          description: 'The physical location of this node (e.g., `telephone closet, 3rd floor'').  If the location is unknown, the value is the zero-length string.'
+          inventory_link: LOCATION
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+        - uuid: 0eb0c412c38c44f382cf87a3471f7d48
+          name: 'Device name'
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.5.0
+          key: sysName
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          trends: '0'
+          description: 'An administratively-assigned name for this managed node. By convention, this is the node''s fully-qualified domain name.  If the name is unknown, the value is the zero-length string.'
+          inventory_link: NAME
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+        - uuid: 8d64069463ff493da2e50afea6ba4e92
+          name: SysUptime
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.3.0
+          key: SysUptime
+          delay: 5m
+          history: 7d
+          value_type: FLOAT
+          trends: 60d
+          units: uptime
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.01'
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: f4587618b2414e0b866cc85e77dafde9
+              expression: 'last(/HP A5120/SysUptime)<10m'
+              name: '{HOST.NAME} has been restarted (uptime < 10m)'
+              priority: INFO
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+        - uuid: 3a6cad2436204ad5985bb9af3825951b
+          name: 'Network interfaces: SNMP walk'
+          type: SNMP_AGENT
+          snmp_oid: 'walk[1.3.6.1.2.1.2.2.1.2,1.3.6.1.2.1.2.2.1.3,1.3.6.1.2.1.2.2.1.7,1.3.6.1.2.1.2.2.1.8,1.3.6.1.2.1.31.1.1.1.1,1.3.6.1.2.1.31.1.1.1.6,1.3.6.1.2.1.31.1.1.1.10,1.3.6.1.2.1.31.1.1.1.15,1.3.6.1.2.1.31.1.1.1.18]'
+          key: net.if.walk
+          history: '0'
+          value_type: TEXT
+          description: 'Master item: collects IF-MIB interface data (ifDescr, ifType, ifAdminStatus, ifOperStatus, ifName, ifHCInOctets, ifHCOutOctets, ifHighSpeed, ifAlias) in one bulk request. Admin and operational status of an interface are therefore always taken from the same poll.'
+          tags:
+            - tag: component
+              value: raw
+      discovery_rules:
+        - uuid: 51bec5585b9e4105bcdcd7d9dca36181
+          name: 'Network interfaces discovery'
+          type: DEPENDENT
+          key: net.if.discovery
+          delay: '0'
+          filter:
+            conditions:
+              - macro: '{#IFTYPE}'
+                value: '{$NET.IF.IFTYPE.MATCHES}'
+                formulaid: A
+          description: 'Discovers interfaces from IF-MIB (ifDescr, ifName, ifAlias, ifType). Interfaces are filtered by ifType using macro {$NET.IF.IFTYPE.MATCHES}.'
+          item_prototypes:
+            - uuid: 2274542b35674bd6aa38a1393fa955a1
+              name: 'Interface {#IFNAME}({#IFALIAS}): Admin status'
+              type: DEPENDENT
+              key: 'net.if.adminstatus[ifAdminStatus.{#SNMPINDEX}]'
+              delay: '0'
+              history: 7d
+              trends: '0'
+              description: 'IF-MIB::ifAdminStatus - the desired (configured) state of the interface. down = shutdown by administrator.'
+              valuemap:
+                name: 'IF-MIB::ifAdminStatus'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.2.1.2.2.1.7.{#SNMPINDEX}'
+                    - '0'
+              master_item:
+                key: net.if.walk
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 2f5910b5c61940139fa39440d498f640
+              name: 'Interface {#IFNAME}({#IFALIAS}): Operational status'
+              type: DEPENDENT
+              key: 'net.if.status[ifOperStatus.{#SNMPINDEX}]'
+              delay: '0'
+              history: 7d
+              trends: '0'
+              description: 'IF-MIB::ifOperStatus - the current operational state of the interface.'
+              valuemap:
+                name: 'IF-MIB::ifOperStatus'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.2.1.2.2.1.8.{#SNMPINDEX}'
+                    - '0'
+              master_item:
+                key: net.if.walk
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 6cd89ecd035f4dabae399ce199616712
+              name: 'Interface {#IFNAME}({#IFALIAS}): Bits received'
+              type: DEPENDENT
+              key: 'net.if.in[ifHCInOctets.{#SNMPINDEX}]'
+              delay: '0'
+              history: 7d
+              units: bps
+              description: 'IF-MIB::ifHCInOctets - incoming traffic on the interface (64-bit counter).'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.2.1.31.1.1.1.6.{#SNMPINDEX}'
+                    - '0'
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              master_item:
+                key: net.if.walk
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: caf8ef4e94274e65bce4f17e54378b9b
+              name: 'Interface {#IFNAME}({#IFALIAS}): Bits sent'
+              type: DEPENDENT
+              key: 'net.if.out[ifHCOutOctets.{#SNMPINDEX}]'
+              delay: '0'
+              history: 7d
+              units: bps
+              description: 'IF-MIB::ifHCOutOctets - outgoing traffic on the interface (64-bit counter).'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.2.1.31.1.1.1.10.{#SNMPINDEX}'
+                    - '0'
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              master_item:
+                key: net.if.walk
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 17a4dbef04874fd68d05c323fb3371b6
+              name: 'Interface {#IFNAME}({#IFALIAS}): Speed'
+              type: DEPENDENT
+              key: 'net.if.speed[ifHighSpeed.{#SNMPINDEX}]'
+              delay: '0'
+              history: 7d
+              units: bps
+              description: 'IF-MIB::ifHighSpeed - current bandwidth of the interface (reported in Mbps, converted to bps).'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - '1.3.6.1.2.1.31.1.1.1.15.{#SNMPINDEX}'
+                    - '0'
+                - type: MULTIPLIER
+                  parameters:
+                    - '1000000'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: net.if.walk
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 62633a9bbeed4dffbf9cd971304b5a17
+              name: 'Interface {#IFNAME}({#IFALIAS}): CRC errors'
+              type: SNMP_AGENT
+              snmp_oid: '1.3.6.1.2.1.10.7.2.1.3.{#SNMPINDEX}'
+              key: 'CRC.Errors[{#SNMPINDEX}]'
+              delay: 2m
+              history: 7d
+              description: 'EtherLike-MIB::dot3StatsFCSErrors - frames received that failed the FCS (CRC) check.'
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+              trigger_prototypes:
+                - uuid: 02a910c9f5bf4964a02bc460453311a3
+                  expression: 'change(/HP A5120/CRC.Errors[{#SNMPINDEX}])>1'
+                  name: 'Interface {#IFNAME}({#IFALIAS}): CRC errors on {HOST.NAME}'
+                  url: 'http://h20564.www2.hp.com/hpsc/doc/public/display?docId=emr_na-c02597187'
+                  priority: AVERAGE
+                  description: 'A Cyclic Redundancy Check (CRC) are a hash function designed to detect accidental changes to raw computer data. A CRC is a short binary sequence present on each block of data. When a block of data is read or received, the device repeats the calculation to check for a match. If the new CRC does not match the original CRC, then a data error is logged and the device can attempt to correct the data error by re-reading or requesting the block of data.'
+                  tags:
+                    - tag: scope
+                      value: performance
+          trigger_prototypes:
+            - uuid: f49e929f83414c0ca0a1e9f91fce7d8d
+              expression: '{$IFCONTROL:"{#IFNAME}"}=1 and last(/HP A5120/net.if.adminstatus[ifAdminStatus.{#SNMPINDEX}])=1 and last(/HP A5120/net.if.status[ifOperStatus.{#SNMPINDEX}])=2 and last(/HP A5120/net.if.status[ifOperStatus.{#SNMPINDEX}],#2)=1'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'last(/HP A5120/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or last(/HP A5120/net.if.adminstatus[ifAdminStatus.{#SNMPINDEX}])=2 or {$IFCONTROL:"{#IFNAME}"}=0'
+              name: 'Interface {#IFNAME}({#IFALIAS}): Link down'
+              opdata: 'Current state: {ITEM.LASTVALUE2}'
+              priority: AVERAGE
+              description: |
+                The interface changed from up to down while its admin status is up (not shutdown).
+                Interfaces that were already down, or that were shut down by an administrator, are ignored.
+                The problem is resolved when the interface is no longer down or is shut down by an administrator.
+                Set {$IFCONTROL:"{#IFNAME}"}=0 to disable this trigger for a specific interface.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: availability
+            - uuid: 91c97393b38745128db209ba961e775e
+              expression: '(avg(/HP A5120/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/HP A5120/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) or avg(/HP A5120/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/HP A5120/net.if.speed[ifHighSpeed.{#SNMPINDEX}])) and last(/HP A5120/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: 'avg(/HP A5120/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/HP A5120/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) and avg(/HP A5120/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/HP A5120/net.if.speed[ifHighSpeed.{#SNMPINDEX}])'
+              name: 'Interface {#IFNAME}({#IFALIAS}): High bandwidth usage (>{$IF.UTIL.MAX:"{#IFNAME}"}%)'
+              opdata: 'In: {ITEM.LASTVALUE1}, out: {ITEM.LASTVALUE3}, speed: {ITEM.LASTVALUE2}'
+              priority: WARNING
+              description: |
+                The 15-minute average of inbound or outbound traffic exceeds {$IF.UTIL.MAX:"{#IFNAME}"}% of the interface speed.
+                The problem is resolved when both directions drop below ({$IF.UTIL.MAX:"{#IFNAME}"} - 3)%.
+                The threshold can be changed per interface with {$IF.UTIL.MAX:"<ifName>"}.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: performance
+          graph_prototypes:
+            - uuid: b4c2ace83c6743c78e442aabfeb64beb
+              name: 'Interface {#IFNAME}({#IFALIAS}): Network traffic'
+              graph_items:
+                - drawtype: GRADIENT_LINE
+                  color: 1A7C11
+                  item:
+                    host: 'HP A5120'
+                    key: 'net.if.in[ifHCInOctets.{#SNMPINDEX}]'
+                - sortorder: '1'
+                  drawtype: BOLD_LINE
+                  color: 2774A4
+                  item:
+                    host: 'HP A5120'
+                    key: 'net.if.out[ifHCOutOctets.{#SNMPINDEX}]'
+          master_item:
+            key: net.if.walk
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#IFDESCR}'
+                - 1.3.6.1.2.1.2.2.1.2
+                - '0'
+                - '{#IFNAME}'
+                - 1.3.6.1.2.1.31.1.1.1.1
+                - '0'
+                - '{#IFALIAS}'
+                - 1.3.6.1.2.1.31.1.1.1.18
+                - '0'
+                - '{#IFTYPE}'
+                - 1.3.6.1.2.1.2.2.1.3
+                - '0'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          overrides:
+            - name: 'VLAN interfaces: status only (no bandwidth, no CRC)'
+              step: '1'
+              filter:
+                conditions:
+                  - macro: '{#IFTYPE}'
+                    value: '{$NET.IF.NO_TRAFFIC.IFTYPE.MATCHES}'
+                    formulaid: A
+              operations:
+                - operationobject: ITEM_PROTOTYPE
+                  operator: REGEXP
+                  value: ': (Bits received|Bits sent|Speed|CRC errors)$'
+                  discover: NO_DISCOVER
+                - operationobject: TRIGGER_PROTOTYPE
+                  operator: REGEXP
+                  value: ': (High bandwidth usage|CRC errors)'
+                  discover: NO_DISCOVER
+                - operationobject: GRAPH_PROTOTYPE
+                  operator: REGEXP
+                  value: ': Network traffic$'
+                  discover: NO_DISCOVER
+      macros:
+        - macro: '{$IF.UTIL.MAX}'
+          value: '90'
+          description: 'Bandwidth usage threshold in % of interface speed (15-minute average, inbound or outbound). Override per interface with context, e.g. {$IF.UTIL.MAX:"Ten-GigabitEthernet1/1/1"}=80.'
+        - macro: '{$IFCONTROL}'
+          value: '1'
+          description: 'Link down trigger: 1 = enabled, 0 = disabled. Override per interface with context, e.g. {$IFCONTROL:"GigabitEthernet1/0/1"}=0.'
+        - macro: '{$NET.IF.IFTYPE.MATCHES}'
+          value: '^(6|136|161)$'
+          description: 'Regex of ifType values to discover. 6 = ethernetCsmacd, 136 = l3ipvlan (Vlan-interface), 161 = ieee8023adLag (Bridge-Aggregation).'
+        - macro: '{$NET.IF.NO_TRAFFIC.IFTYPE.MATCHES}'
+          value: '^136$'
+          description: 'Regex of ifType values that are discovered for status only: no bandwidth, speed, CRC items and no bandwidth / CRC triggers. Default 136 = l3ipvlan (Vlan-interface).'
+      valuemaps:
+        - uuid: 7c54cf593a304df997b61a5f9f940e01
+          name: 'IF-MIB::ifAdminStatus'
+          mappings:
+            - value: '1'
+              newvalue: up
+            - value: '2'
+              newvalue: down
+            - value: '3'
+              newvalue: testing
+        - uuid: 40d70919c78a46ba92970004f1795aad
+          name: 'IF-MIB::ifOperStatus'
+          mappings:
+            - value: '1'
+              newvalue: up
+            - value: '2'
+              newvalue: down
+            - value: '3'
+              newvalue: testing
+            - value: '4'
+              newvalue: unknown
+            - value: '5'
+              newvalue: dormant
+            - value: '6'
+              newvalue: notPresent
+            - value: '7'
+              newvalue: lowerLayerDown
+        - uuid: fd3e855873184b5abd7217fa48871b94
+          name: 'HH3C-LSW-DEV-ADM-MIB::DevStatus'
+          mappings:
+            - value: '1'
+              newvalue: active
+            - value: '2'
+              newvalue: deactive
+            - value: '3'
+              newvalue: not-install
+            - value: '4'
+              newvalue: unsupport
+  graphs:
+    - uuid: 7a0b8d49bdf246f9b7a46952fcc16835
+      name: 'CPU usage'
+      graph_items:
+        - color: 1A7C11
+          item:
+            host: 'HP A5120'
+            key: switch.cpu
+    - uuid: 8a6777c7ddbf435cafe684e0396dd6f1
+      name: 'Memory usage'
+      graph_items:
+        - color: 1A7C11
+          item:
+            host: 'HP A5120'
+            key: switch.memory

--- a/Network_Devices/HP/template_hp_a5500_switch_snmp/7.0/README.md
+++ b/Network_Devices/HP/template_hp_a5500_switch_snmp/7.0/README.md
@@ -1,0 +1,192 @@
+# HP A5500 HI — Comware 5 — Zabbix 7.0
+
+[English](README.md) | [Vietnamese](readme_vi.md)
+
+SNMP template for the **HP A5500-48G-4SFP HI Switch with 2 interface Slots**, running
+**Comware 5.20.99, Release 5501P36**. Imported template name: **HP A5500 HI**.
+No linked templates are required. Supports SNMPv2c/SNMPv3 as configured on the host's SNMP interface.
+
+## Target device
+
+Successfully tested on **HP A5500-48G-4SFP HI** running **Comware 5.20.99, Release 5501P36**,
+with **Zabbix 7.0.29**. Hardware details below come from the supplied `display version` output.
+
+| Component | Details |
+|---|---|
+| Model | HP A5500-48G-4SFP HI Switch with 2 interface Slots |
+| Software | HPE Comware 5.20.99, Release 5501P36 |
+| CPU / SDRAM | 2 processors / 1024 MB |
+| Flash | 4096 KB NOR, 512 MB NAND |
+| Hardware / CPLD / Bootrom | REV.C / 003 / 215 |
+| SubSlot 0 | 48GE + 4SFP + 2SFP PLUS, REV.C |
+| SubSlot 1 | 2 XFP, REV.B |
+| SubSlot 2 | 2 XFP, REV.B |
+
+The template does not hard-code port counts, processor counts, slots or physical entity indexes.
+The SDRAM/flash capacities above describe the device; they are not hard-coded item values.
+The `2 Processors` line does not guarantee two CPU entries in SNMP: Comware may report
+aggregate utilization per module.
+
+## Setup
+
+1. Import `template_hp_a5500_switch_snmp.yaml` under **Data collection → Templates** in Zabbix 7.0.
+2. Add an SNMP interface to the host using the switch management IP and UDP port `161`.
+   Allow the server/proxy to access SNMP and read the MIB branches listed below.
+3. Match the host's SNMP settings to the switch configuration. For **SNMPv3 authPriv**,
+   use SHA/AES if configured on the switch, then create and reference these host macros:
+   `{$SNMP_V3_USER}` (Security name), `{$SNMP_V3_AUTHPASSPHRASE}` (Authentication
+   passphrase), and `{$SNMP_V3_PRIVPASSPHRASE}` (Privacy passphrase). Set both passphrase
+   macros to **Secret text**. For **SNMPv2c**, create `{$SNMP_COMMUNITY}` on the host
+   and reference it in the SNMP community field.
+4. Link **HP A5500 HI**, allow the master items and discovery rules to run, then check
+   **Monitoring → Latest data** and any items marked `Unsupported`.
+
+Create the authentication macros on the host; the YAML contains no sample passwords.
+Numeric OIDs are used throughout, so MIB files do not need to be installed on the server/proxy.
+
+Separate UUIDs allow this template to be imported alongside the A5120 template. If the
+host already uses A5120, resolve the existing template linkage before linking A5500,
+since several item keys overlap. The new template does not automatically migrate
+CPU/memory/temperature history from fixed items to LLD items. If an earlier A5500 copy
+was imported under the A5120 name, check which template the host uses before unlinking
+it or deleting old data.
+
+## Collected data
+
+| Category | Item / discovery | Collection |
+|---|---|---|
+| System information | `sysName`, `sysDescr`, `sysLocation`, `sysContact` | SNMP, every hour |
+| SNMP uptime | `SysUptime` | SNMP, every 5 minutes; TimeTicks converted to seconds |
+| Hardware | `hardware.walk` | ENTITY-MIB + HH3C-ENTITY-EXT-MIB, every minute |
+| CPU/memory | `module.discovery`; `switch.cpu[index]`, `switch.memory[index]` | Dependent discovery/items per module |
+| Temperature | `temperature.discovery`; `switch.temp[index]` | Dependent discovery/items per entity |
+| Fans | `fan.discovery`; `fan.status[index]` | Entity class 7, HH3C status |
+| Power supplies | `psu.discovery`; `psu.status[index]` | Entity class 6, HH3C status |
+| Interfaces | `net.if.walk`, `net.if.discovery` | Bulk walk every minute, dependent discovery/items |
+| Traffic | `net.if.in[...]`, `net.if.out[...]` | Counter64 → change per second → multiply by 8, bps |
+| Speed | `net.if.speed[...]` | ifHighSpeed × 1,000,000, bps |
+| Interface status | `net.if.adminstatus[...]`, `net.if.status[...]` | ifAdminStatus / ifOperStatus |
+| CRC | `CRC.Errors[index]` | dot3StatsFCSErrors every 2 minutes, Ethernet only |
+
+Master items do not store history. Discovery uses a one-hour heartbeat for unchanged
+results; metric items still update at the master item's polling interval. Graphs are
+provided for CPU/memory per module and traffic per interface. A single `walk[]` may
+require multiple SNMP packets: admin/operational status share the same master result,
+but this is not an atomic snapshot of the switch.
+
+### Hardware discovery
+
+- CPU/memory discovery selects entities whose `entPhysicalDescr` matches
+  `{$HP.MODULE.DESCR.MATCHES}` and whose CPU and memory readings are both within 0–100%.
+  By default, it matches `Module level1`, Fabric Module descriptions, or descriptions
+  containing `CPU`, without case sensitivity. Idle CPUs reporting 0% are included.
+- If CPU/memory items are missing, inspect the actual entity descriptions and adjust
+  the filter macro. Do not infer indexes from slot numbers or reuse index `.30` from
+  another device.
+- Temperature discovery accepts entities reporting 1–999 °C. Zero and negative values
+  are excluded to avoid unsupported readings; this filter is not intended for sensors
+  that must measure 0 °C or negative temperatures.
+- Rows missing required columns do not create items. Empty entity names fall back to
+  the description, then to the entity index.
+- Fan/power supply monitoring uses `hh3cEntityExtErrorStatus`: `2 = normal`,
+  `4 = entityAbsent`, `1 = notSupported`. This differs from the active/deactive mapping
+  in LSW-DEV-ADM-MIB. Empty slots and unsupported states do not raise fault alerts;
+  an empty power supply slot alone does not trigger a loss-of-redundancy alert.
+
+### Interface discovery
+
+Discovery includes `ifType=6` (Ethernet, including GE/10GE), `136` (Vlan-interface),
+and `161` (Bridge-Aggregation). SFP+/XFP ports are discovered through IF-MIB without
+hard-coded interface names.
+
+VLAN interfaces are monitored for status and link down only by default. Set
+`{$NET.IF.NO_TRAFFIC.IFTYPE.MATCHES}` to `^$` to enable traffic, speed and graphs
+if the VLAN interfaces actually support those counters. CRC remains limited to
+`ifType=6`. Bridge-Aggregation interfaces have traffic, speed and status monitoring
+where supported by the device, but no CRC items.
+
+## Alerts
+
+| Alert | Problem / recovery conditions |
+|---|---|
+| High CPU/memory usage | All samples within 5 minutes exceed the threshold, default 80%. Recovers when all samples within 5 minutes are below the threshold minus 5 percentage points. |
+| High temperature | The 5-minute average exceeds the threshold, default 60 °C. Recovers when all samples within 5 minutes are at or below the threshold minus 5 °C. |
+| Fan fault | Status 3 (POST failure), 41 (fan error), or 91 (hardware faulty). |
+| Power supply fault | Status 3, 51 (PSU error), 61 (RPS error), or 91. |
+| Link down | Admin status is up, current operational status is down, and the previous operational sample was up. Remains open until operational status is no longer down, admin status becomes down, or IFCONTROL=0. |
+| High bandwidth usage | The 15-minute inbound or outbound average exceeds the threshold, default 90%. Recovers when both directions are below the threshold minus 3 percentage points, or speed=0. |
+| CRC errors | More than 1 new FCS error between two samples taken 2 minutes apart. A counter decrease due to reset does not raise an alert. |
+| Low SNMP uptime | sysUpTime is below 10 minutes; check the CLI/logs to determine the cause. |
+
+Interfaces already down when monitoring starts do not raise link-down alerts.
+The 60 °C threshold is configurable monitoring policy, **not a hardware temperature
+limit published by HPE**.
+
+`sysUpTime.0` measures time since the SNMP management subsystem initialized. It may
+differ from chassis uptime in `display version` and wraps after approximately 497 days.
+The alert is named **SNMP uptime is less than 10 minutes**; it does not confirm a switch
+reboot. Check logs/CLI output to distinguish a reboot, SNMP agent restart and counter
+wrap, particularly for a device that has already been running for 60 weeks as reported.
+
+## Configuration macros
+
+| Macro | Default | Purpose |
+|---|---|---|
+| `{$HP.MODULE.DESCR.MATCHES}` | `(?i)(^module level1$\|fabric.*module\|cpu)` | CPU/memory module description regex |
+| `{$CPU.UTIL.MAX}` | `80` | CPU threshold in %, supports entity-name context |
+| `{$MEMORY.UTIL.MAX}` | `80` | Memory threshold in %, supports entity-name context |
+| `{$TEMP.MAX}` | `60` | Temperature threshold in °C, supports entity-name context |
+| `{$IF.UTIL.MAX}` | `90` | Bandwidth threshold in %, supports ifName context |
+| `{$IFCONTROL}` | `1` | Set to 0 to disable the link-down trigger, supports ifName context |
+| `{$NET.IF.IFTYPE.MATCHES}` | `^(6\|136\|161)$` | Interface types to discover |
+| `{$NET.IF.NO_TRAFFIC.IFTYPE.MATCHES}` | `^136$` | Interface types monitored for status only |
+
+Examples: `{$IFCONTROL:"GigabitEthernet1/0/24"}=0`,
+`{$IF.UTIL.MAX:"Ten-GigabitEthernet1/1/1"}=80`. Use the actual names returned by discovery;
+these examples do not guarantee the switch's interface numbering. Keep thresholds
+above the corresponding hysteresis offsets so that recovery conditions remain reachable.
+
+## Verify OIDs on R5501P36
+
+Run these commands from the server/proxy with valid SNMP credentials. Replace the
+placeholders before running them:
+
+```sh
+snmpwalk -v3 -l authPriv -u '<SNMP_USER>' -a SHA -A '<AUTH_PASSPHRASE>' \
+  -x AES -X '<PRIV_PASSPHRASE>' -On '<SWITCH_IP>' 1.3.6.1.2.1.47.1.1.1.1
+
+snmpwalk -v3 -l authPriv -u '<SNMP_USER>' -a SHA -A '<AUTH_PASSPHRASE>' \
+  -x AES -X '<PRIV_PASSPHRASE>' -On '<SWITCH_IP>' 1.3.6.1.4.1.25506.2.6.1.1.1.1
+```
+
+| OID | Data |
+|---|---|
+| `1.3.6.1.2.1.47.1.1.1.1.2` | entPhysicalDescr |
+| `1.3.6.1.2.1.47.1.1.1.1.5` | entPhysicalClass |
+| `1.3.6.1.2.1.47.1.1.1.1.7` | entPhysicalName |
+| `1.3.6.1.4.1.25506.2.6.1.1.1.1.6` | hh3cEntityExtCpuUsage |
+| `1.3.6.1.4.1.25506.2.6.1.1.1.1.8` | hh3cEntityExtMemUsage |
+| `1.3.6.1.4.1.25506.2.6.1.1.1.1.12` | hh3cEntityExtTemperature |
+| `1.3.6.1.4.1.25506.2.6.1.1.1.1.19` | hh3cEntityExtErrorStatus |
+| `1.3.6.1.2.1.31.1.1.1.6` / `1.3.6.1.2.1.31.1.1.1.10` | ifHCInOctets / ifHCOutOctets |
+| `1.3.6.1.2.1.31.1.1.1.15` | ifHighSpeed, Mbps |
+| `1.3.6.1.2.1.10.7.2.1.3` | dot3StatsFCSErrors |
+
+Match index suffixes between ENTITY-MIB and HH3C-ENTITY-EXT-MIB. If discovery returns
+no entities, check the SNMP view/ACL, missing columns and module filter macro. An uplink
+operating at 10 Gbit/s should report `10000` for `ifHighSpeed`; compare this with the
+CLI speed. If walks time out, check connectivity and adjust the SNMP interface timeout
+or Max repetition setting.
+
+For other firmware releases or hardware configurations, use the checks above to confirm
+available MIB branches, entity names and logical interface counters.
+
+## References and credits
+
+- [HPE: Comware CPU/memory/temperature OIDs and device-specific indexes](https://support.hpe.com/hpesc/public/docDisplay?docId=sf000098678en_us&docLocale=en_US).
+- [Official HP Comware HH3C template, Zabbix 7.0](https://github.com/zabbix/zabbix/blob/release/7.0/templates/net/hp_hh3c_snmp/template_net_hp_hh3c_snmp.yaml): reference for module filters, entity classes and the HH3C status mapping.
+- [Zabbix 7.0: SNMP agent and bulk walks](https://www.zabbix.com/documentation/7.0/en/manual/config/items/itemtypes/snmp).
+
+Adapted from the HP A5120 template by **Jakub Samek**. This version replaces fixed
+hardware OIDs with discovery, assigns separate UUIDs, retains interface monitoring
+from the 7.0 version and updates the documentation for the A5500 HI.

--- a/Network_Devices/HP/template_hp_a5500_switch_snmp/7.0/README.md
+++ b/Network_Devices/HP/template_hp_a5500_switch_snmp/7.0/README.md
@@ -1,6 +1,6 @@
 # HP A5500 HI — Comware 5 — Zabbix 7.0
 
-[English](README.md) | [Vietnamese](readme_vi.md)
+[English](README.md) | [Vietnamese](files/readme_vi.md)
 
 SNMP template for the **HP A5500-48G-4SFP HI Switch with 2 interface Slots**, running
 **Comware 5.20.99, Release 5501P36**. Imported template name: **HP A5500 HI**.

--- a/Network_Devices/HP/template_hp_a5500_switch_snmp/7.0/files/readme_vi.md
+++ b/Network_Devices/HP/template_hp_a5500_switch_snmp/7.0/files/readme_vi.md
@@ -1,6 +1,6 @@
 # HP A5500 HI — Comware 5 — Zabbix 7.0
 
-[English](README.md) | [Tiếng Việt](readme_vi.md)
+[English](../README.md) | [Tiếng Việt](readme_vi.md)
 
 Template SNMP cho **HP A5500-48G-4SFP HI Switch with 2 interface Slots**, chạy
 **Comware 5.20.99, Release 5501P36**. Tên khi import: **HP A5500 HI**.

--- a/Network_Devices/HP/template_hp_a5500_switch_snmp/7.0/readme_vi.md
+++ b/Network_Devices/HP/template_hp_a5500_switch_snmp/7.0/readme_vi.md
@@ -1,0 +1,180 @@
+# HP A5500 HI — Comware 5 — Zabbix 7.0
+
+[English](README.md) | [Tiếng Việt](readme_vi.md)
+
+Template SNMP cho **HP A5500-48G-4SFP HI Switch with 2 interface Slots**, chạy
+**Comware 5.20.99, Release 5501P36**. Tên khi import: **HP A5500 HI**.
+Không liên kết template khác. Hỗ trợ SNMPv2c/SNMPv3 theo cấu hình SNMP interface của host.
+
+## Thiết bị mục tiêu
+
+Đã kiểm thử thành công trên **HP A5500-48G-4SFP HI**, chạy **Comware 5.20.99, Release 5501P36**,
+với **Zabbix 7.0.29**. Thông tin phần cứng dưới đây lấy từ `display version` được cung cấp:
+
+| Thành phần | Thông tin |
+|---|---|
+| Model | HP A5500-48G-4SFP HI Switch with 2 interface Slots |
+| Phần mềm | HPE Comware 5.20.99, Release 5501P36 |
+| CPU / SDRAM | 2 processors / 1024 MB |
+| Flash | 4096 KB NOR, 512 MB NAND |
+| Hardware / CPLD / Bootrom | REV.C / 003 / 215 |
+| SubSlot 0 | 48GE + 4SFP + 2SFP PLUS, REV.C |
+| SubSlot 1 | 2 XFP, REV.B |
+| SubSlot 2 | 2 XFP, REV.B |
+
+Template không cố định số cổng, CPU, slot hoặc index phần cứng. SDRAM/flash ở trên
+là thông tin thiết bị, không phải dung lượng gán cứng vào item. Dòng `2 Processors`
+không đảm bảo có hai hàng CPU trong SNMP: Comware có thể báo mức sử dụng tổng hợp theo module.
+
+## Cài đặt
+
+1. Import `template_hp_a5500_switch_snmp.yaml` trong **Data collection → Templates** của Zabbix 7.0.
+2. Thêm SNMP interface cho host với IP quản trị switch, UDP port `161`. Cho phép
+   server/proxy truy cập SNMP và đọc các nhánh MIB trong bảng kiểm tra bên dưới.
+3. Cấu hình SNMP interface giống switch. Với **SNMPv3 authPriv**, dùng SHA/AES nếu
+   switch được cấu hình tương ứng, rồi tạo và tham chiếu các host macro:
+   `{$SNMP_V3_USER}` (Security name), `{$SNMP_V3_AUTHPASSPHRASE}` (Authentication
+   passphrase), `{$SNMP_V3_PRIVPASSPHRASE}` (Privacy passphrase). Đặt hai passphrase
+   ở kiểu **Secret text**. Với **SNMPv2c**, tạo `{$SNMP_COMMUNITY}` trên host và
+   tham chiếu nó trong trường SNMP community.
+4. Link **HP A5500 HI**, đợi master items và discovery chạy, kiểm tra
+   **Monitoring → Latest data** cùng các item báo `Unsupported`.
+
+Các macro xác thực do người dùng tạo trên host; YAML không chứa mật khẩu mẫu.
+Template dùng OID dạng số nên không yêu cầu cài MIB trên server/proxy.
+
+UUID riêng cho phép import cùng template A5120. Nếu host đã link A5120, cần xử lý
+liên kết template cũ trước khi link A5500 vì nhiều item key trùng nhau. Template mới
+không tự di chuyển lịch sử CPU/RAM/nhiệt độ từ item cố định sang item LLD. Nếu bản sao
+A5500 trước đây đã được import với tên A5120, kiểm tra template đang được host sử dụng
+trước khi gỡ liên kết hoặc xóa dữ liệu cũ.
+
+## Dữ liệu giám sát
+
+| Nhóm | Item / discovery | Thu thập |
+|---|---|---|
+| Hệ thống | `sysName`, `sysDescr`, `sysLocation`, `sysContact` | SNMP, mỗi 1 giờ |
+| Uptime SNMP | `SysUptime` | SNMP, mỗi 5 phút, chuyển TimeTicks sang giây |
+| Phần cứng | `hardware.walk` | ENTITY-MIB + HH3C-ENTITY-EXT-MIB, mỗi 1 phút |
+| CPU/RAM | `module.discovery`; `switch.cpu[index]`, `switch.memory[index]` | Dependent discovery/items theo module |
+| Nhiệt độ | `temperature.discovery`; `switch.temp[index]` | Dependent discovery/items theo entity |
+| Quạt | `fan.discovery`; `fan.status[index]` | Entity class 7, trạng thái HH3C |
+| Nguồn | `psu.discovery`; `psu.status[index]` | Entity class 6, trạng thái HH3C |
+| Interface | `net.if.walk`, `net.if.discovery` | Bulk walk mỗi 1 phút, dependent discovery/items |
+| Lưu lượng | `net.if.in[...]`, `net.if.out[...]` | Counter64 → thay đổi mỗi giây → nhân 8, bps |
+| Tốc độ | `net.if.speed[...]` | ifHighSpeed × 1.000.000, bps |
+| Trạng thái cổng | `net.if.adminstatus[...]`, `net.if.status[...]` | ifAdminStatus / ifOperStatus |
+| CRC | `CRC.Errors[index]` | dot3StatsFCSErrors mỗi 2 phút, chỉ Ethernet |
+
+Master items không lưu history. Discovery có heartbeat 1 giờ cho kết quả không đổi;
+các item chỉ số vẫn cập nhật theo chu kỳ master. Có biểu đồ CPU/RAM theo module và
+lưu lượng theo interface. Một `walk[]` có thể cần nhiều gói SNMP; admin/oper status
+dùng chung kết quả master nhưng không phải trạng thái đồng thời tuyệt đối của switch.
+
+### Phần cứng
+
+- CPU/RAM chọn `entPhysicalDescr` khớp `{$HP.MODULE.DESCR.MATCHES}` và có cả hai giá trị
+  sử dụng trong khoảng 0–100%. Mặc định nhận `Module level1`, Fabric Module hoặc mô tả
+  chứa `CPU`, không phân biệt hoa/thường. CPU 0% vẫn được nhận.
+- Nếu không thấy CPU/RAM, xem mô tả entity thực tế rồi chỉnh macro lọc. Không đoán
+  index từ số slot hoặc dùng lại index `.30` của thiết bị khác.
+- Nhiệt độ nhận entity báo 1–999 °C. Loại giá trị 0/âm để tránh giá trị không hỗ trợ;
+  bộ lọc này không dành cho sensor cần đo 0 °C hoặc nhiệt độ âm.
+- Hàng thiếu cột bắt buộc không tạo item. Tên entity trống dùng mô tả, rồi đến index.
+- Quạt/nguồn dùng `hh3cEntityExtErrorStatus`: `2 = normal`, `4 = entityAbsent`,
+  `1 = notSupported`, khác bảng active/deactive của LSW-DEV-ADM-MIB. Khe trống và
+  trạng thái không hỗ trợ không phát cảnh báo lỗi; template không cảnh báo mất
+  dự phòng chỉ vì một khe nguồn trống.
+
+### Interface
+
+Khám phá `ifType=6` (Ethernet gồm GE/10GE), `136` (Vlan-interface), `161`
+(Bridge-Aggregation). Cổng SFP+/XFP được nhận qua IF-MIB, không theo tên cố định.
+
+VLAN mặc định chỉ theo dõi trạng thái và link down. Đổi
+`{$NET.IF.NO_TRAFFIC.IFTYPE.MATCHES}` thành `^$` để bật lưu lượng/tốc độ/biểu đồ
+nếu VLAN thực sự hỗ trợ các bộ đếm đó. CRC vẫn chỉ dành cho `ifType=6`.
+Bridge-Aggregation có lưu lượng/tốc độ/trạng thái nếu thiết bị cung cấp; không tạo CRC.
+
+## Cảnh báo
+
+| Cảnh báo | Điều kiện / phục hồi |
+|---|---|
+| CPU/RAM cao | Mọi mẫu trong 5 phút > ngưỡng, mặc định 80%. Phục hồi khi mọi mẫu trong 5 phút < ngưỡng trừ 5 điểm phần trăm. |
+| Nhiệt độ cao | Trung bình 5 phút > ngưỡng, mặc định 60 °C. Phục hồi khi mọi mẫu trong 5 phút ≤ ngưỡng trừ 5 °C. |
+| Quạt lỗi | Trạng thái 3 (POST failure), 41 (fan error), 91 (hardware faulty). |
+| Nguồn lỗi | Trạng thái 3, 51 (PSU error), 61 (RPS error), 91. |
+| Link down | Admin đang up, oper hiện tại down và mẫu oper trước up. Giữ problem đến khi hết down, admin down hoặc IFCONTROL=0. |
+| Băng thông cao | Trung bình 15 phút của chiều vào hoặc ra > ngưỡng, mặc định 90%. Phục hồi khi cả hai chiều < ngưỡng trừ 3 điểm phần trăm, hoặc speed=0. |
+| CRC | Hơn 1 lỗi FCS mới giữa hai mẫu 2 phút; counter giảm do reset không báo lỗi. |
+| Uptime SNMP thấp | sysUpTime dưới 10 phút; cần đối chiếu CLI/log để xác định nguyên nhân. |
+
+Cổng vốn down khi bắt đầu giám sát không tạo link-down alert. Ngưỡng 60 °C là ngưỡng
+giám sát có thể chỉnh, **không phải giới hạn nhiệt độ phần cứng do HPE công bố**.
+
+`sysUpTime.0` tính từ lúc bộ phận quản lý SNMP khởi tạo, có thể khác uptime chassis
+trong `display version` và quay vòng sau khoảng 497 ngày. Cảnh báo được đặt tên
+**SNMP uptime is less than 10 minutes**, không khẳng định switch vừa reboot.
+Đối chiếu log/CLI để phân biệt reboot, SNMP agent restart và counter wrap, nhất là
+với thiết bị đã chạy 60 tuần như thông tin được cung cấp.
+
+## Macro điều chỉnh
+
+| Macro | Mặc định | Ý nghĩa |
+|---|---|---|
+| `{$HP.MODULE.DESCR.MATCHES}` | `(?i)(^module level1$\|fabric.*module\|cpu)` | Regex mô tả module CPU/RAM |
+| `{$CPU.UTIL.MAX}` | `80` | Ngưỡng CPU %, hỗ trợ context tên entity |
+| `{$MEMORY.UTIL.MAX}` | `80` | Ngưỡng RAM %, hỗ trợ context tên entity |
+| `{$TEMP.MAX}` | `60` | Ngưỡng °C, hỗ trợ context tên entity |
+| `{$IF.UTIL.MAX}` | `90` | Ngưỡng băng thông %, hỗ trợ context ifName |
+| `{$IFCONTROL}` | `1` | 0 để tắt link-down trigger, hỗ trợ context ifName |
+| `{$NET.IF.IFTYPE.MATCHES}` | `^(6\|136\|161)$` | Loại interface khám phá |
+| `{$NET.IF.NO_TRAFFIC.IFTYPE.MATCHES}` | `^136$` | Loại interface chỉ theo dõi trạng thái |
+
+Ví dụ: `{$IFCONTROL:"GigabitEthernet1/0/24"}=0`,
+`{$IF.UTIL.MAX:"Ten-GigabitEthernet1/1/1"}=80`. Dùng tên thực tế từ discovery;
+tên cổng ví dụ không phải cam kết về cách đánh số trên switch. Giữ ngưỡng lớn hơn
+hysteresis tương ứng để điều kiện phục hồi có thể đạt được.
+
+## Kiểm tra OID trên R5501P36
+
+Chạy từ server/proxy với thông tin SNMP thực tế; thay placeholder trước khi chạy:
+
+```sh
+snmpwalk -v3 -l authPriv -u '<SNMP_USER>' -a SHA -A '<AUTH_PASSPHRASE>' \
+  -x AES -X '<PRIV_PASSPHRASE>' -On '<SWITCH_IP>' 1.3.6.1.2.1.47.1.1.1.1
+
+snmpwalk -v3 -l authPriv -u '<SNMP_USER>' -a SHA -A '<AUTH_PASSPHRASE>' \
+  -x AES -X '<PRIV_PASSPHRASE>' -On '<SWITCH_IP>' 1.3.6.1.4.1.25506.2.6.1.1.1.1
+```
+
+| OID | Dữ liệu |
+|---|---|
+| `1.3.6.1.2.1.47.1.1.1.1.2` | entPhysicalDescr |
+| `1.3.6.1.2.1.47.1.1.1.1.5` | entPhysicalClass |
+| `1.3.6.1.2.1.47.1.1.1.1.7` | entPhysicalName |
+| `1.3.6.1.4.1.25506.2.6.1.1.1.1.6` | hh3cEntityExtCpuUsage |
+| `1.3.6.1.4.1.25506.2.6.1.1.1.1.8` | hh3cEntityExtMemUsage |
+| `1.3.6.1.4.1.25506.2.6.1.1.1.1.12` | hh3cEntityExtTemperature |
+| `1.3.6.1.4.1.25506.2.6.1.1.1.1.19` | hh3cEntityExtErrorStatus |
+| `1.3.6.1.2.1.31.1.1.1.6` / `1.3.6.1.2.1.31.1.1.1.10` | ifHCInOctets / ifHCOutOctets |
+| `1.3.6.1.2.1.31.1.1.1.15` | ifHighSpeed, Mbps |
+| `1.3.6.1.2.1.10.7.2.1.3` | dot3StatsFCSErrors |
+
+Đối chiếu suffix index ENTITY-MIB và HH3C-ENTITY-EXT-MIB. Nếu discovery trống, kiểm tra
+SNMP view/ACL, cột bị thiếu và macro lọc module. Với uplink đang chạy 10 Gbit/s,
+`ifHighSpeed` cần báo `10000`; đối chiếu tốc độ CLI. Nếu walk timeout, kiểm tra đường
+truyền và điều chỉnh timeout/Max repetition trên SNMP interface.
+
+Với firmware hoặc cấu hình phần cứng khác, dùng các bước kiểm tra trên để xác nhận
+các nhánh MIB được hỗ trợ, tên entity và bộ đếm cổng logic.
+
+## Tham khảo và nguồn gốc
+
+- [HPE: OID CPU/RAM/nhiệt độ Comware và index phụ thuộc thiết bị](https://support.hpe.com/hpesc/public/docDisplay?docId=sf000098678en_us&docLocale=en_US).
+- [Template HP Comware HH3C chính thức, Zabbix 7.0](https://github.com/zabbix/zabbix/blob/release/7.0/templates/net/hp_hh3c_snmp/template_net_hp_hh3c_snmp.yaml): tham chiếu bộ lọc module, entity class, bảng trạng thái HH3C.
+- [Zabbix 7.0: SNMP agent và bulk walk](https://www.zabbix.com/documentation/7.0/en/manual/config/items/itemtypes/snmp).
+
+Phát triển từ template HP A5120 của **Jakub Samek**. Bản này thay OID phần cứng cố định
+bằng discovery, cấp UUID riêng, giữ giám sát interface của bản 7.0 và cập nhật tài liệu
+cho A5500 HI.

--- a/Network_Devices/HP/template_hp_a5500_switch_snmp/7.0/template_hp_a5500_switch_snmp.yaml
+++ b/Network_Devices/HP/template_hp_a5500_switch_snmp/7.0/template_hp_a5500_switch_snmp.yaml
@@ -1,0 +1,915 @@
+zabbix_export:
+  version: '7.0'
+  template_groups:
+    - uuid: 59ecf1b9ff1643f9bafae26e6fa2de0b
+      name: Template Switches
+  templates:
+    - uuid: 0d94e5a12a40444ba411da5f2ea56d33
+      template: HP A5500 HI
+      name: HP A5500 HI
+      description: |
+        HP A5500 HI switches running Comware 5, for Zabbix 7.0.
+        Target: HP A5500-48G-4SFP HI with 2 interface slots, Comware 5.20.99 R5501P36.
+        Successfully tested on HP A5500-48G-4SFP HI with Zabbix 7.0.29.
+
+        Discovers CPU/memory modules, temperature sensors, fans and power supplies using
+        ENTITY-MIB and HH3C-ENTITY-EXT-MIB. No fixed physical entity or interface indexes.
+        CPU utilization is reported per SNMP entity, not necessarily per physical processor.
+        Module descriptions are filtered by {$HP.MODULE.DESCR.MATCHES}.
+
+        IF-MIB discovery covers GE/10GE ports, expansion modules, VLAN interfaces and link
+        aggregations. Uses 64-bit traffic counters and ifHighSpeed for 10 Gbit/s links.
+        VLAN interfaces are status-only by default; CRC items are Ethernet-only.
+        Link down alerts require a previously up port and current admin status up.
+        Bandwidth alerts use a 15-minute average and {$IF.UTIL.MAX} (default 90%).
+
+        Configure SNMPv2c or SNMPv3 on the host SNMP interface. For SNMPv3 authPriv,
+        use SHA/AES if configured on the switch, with host macros {$SNMP_V3_USER},
+        {$SNMP_V3_AUTHPASSPHRASE} and {$SNMP_V3_PRIVPASSPHRASE} in the interface fields.
+        No linked templates. See README for setup, OID checks and limitations.
+
+        Adapted from the HP A5120 template by Jakub Samek.
+      groups:
+        - name: Template Switches
+      items:
+        - uuid: 38ec55f373de497e9ea6fef7bcffbacc
+          name: Device contact details
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.4.0
+          key: sysContact
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          trends: '0'
+          description: The textual identification of the contact person for this managed node, together with information on how to contact this person.  If no contact information is
+            known, the value is the zero-length string.
+          inventory_link: CONTACT
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+        - uuid: 2bd7eb96b3c0454e888b938df75b3399
+          name: Device description
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.1.0
+          key: sysDescr
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          trends: '0'
+          description: A textual description of the entity.  This value should include the full name and version identification of the system's hardware type, software operating-system,
+            and networking software.
+          inventory_link: HARDWARE
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+        - uuid: 2a746389968e416e81092d470c907761
+          name: Device location
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.6.0
+          key: sysLocation
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          trends: '0'
+          description: The physical location of this node (e.g., `telephone closet, 3rd floor').  If the location is unknown, the value is the zero-length string.
+          inventory_link: LOCATION
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+        - uuid: da1ba9106515457799218f41dcc503a1
+          name: Device name
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.5.0
+          key: sysName
+          delay: 1h
+          history: 7d
+          value_type: CHAR
+          trends: '0'
+          description: An administratively-assigned name for this managed node. By convention, this is the node's fully-qualified domain name.  If the name is unknown, the value is the
+            zero-length string.
+          inventory_link: NAME
+          preprocessing:
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1d
+          tags:
+            - tag: component
+              value: system
+        - uuid: e94553ca510a4c4ebf2cf5526de29a85
+          name: SNMP agent uptime
+          type: SNMP_AGENT
+          snmp_oid: 1.3.6.1.2.1.1.3.0
+          key: SysUptime
+          delay: 5m
+          history: 7d
+          value_type: FLOAT
+          trends: 60d
+          units: uptime
+          preprocessing:
+            - type: MULTIPLIER
+              parameters:
+                - '0.01'
+          tags:
+            - tag: component
+              value: system
+          triggers:
+            - uuid: a80cecd7a2a4431fa5704ff0be6dc2d3
+              expression: last(/HP A5500 HI/SysUptime)<10m
+              name: '{HOST.NAME}: SNMP uptime is less than 10 minutes'
+              priority: INFO
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: notice
+              description: May indicate a switch reboot, SNMP agent restart or TimeTicks counter wrap; confirm against the switch logs and display version.
+          description: SNMPv2-MIB::sysUpTime. Time since the SNMP management subsystem initialized, not necessarily chassis uptime. The 32-bit TimeTicks counter wraps after approximately
+            497 days.
+        - uuid: 661d1e37f0844051bc250ca61bdeb0da
+          name: 'Network interfaces: SNMP walk'
+          type: SNMP_AGENT
+          snmp_oid: walk[1.3.6.1.2.1.2.2.1.2,1.3.6.1.2.1.2.2.1.3,1.3.6.1.2.1.2.2.1.7,1.3.6.1.2.1.2.2.1.8,1.3.6.1.2.1.31.1.1.1.1,1.3.6.1.2.1.31.1.1.1.6,1.3.6.1.2.1.31.1.1.1.10,1.3.6.1.2.1.31.1.1.1.15,1.3.6.1.2.1.31.1.1.1.18]
+          key: net.if.walk
+          history: '0'
+          value_type: TEXT
+          description: Collects IF-MIB columns in one master item using bulk SNMP walks. Dependent items share this result, but the device may answer the walk in multiple requests; this
+            is not an atomic snapshot.
+          tags:
+            - tag: component
+              value: raw
+          delay: 1m
+        - uuid: 4c1e42eeca78437cb6f8855e14aeec42
+          name: 'Hardware entities: SNMP walk'
+          type: SNMP_AGENT
+          snmp_oid: walk[1.3.6.1.2.1.47.1.1.1.1.2,1.3.6.1.2.1.47.1.1.1.1.5,1.3.6.1.2.1.47.1.1.1.1.7,1.3.6.1.4.1.25506.2.6.1.1.1.1.6,1.3.6.1.4.1.25506.2.6.1.1.1.1.8,1.3.6.1.4.1.25506.2.6.1.1.1.1.12,1.3.6.1.4.1.25506.2.6.1.1.1.1.19]
+          key: hardware.walk
+          delay: 1m
+          history: '0'
+          value_type: TEXT
+          description: ENTITY-MIB identity and HH3C-ENTITY-EXT-MIB health columns joined by entPhysicalIndex. Supplies hardware discovery and dependent metrics.
+          tags:
+            - tag: component
+              value: raw
+      discovery_rules:
+        - uuid: f09065f8f9b04a929bdb761368aa0ce2
+          name: CPU and memory discovery
+          type: DEPENDENT
+          key: module.discovery
+          delay: '0'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#ENT_DESCR}'
+                value: '{$HP.MODULE.DESCR.MATCHES}'
+                formulaid: A
+              - macro: '{#CPU}'
+                value: ^(100|[0-9]{1,2})$
+                formulaid: B
+              - macro: '{#MEMORY}'
+                value: ^(100|[0-9]{1,2})$
+                formulaid: C
+          description: Discovers Comware processing modules by description and valid CPU/memory readings (including idle CPU at 0%). Adjust the description macro after inspecting ENTITY-MIB.
+            Two physical processors do not imply two SNMP entries.
+          item_prototypes:
+            - uuid: 55b93ba5859e46f5806d59fc51d205d6
+              name: 'Entity {#SNMPINDEX} {#ENT_NAME}: CPU usage'
+              type: DEPENDENT
+              key: switch.cpu[{#SNMPINDEX}]
+              delay: '0'
+              history: 7d
+              description: 'Entity: {#ENT_DESCR}. Index is discovered from ENTITY-MIB.'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - 1.3.6.1.4.1.25506.2.6.1.1.1.1.6.{#SNMPINDEX}
+                    - '0'
+                - type: IN_RANGE
+                  parameters:
+                    - '0'
+                    - '100'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: hardware.walk
+              tags:
+                - tag: component
+                  value: cpu
+                - tag: entity
+                  value: '{#ENT_NAME}'
+              units: '%'
+              value_type: FLOAT
+              trigger_prototypes:
+                - uuid: c41c51c2b54948f4870459c1eaac51ae
+                  expression: min(/HP A5500 HI/switch.cpu[{#SNMPINDEX}],5m)>{$CPU.UTIL.MAX:"{#ENT_NAME}"}
+                  name: 'Entity {#SNMPINDEX} {#ENT_NAME}: CPU usage is high'
+                  priority: HIGH
+                  tags:
+                    - tag: scope
+                      value: performance
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: max(/HP A5500 HI/switch.cpu[{#SNMPINDEX}],5m)<({$CPU.UTIL.MAX:"{#ENT_NAME}"}-5)
+            - uuid: 4c500596501d4c2d8b8905d2aeb80b20
+              name: 'Entity {#SNMPINDEX} {#ENT_NAME}: Memory usage'
+              type: DEPENDENT
+              key: switch.memory[{#SNMPINDEX}]
+              delay: '0'
+              history: 7d
+              description: 'Entity: {#ENT_DESCR}. Index is discovered from ENTITY-MIB.'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - 1.3.6.1.4.1.25506.2.6.1.1.1.1.8.{#SNMPINDEX}
+                    - '0'
+                - type: IN_RANGE
+                  parameters:
+                    - '0'
+                    - '100'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: hardware.walk
+              tags:
+                - tag: component
+                  value: memory
+                - tag: entity
+                  value: '{#ENT_NAME}'
+              units: '%'
+              value_type: FLOAT
+              trigger_prototypes:
+                - uuid: 330cb009eda5424c8a78173908321539
+                  expression: min(/HP A5500 HI/switch.memory[{#SNMPINDEX}],5m)>{$MEMORY.UTIL.MAX:"{#ENT_NAME}"}
+                  name: 'Entity {#SNMPINDEX} {#ENT_NAME}: Memory usage is high'
+                  priority: HIGH
+                  tags:
+                    - tag: scope
+                      value: capacity
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: max(/HP A5500 HI/switch.memory[{#SNMPINDEX}],5m)<({$MEMORY.UTIL.MAX:"{#ENT_NAME}"}-5)
+          master_item:
+            key: hardware.walk
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#ENT_DESCR}'
+                - 1.3.6.1.2.1.47.1.1.1.1.2
+                - '0'
+                - '{#ENT_NAME}'
+                - 1.3.6.1.2.1.47.1.1.1.1.7
+                - '0'
+                - '{#CPU}'
+                - 1.3.6.1.4.1.25506.2.6.1.1.1.1.6
+                - '0'
+                - '{#MEMORY}'
+                - 1.3.6.1.4.1.25506.2.6.1.1.1.1.8
+                - '0'
+            - type: JAVASCRIPT
+              parameters:
+                - |-
+                  var rows = JSON.parse(value);
+                  var fields = ['{#CPU}', '{#MEMORY}'];
+                  return JSON.stringify(rows.filter(function (row) {
+                      row['{#ENT_DESCR}'] = row['{#ENT_DESCR}'] || '';
+                      row['{#ENT_NAME}'] = row['{#ENT_NAME}'] || row['{#ENT_DESCR}'] || ('Entity ' + row['{#SNMPINDEX}']);
+                      return fields.every(function (field) {
+                          return typeof row[field] !== 'undefined' && row[field] !== '';
+                      });
+                  }));
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          graph_prototypes:
+            - uuid: 96b94a7188e54f06a0647ef6e46f55ee
+              name: 'Entity {#SNMPINDEX} {#ENT_NAME}: CPU usage'
+              ymin_type_1: FIXED
+              ymax_type_1: FIXED
+              yaxismin: '0'
+              yaxismax: '100'
+              graph_items:
+                - color: 1A7C11
+                  item:
+                    host: HP A5500 HI
+                    key: switch.cpu[{#SNMPINDEX}]
+            - uuid: 4a8238a00d5646cf8648fd98ab7a121e
+              name: 'Entity {#SNMPINDEX} {#ENT_NAME}: Memory usage'
+              ymin_type_1: FIXED
+              ymax_type_1: FIXED
+              yaxismin: '0'
+              yaxismax: '100'
+              graph_items:
+                - color: 1A7C11
+                  item:
+                    host: HP A5500 HI
+                    key: switch.memory[{#SNMPINDEX}]
+        - uuid: 2377789c82da47bb978caefde74470d1
+          name: Temperature discovery
+          type: DEPENDENT
+          key: temperature.discovery
+          delay: '0'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#TEMP}'
+                value: ^[1-9][0-9]{0,2}$
+                formulaid: A
+          description: Discovers entities reporting 1..999 degrees C. Zero and negative sentinel values are excluded for this indoor switch. Does not assume a fixed sensor index.
+          item_prototypes:
+            - uuid: 69e777f15e7e459f8decf9bd5c818692
+              name: 'Entity {#SNMPINDEX} {#ENT_NAME}: Temperature'
+              type: DEPENDENT
+              key: switch.temp[{#SNMPINDEX}]
+              delay: '0'
+              history: 7d
+              description: 'Entity: {#ENT_DESCR}. Index is discovered from ENTITY-MIB.'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - 1.3.6.1.4.1.25506.2.6.1.1.1.1.12.{#SNMPINDEX}
+                    - '0'
+                - type: IN_RANGE
+                  parameters:
+                    - '1'
+                    - '999'
+                  error_handler: DISCARD_VALUE
+              master_item:
+                key: hardware.walk
+              tags:
+                - tag: component
+                  value: temperature
+                - tag: entity
+                  value: '{#ENT_NAME}'
+              units: °C
+              value_type: FLOAT
+              trigger_prototypes:
+                - uuid: 4563371b20ae453fb7ae7d38de257b4f
+                  expression: avg(/HP A5500 HI/switch.temp[{#SNMPINDEX}],5m)>{$TEMP.MAX:"{#ENT_NAME}"}
+                  name: 'Entity {#SNMPINDEX} {#ENT_NAME}: Temperature is high'
+                  priority: HIGH
+                  tags:
+                    - tag: scope
+                      value: availability
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: max(/HP A5500 HI/switch.temp[{#SNMPINDEX}],5m)<=({$TEMP.MAX:"{#ENT_NAME}"}-5)
+          master_item:
+            key: hardware.walk
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#ENT_DESCR}'
+                - 1.3.6.1.2.1.47.1.1.1.1.2
+                - '0'
+                - '{#ENT_NAME}'
+                - 1.3.6.1.2.1.47.1.1.1.1.7
+                - '0'
+                - '{#TEMP}'
+                - 1.3.6.1.4.1.25506.2.6.1.1.1.1.12
+                - '0'
+            - type: JAVASCRIPT
+              parameters:
+                - |-
+                  var rows = JSON.parse(value);
+                  var fields = ['{#TEMP}'];
+                  return JSON.stringify(rows.filter(function (row) {
+                      row['{#ENT_DESCR}'] = row['{#ENT_DESCR}'] || '';
+                      row['{#ENT_NAME}'] = row['{#ENT_NAME}'] || row['{#ENT_DESCR}'] || ('Entity ' + row['{#SNMPINDEX}']);
+                      return fields.every(function (field) {
+                          return typeof row[field] !== 'undefined' && row[field] !== '';
+                      });
+                  }));
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+        - uuid: 366708de8ab04ca889573ab5909f3bf9
+          name: Fan discovery
+          type: DEPENDENT
+          key: fan.discovery
+          delay: '0'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#ENT_CLASS}'
+                value: ^7$
+                formulaid: A
+              - macro: '{#ERROR}'
+                value: ^[0-9]+$
+                formulaid: B
+          description: Discovers ENTITY-MIB class 7 with an HH3C error-status entry. Absent and unsupported entities do not generate fault alerts.
+          item_prototypes:
+            - uuid: 5d56a4ba693d4efab0315dbbba6f5959
+              name: 'Entity {#SNMPINDEX} {#ENT_NAME}: Fan status'
+              type: DEPENDENT
+              key: fan.status[{#SNMPINDEX}]
+              delay: '0'
+              history: 7d
+              description: 'Entity: {#ENT_DESCR}. Index is discovered from ENTITY-MIB. Uses hh3cEntityExtErrorStatus: normal=2, entityAbsent=4; not the legacy LSW DevStatus enumeration.'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - 1.3.6.1.4.1.25506.2.6.1.1.1.1.19.{#SNMPINDEX}
+                    - '0'
+              master_item:
+                key: hardware.walk
+              tags:
+                - tag: component
+                  value: fan
+                - tag: entity
+                  value: '{#ENT_NAME}'
+              trends: '0'
+              valuemap:
+                name: HH3C-ENTITY-EXT-MIB::hh3cEntityExtErrorStatus
+              trigger_prototypes:
+                - uuid: d92d89a1fa9c49d09eef5b9ada93d2ef
+                  expression: last(/HP A5500 HI/fan.status[{#SNMPINDEX}])=3 or last(/HP A5500 HI/fan.status[{#SNMPINDEX}])=41 or last(/HP A5500 HI/fan.status[{#SNMPINDEX}])=91
+                  name: 'Entity {#SNMPINDEX} {#ENT_NAME}: Fan fault'
+                  priority: HIGH
+                  tags:
+                    - tag: scope
+                      value: availability
+          master_item:
+            key: hardware.walk
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#ENT_DESCR}'
+                - 1.3.6.1.2.1.47.1.1.1.1.2
+                - '0'
+                - '{#ENT_NAME}'
+                - 1.3.6.1.2.1.47.1.1.1.1.7
+                - '0'
+                - '{#ENT_CLASS}'
+                - 1.3.6.1.2.1.47.1.1.1.1.5
+                - '0'
+                - '{#ERROR}'
+                - 1.3.6.1.4.1.25506.2.6.1.1.1.1.19
+                - '0'
+            - type: JAVASCRIPT
+              parameters:
+                - |-
+                  var rows = JSON.parse(value);
+                  var fields = ['{#ENT_CLASS}', '{#ERROR}'];
+                  return JSON.stringify(rows.filter(function (row) {
+                      row['{#ENT_DESCR}'] = row['{#ENT_DESCR}'] || '';
+                      row['{#ENT_NAME}'] = row['{#ENT_NAME}'] || row['{#ENT_DESCR}'] || ('Entity ' + row['{#SNMPINDEX}']);
+                      return fields.every(function (field) {
+                          return typeof row[field] !== 'undefined' && row[field] !== '';
+                      });
+                  }));
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+        - uuid: 6b4a7f8b37ea474dab8b5e49e227ab76
+          name: Power supply discovery
+          type: DEPENDENT
+          key: psu.discovery
+          delay: '0'
+          filter:
+            evaltype: AND
+            conditions:
+              - macro: '{#ENT_CLASS}'
+                value: ^6$
+                formulaid: A
+              - macro: '{#ERROR}'
+                value: ^[0-9]+$
+                formulaid: B
+          description: Discovers ENTITY-MIB class 6 with an HH3C error-status entry. Absent and unsupported entities do not generate fault alerts.
+          item_prototypes:
+            - uuid: 1f5ed95428ec4991abd3b712869000d7
+              name: 'Entity {#SNMPINDEX} {#ENT_NAME}: Power supply status'
+              type: DEPENDENT
+              key: psu.status[{#SNMPINDEX}]
+              delay: '0'
+              history: 7d
+              description: 'Entity: {#ENT_DESCR}. Index is discovered from ENTITY-MIB. Uses hh3cEntityExtErrorStatus: normal=2, entityAbsent=4; not the legacy LSW DevStatus enumeration.'
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - 1.3.6.1.4.1.25506.2.6.1.1.1.1.19.{#SNMPINDEX}
+                    - '0'
+              master_item:
+                key: hardware.walk
+              tags:
+                - tag: component
+                  value: power-supply
+                - tag: entity
+                  value: '{#ENT_NAME}'
+              trends: '0'
+              valuemap:
+                name: HH3C-ENTITY-EXT-MIB::hh3cEntityExtErrorStatus
+              trigger_prototypes:
+                - uuid: 03fd5591019a45139171801d9663be03
+                  expression: last(/HP A5500 HI/psu.status[{#SNMPINDEX}])=3 or last(/HP A5500 HI/psu.status[{#SNMPINDEX}])=51 or last(/HP A5500 HI/psu.status[{#SNMPINDEX}])=61 or last(/HP
+                    A5500 HI/psu.status[{#SNMPINDEX}])=91
+                  name: 'Entity {#SNMPINDEX} {#ENT_NAME}: Power supply fault'
+                  priority: HIGH
+                  tags:
+                    - tag: scope
+                      value: availability
+          master_item:
+            key: hardware.walk
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#ENT_DESCR}'
+                - 1.3.6.1.2.1.47.1.1.1.1.2
+                - '0'
+                - '{#ENT_NAME}'
+                - 1.3.6.1.2.1.47.1.1.1.1.7
+                - '0'
+                - '{#ENT_CLASS}'
+                - 1.3.6.1.2.1.47.1.1.1.1.5
+                - '0'
+                - '{#ERROR}'
+                - 1.3.6.1.4.1.25506.2.6.1.1.1.1.19
+                - '0'
+            - type: JAVASCRIPT
+              parameters:
+                - |-
+                  var rows = JSON.parse(value);
+                  var fields = ['{#ENT_CLASS}', '{#ERROR}'];
+                  return JSON.stringify(rows.filter(function (row) {
+                      row['{#ENT_DESCR}'] = row['{#ENT_DESCR}'] || '';
+                      row['{#ENT_NAME}'] = row['{#ENT_NAME}'] || row['{#ENT_DESCR}'] || ('Entity ' + row['{#SNMPINDEX}']);
+                      return fields.every(function (field) {
+                          return typeof row[field] !== 'undefined' && row[field] !== '';
+                      });
+                  }));
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+        - uuid: 4153694b85b54da88e9a5c6a923fe2a0
+          name: Network interfaces discovery
+          type: DEPENDENT
+          key: net.if.discovery
+          delay: '0'
+          filter:
+            conditions:
+              - macro: '{#IFTYPE}'
+                value: '{$NET.IF.IFTYPE.MATCHES}'
+                formulaid: A
+          description: Discovers interfaces from IF-MIB (ifDescr, ifName, ifAlias, ifType). Interfaces are filtered by ifType using macro {$NET.IF.IFTYPE.MATCHES}.
+          item_prototypes:
+            - uuid: aa93e5bda3cf4c0e9603da063aadd724
+              name: 'Interface {#IFNAME}({#IFALIAS}): Admin status'
+              type: DEPENDENT
+              key: net.if.adminstatus[ifAdminStatus.{#SNMPINDEX}]
+              delay: '0'
+              history: 7d
+              trends: '0'
+              description: IF-MIB::ifAdminStatus - the desired (configured) state of the interface. down = shutdown by administrator.
+              valuemap:
+                name: IF-MIB::ifAdminStatus
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - 1.3.6.1.2.1.2.2.1.7.{#SNMPINDEX}
+                    - '0'
+              master_item:
+                key: net.if.walk
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 937cb0f040d34932a43611dd375cb782
+              name: 'Interface {#IFNAME}({#IFALIAS}): Operational status'
+              type: DEPENDENT
+              key: net.if.status[ifOperStatus.{#SNMPINDEX}]
+              delay: '0'
+              history: 7d
+              trends: '0'
+              description: IF-MIB::ifOperStatus - the current operational state of the interface.
+              valuemap:
+                name: IF-MIB::ifOperStatus
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - 1.3.6.1.2.1.2.2.1.8.{#SNMPINDEX}
+                    - '0'
+              master_item:
+                key: net.if.walk
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 1678e44f4ecc451982683cb25f5b0be6
+              name: 'Interface {#IFNAME}({#IFALIAS}): Bits received'
+              type: DEPENDENT
+              key: net.if.in[ifHCInOctets.{#SNMPINDEX}]
+              delay: '0'
+              history: 7d
+              units: bps
+              description: IF-MIB::ifHCInOctets - incoming traffic on the interface (64-bit counter).
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - 1.3.6.1.2.1.31.1.1.1.6.{#SNMPINDEX}
+                    - '0'
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              master_item:
+                key: net.if.walk
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: ecf85180a21b44889e68fa49450f3f1d
+              name: 'Interface {#IFNAME}({#IFALIAS}): Bits sent'
+              type: DEPENDENT
+              key: net.if.out[ifHCOutOctets.{#SNMPINDEX}]
+              delay: '0'
+              history: 7d
+              units: bps
+              description: IF-MIB::ifHCOutOctets - outgoing traffic on the interface (64-bit counter).
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - 1.3.6.1.2.1.31.1.1.1.10.{#SNMPINDEX}
+                    - '0'
+                - type: CHANGE_PER_SECOND
+                  parameters:
+                    - ''
+                - type: MULTIPLIER
+                  parameters:
+                    - '8'
+              master_item:
+                key: net.if.walk
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: bff1030a0bb84b44a13226cd2193aa2a
+              name: 'Interface {#IFNAME}({#IFALIAS}): Speed'
+              type: DEPENDENT
+              key: net.if.speed[ifHighSpeed.{#SNMPINDEX}]
+              delay: '0'
+              history: 7d
+              units: bps
+              description: IF-MIB::ifHighSpeed - current bandwidth of the interface (reported in Mbps, converted to bps).
+              preprocessing:
+                - type: SNMP_WALK_VALUE
+                  parameters:
+                    - 1.3.6.1.2.1.31.1.1.1.15.{#SNMPINDEX}
+                    - '0'
+                - type: MULTIPLIER
+                  parameters:
+                    - '1000000'
+                - type: DISCARD_UNCHANGED_HEARTBEAT
+                  parameters:
+                    - 1h
+              master_item:
+                key: net.if.walk
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+            - uuid: 2aa1419d10d04ec1892dbcffcdfb78ef
+              name: 'Interface {#IFNAME}({#IFALIAS}): CRC errors'
+              type: SNMP_AGENT
+              snmp_oid: 1.3.6.1.2.1.10.7.2.1.3.{#SNMPINDEX}
+              key: CRC.Errors[{#SNMPINDEX}]
+              delay: 2m
+              history: 7d
+              description: EtherLike-MIB::dot3StatsFCSErrors - frames received that failed the FCS (CRC) check.
+              tags:
+                - tag: component
+                  value: network
+                - tag: interface
+                  value: '{#IFNAME}'
+                - tag: description
+                  value: '{#IFALIAS}'
+              trigger_prototypes:
+                - uuid: 8911a5848fe746e5bf70e709147a7b62
+                  expression: change(/HP A5500 HI/CRC.Errors[{#SNMPINDEX}])>1
+                  name: 'Interface {#IFNAME}({#IFALIAS}): CRC errors on {HOST.NAME}'
+                  priority: AVERAGE
+                  description: More than one new FCS/CRC error since the previous sample (2-minute polling). A counter reset does not raise this alert.
+                  tags:
+                    - tag: scope
+                      value: performance
+          trigger_prototypes:
+            - uuid: 35532ac69481435a977f3ca79dd60ee0
+              expression: '{$IFCONTROL:"{#IFNAME}"}=1 and last(/HP A5500 HI/net.if.adminstatus[ifAdminStatus.{#SNMPINDEX}])=1 and last(/HP A5500 HI/net.if.status[ifOperStatus.{#SNMPINDEX}])=2
+                and last(/HP A5500 HI/net.if.status[ifOperStatus.{#SNMPINDEX}],#2)=1'
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: last(/HP A5500 HI/net.if.status[ifOperStatus.{#SNMPINDEX}])<>2 or last(/HP A5500 HI/net.if.adminstatus[ifAdminStatus.{#SNMPINDEX}])=2 or {$IFCONTROL:"{#IFNAME}"}=0
+              name: 'Interface {#IFNAME}({#IFALIAS}): Link down'
+              opdata: 'Current state: {ITEM.LASTVALUE2}'
+              priority: AVERAGE
+              description: |
+                The interface changed from up to down while its admin status is up (not shutdown).
+                Interfaces that were already down, or that were shut down by an administrator, are ignored.
+                The problem is resolved when the interface is no longer down or is shut down by an administrator.
+                Set {$IFCONTROL:"{#IFNAME}"}=0 to disable this trigger for a specific interface.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: availability
+            - uuid: 08a2e4cd79244b058ab38edded0fd6e1
+              expression: (avg(/HP A5500 HI/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/HP A5500 HI/net.if.speed[ifHighSpeed.{#SNMPINDEX}]) or avg(/HP
+                A5500 HI/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)>({$IF.UTIL.MAX:"{#IFNAME}"}/100)*last(/HP A5500 HI/net.if.speed[ifHighSpeed.{#SNMPINDEX}])) and last(/HP A5500 HI/net.if.speed[ifHighSpeed.{#SNMPINDEX}])>0
+              recovery_mode: RECOVERY_EXPRESSION
+              recovery_expression: (avg(/HP A5500 HI/net.if.in[ifHCInOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/HP A5500 HI/net.if.speed[ifHighSpeed.{#SNMPINDEX}])
+                and avg(/HP A5500 HI/net.if.out[ifHCOutOctets.{#SNMPINDEX}],15m)<(({$IF.UTIL.MAX:"{#IFNAME}"}-3)/100)*last(/HP A5500 HI/net.if.speed[ifHighSpeed.{#SNMPINDEX}])) or last(/HP
+                A5500 HI/net.if.speed[ifHighSpeed.{#SNMPINDEX}])=0
+              name: 'Interface {#IFNAME}({#IFALIAS}): High bandwidth usage (>{$IF.UTIL.MAX:"{#IFNAME}"}%)'
+              opdata: 'In: {ITEM.LASTVALUE1}, out: {ITEM.LASTVALUE3}, speed: {ITEM.LASTVALUE2}'
+              priority: WARNING
+              description: |-
+                The 15-minute average of inbound or outbound traffic exceeds {$IF.UTIL.MAX:"{#IFNAME}"}% of the interface speed.
+                The problem is resolved when both directions drop below ({$IF.UTIL.MAX:"{#IFNAME}"} - 3)%.
+                The threshold can be changed per interface with {$IF.UTIL.MAX:"<ifName>"}.
+
+                The problem also resolves if the reported interface speed becomes zero.
+              manual_close: 'YES'
+              tags:
+                - tag: scope
+                  value: performance
+          graph_prototypes:
+            - uuid: c147059af5344a2ba1c177ff8de7a611
+              name: 'Interface {#IFNAME}({#IFALIAS}): Network traffic'
+              graph_items:
+                - drawtype: GRADIENT_LINE
+                  color: 1A7C11
+                  item:
+                    host: HP A5500 HI
+                    key: net.if.in[ifHCInOctets.{#SNMPINDEX}]
+                - sortorder: '1'
+                  drawtype: BOLD_LINE
+                  color: 2774A4
+                  item:
+                    host: HP A5500 HI
+                    key: net.if.out[ifHCOutOctets.{#SNMPINDEX}]
+          master_item:
+            key: net.if.walk
+          preprocessing:
+            - type: SNMP_WALK_TO_JSON
+              parameters:
+                - '{#IFDESCR}'
+                - 1.3.6.1.2.1.2.2.1.2
+                - '0'
+                - '{#IFNAME}'
+                - 1.3.6.1.2.1.31.1.1.1.1
+                - '0'
+                - '{#IFALIAS}'
+                - 1.3.6.1.2.1.31.1.1.1.18
+                - '0'
+                - '{#IFTYPE}'
+                - 1.3.6.1.2.1.2.2.1.3
+                - '0'
+            - type: DISCARD_UNCHANGED_HEARTBEAT
+              parameters:
+                - 1h
+          overrides:
+            - name: 'VLAN interfaces: status only (no bandwidth, no CRC)'
+              step: '1'
+              filter:
+                conditions:
+                  - macro: '{#IFTYPE}'
+                    value: '{$NET.IF.NO_TRAFFIC.IFTYPE.MATCHES}'
+                    formulaid: A
+              operations:
+                - operationobject: ITEM_PROTOTYPE
+                  operator: REGEXP
+                  value: ': (Bits received|Bits sent|Speed|CRC errors)$'
+                  discover: NO_DISCOVER
+                - operationobject: TRIGGER_PROTOTYPE
+                  operator: REGEXP
+                  value: ': (High bandwidth usage|CRC errors)'
+                  discover: NO_DISCOVER
+                - operationobject: GRAPH_PROTOTYPE
+                  operator: REGEXP
+                  value: ': Network traffic$'
+                  discover: NO_DISCOVER
+            - name: 'Non-Ethernet interfaces: no CRC counters'
+              step: '2'
+              filter:
+                conditions:
+                  - macro: '{#IFTYPE}'
+                    value: ^6$
+                    operator: NOT_MATCHES_REGEX
+                    formulaid: A
+              operations:
+                - operationobject: ITEM_PROTOTYPE
+                  operator: REGEXP
+                  value: ': CRC errors$'
+                  discover: NO_DISCOVER
+                - operationobject: TRIGGER_PROTOTYPE
+                  operator: REGEXP
+                  value: ': CRC errors'
+                  discover: NO_DISCOVER
+      macros:
+        - macro: '{$HP.MODULE.DESCR.MATCHES}'
+          value: (?i)(^module level1$|fabric.*module|cpu)
+          description: Processing-module entPhysicalDescr filter. Inspect ENTITY-MIB before adapting this regex for firmware-specific names.
+        - macro: '{$CPU.UTIL.MAX}'
+          value: '80'
+          description: CPU percentage above this value for 5m raises an alert. Recovers below threshold minus 5 for 5m. Supports entity-name context.
+        - macro: '{$MEMORY.UTIL.MAX}'
+          value: '80'
+          description: Memory percentage above this value for 5m raises an alert. Recovers below threshold minus 5 for 5m. Supports entity-name context.
+        - macro: '{$TEMP.MAX}'
+          value: '60'
+          description: Configurable monitoring threshold in degrees C (5m average), not a manufacturer hardware limit. Recovers at threshold minus 5 or below for 5m. Supports entity-name
+            context.
+        - macro: '{$IF.UTIL.MAX}'
+          value: '90'
+          description: Bandwidth usage threshold in % of interface speed (15-minute average, inbound or outbound). Override per interface with context, e.g. {$IF.UTIL.MAX:"Ten-GigabitEthernet1/1/1"}=80.
+        - macro: '{$IFCONTROL}'
+          value: '1'
+          description: 'Link down trigger: 1 = enabled, 0 = disabled. Override per interface with context, e.g. {$IFCONTROL:"GigabitEthernet1/0/1"}=0.'
+        - macro: '{$NET.IF.IFTYPE.MATCHES}'
+          value: ^(6|136|161)$
+          description: Regex of ifType values to discover. 6 = ethernetCsmacd, 136 = l3ipvlan (Vlan-interface), 161 = ieee8023adLag (Bridge-Aggregation).
+        - macro: '{$NET.IF.NO_TRAFFIC.IFTYPE.MATCHES}'
+          value: ^136$
+          description: 'Regex of ifType values that are discovered for status only: no bandwidth, speed, CRC items and no bandwidth / CRC triggers. Default 136 = l3ipvlan (Vlan-interface).'
+      valuemaps:
+        - uuid: 5e1b7450580a4819a731e3410c59daa8
+          name: IF-MIB::ifAdminStatus
+          mappings:
+            - value: '1'
+              newvalue: up
+            - value: '2'
+              newvalue: down
+            - value: '3'
+              newvalue: testing
+        - uuid: c93b6d3c4cc6425c90f16e8d9a0b212d
+          name: IF-MIB::ifOperStatus
+          mappings:
+            - value: '1'
+              newvalue: up
+            - value: '2'
+              newvalue: down
+            - value: '3'
+              newvalue: testing
+            - value: '4'
+              newvalue: unknown
+            - value: '5'
+              newvalue: dormant
+            - value: '6'
+              newvalue: notPresent
+            - value: '7'
+              newvalue: lowerLayerDown
+        - uuid: 88de12cb20f64544bd760e7194389955
+          name: HH3C-ENTITY-EXT-MIB::hh3cEntityExtErrorStatus
+          mappings:
+            - value: '1'
+              newvalue: notSupported
+            - value: '2'
+              newvalue: normal
+            - value: '3'
+              newvalue: postFailure
+            - value: '4'
+              newvalue: entityAbsent
+            - value: '11'
+              newvalue: poeError
+            - value: '21'
+              newvalue: stackError
+            - value: '22'
+              newvalue: stackPortBlocked
+            - value: '23'
+              newvalue: stackPortFailed
+            - value: '31'
+              newvalue: sfpRecvError
+            - value: '32'
+              newvalue: sfpSendError
+            - value: '33'
+              newvalue: sfpBothError
+            - value: '41'
+              newvalue: fanError
+            - value: '51'
+              newvalue: psuError
+            - value: '61'
+              newvalue: rpsError
+            - value: '71'
+              newvalue: moduleFaulty
+            - value: '81'
+              newvalue: sensorError
+            - value: '91'
+              newvalue: hardwareFaulty


### PR DESCRIPTION
- Convert export to Zabbix 7.0 format (template_groups, no date field)
- Bulk interface collection via walk[] master item with dependent items
- Interface discovery: bandwidth in/out (64-bit), speed, admin/oper status
- Link down trigger: fires only on up -> down while admin status is up; interfaces already down or administratively shut down are ignored
- High bandwidth usage trigger: 15m average > {$IF.UTIL.MAX}% (default 90)
- Vlan-interfaces discovered for status only (LLD override excludes bandwidth, speed and CRC)
- CRC item uses dot3StatsFCSErrors instead of dot3StatsAlignmentErrors
- Fix memory trigger that referenced the CPU item
- Add fan / power supply value map and "deactive" triggers
- Remove duplicate "Power Supply Sensor" item
- Replace deprecated {HOSTNAME} and positional $1 macros
- README: document macros, triggers and tested environment (HP A5120-48G EI, Zabbix 7.0.29)