### PR TITLE
updated version of template_seh_dongleserver_promax_by_snmp with new items and triggers

### DIFF
--- a/Network_Appliances/template_seh_dongleserver_promax_by_snmp/7.0/README.md
+++ b/Network_Appliances/template_seh_dongleserver_promax_by_snmp/7.0/README.md
@@ -19,7 +19,7 @@ The template uses the vendor's private enterprise MIB (`1.3.6.1.4.1.1229`, SEH C
 
 ## Template Group
 
-`Templates/Network devices`
+`Templates/Network Appliances`
 
 ## Setup
 
@@ -32,30 +32,31 @@ The template uses the vendor's private enterprise MIB (`1.3.6.1.4.1.1229`, SEH C
 
 ## Macros
 
-| Macro | Default | Description                                                |
-|---|---|------------------------------------------------------------|
-| `{$SEH.BOX.TEMP.CRIT}` | `60` | Internal enclosure temperature, critical threshold (°C)    |
-| `{$SEH.BOX.TEMP.WARN}` | `50` | Internal enclosure temperature, warning threshold (°C)     |
-| `{$SEH.CPU.TEMP.CRIT}` | `85` | CPU temperature, critical threshold (°C)                   |
-| `{$SEH.CPU.TEMP.WARN}` | `75` | CPU temperature, warning threshold (°C)                    |
-| `{$SEH.CPU.UTIL.CRIT}` | `90` | CPU utilization, critical threshold (%)                    |
-| `{$SEH.CPU.UTIL.WARN}` | `80` | CPU utilization, warning threshold (%)                     |
-| `{$SEH.ICMP_LOSS_WARN}` | `20` | ICMP packet loss warning threshold (%)                     |
-| `{$SEH.ICMP_RESPONSE_TIME_WARN}` | `0.15` | ICMP response time warning threshold (seconds)             |
-| `{$SEH.IF.ERRORS.WARN}` | `2` | Interface in/out error rate warning threshold (errors/sec) |
-| `{$SEH.IF.UTIL.MAX}` | `90` | Interface bandwidth utilization warning threshold (%)      |
-| `{$SEH.MEMORY.UTIL.CRIT}` | `90` | Memory utilization, critical threshold (%)                 |
-| `{$SEH.MEMORY.UTIL.WARN}` | `80` | Memory utilization, warning threshold (%)                  |
-| `{$SEH.PHY.TEMP.CRIT}` | `85` | Ethernet transceiver temperature, critical threshold (°C)  |
-| `{$SEH.PHY.TEMP.WARN}` | `75` | Ethernet transceiver temperature, warning threshold (°C)*  |
-| `{$SEH.PORT.MATCHES}` | `^.*` | Regex to include USB ports in discovery*                   |
+| Macro | Default         | Description                                                |
+|---|-----------------|------------------------------------------------------------|
+| `{$SEH.BOX.TEMP.CRIT}` | `60`            | Internal enclosure temperature, critical threshold (°C)    |
+| `{$SEH.BOX.TEMP.WARN}` | `50`            | Internal enclosure temperature, warning threshold (°C)     |
+| `{$SEH.CPU.TEMP.CRIT}` | `85`            | CPU temperature, critical threshold (°C)                   |
+| `{$SEH.CPU.TEMP.WARN}` | `75`            | CPU temperature, warning threshold (°C)                    |
+| `{$SEH.CPU.UTIL.CRIT}` | `90`            | CPU utilization, critical threshold (%)                    |
+| `{$SEH.CPU.UTIL.WARN}` | `80`            | CPU utilization, warning threshold (%)                     |
+| `{$SEH.ICMP_LOSS_WARN}` | `20`            | ICMP packet loss warning threshold (%)                     |
+| `{$SEH.ICMP_RESPONSE_TIME_WARN}` | `0.15`          | ICMP response time warning threshold (seconds)             |
+| `{$SEH.IF.ERRORS.WARN}` | `2`             | Interface in/out error rate warning threshold (errors/sec) |
+| `{$SEH.IF.UTIL.MAX}` | `90`            | Interface bandwidth utilization warning threshold (%)      |
+| `{$SEH.MEMORY.UTIL.CRIT}` | `90`            | Memory utilization, critical threshold (%)                 |
+| `{$SEH.MEMORY.UTIL.WARN}` | `80`            | Memory utilization, warning threshold (%)                  |
+| `{$SEH.PHY.TEMP.CRIT}` | `85`            | Ethernet transceiver temperature, critical threshold (°C)  |
+| `{$SEH.PHY.TEMP.WARN}` | `75`            | Ethernet transceiver temperature, warning threshold (°C)*  |
+| `{$SEH.PORT.MATCHES}` | `^.*`           | Regex to include USB ports in discovery*                   |
 | `{$SEH.PORT.NOT_MATCHES}` | `CHANGE_IF_NEEDED` | Regex to exclude USB ports from discovery                  |
-| `{$SEH.SNMP.USER}` | `sehread` | SNMPv3 username                                            |
+| `{$SEH.SNMP.USER}` | `sehread`       | SNMPv3 username                                            |
 | `{$SEH.SNMP.AUTHPRIV_PASSWORD}` | *(secret, unset)* | SNMPv3 auth/priv passphrase                                |
-| `{$SEH.URL}` | *(unset)* | URL used by the "URL Check" web scenario                   |
-| `{$SEH.USB.UTIL.MAX}` | `80` | USB port capacity-usage warning threshold (%)              |
-| `{$SEH.UTN.PORT}` | `9200` | UTN (non-SSL) TCP port checked for availability            |
-| `{$SEH.UTNSSL.PORT}` | `9443` | UTN SSL TCP port checked for availability                  |
+| `{$SEH.URL}` | *(unset)*       | URL used by the "URL Check" web scenario                   |
+| `{$SEH.USB.UTIL.MAX}` | `90`            | USB port capacity-usage warning threshold (%)              |
+| `{$SEH.UTN.PORT}` | `9200`          | UTN (non-SSL) TCP port checked for availability            |
+| `{$SEH.UTNSSL.PORT}` | `9443`          | UTN SSL TCP port checked for availability                  |
+| `{$SEH.UNSUPPORTED.ITEMS.MAX}` | `3`             | Maximum number of unsupported items                  |
 
 \* `{$SEH.PHY.TEMP.WARN}` and `{$SEH.PORT.MATCHES}` have their in-template descriptions swapped (see [Known Limitations](#known-limitations)); the table above shows their correct/intended meaning.
 
@@ -121,9 +122,10 @@ Trigger prototypes: dongle present but not connected to a UTN manager host, dong
 | `All USB Ports Occupied` | High | Manual close, fires when connected count = total usb ports available |
 | `No USB devices connected` | Info | Recovers via explicit recovery expression                                                                          |
 | `USB port utilization is above {$SEH.USB.UTIL.MAX}%` | High | Template-level, connected/total ratio                                                                              |
-| `Interface link down / high error rate / high bandwidth usage` | High / Warning | Per-interface, from discovery                                                                                      |
-| `USB Not Connected to any UTN Manager on Port {#PORT}` | Warning | Per-port, from discovery                                                                                           |
-| `USB Dongle Removed from Port {#PORT}` | Average | Per-port, from discovery                                                                                           |
+| `Interface link down / high error rate / high bandwidth usage` | High / Warning | Per-interface, from discovery            |                                                                          |
+| `USB Not Connected to any UTN Manager on Port {#PORT}` | Warning | Per-port, from discovery                                 |                                                          |
+| `USB Dongle Removed from Port {#PORT}` | Average | Per-port, from discovery                                                  |                                         |
+| `Too many unsupported items on {HOST.NAME}` | Warning	| zabbix[host,,items_unsupported] ≥ {$SEH.UNSUPPORTED.ITEMS.MAX} |
 
 ## Value Maps
 

--- a/Network_Appliances/template_seh_dongleserver_promax_by_snmp/7.0/template_seh_dongleserver_promax_by_snmp.yaml
+++ b/Network_Appliances/template_seh_dongleserver_promax_by_snmp/7.0/template_seh_dongleserver_promax_by_snmp.yaml
@@ -95,9 +95,9 @@ zabbix_export:
           trends: '0'
           description: 'SEH Bonjour Name'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: 85f50c740d674ac7b78fecc27f8af9f3
           name: 'CPU Utilization'
           type: SNMP_AGENT
@@ -129,9 +129,9 @@ zabbix_export:
           trends: '0'
           description: 'SEH Device Information'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: 283cd94ff91d4a35ae9c6d7916100a3c
           name: 'Primary DNS Address'
           type: SNMP_AGENT
@@ -142,9 +142,9 @@ zabbix_export:
           trends: '0'
           description: 'SEH Primary DNS Address'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: ddf368e475874adfa2583aee2b1e11f8
           name: 'Secondary DNS Address'
           type: SNMP_AGENT
@@ -155,9 +155,9 @@ zabbix_export:
           trends: '0'
           description: 'SEH Secondary DNS Address'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: e9451ae4ac124ed088330f8693b45bb5
           name: 'Current Firmware Version'
           type: DEPENDENT
@@ -209,9 +209,9 @@ zabbix_export:
           key: seh.fw.major
           delay: 1h
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: 7db2da15eb8d4c2c806e2c231b0a9b13
           name: 'Current Firmware Numeric Version'
           type: CALCULATED
@@ -224,7 +224,7 @@ zabbix_export:
           preprocessing:
             - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - '86400'
+                - 6h
         - uuid: 28f8fec09719480f8a65027e704d1d88
           name: 'Latest Firmware Page'
           type: HTTP_AGENT
@@ -241,9 +241,9 @@ zabbix_export:
           key: seh.fw.release
           delay: 1h
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: ebb777c667514626ab0d727ade1c3b06
           name: 'Firmware SubRelease Version'
           type: SNMP_AGENT
@@ -251,9 +251,9 @@ zabbix_export:
           key: seh.fw.subrelease
           delay: 1h
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: c0ca82c5fd504a0da464441688ec940f
           name: 'IP Address'
           type: SNMP_AGENT
@@ -264,9 +264,9 @@ zabbix_export:
           trends: '0'
           description: 'SEH IP Address'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: ca8bda55784d4c49aa97f171ab7adde9
           name: 'Gateway Address'
           type: SNMP_AGENT
@@ -277,9 +277,9 @@ zabbix_export:
           trends: '0'
           description: 'SEH Gateway Address'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: 92a7f726a7d14ef5907ee01c771e9d00
           name: 'MAC Address'
           type: SNMP_AGENT
@@ -290,9 +290,9 @@ zabbix_export:
           trends: '0'
           description: 'SEH MAC Address'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: 704c6183c7074c4b8514f5875d52f864
           name: 'Memory Utilization'
           type: SNMP_AGENT
@@ -327,9 +327,9 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: 73855d037a9c4138a1053b013b8bb679
           name: 'NTP Status'
           type: SNMP_AGENT
@@ -339,9 +339,9 @@ zabbix_export:
           valuemap:
             name: NTP-Status-Mapping
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: d92450b95cd341c69ad1afb4bb261afc
           name: 'NTP Timezone'
           type: SNMP_AGENT
@@ -351,9 +351,9 @@ zabbix_export:
           value_type: TEXT
           trends: '0'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: b80aa16e858a4203819ee69be4d3708a
           name: 'SNMPv1 Status'
           type: SNMP_AGENT
@@ -386,9 +386,9 @@ zabbix_export:
           trends: '0'
           description: 'SEH System Information'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: 480e65c127444d1fb3feae2b9def4356
           name: 'System Name'
           type: SNMP_AGENT
@@ -399,9 +399,9 @@ zabbix_export:
           trends: '0'
           description: 'SEH System Name'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: e03c51dc0e6746dcb9cd127e9c0d6382
           name: 'System Uptime'
           type: SNMP_AGENT
@@ -564,7 +564,7 @@ zabbix_export:
           name: 'Connected USB Devices Count'
           type: CALCULATED
           key: seh.usb.connected.count
-          params: 'count(last_foreach(/*/seh.usb.status[*]),"gt",0)'
+          params: 'count(last_foreach(//seh.usb.status[*]),"gt",0)'
           triggers:
             - uuid: a2893399aa544b1f80629d1a8abef20a
               expression: 'last(/SEH Dongle Server ProMAX by SNMP/seh.usb.connected.count)=0'
@@ -572,6 +572,7 @@ zabbix_export:
               recovery_expression: 'last(/SEH Dongle Server ProMAX by SNMP/seh.usb.connected.count)>0'
               name: 'No USB devices connected'
               priority: INFO
+              manual_close: 'YES'
         - uuid: 1c98992b94264708813659aed5664549
           name: 'Total USB Ports'
           type: SNMP_AGENT
@@ -580,9 +581,9 @@ zabbix_export:
           delay: 1d
           description: 'Number of entries in the UTN port table.'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: 11c2de03c0bd40c49ba69622b78f5b8b
           name: 'UTN Port'
           type: SNMP_AGENT
@@ -591,9 +592,9 @@ zabbix_export:
           delay: 1h
           description: 'SEH UTN Port'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
         - uuid: bc1b3a7ecfe44fdeb382107e01e488de
           name: 'UTN SSL Port'
           type: SNMP_AGENT
@@ -602,9 +603,19 @@ zabbix_export:
           delay: 1h
           description: 'SEH UTN SSL Port'
           preprocessing:
-            - type: DISCARD_UNCHANGED
+            - type: DISCARD_UNCHANGED_HEARTBEAT
               parameters:
-                - ''
+                - 6h
+        - uuid: 344322cb2dd44d8b8237505783dc0646
+          name: 'Number of unsupported items'
+          type: INTERNAL
+          key: 'zabbix[host,,items_unsupported]'
+          description: 'Total number of unsupported items'
+          triggers:
+            - uuid: acb991c0cac34e188c4a525b4a565bbc
+              expression: 'last(/SEH Dongle Server ProMAX by SNMP/zabbix[host,,items_unsupported]) >= {$SEH.UNSUPPORTED.ITEMS.MAX}'
+              name: 'Too many unsupported items on {HOST.NAME}'
+              priority: WARNING
       discovery_rules:
         - uuid: e723c111c4854a898bbfb207832ec7b1
           name: 'Network Interface Discovery'
@@ -930,7 +941,9 @@ zabbix_export:
               trends: '0'
               trigger_prototypes:
                 - uuid: 072876d592344cf183fa96fb6c1a888e
-                  expression: 'find(/SEH Dongle Server ProMAX by SNMP/seh.usb.host[{#SNMPINDEX}], #1, "regexp","^Available$")=1'
+                  expression: 'last(/SEH Dongle Server ProMAX by SNMP/seh.usb.host[{#SNMPINDEX}])="Available"'
+                  recovery_mode: RECOVERY_EXPRESSION
+                  recovery_expression: 'last(/SEH Dongle Server ProMAX by SNMP/seh.usb.host[{#SNMPINDEX}])<>"Available"'
                   name: 'USB Not Connected to any UTN Manager on Port {#PORT}'
                   priority: WARNING
                   description: 'USB exists but no host is connected.'
@@ -1070,11 +1083,14 @@ zabbix_export:
         - macro: '{$SEH.SNMP.USER}'
           value: sehread
           description: 'SNMPv3 username'
+        - macro: '{$SEH.UNSUPPORTED.ITEMS.MAX}'
+          value: '3'
+          description: 'Maximum number of unsupported items'
         - macro: '{$SEH.URL}'
           value: 'https://seh-dongleserver.promax'
           description: 'URL used by the "URL Check" web scenario'
         - macro: '{$SEH.USB.UTIL.MAX}'
-          value: '80'
+          value: '90'
           description: 'USB port capacity-usage warning threshold (%)'
         - macro: '{$SEH.UTN.PORT}'
           value: '9200'
@@ -1176,3 +1192,4 @@ zabbix_export:
         >= {$SEH.USB.UTIL.MAX}
       name: 'USB port utilization is above {$SEH.USB.UTIL.MAX}%'
       priority: HIGH
+      manual_close: 'YES'


### PR DESCRIPTION
Updated README.md
Updated Template Group

Triggers added: 

- USB port occupancy
- Unsupported items catcher

Items added:

- Number of unsupported items


Items modified:

- Preprocessing for all inert values like system information (Discard unchanged with heartbeat)
- Connected USB Devices Count (Optimized formula)

Macros added:

- {$SEH.UNSUPPORTED.ITEMS.MAX} (used in triggers to find premature SNMP monitoring)